### PR TITLE
Module update - ImportAcr - adding an output

### DIFF
--- a/modules/deployment-scripts/import-acr/README.md
+++ b/modules/deployment-scripts/import-acr/README.md
@@ -2,6 +2,10 @@
 
 An Azure CLI Deployment Script that imports public container images to an Azure Container Registry
 
+## Description
+
+An Azure CLI Deployment Script that imports public container images to an Azure Container Registry.
+
 ## Parameters
 
 | Name                                       | Type     | Required | Description                                                                                                   |
@@ -20,8 +24,9 @@ An Azure CLI Deployment Script that imports public container images to an Azure 
 
 ## Outputs
 
-| Name | Type | Description |
-| :--- | :--: | :---------- |
+| Name   | Type  | Description                                  |
+| :----- | :---: | :------------------------------------------- |
+| images | array | Returning an array of the imported imageUris |
 
 ## Examples
 
@@ -33,7 +38,7 @@ param acrName string =  'yourAzureContainerRegistry'
 
 var imageName = 'mcr.microsoft.com/azuredocs/azure-vote-front:v1'
 
-module acrImport 'br/public:deployment-scripts/import-acr:2.0.1' = {
+module acrImport 'br/public:deployment-scripts/import-acr:2.1.1' = {
   name: 'testAcrImportSingle'
   params: {
     acrName: acrName
@@ -55,7 +60,7 @@ var imageNames = [
   'docker.io/bitnami/redis:latest'
 ]
 
-module acrImport 'br/public:deployment-scripts/import-acr:2.0.1' = {
+module acrImport 'br/public:deployment-scripts/import-acr:2.1.1' = {
   name: 'testAcrImportMulti'
   params: {
     acrName: acrName
@@ -72,7 +77,7 @@ param location string = resourceGroup().location
 param acrName string =  'yourAzureContainerRegistry'
 param existingManagedIdName = 'yourExistingManagedIdentity'
 
-module acrImport 'br/public:deployment-scripts/import-acr:2.0.1' = {
+module acrImport 'br/public:deployment-scripts/import-acr:2.1.1' = {
   name: 'testAcrImport'
   params: {
     useExistingManagedIdentity: true
@@ -93,7 +98,7 @@ module acrImport 'br/public:deployment-scripts/import-acr:2.0.1' = {
 param location string = resourceGroup().location
 param acrName string =  'yourAzureContainerRegistry'
 
-module acrImport 'br/public:deployment-scripts/import-acr:2.0.1' = {
+module acrImport 'br/public:deployment-scripts/import-acr:2.1.1' = {
   name: 'testAcrImport'
   params: {
     initialScriptDelay: '60s'

--- a/modules/deployment-scripts/import-acr/README.md
+++ b/modules/deployment-scripts/import-acr/README.md
@@ -24,9 +24,9 @@ An Azure CLI Deployment Script that imports public container images to an Azure 
 
 ## Outputs
 
-| Name   | Type  | Description                                  |
-| :----- | :---: | :------------------------------------------- |
-| images | array | Returning an array of the imported imageUris |
+| Name   | Type  | Description                        |
+| :----- | :---: | :--------------------------------- |
+| images | array | An array of the imported imageUris |
 
 ## Examples
 

--- a/modules/deployment-scripts/import-acr/main.bicep
+++ b/modules/deployment-scripts/import-acr/main.bicep
@@ -123,3 +123,9 @@ resource createImportImage 'Microsoft.Resources/deploymentScripts@2020-10-01' = 
     cleanupPreference: cleanupPreference
   }
 }]
+
+@description('An array of the imported imageUris')
+output images array = [for image in images: {
+  originalImageUri: image
+  acrHostedImageUri : '${acr.properties.loginServer}${skip(image, indexOf(image,'/'))}'
+}]

--- a/modules/deployment-scripts/import-acr/main.json
+++ b/modules/deployment-scripts/import-acr/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.8.9.13224",
-      "templateHash": "2241692591084475519"
+      "templateHash": "15255844397914304046"
     }
   },
   "parameters": {
@@ -176,7 +176,7 @@
         }
       },
       "metadata": {
-        "description": "Returning an array of the imported imageUris"
+        "description": "An array of the imported imageUris"
       }
     }
   }

--- a/modules/deployment-scripts/import-acr/main.json
+++ b/modules/deployment-scripts/import-acr/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.5.6.12127",
-      "templateHash": "13896569015360344837"
+      "version": "0.8.9.13224",
+      "templateHash": "2241692591084475519"
     }
   },
   "parameters": {
@@ -164,5 +164,20 @@
         "[extensionResourceId(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), 'Microsoft.Authorization/roleAssignments', guid(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), parameters('rbacRoleNeeded'), if(parameters('useExistingManagedIdentity'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('existingManagedIdentitySubId'), parameters('existingManagedIdentityResourceGroupName')), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')))))]"
       ]
     }
-  ]
+  ],
+  "outputs": {
+    "images": {
+      "type": "array",
+      "copy": {
+        "count": "[length(parameters('images'))]",
+        "input": {
+          "originalImageUri": "[parameters('images')[copyIndex()]]",
+          "acrHostedImageUri": "[format('{0}{1}', reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2021-12-01-preview').loginServer, skip(parameters('images')[copyIndex()], indexOf(parameters('images')[copyIndex()], '/')))]"
+        }
+      },
+      "metadata": {
+        "description": "Returning an array of the imported imageUris"
+      }
+    }
+  }
 }

--- a/modules/deployment-scripts/import-acr/metadata.json
+++ b/modules/deployment-scripts/import-acr/metadata.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema#",
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
   "name": "ACR Image Import",
-  "description": "An Azure CLI Deployment Script that imports public container images to an Azure Container Registry",
+  "summary": "An Azure CLI Deployment Script that imports public container images to an Azure Container Registry",
   "owner": "Aks-Bicep-Accelerator-Maintainers"
 }

--- a/modules/deployment-scripts/import-acr/version.json
+++ b/modules/deployment-scripts/import-acr/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "v2.0",
+  "version": "v2.1",
   "pathFilters": [
     "./main.json",
     "./metadata.json"


### PR DESCRIPTION
## Description

<!--Why this PR? What is changed? What is the effect? etc.-->

This adds an output of the images that were imported, including the original and the new URIs.

This will be handy for authors that consume this module to leverage the ACR hosted uri of their image.
It also helps by streamlining the dependsOn that would be needed by consuming modules/resources.

Typical output value is

```json
[{
	"originalImageUri": "docker.io/bitnami/external-dns:latest",
	"acrHostedImageUri": "crtestrq7mjdnsylkok.azurecr.io/bitnami/external-dns:latest"
}, {
	"originalImageUri": "quay.io/jetstack/cert-manager-cainjector:v1.7.2",
	"acrHostedImageUri": "crtestrq7mjdnsylkok.azurecr.io/jetstack/cert-manager-cainjector:v1.7.2"
}, {
	"originalImageUri": "docker.io/bitnami/redis:latest",
	"acrHostedImageUri": "crtestrq7mjdnsylkok.azurecr.io/bitnami/redis:latest"
}]
```

## Updating an existing module

<!--Run through the checklist if your PR updates an existing module.-->

- [ ] This is a bug fix:
  - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
  - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
- [x] I have run `brm validate` locally to verify the module files.
- [x] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](../CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [ ] The PR contains backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
  - [x] The PR contains backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
