### PR TITLE
Import ACR Images - Better output names

### DIFF
--- a/modules/deployment-scripts/import-acr/README.md
+++ b/modules/deployment-scripts/import-acr/README.md
@@ -24,9 +24,9 @@ An Azure CLI Deployment Script that imports public container images to an Azure 
 
 ## Outputs
 
-| Name   | Type  | Description                        |
-| :----- | :---: | :--------------------------------- |
-| images | array | An array of the imported imageUris |
+| Name           | Type  | Description                     |
+| :------------- | :---: | :------------------------------ |
+| importedImages | array | An array of the imported images |
 
 ## Examples
 

--- a/modules/deployment-scripts/import-acr/README.md
+++ b/modules/deployment-scripts/import-acr/README.md
@@ -38,7 +38,7 @@ param acrName string =  'yourAzureContainerRegistry'
 
 var imageName = 'mcr.microsoft.com/azuredocs/azure-vote-front:v1'
 
-module acrImport 'br/public:deployment-scripts/import-acr:2.1.1' = {
+module acrImport 'br/public:deployment-scripts/import-acr:3.0.1' = {
   name: 'testAcrImportSingle'
   params: {
     acrName: acrName
@@ -60,7 +60,7 @@ var imageNames = [
   'docker.io/bitnami/redis:latest'
 ]
 
-module acrImport 'br/public:deployment-scripts/import-acr:2.1.1' = {
+module acrImport 'br/public:deployment-scripts/import-acr:3.0.1' = {
   name: 'testAcrImportMulti'
   params: {
     acrName: acrName
@@ -77,7 +77,7 @@ param location string = resourceGroup().location
 param acrName string =  'yourAzureContainerRegistry'
 param existingManagedIdName = 'yourExistingManagedIdentity'
 
-module acrImport 'br/public:deployment-scripts/import-acr:2.1.1' = {
+module acrImport 'br/public:deployment-scripts/import-acr:3.0.1' = {
   name: 'testAcrImport'
   params: {
     useExistingManagedIdentity: true
@@ -98,7 +98,7 @@ module acrImport 'br/public:deployment-scripts/import-acr:2.1.1' = {
 param location string = resourceGroup().location
 param acrName string =  'yourAzureContainerRegistry'
 
-module acrImport 'br/public:deployment-scripts/import-acr:2.1.1' = {
+module acrImport 'br/public:deployment-scripts/import-acr:3.0.1' = {
   name: 'testAcrImport'
   params: {
     initialScriptDelay: '60s'

--- a/modules/deployment-scripts/import-acr/main.bicep
+++ b/modules/deployment-scripts/import-acr/main.bicep
@@ -124,8 +124,8 @@ resource createImportImage 'Microsoft.Resources/deploymentScripts@2020-10-01' = 
   }
 }]
 
-@description('An array of the imported imageUris')
-output images array = [for image in images: {
-  originalImageUri: image
-  acrHostedImageUri : '${acr.properties.loginServer}${skip(image, indexOf(image,'/'))}'
+@description('An array of the imported images')
+output importedImages array = [for image in images: {
+  originalImage : image
+  acrHostedImage : '${acr.properties.loginServer}${string(skip(image, indexOf(image,'/')))}'
 }]

--- a/modules/deployment-scripts/import-acr/main.json
+++ b/modules/deployment-scripts/import-acr/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.8.9.13224",
-      "templateHash": "15255844397914304046"
+      "version": "0.11.1.770",
+      "templateHash": "8432140579349303037"
     }
   },
   "parameters": {
@@ -166,17 +166,17 @@
     }
   ],
   "outputs": {
-    "images": {
+    "importedImages": {
       "type": "array",
       "copy": {
         "count": "[length(parameters('images'))]",
         "input": {
-          "originalImageUri": "[parameters('images')[copyIndex()]]",
-          "acrHostedImageUri": "[format('{0}{1}', reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2021-12-01-preview').loginServer, skip(parameters('images')[copyIndex()], indexOf(parameters('images')[copyIndex()], '/')))]"
+          "originalImage": "[parameters('images')[copyIndex()]]",
+          "acrHostedImage": "[format('{0}{1}', reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('acrName')), '2021-12-01-preview').loginServer, string(skip(parameters('images')[copyIndex()], indexOf(parameters('images')[copyIndex()], '/'))))]"
         }
       },
       "metadata": {
-        "description": "An array of the imported imageUris"
+        "description": "An array of the imported images"
       }
     }
   }

--- a/modules/deployment-scripts/import-acr/version.json
+++ b/modules/deployment-scripts/import-acr/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "v2.1",
+  "version": "v3.0",
   "pathFilters": [
     "./main.json",
     "./metadata.json"


### PR DESCRIPTION
## Description

Refining the outputs from the module, to ease the consumption of it by other modules.

#### Context 

Because of the uri portion to the names, it was getting stuck when being consumed in a quickstart, in the azure quickstart repo CI.

## Updating an existing module

<!--Run through the checklist if your PR updates an existing module.-->

- [x] I have run `brm validate` locally to verify the module files.
- [x] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](../CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [x] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
