### PR TITLE
ACR Build - support more flexible working directory

### DIFF
--- a/modules/deployment-scripts/build-acr/README.md
+++ b/modules/deployment-scripts/build-acr/README.md
@@ -9,26 +9,26 @@ This bicep module leverages DeploymentScript to orchestrate the image build.
 
 ## Parameters
 
-| Name                                       | Type     | Required | Description                                                                                                                    |
-| :----------------------------------------- | :------: | :------: | :----------------------------------------------------------------------------------------------------------------------------- |
-| `AcrName`                                  | `string` | Yes      | The name of the Azure Container Registry                                                                                       |
-| `location`                                 | `string` | No       | The location of the ACR and where to deploy the module resources to                                                            |
-| `forceUpdateTag`                           | `string` | No       | How the deployment script should be forced to execute                                                                          |
-| `rbacRoleNeeded`                           | `string` | No       | Azure RoleId that are required for the DeploymentScript resource to import images                                              |
-| `useExistingManagedIdentity`               | `bool`   | No       | Does the Managed Identity already exists, or should be created                                                                 |
-| `managedIdentityName`                      | `string` | No       | Name of the Managed Identity resource                                                                                          |
-| `existingManagedIdentitySubId`             | `string` | No       | For an existing Managed Identity, the Subscription Id it is located in                                                         |
-| `existingManagedIdentityResourceGroupName` | `string` | No       | For an existing Managed Identity, the Resource Group it is located in                                                          |
-| `initialScriptDelay`                       | `string` | No       | A delay before the script import operation starts. Primarily to allow Azure AAD Role Assignments to propagate                  |
-| `cleanupPreference`                        | `string` | No       | When the script resource is cleaned up                                                                                         |
-| `gitRepositoryUrl`                         | `string` | Yes      | The Git Repository URL, eg. https://github.com/YOURORG/YOURREPO.git                                                            |
-| `gitBranch`                                | `string` | No       | The name of the repository branch to use                                                                                       |
-| `buildWorkingDirectory`                    | `string` | No       | The docker context working directory, change this when your Dockerfile and source files are ALL located in a repo subdirectory |
-| `dockerfileDirectory`                      | `string` | No       | The subdirectory relative to the working directory that contains the Dockerfile                                                |
-| `dockerfileName`                           | `string` | No       | The name of the dockerfile                                                                                                     |
-| `imageName`                                | `string` | Yes      | The image name/path you want to create in ACR                                                                                  |
-| `imageTag`                                 | `string` | No       | The image tag you want to create                                                                                               |
-| `acrBuildPlatform`                         | `string` | No       | The ACR compute platform needed to build the image                                                                             |
+| Name                                       | Type     | Required | Description                                                                                                   |
+| :----------------------------------------- | :------: | :------: | :------------------------------------------------------------------------------------------------------------ |
+| `AcrName`                                  | `string` | Yes      | The name of the Azure Container Registry                                                                      |
+| `location`                                 | `string` | No       | The location of the ACR and where to deploy the module resources to                                           |
+| `forceUpdateTag`                           | `string` | No       | How the deployment script should be forced to execute                                                         |
+| `rbacRoleNeeded`                           | `string` | No       | Azure RoleId that are required for the DeploymentScript resource to import images                             |
+| `useExistingManagedIdentity`               | `bool`   | No       | Does the Managed Identity already exists, or should be created                                                |
+| `managedIdentityName`                      | `string` | No       | Name of the Managed Identity resource                                                                         |
+| `existingManagedIdentitySubId`             | `string` | No       | For an existing Managed Identity, the Subscription Id it is located in                                        |
+| `existingManagedIdentityResourceGroupName` | `string` | No       | For an existing Managed Identity, the Resource Group it is located in                                         |
+| `initialScriptDelay`                       | `string` | No       | A delay before the script import operation starts. Primarily to allow Azure AAD Role Assignments to propagate |
+| `cleanupPreference`                        | `string` | No       | When the script resource is cleaned up                                                                        |
+| `gitRepositoryUrl`                         | `string` | Yes      | The Git Repository URL, eg. https://github.com/YOURORG/YOURREPO.git                                           |
+| `gitBranch`                                | `string` | No       | The name of the repository branch to use                                                                      |
+| `dockerfileDirectory`                      | `string` | No       | The directory in the repo that contains the dockerfile                                                        |
+| `dockerfileName`                           | `string` | No       | The name of the dockerfile                                                                                    |
+| `buildWorkingDirectory`                    | `string` | No       | The docker context working directory, defaults to the Dockerfile directory                                    |
+| `imageName`                                | `string` | Yes      | The image name/path you want to create in ACR                                                                 |
+| `imageTag`                                 | `string` | No       | The image tag you want to create                                                                              |
+| `acrBuildPlatform`                         | `string` | No       | The ACR compute platform needed to build the image                                                            |
 
 ## Outputs
 
