### PR TITLE
Skip module checks if only README has changed

### DIFF
--- a/scripts/github-actions/get-changed-module.js
+++ b/scripts/github-actions/get-changed-module.js
@@ -50,6 +50,8 @@ async function getChangedModule({ require, github, context, core }) {
     ...new Set(
       data.files
         .filter((file) => file.filename.startsWith("modules/"))
+        // Do not consider module changed if only the README.md has changed
+        .filter((file) => !file.filename.endsWith("README.md"))
         .map((file) => {
           const dir = path.dirname(file.filename);
           const segments = dir.split("/");


### PR DESCRIPTION
## Description

<!--Why this PR? What is changed? What is the effect? etc.-->
This PR updates the changed-module detection, and no longer considers a module updated if only the README.md has changed. This prevents all the pipelines from kicking off when we have only made documentation updates.