### PR TITLE
fix: improve error message if subnetID is not provided for Storage Module

### DIFF
--- a/modules/storage/storage-account/main.bicep
+++ b/modules/storage/storage-account/main.bicep
@@ -5,7 +5,8 @@ param location string
 param name string = 'st${uniqueString(resourceGroup().id, subscription().id)}'
 
 @description('ID of the subnet where the Storage Account will be deployed, if virtual network access is enabled.')
-param subnetID string = ''
+#disable-next-line BCP321
+param subnetID string = enableVNET ? null : ''
 
 @description('Toggle to enable or disable virtual network access for the Storage Account.')
 param enableVNET bool = false

--- a/modules/storage/storage-account/main.json
+++ b/modules/storage/storage-account/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.16.1.55165",
-      "templateHash": "3507117336367126124"
+      "templateHash": "15185028446071276240"
     }
   },
   "parameters": {
@@ -24,7 +24,7 @@
     },
     "subnetID": {
       "type": "string",
-      "defaultValue": "",
+      "defaultValue": "[if(parameters('enableVNET'), null(), '')]",
       "metadata": {
         "description": "ID of the subnet where the Storage Account will be deployed, if virtual network access is enabled."
       }

--- a/modules/storage/storage-account/main.json
+++ b/modules/storage/storage-account/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.15.31.15270",
-      "templateHash": "6249334553241462209"
+      "version": "0.16.1.55165",
+      "templateHash": "3507117336367126124"
     }
   },
   "parameters": {
@@ -86,10 +86,10 @@
   "outputs": {
     "id": {
       "type": "string",
-      "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]",
       "metadata": {
         "description": "The ID of the created or existing Storage Account. Use this ID to reference the Storage Account in other Azure resource deployments."
-      }
+      },
+      "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]"
     }
   }
 }

--- a/modules/storage/storage-account/test/main.test.bicep
+++ b/modules/storage/storage-account/test/main.test.bicep
@@ -20,3 +20,12 @@ module test0 '../main.bicep' = {
     location: location
   }
 }
+
+// Test 1 - Enable Subnet
+module test0 '../main.bicep' = {
+  name: 'test0'
+  params: {
+    location: location
+    enableVNET: true
+  }
+}

--- a/modules/storage/storage-account/test/main.test.bicep
+++ b/modules/storage/storage-account/test/main.test.bicep
@@ -13,7 +13,7 @@ param location string = resourceGroup().location
 //   }
 // }
 
