### PR TITLE
Fix paths to reusable workflows

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   get-module-to-validate:
     # TODO: switch to relative path once https://github.com/github/feedback/discussions/10679 is fixed.
-    uses: Azure/bicep-registry-modules/workflows/get-changed-module.yml@main
+    uses: Azure/bicep-registry-modules/.github/workflows/get-changed-module.yml@main
 
   validate-module-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   get-module-to-publish:
     # TODO: switch to relative path once https://github.com/github/feedback/discussions/10679 is fixed.
-    uses: Azure/bicep-registry-modules/workflows/get-changed-module.yml@main
+    uses: Azure/bicep-registry-modules/.github/workflows/get-changed-module.yml@main
 
   create-tag:
     runs-on: ubuntu-latest
@@ -55,6 +55,6 @@ jobs:
     needs: create-tag
     if: needs.create-tag.outputs.tag
     # TODO: switch to relative path once https://github.com/github/feedback/discussions/10679 is fixed.
-    uses: Azure/bicep-registry-modules/workflows/publish-module.yml@main
+    uses: Azure/bicep-registry-modules/.github/workflows/publish-module.yml@main
     with:
       tag: ${{ needs.create-tag.outputs.tag }}


### PR DESCRIPTION
Missing `.github` in the paths to the reusable workflows.