### PR TITLE
Change helm scripting

### DIFF
--- a/modules/deployment-scripts/aks-run-helm/README.md
+++ b/modules/deployment-scripts/aks-run-helm/README.md
@@ -55,9 +55,7 @@ module runCmd 'br/public:deployment-scripts/aks-run-helm:1.0.1' = {
   name: 'kubectlGetNodes'
   params: {
     useExistingManagedIdentity: true
-    initialScriptDelay: '0'
     managedIdentityName: managedIdentityName
-    rbacRolesNeeded:[]
     aksName: aksName
     location: location
     helmApps: [{helmApp: 'azure-marketplace/wordpress', helmAppName: 'my-wordpress'}]

--- a/modules/deployment-scripts/aks-run-helm/README.md
+++ b/modules/deployment-scripts/aks-run-helm/README.md
@@ -28,8 +28,9 @@ More information about using Helm on Azure can be found [here](https://docs.micr
 
 ## Outputs
 
-| Name | Type | Description |
-| :--- | :--: | :---------- |
+| Name        | Type  | Description                |
+| :---------- | :---: | :------------------------- |
+| helmOutputs | array | Helm Command Output Values |
 
 ## Examples
 

--- a/modules/deployment-scripts/aks-run-helm/README.md
+++ b/modules/deployment-scripts/aks-run-helm/README.md
@@ -104,7 +104,7 @@ module helmInstallIngressController 'br/public:deployment-scripts/aks-run-helm:1
       {
         helmApp: 'bitnami/contour'
         helmAppName: 'contour-ingress'
-        helmParams: '--version 7.7.1 --namespace ingress-basic --create_namespace --set envoy.kind=deployment --set contour.service.externalTrafficPolicy=cluster'
+        helmAppParams: '--version 7.7.1 --namespace ingress-basic --create_namespace --set envoy.kind=deployment --set contour.service.externalTrafficPolicy=cluster'
       }
     ]
   }

--- a/modules/deployment-scripts/aks-run-helm/main.bicep
+++ b/modules/deployment-scripts/aks-run-helm/main.bicep
@@ -52,3 +52,8 @@ module helmAppInstalls 'br/public:deployment-scripts/aks-run-command:1.0.1' = [f
     cleanupPreference: cleanupPreference
   }
 }]
+
+output helmOutputs array = [for (app, i) in helmApps: {
+  appName: app.helmAppName
+  outputs: helmAppInstalls[i].outputs.commandOutput
+}]

--- a/modules/deployment-scripts/aks-run-helm/main.bicep
+++ b/modules/deployment-scripts/aks-run-helm/main.bicep
@@ -5,7 +5,7 @@ param aksName string
 param location string = resourceGroup().location
 
 @description('How the deployment script should be forced to execute')
-param forceUpdateTag  string = utcNow()
+param forceUpdateTag string = utcNow()
 
 @description('Does the Managed Identity already exists, or should be created')
 param useExistingManagedIdentity bool = false
@@ -26,7 +26,7 @@ param helmRepo string = 'azure-marketplace'
 param helmRepoURL string = 'https://marketplace.azurecr.io/helm/v1/repo'
 
 @description('Helm Apps {helmApp: \'azure-marketplace/wordpress\', helmAppName: \'my-wordpress\'}')
