### PR TITLE
feat: add authorization/resource-scope-role-assignment module

### DIFF
--- a/modules/authorization/resource-scope-role-assignment/README.md
+++ b/modules/authorization/resource-scope-role-assignment/README.md
@@ -30,10 +30,11 @@ guid(principalId|objectId, roleDefinitionId|roleName, resourceId)
 
 ## Outputs
 
-| Name | Type   | Description                                                 |
-| :--- | :----: | :---------------------------------------------------------- |
-| name | string | The unique name guid used for the roleAssignment            |
-| id   | string | The roleAssignmentId created on the scope of the resourceId |
+| Name     | Type   | Description                                                 |
+| :------- | :----: | :---------------------------------------------------------- |
+| name     | string | The unique name guid used for the roleAssignment            |
+| roleName | string | The name for the role, used for logging                     |
+| id       | string | The roleAssignmentId created on the scope of the resourceId |
 
 ## Examples
 

--- a/modules/authorization/resource-scope-role-assignment/README.md
+++ b/modules/authorization/resource-scope-role-assignment/README.md
@@ -63,7 +63,7 @@ module storageAccount 'br/public:storage/storage-account:1.0.1' = {
 }
 
 // module call with all parameters
-module roleAssignmentOperator 'br/public:authorization/resource-scope-role-assignment:1.0.0' = {
+module roleAssignmentOperator 'br/public:authorization/resource-scope-role-assignment:1.0.1' = {
   name: take('roleAssignment-storage-accountKeyOperator',64)
   params: {
     name: guid(UAI.properties.principalId, roleInfoOperator.roleDefinitionId, storageAccount.outputs.id)
@@ -119,7 +119,7 @@ module storageAccount 'br/public:storage/storage-account:1.0.1' = {
 }
 
 // module call with only required parameters
-module roleAssignmentContributor 'br/public:authorization/resource-scope-role-assignment:1.0.0' = {
+module roleAssignmentContributor 'br/public:authorization/resource-scope-role-assignment:1.0.1' = {
   name: take('roleAssignment-storage-accountContributor',64)
   params: {
     name: guid(UAI.properties.principalId, roleInfoContributor.roleDefinitionId, storageAccount.outputs.id)

--- a/modules/authorization/resource-scope-role-assignment/README.md
+++ b/modules/authorization/resource-scope-role-assignment/README.md
@@ -63,7 +63,7 @@ module storageAccount 'br/public:storage/storage-account:1.0.1' = {
 }
 
 // module call with all parameters
-module roleAssignmentOperator '../main.bicep' = {
+module roleAssignmentOperator 'br/public:authorization/resource-scope-role-assignment:1.0.0' = {
   name: take('roleAssignment-storage-accountKeyOperator',64)
   params: {
     name: guid(UAI.properties.principalId, roleInfoOperator.roleDefinitionId, storageAccount.outputs.id)
@@ -119,7 +119,7 @@ module storageAccount 'br/public:storage/storage-account:1.0.1' = {
 }
 
 // module call with only required parameters
-module roleAssignmentContributor '../main.bicep' = {
+module roleAssignmentContributor 'br/public:authorization/resource-scope-role-assignment:1.0.0' = {
   name: take('roleAssignment-storage-accountContributor',64)
   params: {
     name: guid(UAI.properties.principalId, roleInfoContributor.roleDefinitionId, storageAccount.outputs.id)

--- a/modules/authorization/resource-scope-role-assignment/README.md
+++ b/modules/authorization/resource-scope-role-assignment/README.md
@@ -1,0 +1,148 @@
+# Resource scoped role assignment
+
+Create an Azure Authorization Role Assignment at the scope of a Resource E.g. on a Storage Container
+
+## Description
+
+Using this Bicep Module allows for Role Assignments at any Scope within Azure. Pass in any ResourceId to perform the role assignment on that Scope.
+
+[Learn - Steps to assign an Azure role](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-steps)
+
+It is required to generate the unique guid name for the role assignment, ensure you follow your own pattern used for other roleAssignments.
+
+Example pattern to generate the guid().
+
+```bicep
+guid(principalId|objectId, roleDefinitionId|roleName, resourceId)
+```
+
+## Parameters
+
+| Name               | Type     | Required | Description                                                   |
+| :----------------- | :------: | :------: | :------------------------------------------------------------ |
+| `resourceId`       | `string` | Yes      | The scope for the role assignment, fully qualified resourceId |
+| `name`             | `string` | Yes      | The unique guid name for the role assignment                  |
+| `roleDefinitionId` | `string` | Yes      | The role definitionId from your tenant/subscription           |
+| `principalId`      | `string` | Yes      | The principal ID                                              |
+| `principalType`    | `string` | No       | The principal type of the assigned principal ID               |
+| `roleName`         | `string` | No       | The name for the role, used for logging                       |
+| `description`      | `string` | No       | The Description of role assignment                            |
+
+## Outputs
+
+| Name | Type   | Description                                                 |
+| :--- | :----: | :---------------------------------------------------------- |
+| name | string | The unique name guid used for the roleAssignment            |
+| id   | string | The roleAssignmentId created on the scope of the resourceId |
+
+## Examples
+
+### Example 1
+
+```bicep
+param location string = resourceGroup().location
+param saname string = 'sa${uniqueString(resourceGroup().id)}'
+param uaiName string = 'storageAccountOperator'
+param roleInfoOperator object = {
+  roleDefinitionId: '81a9662b-bebf-436f-a333-f67b29880f12'
+  roleName: 'Storage Account Key Operator Service Role'
+  description: 'Storage account key operator for User assigned identity'
+}
+
+resource UAI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: uaiName
+  location: location
+}
+
+module storageAccount 'br/public:storage/storage-account:1.0.1' = {
+  name: saname
+  params: {
+    location: location
+    name: saname
+  }
+}
+
+// module call with all parameters
+module roleAssignmentOperator '../main.bicep' = {
+  name: take('roleAssignment-storage-accountKeyOperator',64)
+  params: {
+    name: guid(UAI.properties.principalId, roleInfoOperator.roleDefinitionId, storageAccount.outputs.id)
+    principalId: UAI.properties.principalId
+    resourceId: storageAccount.outputs.id
+    roleDefinitionId: roleInfoOperator.roleDefinitionId
+    description: roleInfoOperator.description
+    roleName: roleInfoOperator.roleName
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output roleAssignmentOperator string = roleAssignmentOperator.outputs.id
+```
+
+```log
+Parameters              :
+                          Name                   Type                       Value
+                          =====================  =========================  ==========
+                          location               String                     "eastus"
+                          saname                 String                     "sat4jdusq4ilet4"
+                          uaiName                String                     "storageAccountOperator"
+                          roleInfoOperator       Object                     {"roleDefinitionId":"81a9662b-bebf-436f-a333-f67b29880f12","roleName":"Storage Account Key Operator Service Role","description":"Storage account key operator for User assigned identity"}
+
+Outputs                 :
+                          Name                         Type                       Value
+                          ===========================  =========================  ==========
+                          roleAssignmentOperator       String                     "/subscriptions/fe8c6f31-247d-4941-a62d-fde7a2185aca/resourceGroups/ResourceGroup01/providers/Microsoft.Storage/storageAccounts/sat4jdusq4ilet4/providers/Microsoft.Authorization/roleAssignments/3b71ddea-994f-5ccc-be34-cecd838b1152"
+```
+
+### Example 2
+
+```bicep
+param location string = resourceGroup().location
+param saname string = 'sa${uniqueString(resourceGroup().id)}'
+param uaiName string = 'storageAccountOperator'
+
+param roleInfoContributor object = {
+  roleDefinitionId: '17d1049b-9a84-46fb-8f53-869881c3d3ab'
+}
+
+resource UAI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: uaiName
+  location: location
+}
+
+module storageAccount 'br/public:storage/storage-account:1.0.1' = {
+  name: saname
+  params: {
+    location: location
+    name: saname
+  }
+}
+
+// module call with only required parameters
+module roleAssignmentContributor '../main.bicep' = {
+  name: take('roleAssignment-storage-accountContributor',64)
+  params: {
+    name: guid(UAI.properties.principalId, roleInfoContributor.roleDefinitionId, storageAccount.outputs.id)
+    principalId: UAI.properties.principalId
+    resourceId: storageAccount.outputs.id
+    roleDefinitionId: roleInfoContributor.roleDefinitionId
+  }
+}
+
+output roleAssignmentContributor string = roleAssignmentContributor.outputs.id
+```
+
+```log
+Parameters              :
+                          Name                   Type                       Value
+                          =====================  =========================  ==========
+                          location               String                     "eastus"
+                          saname                 String                     "sat4jdusq4ilet4"
+                          uaiName                String                     "storageAccountOperator"
+                          roleInfoContributor    Object                     {"roleDefinitionId":"17d1049b-9a84-46fb-8f53-869881c3d3ab"}
+
+Outputs                 :
+                          Name                         Type                       Value
+                          ===========================  =========================  ==========
+                          roleAssignmentContributor    String                     "/subscriptions/fe8c6f31-247d-4941-a62d-fde7a2185aca/resourceGroups/ResourceGroup01/providers/Microsoft.Storage/storageAccounts/sat4jdusq4ilet4/providers/Microsoft.Authorization/roleAssignments/afd5b488-e47c-5d0c-8389-4f40ef374e4b"
+```

--- a/modules/authorization/resource-scope-role-assignment/main.bicep
+++ b/modules/authorization/resource-scope-role-assignment/main.bicep
@@ -1,0 +1,66 @@
+@sys.description('The scope for the role assignment, fully qualified resourceId')
+param resourceId string
+
+@sys.description('The unique guid name for the role assignment')
+param name string
+
+@sys.description('The role definitionId from your tenant/subscription')
+param roleDefinitionId string
+
+@sys.description('The principal ID')
+param principalId string
+
+@sys.description('The principal type of the assigned principal ID')
+@allowed([
+  'Device'
+  'ForeignGroup'
+  'Group'
+  'ServicePrincipal'
+  'User'
+  ''
+])
+param principalType string = ''
+
+@sys.description('The name for the role, used for logging')
+#disable-next-line no-unused-params
+param roleName string = ''
+
+@sys.description('The Description of role assignment')
+param description string = ''
+
+resource resourceRoleAssignment 'Microsoft.Resources/deployments@2022-09-01' = {
+  name: take('RA-${name}-${last(split(resourceId,'/'))}', 64)
+  properties: {
+    mode: 'Incremental'
+    expressionEvaluationOptions: {
+      scope: 'Outer'
+    }
+    template: loadJsonContent('modules/authorization/genericRoleAssignment.json')
+    parameters: {
+      scope: {
+        value: resourceId
+      }
+      name: {
+        value: name
+      }
+      roleDefinitionId: {
+        value: roleDefinitionId
+      }
+      principalId: {
+        value: principalId
+      }
+      principalType: {
+        value: principalType
+      }
+      description: {
+        value: description
+      }
+    }
+  }
+}
+
+@sys.description('The unique name guid used for the roleAssignment')
+output name string = name
+
+@sys.description('The roleAssignmentId created on the scope of the resourceId')
+output id string = resourceRoleAssignment.properties.outputs.roleAssignmentId.value

--- a/modules/authorization/resource-scope-role-assignment/main.bicep
+++ b/modules/authorization/resource-scope-role-assignment/main.bicep
@@ -22,7 +22,6 @@ param principalId string
 param principalType string = ''
 
 @sys.description('The name for the role, used for logging')
-#disable-next-line no-unused-params
 param roleName string = ''
 
 @sys.description('The Description of role assignment')
@@ -61,6 +60,9 @@ resource resourceRoleAssignment 'Microsoft.Resources/deployments@2022-09-01' = {
 
 @sys.description('The unique name guid used for the roleAssignment')
 output name string = name
+
+@sys.description('The name for the role, used for logging')
+output roleName string = roleName
 
 @sys.description('The roleAssignmentId created on the scope of the resourceId')
 output id string = resourceRoleAssignment.properties.outputs.roleAssignmentId.value

--- a/modules/authorization/resource-scope-role-assignment/main.json
+++ b/modules/authorization/resource-scope-role-assignment/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.17.1.54307",
-      "templateHash": "10126657644886339409"
+      "version": "0.17.31.8712",
+      "templateHash": "116803431937761815"
     }
   },
   "parameters": {
@@ -150,6 +150,13 @@
         "description": "The unique name guid used for the roleAssignment"
       },
       "value": "[parameters('name')]"
+    },
+    "roleName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name for the role, used for logging"
+      },
+      "value": "[parameters('roleName')]"
     },
     "id": {
       "type": "string",

--- a/modules/authorization/resource-scope-role-assignment/main.json
+++ b/modules/authorization/resource-scope-role-assignment/main.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.16.2.56959",
+      "templateHash": "2036050830216971941"
+    }
+  },
+  "parameters": {
+    "resourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "The scope for the role assignment, fully qualified resourceId"
+      }
+    },
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The unique guid name for the role assignment"
+      }
+    },
+    "roleDefinitionId": {
+      "type": "string",
+      "metadata": {
+        "description": "The role definitionId from your tenant/subscription"
+      }
+    },
+    "principalId": {
+      "type": "string",
+      "metadata": {
+        "description": "The principal ID"
+      }
+    },
+    "principalType": {
+      "type": "string",
+      "defaultValue": "",
+      "allowedValues": [
+        "Device",
+        "ForeignGroup",
+        "Group",
+        "ServicePrincipal",
+        "User",
+        ""
+      ],
+      "metadata": {
+        "description": "The principal type of the assigned principal ID"
+      }
+    },
+    "roleName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The name for the role, used for logging"
+      }
+    },
+    "description": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The Description of role assignment"
+      }
+    }
+  },
+  "variables": {
+    "$fxv#0": {
+      "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {
+        "scope": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "roleDefinitionId": {
+          "type": "string"
+        },
+        "principalId": {
+          "type": "string"
+        },
+        "principalType": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "resources": [
+        {
+          "type": "Microsoft.Authorization/roleAssignments",
+          "apiVersion": "2022-04-01",
+          "scope": "[[parameters('scope')]",
+          "name": "[[parameters('name')]",
+          "properties": {
+            "roleDefinitionId": "[[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]",
+            "principalId": "[[parameters('principalId')]",
+            "principalType": "[[parameters('principalType')]",
+            "description": "[[parameters('description')]"
+          }
+        }
+      ],
+      "outputs": {
+        "roleAssignmentId": {
+          "type": "string",
+          "value": "[[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]"
+        }
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[take(format('RA-{0}-{1}', parameters('name'), last(split(parameters('resourceId'), '/'))), 64)]",
+      "properties": {
+        "mode": "Incremental",
+        "expressionEvaluationOptions": {
+          "scope": "Outer"
+        },
+        "template": "[variables('$fxv#0')]",
+        "parameters": {
+          "scope": {
+            "value": "[parameters('resourceId')]"
+          },
+          "name": {
+            "value": "[parameters('name')]"
+          },
+          "roleDefinitionId": {
+            "value": "[parameters('roleDefinitionId')]"
+          },
+          "principalId": {
+            "value": "[parameters('principalId')]"
+          },
+          "principalType": {
+            "value": "[parameters('principalType')]"
+          },
+          "description": {
+            "value": "[parameters('description')]"
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The unique name guid used for the roleAssignment"
+      },
+      "value": "[parameters('name')]"
+    },
+    "id": {
+      "type": "string",
+      "metadata": {
+        "description": "The roleAssignmentId created on the scope of the resourceId"
+      },
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', take(format('RA-{0}-{1}', parameters('name'), last(split(parameters('resourceId'), '/'))), 64)), '2022-09-01').outputs.roleAssignmentId.value]"
+    }
+  }
+}

--- a/modules/authorization/resource-scope-role-assignment/main.json
+++ b/modules/authorization/resource-scope-role-assignment/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.16.2.56959",
-      "templateHash": "2036050830216971941"
+      "version": "0.17.1.54307",
+      "templateHash": "10126657644886339409"
     }
   },
   "parameters": {

--- a/modules/authorization/resource-scope-role-assignment/main.json
+++ b/modules/authorization/resource-scope-role-assignment/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.17.31.8712",
-      "templateHash": "116803431937761815"
+      "version": "0.17.1.54307",
+      "templateHash": "8247725218821663644"
     }
   },
   "parameters": {

--- a/modules/authorization/resource-scope-role-assignment/metadata.json
+++ b/modules/authorization/resource-scope-role-assignment/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "Resource scoped role assignment",
+  "summary": "Create an Azure Authorization Role Assignment at the scope of a Resource E.g. on a Storage Container",
+  "owner": "brwilkinson"
+}