-//Test 0. 
+//Test 0.
 module test0 '../main.bicep' = {
   name: 'test0'
   params: {
@@ -22,8 +22,8 @@ module test0 '../main.bicep' = {
 }
 
 // Test 1 - Enable Subnet
-module test0 '../main.bicep' = {
-  name: 'test0'
+module test1 '../main.bicep' = {
+  name: 'test1'
   params: {
     location: location
     enableVNET: true

--- a/modules/storage/storage-account/test/main.test.bicep
+++ b/modules/storage/storage-account/test/main.test.bicep
@@ -5,13 +5,13 @@ module file is a deployment test. Make sure at least one test is added.
 
 param location string = resourceGroup().location
 
-//Prerequisites
-// module prereq 'prereq.test.bicep' = {
-//   name: 'test-prereqs'
-//   params: {
-//     location: location
-//   }
-// }
+// Prerequisites
+module prereq 'prereq.test.bicep' = {
+  name: 'test-prereqs'
+  params: {
+    location: location
+  }
+}
 
 //Test 0.
 module test0 '../main.bicep' = {
@@ -27,5 +27,6 @@ module test1 '../main.bicep' = {
   params: {
     location: location
     enableVNET: true
+    subnetID: prereq.outputs.subnetID
   }
 }

--- a/modules/storage/storage-account/test/prereq.test.bicep
+++ b/modules/storage/storage-account/test/prereq.test.bicep
@@ -1,0 +1,56 @@
+param location string
+param serviceShort string = 'vnet'
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: 'dep-${serviceShort}-az-msi-x-01'
+  location: location
+}
+
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
+  name: 'dep-${serviceShort}-az-nsg-x-01'
+  location: location
+}
+
+resource routeTable 'Microsoft.Network/routeTables@2021-05-01' = {
+  name: 'dep-${serviceShort}-az-rt-x-01'
+  location: location
+}
+
+module genvnet 'br/public:network/virtual-network:1.0.1' = {
+  name: '${uniqueString(deployment().name, location)}-genvnet'
+  params: {
+    name: '${serviceShort}-az-vnet-gen-01'
+    location: location
+    addressPrefixes: [
+      '10.0.0.0/16'
+    ]
+    subnets: [
+      {
+        name: 'GatewaySubnet'
+        addressPrefix: '10.0.255.0/24'
+      }
+      {
+        name: '${serviceShort}-az-subnet-x-001'
+        addressPrefix: '10.0.0.0/24'
+        networkSecurityGroupId: networkSecurityGroup.id
+        serviceEndpoints: [
+          {
+            service: 'Microsoft.Storage'
+          }
+        ]
+        routeTableId: routeTable.id
+      }
+    ]
+    roleAssignments: [
+      {
+        roleDefinitionIdOrName: 'Reader'
+        principalIds: [
+          managedIdentity.properties.principalId
+        ]
+        principalType: 'ServicePrincipal'
+      }
+    ]
+  }
+}
+
+output subnetID string = genvnet.outputs.subnetResourceIds[0]


### PR DESCRIPTION
## Description
Update the `subnetID` to be conditionally required based on `enableVNET`. This provides a more clear error message to users about what has gone wrong if they enableVNET without provided a subnetID.

### Previous Error Message

```yaml
status: Failed
error:
  code: DeploymentFailed
  target: >-
    /subscriptions/edf507a2-6235-46c5-b560-fd463ba2e771/resourceGroups/dcibTestDeploy2/providers/Microsoft.Resources/deployments/main.test-230407-2204
  message: >-
    At least one resource deployment operation failed. Please list deployment
    operations for details. Please see https://aka.ms/arm-deployment-operations
    for usage details.
  details:
    - code: ResourceDeploymentFailure
      target: >-
        /subscriptions/edf507a2-6235-46c5-b560-fd463ba2e771/resourceGroups/dcibTestDeploy2/providers/Microsoft.Resources/deployments/test1
      message: >-
        The 'AzureAsyncOperationWaiting' resource operation completed with
        terminal provisioning state 'Failed'.
      details:
        - code: DeploymentFailed
          target: >-
            /subscriptions/edf507a2-6235-46c5-b560-fd463ba2e771/resourceGroups/dcibTestDeploy2/providers/Microsoft.Resources/deployments/test1
          message: >-
            At least one resource deployment operation failed. Please list
            deployment operations for details. Please see
            https://aka.ms/arm-deployment-operations for usage details.
          details:
            - code: StorageAccountOperationInProgress
              message: >-
                An operation is currently performing on this storage account
                that requires exclusive access.
```
### New Error Message
```yaml
status: Failed
error:
  code: DeploymentFailed
  target: >-
    /subscriptions/edf507a2-6235-46c5-b560-fd463ba2e771/resourceGroups/dcibTestDeploy2/providers/Microsoft.Resources/deployments/main.test-230407-2204
  message: >-
    At least one resource deployment operation failed. Please list deployment
    operations for details. Please see https://aka.ms/arm-deployment-operations
    for usage details.
  details:
    - code: InvalidTemplate
      message: >-
        Deployment template validation failed: 'Template parameter 'subnetID'
        was provided an invalid value. Expected a value of type 'String, Uri',
        but received a value of type 'Null'. Please see
        https://aka.ms/arm-create-parameter-file for usage details.'.
      additionalInfo:
        - type: TemplateViolation
          info:
            lineNumber: 1
            linePosition: 709
            path: properties.template.parameters.subnetID.type
```

<!--Why this PR? What is changed? What is the effect? etc.-->

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep-registry-modules/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, edit the PR description and run through the relevant checklist below.

Enable GitHub Worksflows in your fork to enable auto-generation of assets with our [GitHub Action](/.github/workflows/push-auto-generate.yml).
To trigger GitHub Actions after auto-generation, [add a GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) as a secret in your forked repository called `PAT`.

## Adding a new module

<!--Run through the checklist if your PR adds a new module.-->

- [ ] A proposal has been submitted and approved.
- [ ] I have included "Closes #{module_proposal_issue_number}" in the PR description.
- [ ] I have run `brm validate` locally to verify the module files.
- [ ] I have run deployment tests locally to ensure the module is deployable.

## Updating an existing module

<!--Run through the checklist if your PR updates an existing module.-->

- [ ] This is a bug fix:
  - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
  - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
- [ ] I have run `brm validate` locally to verify the module files.
- [ ] I have run deployment tests locally to ensure the module is deployable.
- [ ] I have read the [Updating an existing module](https://github.com/Azure/bicep-registry-modules/blob/main/CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [ ] The PR contains backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
  - [ ] The PR contains backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
- [ ] I have updated the examples in README with the latest module version number.
