### PR TITLE
Deployment Scripts - Acr build concurrency

### DIFF
--- a/modules/deployment-scripts/build-acr/main.bicep
+++ b/modules/deployment-scripts/build-acr/main.bicep
@@ -80,7 +80,7 @@ resource rbac 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(
 }
 
 resource createImportImage 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-  name: 'ACR-Build-${cleanRepoName}'
+  name: 'ACR-Build-${imageName}-${cleanRepoName}'
   location: location
   identity: {
     type: 'UserAssigned'

--- a/modules/deployment-scripts/build-acr/main.bicep
+++ b/modules/deployment-scripts/build-acr/main.bicep
@@ -53,6 +53,7 @@ param acrBuildPlatform string = 'linux'
 
 var repo = '${gitRepositoryUrl}#${gitBranch}:${gitRepoDirectory}'
 var cleanRepoName = last(split(gitRepositoryUrl, '/'))
+var cleanImageName = replace(imageName,'/','')
 var taggedImageName = '${imageName}:${imageTag}'
 
 resource acr 'Microsoft.ContainerRegistry/registries@2021-12-01-preview' existing = {
@@ -80,7 +81,7 @@ resource rbac 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(
 }
 
 resource createImportImage 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-  name: 'ACR-Build-${imageName}-${cleanRepoName}'
+  name: 'ACR-Build-${cleanImageName}-${cleanRepoName}'
   location: location
   identity: {
     type: 'UserAssigned'

--- a/modules/deployment-scripts/build-acr/main.json
+++ b/modules/deployment-scripts/build-acr/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.11.1.770",
-      "templateHash": "13642411578150246430"
+      "templateHash": "6911180040708541168"
     }
   },
   "parameters": {
@@ -156,7 +156,7 @@
     {
       "type": "Microsoft.Resources/deploymentScripts",
       "apiVersion": "2020-10-01",
-      "name": "[format('ACR-Build-{0}', variables('cleanRepoName'))]",
+      "name": "[format('ACR-Build-{0}-{1}', parameters('imageName'), variables('cleanRepoName'))]",
       "location": "[parameters('location')]",
       "identity": {
         "type": "UserAssigned",

--- a/modules/deployment-scripts/build-acr/main.json
+++ b/modules/deployment-scripts/build-acr/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.11.1.770",
-      "templateHash": "6911180040708541168"
+      "templateHash": "12363648850858759275"
     }
   },
   "parameters": {
@@ -128,6 +128,7 @@
     "$fxv#0": "#!/bin/bash\nset -e\n\necho \"Waiting on RBAC replication ($initialDelay)\"\nsleep $initialDelay\n\naz acr build --resource-group $acrResourceGroup \\\n  --registry $acrName \\\n  --image $taggedImageName $repo \\\n  --platform $platform",
     "repo": "[format('{0}#{1}:{2}', parameters('gitRepositoryUrl'), parameters('gitBranch'), parameters('gitRepoDirectory'))]",
     "cleanRepoName": "[last(split(parameters('gitRepositoryUrl'), '/'))]",
+    "cleanImageName": "[replace(parameters('imageName'), '/', '')]",
     "taggedImageName": "[format('{0}:{1}', parameters('imageName'), parameters('imageTag'))]"
   },
   "resources": [
@@ -156,7 +157,7 @@
     {
       "type": "Microsoft.Resources/deploymentScripts",
       "apiVersion": "2020-10-01",
-      "name": "[format('ACR-Build-{0}-{1}', parameters('imageName'), variables('cleanRepoName'))]",
+      "name": "[format('ACR-Build-{0}-{1}', variables('cleanImageName'), variables('cleanRepoName'))]",
       "location": "[parameters('location')]",
       "identity": {
         "type": "UserAssigned",


### PR DESCRIPTION
## Description

It's not possible to build multiple images concurrently from the same git repository.
This PR fixes the naming of the deployment script resource to facilitate that scenario.

## Updating an existing module

<!--Run through the checklist if your PR updates an existing module.-->

- [x] This is a bug fix:
  - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
- [x] I have run `brm validate` locally to verify the module files.
- [x] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](../CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [x] The PR contains backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
