### PR TITLE
Update publish command to include optional argument --documentationUri

### DIFF
--- a/.github/workflows/publish-module.yml
+++ b/.github/workflows/publish-module.yml
@@ -70,4 +70,4 @@ jobs:
           bicep --version
 
       - name: Publish module
-        run: bicep publish "modules/${{ steps.parse-tag.outputs.module_path }}/main.json" --target "br:${{ secrets.PUBLISH_REGISTRY_SERVER }}/public/bicep/${{ steps.parse-tag.outputs.module_path }}:${{ steps.parse-tag.outputs.version }}"
+        run: bicep publish "modules/${{ steps.parse-tag.outputs.module_path }}/main.json" --target "br:${{ secrets.PUBLISH_REGISTRY_SERVER }}/public/bicep/${{ steps.parse-tag.outputs.module_path }}:${{ steps.parse-tag.outputs.version }}" --documentationUri "${{ steps.parse-tag.outputs.documentation_uri }}"

--- a/scripts/github-actions/parse-tag.js
+++ b/scripts/github-actions/parse-tag.js
@@ -42,6 +42,9 @@ function parseTag({ core, tag }) {
 
   core.setOutput("module_path", `${moduleFolder}/${moduleName}`);
   core.setOutput("version", version);
+
+  const readmeLink = `https://github.com/Azure/bicep-registry-modules/tree/${tag}/modules/${moduleFolder}/${moduleName}/README.md`;
+  core.setOutput("documentation_uri", readmeLink);
 }
 
 module.exports = parseTag;


### PR DESCRIPTION
Updated publish command to include optional argument --documentationUri. 

Verified the changes here:
https://github.com/bhsubra/bicep-registry-modules/pull/3
https://github.com/bhsubra/bicep-registry-modules/actions/runs/4118663289/jobs/7111463998