-param helmApps array  = []
+param helmApps array = []
 
 @allowed([
   'OnSuccess'
@@ -43,7 +43,7 @@ module helmAppInstalls 'br/public:deployment-scripts/aks-run-command:1.0.1' = [f
     location: location
     commands: [
       'helm repo add ${helmRepo} ${helmRepoURL}; helm repo update'
-      'helm upgrade --install  ${app.helmApp} ${app.helmAppName} ${contains(app, 'helmAppParams') ? app.helmAppParams : ''}'
+      'helm upgrade --install ${app.helmAppName} ${app.helmApp} ${contains(app, 'helmAppParams') ? app.helmAppParams : ''}'
     ]
     forceUpdateTag: forceUpdateTag
     useExistingManagedIdentity: useExistingManagedIdentity

--- a/modules/deployment-scripts/aks-run-helm/main.bicep
+++ b/modules/deployment-scripts/aks-run-helm/main.bicep
@@ -42,8 +42,7 @@ module helmAppInstalls 'br/public:deployment-scripts/aks-run-command:1.0.1' = [f
     aksName: aksName
     location: location
     commands: [
-      'helm repo add ${helmRepo} ${helmRepoURL}; helm repo update'
-      'helm upgrade --install ${app.helmAppName} ${app.helmApp} ${contains(app, 'helmAppParams') ? app.helmAppParams : ''}'
+      'helm repo add ${helmRepo} ${helmRepoURL} && helm repo update && helm upgrade --install ${app.helmAppName} ${app.helmApp} ${contains(app, 'helmAppParams') ? app.helmAppParams : ''}'
     ]
     forceUpdateTag: forceUpdateTag
     useExistingManagedIdentity: useExistingManagedIdentity

--- a/modules/deployment-scripts/aks-run-helm/main.bicep
+++ b/modules/deployment-scripts/aks-run-helm/main.bicep
@@ -53,6 +53,7 @@ module helmAppInstalls 'br/public:deployment-scripts/aks-run-command:1.0.1' = [f
   }
 }]
 
+@description('Helm Command Output Values')
 output helmOutputs array = [for (app, i) in helmApps: {
   appName: app.helmAppName
   outputs: helmAppInstalls[i].outputs.commandOutput

--- a/modules/deployment-scripts/aks-run-helm/main.json
+++ b/modules/deployment-scripts/aks-run-helm/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.12.40.16777",
-      "templateHash": "3029187388790019340"
+      "templateHash": "6013903518664539641"
     }
   },
   "parameters": {
@@ -340,6 +340,9 @@
           "appName": "[parameters('helmApps')[copyIndex()].helmAppName]",
           "outputs": "[reference(resourceId('Microsoft.Resources/deployments', format('helmInstall-{0}-{1}', parameters('helmApps')[copyIndex()].helmAppName, copyIndex())), '2020-10-01').outputs.commandOutput.value]"
         }
+      },
+      "metadata": {
+        "description": "Helm Command Output Values"
       }
     }
   }

--- a/modules/deployment-scripts/aks-run-helm/main.json
+++ b/modules/deployment-scripts/aks-run-helm/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.12.40.16777",
-      "templateHash": "17889908750769342776"
+      "templateHash": "3029187388790019340"
     }
   },
   "parameters": {
@@ -330,5 +330,17 @@
         }
       }
     }
-  ]
+  ],
+  "outputs": {
+    "helmOutputs": {
+      "type": "array",
+      "copy": {
+        "count": "[length(parameters('helmApps'))]",
+        "input": {
+          "appName": "[parameters('helmApps')[copyIndex()].helmAppName]",
+          "outputs": "[reference(resourceId('Microsoft.Resources/deployments', format('helmInstall-{0}-{1}', parameters('helmApps')[copyIndex()].helmAppName, copyIndex())), '2020-10-01').outputs.commandOutput.value]"
+        }
+      }
+    }
+  }
 }

