### PR TITLE
Additional fixes for fabricbot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/.github/ @Azure/bicep-admins
+/scripts/ @Azure/bicep-admins

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -438,18 +438,12 @@
       },
       "eventType": "pull_request",
       "eventNames": ["pull_request", "issues", "project_card"],
-      "taskName": "Add a comment and request reviews from bicep-admins when the CI files are changed",
+      "taskName": "Add a comment to notify bicep-admins when the CI files are changed",
       "actions": [
         {
           "name": "addReply",
           "parameters": {
             "comment": "This PR contains changes to the CI definitions. Reviews from @Azure/bicep-admins are needed."
-          }
-        },
-        {
-          "name": "requestReviewer",
-          "parameters": {
-            "reviewer": "Azure/bicep-admins"
           }
         }
       ]


### PR DESCRIPTION
- Added a CODEOWNERS file to force reviews from bicep-admins if CI files are changed in a PR
- The write access permission check was removed because it doesn't seem to work for the github-actions bot