@@ -44,13 +44,13 @@ This bicep module leverages DeploymentScript to orchestrate the image build.
 param acrName string
 param location string
 
-module buildDaprImage 'br/public:deployment-scripts/build-acr:1.0.1' = {
+module buildDaprImage 'br/public:deployment-scripts/build-acr:2.0.1' = {
   name: 'buildAcrImage-linux-dapr'
   params: {
     AcrName: acrName
     location: location
     gitRepositoryUrl:  'https://github.com/Azure-Samples/container-apps-store-api-microservice.git'
-    gitRepoDirectory:  'python-service'
+    buildWorkingDirectory:  'python-service'
     imageName: 'aca/dapr'
   }
 }
@@ -62,13 +62,13 @@ module buildDaprImage 'br/public:deployment-scripts/build-acr:1.0.1' = {
 param acrName string
 param location string
 
-module buildWinAcrImage 'br/public:deployment-scripts/build-acr:1.0.1' = {
+module buildWinAcrImage 'br/public:deployment-scripts/build-acr:2.0.1' = {
   name: 'buildAcrImage-win-eshop'
   params: {
     AcrName: acrName
     location: location
     gitRepositoryUrl:  'https://github.com/Azure-Samples/DotNet47WinContainerModernize.git'
-    gitRepoDirectory:  'eShopLegacyWebFormsSolution'
+    buildWorkingDirectory:  'eShopLegacyWebFormsSolution'
     imageName: 'dotnet/framework/aspnet'
     imageTag: '4.8-windowsservercore-ltsc2019'
     acrBuildPlatform: 'windows'
@@ -83,18 +83,18 @@ param acrName string
 param acaEnvName string
 param location string
 
-module buildDaprImage 'br/public:deployment-scripts/build-acr:1.0.1' = {
+module buildDaprImage 'br/public:deployment-scripts/build-acr:2.0.1' = {
   name: 'buildAcrImage-linux-dapr'
   params: {
     AcrName: acrName
     location: location
     gitRepositoryUrl:  'https://github.com/Azure-Samples/container-apps-store-api-microservice.git'
-    gitRepoDirectory:  'python-service'
+    buildWorkingDirectory:  'python-service'
     imageName: 'aca/dapr'
   }
 }
 
-module aca 'br/public:app/dapr-containerapp:1.0.2' = {
+module aca 'br/public:app/dapr-containerapp:1.2.1' = {
   name: 'stateNodeApp'
   params: {
     location: location
@@ -102,6 +102,23 @@ module aca 'br/public:app/dapr-containerapp:1.0.2' = {
     containerAppEnvName: acaEnvName
     containerImage: buildDaprImage.outputs.acrImage
     azureContainerRegistry: acrName
+  }
+}
+```
+
+## Building a Dockerfile with repo root context
+
+```bicep
+module buildImage 'br/public:deployment-scripts/build-acr:2.0.1' = {
+  name: 'differentbuildcontext'
+  params: {
+    AcrName: acr.name
+    location: location
+    gitRepositoryUrl:  'https://github.com/azure-octo/dapr-kafka-csharp.git'
+    gitBranch: 'master'
+    dockerfileDirectory: 'producer'
+    buildWorkingDirectory: '.' //Dockerfile uses files in parent directory structure. Working directory needs to be root.
+    imageName: 'daprkafka/producer'
   }
 }
 ```

--- a/modules/deployment-scripts/build-acr/README.md
+++ b/modules/deployment-scripts/build-acr/README.md
@@ -9,24 +9,26 @@ This bicep module leverages DeploymentScript to orchestrate the image build.
 
 ## Parameters
 
-| Name                                       | Type     | Required | Description                                                                                                   |
-| :----------------------------------------- | :------: | :------: | :------------------------------------------------------------------------------------------------------------ |
-| `AcrName`                                  | `string` | Yes      | The name of the Azure Container Registry                                                                      |
-| `location`                                 | `string` | No       | The location of the ACR and where to deploy the module resources to                                           |
-| `forceUpdateTag`                           | `string` | No       | How the deployment script should be forced to execute                                                         |
-| `rbacRoleNeeded`                           | `string` | No       | Azure RoleId that are required for the DeploymentScript resource to import images                             |
-| `useExistingManagedIdentity`               | `bool`   | No       | Does the Managed Identity already exists, or should be created                                                |
-| `managedIdentityName`                      | `string` | No       | Name of the Managed Identity resource                                                                         |
-| `existingManagedIdentitySubId`             | `string` | No       | For an existing Managed Identity, the Subscription Id it is located in                                        |
-| `existingManagedIdentityResourceGroupName` | `string` | No       | For an existing Managed Identity, the Resource Group it is located in                                         |
-| `initialScriptDelay`                       | `string` | No       | A delay before the script import operation starts. Primarily to allow Azure AAD Role Assignments to propagate |
-| `cleanupPreference`                        | `string` | No       | When the script resource is cleaned up                                                                        |
-| `gitRepositoryUrl`                         | `string` | Yes      | The Git Repository URL, eg. https://github.com/YOURORG/YOURREPO.git                                           |
-| `gitBranch`                                | `string` | No       | The name of the repository branch to use                                                                      |
-| `gitRepoDirectory`                         | `string` | No       | The directory in the repo that contains the dockerfile                                                        |
-| `imageName`                                | `string` | Yes      | The image name/path you want to create in ACR                                                                 |
-| `imageTag`                                 | `string` | No       | The image tag you want to create                                                                              |
-| `acrBuildPlatform`                         | `string` | No       | The ACR compute platform needed to build the image                                                            |
+| Name                                       | Type     | Required | Description                                                                                                                    |
+| :----------------------------------------- | :------: | :------: | :----------------------------------------------------------------------------------------------------------------------------- |
+| `AcrName`                                  | `string` | Yes      | The name of the Azure Container Registry                                                                                       |
+| `location`                                 | `string` | No       | The location of the ACR and where to deploy the module resources to                                                            |
+| `forceUpdateTag`                           | `string` | No       | How the deployment script should be forced to execute                                                                          |
+| `rbacRoleNeeded`                           | `string` | No       | Azure RoleId that are required for the DeploymentScript resource to import images                                              |
+| `useExistingManagedIdentity`               | `bool`   | No       | Does the Managed Identity already exists, or should be created                                                                 |
+| `managedIdentityName`                      | `string` | No       | Name of the Managed Identity resource                                                                                          |
+| `existingManagedIdentitySubId`             | `string` | No       | For an existing Managed Identity, the Subscription Id it is located in                                                         |
+| `existingManagedIdentityResourceGroupName` | `string` | No       | For an existing Managed Identity, the Resource Group it is located in                                                          |
+| `initialScriptDelay`                       | `string` | No       | A delay before the script import operation starts. Primarily to allow Azure AAD Role Assignments to propagate                  |
+| `cleanupPreference`                        | `string` | No       | When the script resource is cleaned up                                                                                         |
+| `gitRepositoryUrl`                         | `string` | Yes      | The Git Repository URL, eg. https://github.com/YOURORG/YOURREPO.git                                                            |
+| `gitBranch`                                | `string` | No       | The name of the repository branch to use                                                                                       |
+| `buildWorkingDirectory`                    | `string` | No       | The docker context working directory, change this when your Dockerfile and source files are ALL located in a repo subdirectory |
+| `dockerfileDirectory`                      | `string` | No       | The subdirectory relative to the working directory that contains the Dockerfile                                                |
+| `dockerfileName`                           | `string` | No       | The name of the dockerfile                                                                                                     |
+| `imageName`                                | `string` | Yes      | The image name/path you want to create in ACR                                                                                  |
+| `imageTag`                                 | `string` | No       | The image tag you want to create                                                                                               |
+| `acrBuildPlatform`                         | `string` | No       | The ACR compute platform needed to build the image                                                                             |
 
 ## Outputs
 

--- a/modules/deployment-scripts/build-acr/README.md
+++ b/modules/deployment-scripts/build-acr/README.md
@@ -9,26 +9,26 @@ This bicep module leverages DeploymentScript to orchestrate the image build.
 
 ## Parameters
 
-| Name                                       | Type     | Required | Description                                                                                                   |
-| :----------------------------------------- | :------: | :------: | :------------------------------------------------------------------------------------------------------------ |
-| `AcrName`                                  | `string` | Yes      | The name of the Azure Container Registry                                                                      |
-| `location`                                 | `string` | No       | The location of the ACR and where to deploy the module resources to                                           |
-| `forceUpdateTag`                           | `string` | No       | How the deployment script should be forced to execute                                                         |
-| `rbacRoleNeeded`                           | `string` | No       | Azure RoleId that are required for the DeploymentScript resource to import images                             |
-| `useExistingManagedIdentity`               | `bool`   | No       | Does the Managed Identity already exists, or should be created                                                |
-| `managedIdentityName`                      | `string` | No       | Name of the Managed Identity resource                                                                         |
-| `existingManagedIdentitySubId`             | `string` | No       | For an existing Managed Identity, the Subscription Id it is located in                                        |
-| `existingManagedIdentityResourceGroupName` | `string` | No       | For an existing Managed Identity, the Resource Group it is located in                                         |
-| `initialScriptDelay`                       | `string` | No       | A delay before the script import operation starts. Primarily to allow Azure AAD Role Assignments to propagate |
-| `cleanupPreference`                        | `string` | No       | When the script resource is cleaned up                                                                        |
-| `gitRepositoryUrl`                         | `string` | Yes      | The Git Repository URL, eg. https://github.com/YOURORG/YOURREPO.git                                           |
-| `gitBranch`                                | `string` | No       | The name of the repository branch to use                                                                      |
-| `dockerfileDirectory`                      | `string` | No       | The directory in the repo that contains the dockerfile                                                        |
-| `dockerfileName`                           | `string` | No       | The name of the dockerfile                                                                                    |
-| `buildWorkingDirectory`                    | `string` | No       | The docker context working directory, defaults to the Dockerfile directory                                    |
-| `imageName`                                | `string` | Yes      | The image name/path you want to create in ACR                                                                 |
-| `imageTag`                                 | `string` | No       | The image tag you want to create                                                                              |
-| `acrBuildPlatform`                         | `string` | No       | The ACR compute platform needed to build the image                                                            |
+| Name                                       | Type     | Required | Description                                                                                                                    |
+| :----------------------------------------- | :------: | :------: | :----------------------------------------------------------------------------------------------------------------------------- |
+| `AcrName`                                  | `string` | Yes      | The name of the Azure Container Registry                                                                                       |
+| `location`                                 | `string` | No       | The location of the ACR and where to deploy the module resources to                                                            |
+| `forceUpdateTag`                           | `string` | No       | How the deployment script should be forced to execute                                                                          |
+| `rbacRoleNeeded`                           | `string` | No       | Azure RoleId that are required for the DeploymentScript resource to import images                                              |
+| `useExistingManagedIdentity`               | `bool`   | No       | Does the Managed Identity already exists, or should be created                                                                 |
+| `managedIdentityName`                      | `string` | No       | Name of the Managed Identity resource                                                                                          |
+| `existingManagedIdentitySubId`             | `string` | No       | For an existing Managed Identity, the Subscription Id it is located in                                                         |
+| `existingManagedIdentityResourceGroupName` | `string` | No       | For an existing Managed Identity, the Resource Group it is located in                                                          |
+| `initialScriptDelay`                       | `string` | No       | A delay before the script import operation starts. Primarily to allow Azure AAD Role Assignments to propagate                  |
+| `cleanupPreference`                        | `string` | No       | When the script resource is cleaned up                                                                                         |
+| `gitRepositoryUrl`                         | `string` | Yes      | The Git Repository URL, eg. https://github.com/YOURORG/YOURREPO.git                                                            |
+| `gitBranch`                                | `string` | No       | The name of the repository branch to use                                                                                       |
+| `buildWorkingDirectory`                    | `string` | No       | The docker context working directory, change this when your Dockerfile and source files are ALL located in a repo subdirectory |
+| `dockerfileDirectory`                      | `string` | No       | The subdirectory relative to the working directory that contains the Dockerfile                                                |
+| `dockerfileName`                           | `string` | No       | The name of the dockerfile                                                                                                     |
+| `imageName`                                | `string` | Yes      | The image name/path you want to create in ACR                                                                                  |
+| `imageTag`                                 | `string` | No       | The image tag you want to create                                                                                               |
+| `acrBuildPlatform`                         | `string` | No       | The ACR compute platform needed to build the image                                                                             |
 
 ## Outputs
 
@@ -102,23 +102,6 @@ module aca 'br/public:app/dapr-containerapp:1.2.1' = {
     containerAppEnvName: acaEnvName
     containerImage: buildDaprImage.outputs.acrImage
     azureContainerRegistry: acrName
-  }
-}
-```
-
-## Building a Dockerfile with repo root context
-
-```bicep
-module buildImage 'br/public:deployment-scripts/build-acr:2.0.1' = {
-  name: 'differentbuildcontext'
-  params: {
-    AcrName: acr.name
-    location: location
-    gitRepositoryUrl:  'https://github.com/azure-octo/dapr-kafka-csharp.git'
-    gitBranch: 'master'
-    dockerfileDirectory: 'producer'
-    buildWorkingDirectory: '.' //Dockerfile uses files in parent directory structure. Working directory needs to be root.
-    imageName: 'daprkafka/producer'
   }
 }
 ```

--- a/modules/deployment-scripts/build-acr/azAcrBuild.sh
+++ b/modules/deployment-scripts/build-acr/azAcrBuild.sh
@@ -7,4 +7,5 @@ sleep $initialDelay
 az acr build --resource-group $acrResourceGroup \
   --registry $acrName \
   --image $taggedImageName $repo \
+  --file $dockerfilePath \
   --platform $platform

--- a/modules/deployment-scripts/build-acr/main.json
+++ b/modules/deployment-scripts/build-acr/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.11.1.770",
-      "templateHash": "12363648850858759275"
+      "version": "0.13.1.58284",
+      "templateHash": "1371553491347240684"
     }
   },
   "parameters": {
@@ -96,11 +96,25 @@
         "description": "The name of the repository branch to use"
       }
     },
-    "gitRepoDirectory": {
+    "buildWorkingDirectory": {
+      "type": "string",
+      "defaultValue": ".",
+      "metadata": {
+        "description": "The docker context working directory, change this when your Dockerfile and source files are ALL located in a repo subdirectory"
+      }
+    },
+    "dockerfileDirectory": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "The directory in the repo that contains the dockerfile"
+        "description": "The subdirectory relative to the working directory that contains the Dockerfile"
+      }
+    },
+    "dockerfileName": {
+      "type": "string",
+      "defaultValue": "Dockerfile",
+      "metadata": {
+        "description": "The name of the dockerfile"
       }
     },
     "imageName": {
@@ -125,11 +139,12 @@
     }
   },
   "variables": {
-    "$fxv#0": "#!/bin/bash\nset -e\n\necho \"Waiting on RBAC replication ($initialDelay)\"\nsleep $initialDelay\n\naz acr build --resource-group $acrResourceGroup \\\n  --registry $acrName \\\n  --image $taggedImageName $repo \\\n  --platform $platform",
-    "repo": "[format('{0}#{1}:{2}', parameters('gitRepositoryUrl'), parameters('gitBranch'), parameters('gitRepoDirectory'))]",
+    "$fxv#0": "#!/bin/bash\nset -e\n\necho \"Waiting on RBAC replication ($initialDelay)\"\nsleep $initialDelay\n\naz acr build --resource-group $acrResourceGroup \\\n  --registry $acrName \\\n  --image $taggedImageName $repo \\\n  --file $dockerfilePath \\\n  --platform $platform",
+    "repo": "[format('{0}#{1}:{2}', parameters('gitRepositoryUrl'), parameters('gitBranch'), parameters('buildWorkingDirectory'))]",
     "cleanRepoName": "[last(split(parameters('gitRepositoryUrl'), '/'))]",
     "cleanImageName": "[replace(parameters('imageName'), '/', '')]",
-    "taggedImageName": "[format('{0}:{1}', parameters('imageName'), parameters('imageTag'))]"
+    "taggedImageName": "[format('{0}:{1}', parameters('imageName'), parameters('imageTag'))]",
+    "dockerfilePath": "[if(not(empty(parameters('dockerfileDirectory'))), format('{0}/{1}', parameters('dockerfileDirectory'), parameters('dockerfileName')), parameters('dockerfileName'))]"
   },
   "resources": [
     {
@@ -187,6 +202,10 @@
           {
             "name": "repo",
             "value": "[variables('repo')]"
+          },
+          {
+            "name": "dockerfilePath",
+            "value": "[variables('dockerfilePath')]"
           },
           {
             "name": "platform",

--- a/modules/deployment-scripts/build-acr/version.json
+++ b/modules/deployment-scripts/build-acr/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "1.0",
+  "version": "2.0",
   "pathFilters": [
     "./main.json",
     "./metadata.json"


### PR DESCRIPTION
## Description

Whilst not common, some Dockerfiles are expected to run from the context of the repo root to reference other directories above where the dockerfile is located. For this reason we need to be able to seperately deal with the build working directory and Dockerfile subdirectory. 

Example of this scenario can be found in this [repo](https://github.com/azure-octo/dapr-kafka-csharp), in the producer and consumer directory.


## Updating an existing module

<!--Run through the checklist if your PR updates an existing module.-->

- [x] I have run `brm validate` locally to verify the module files.
- [x] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](../CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [x] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