--- a/modules/deployment-scripts/aks-run-helm/main.json
+++ b/modules/deployment-scripts/aks-run-helm/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.12.40.16777",
-      "templateHash": "6013903518664539641"
+      "version": "0.15.31.15270",
+      "templateHash": "1311160354913464789"
     }
   },
   "parameters": {

--- a/modules/deployment-scripts/aks-run-helm/main.json
+++ b/modules/deployment-scripts/aks-run-helm/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.12.40.16777",
-      "templateHash": "16688079330702350385"
+      "templateHash": "17889908750769342776"
     }
   },
   "parameters": {
@@ -114,8 +114,7 @@
           },
           "commands": {
             "value": [
-              "[format('helm repo add {0} {1}; helm repo update', parameters('helmRepo'), parameters('helmRepoURL'))]",
-              "[format('helm upgrade --install {0} {1} {2}', parameters('helmApps')[copyIndex()].helmAppName, parameters('helmApps')[copyIndex()].helmApp, if(contains(parameters('helmApps')[copyIndex()], 'helmAppParams'), parameters('helmApps')[copyIndex()].helmAppParams, ''))]"
+              "[format('helm repo add {0} {1} && helm repo update && helm upgrade --install {2} {3} {4}', parameters('helmRepo'), parameters('helmRepoURL'), parameters('helmApps')[copyIndex()].helmAppName, parameters('helmApps')[copyIndex()].helmApp, if(contains(parameters('helmApps')[copyIndex()], 'helmAppParams'), parameters('helmApps')[copyIndex()].helmAppParams, ''))]"
             ]
           },
           "forceUpdateTag": {

--- a/modules/deployment-scripts/aks-run-helm/main.json
+++ b/modules/deployment-scripts/aks-run-helm/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.9.1.41621",
-      "templateHash": "2465942561230693956"
+      "version": "0.12.40.16777",
+      "templateHash": "16688079330702350385"
     }
   },
   "parameters": {
@@ -115,7 +115,7 @@
           "commands": {
             "value": [
               "[format('helm repo add {0} {1}; helm repo update', parameters('helmRepo'), parameters('helmRepoURL'))]",
-              "[format('helm upgrade --install  {0} {1} {2}', parameters('helmApps')[copyIndex()].helmApp, parameters('helmApps')[copyIndex()].helmAppName, if(contains(parameters('helmApps')[copyIndex()], 'helmAppParams'), parameters('helmApps')[copyIndex()].helmAppParams, ''))]"
+              "[format('helm upgrade --install {0} {1} {2}', parameters('helmApps')[copyIndex()].helmAppName, parameters('helmApps')[copyIndex()].helmApp, if(contains(parameters('helmApps')[copyIndex()], 'helmAppParams'), parameters('helmApps')[copyIndex()].helmAppParams, ''))]"
             ]
           },
           "forceUpdateTag": {

--- a/modules/deployment-scripts/aks-run-helm/test/main.test.bicep
+++ b/modules/deployment-scripts/aks-run-helm/test/main.test.bicep
@@ -42,7 +42,7 @@ module helmContour '../main.bicep' = {
       {
         helmApp: 'bitnami/contour'
         helmAppName: 'contour-ingress'
-        helmParams: '--version 7.7.1 --namespace ingress-basic --create_namespace --set envoy.kind=deployment --set contour.service.externalTrafficPolicy=cluster'
+        helmAppParams: '--version 7.7.1 --namespace ingress-basic --create_namespace --set envoy.kind=deployment --set contour.service.externalTrafficPolicy=cluster'
       }
     ]
   }

--- a/modules/deployment-scripts/aks-run-helm/test/prereq.test.bicep
+++ b/modules/deployment-scripts/aks-run-helm/test/prereq.test.bicep
@@ -1,4 +1,4 @@
-param aksName string =  'crtest${uniqueString(newGuid())}'
+param aksName string = 'crtest${uniqueString(resourceGroup().id)}'
 param location string = resourceGroup().location
 
 resource aks 'Microsoft.ContainerService/managedClusters@2022-01-02-preview' = {

--- a/modules/deployment-scripts/aks-run-helm/version.json
+++ b/modules/deployment-scripts/aks-run-helm/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "v1.0",
+  "version": "v2.0",
   "pathFilters": [
     "./main.json",
     "./metadata.json"


### PR DESCRIPTION
## Description

The current helm scripting is not working. That has 2 reasons:
- Multiline (every line is executed in a different container which don't share state)
- the order of the arguments given to helm. An example of that here:
[helm update --install cert-manager jetstack/cert-manager](https://cert-manager.io/docs/installation/helm/#4-install-cert-manager) == helm update --install `helmAppName` `helmApp`

Closes #213, #231

## Updating an existing module

<!--Run through the checklist if your PR updates an existing module.-->

- [x] This is a bug fix:
  - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
- [x] I have run `brm validate` locally to verify the module files.
- [x] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](../CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [x] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