--- a/modules/authorization/resource-scope-role-assignment/modules/authorization/genericRoleAssignment.json
+++ b/modules/authorization/resource-scope-role-assignment/modules/authorization/genericRoleAssignment.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "scope": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "roleDefinitionId": {
+      "type": "string"
+    },
+    "principalId": {
+      "type": "string"
+    },
+    "principalType": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "scope": "[parameters('scope')]",
+      "name": "[parameters('name')]",
+      "properties": {
+        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]",
+        "principalId": "[parameters('principalId')]",
+        "principalType": "[parameters('principalType')]",
+        "description": "[parameters('description')]"
+      }
+    }
+  ],
+  "outputs": {
+    "roleAssignmentId": {
+      "type": "string",
+      "value": "[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]"
+    }
+  }
+}

--- a/modules/authorization/resource-scope-role-assignment/test/main.test.bicep
+++ b/modules/authorization/resource-scope-role-assignment/test/main.test.bicep
@@ -1,0 +1,53 @@
+param location string = resourceGroup().location
+param saname string = 'sa${uniqueString(resourceGroup().id)}'
+param uaiName string = 'storageAccountOperator'
+param roleInfoOperator object = {
+  roleDefinitionId: '81a9662b-bebf-436f-a333-f67b29880f12'
+  roleName: 'Storage Account Key Operator Service Role'
+  description: 'Storage account key operator for User assigned identity'
+}
+
+param roleInfoContributor object = {
+  roleDefinitionId: '17d1049b-9a84-46fb-8f53-869881c3d3ab'
+}
+
+resource UAI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: uaiName
+  location: location
+}
+
+module storageAccount 'br/public:storage/storage-account:1.0.1' = {
+  name: saname
+  params: {
+    location: location
+    name: saname
+  }
+}
+
+// module call with all parameters
+module roleAssignmentOperator '../main.bicep' = {
+  name: take('roleAssignment-storage-accountKeyOperator', 64)
+  params: {
+    name: guid(UAI.properties.principalId, roleInfoOperator.roleDefinitionId, storageAccount.outputs.id)
+    principalId: UAI.properties.principalId
+    resourceId: storageAccount.outputs.id
+    roleDefinitionId: roleInfoOperator.roleDefinitionId
+    description: roleInfoOperator.description
+    roleName: roleInfoOperator.roleName
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// module call with only required parameters
+module roleAssignmentContributor '../main.bicep' = {
+  name: take('roleAssignment-storage-accountContributor', 64)
+  params: {
+    name: guid(UAI.properties.principalId, roleInfoContributor.roleDefinitionId, storageAccount.outputs.id)
+    principalId: UAI.properties.principalId
+    resourceId: storageAccount.outputs.id
+    roleDefinitionId: roleInfoContributor.roleDefinitionId
+  }
+}
+
+output roleAssignmentOperator string = roleAssignmentOperator.outputs.id
+output roleAssignmentContributor string = roleAssignmentContributor.outputs.id

--- a/modules/authorization/resource-scope-role-assignment/version.json
+++ b/modules/authorization/resource-scope-role-assignment/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "1.0",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}


### PR DESCRIPTION
- Closes #354 
- initial module creation
- main and nested json deployment for role assignments on resource scope
- main.test module standalone test with storage and managed identity
- add readme and examples for managed identity assignment on storage account
- brm validate:
  - given unique capability of assigning role assignment on resourceId scope 
    - no requirement for location, prefix 
    - name param is required to be unique guid

## Description

<!--Why this PR? What is changed? What is the effect? etc.-->

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep-registry-modules/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, edit the PR description and run through the relevant checklist below.

Enable GitHub Worksflows in your fork to enable auto-generation of assets with our [GitHub Action](/.github/workflows/push-auto-generate.yml).
To trigger GitHub Actions after auto-generation, [add a GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) as a secret in your forked repository called `PAT`.

## Adding a new module

<!--Run through the checklist if your PR adds a new module.-->

- [x] A proposal has been submitted and approved.
- [x] I have included "Closes #{module_proposal_issue_number}" in the PR description.
- [x] I have run `brm validate` locally to verify the module files.
- [x] I have run deployment tests locally to ensure the module is deployable.
