### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.bicep text eol=lf


### PR DESCRIPTION
We need to stop Git from changing line endings of Bicep files when checking out the repo to prevent errors like https://github.com/Azure/bicep-registry-modules/pull/65#discussion_r844481706 from happening.