### PR TITLE
ci: added on-workflow-dispatch test workflow

### DIFF
--- a/.github/workflows/on-workflow-dispatch.yml
+++ b/.github/workflows/on-workflow-dispatch.yml
@@ -1,0 +1,24 @@
+name: Run Azure Login with OpenID Connect
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Log in to Azure
+      uses: azure/login@v1
+      with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Display Azure Information
+      run: |
+          az account show
+          az group list


### PR DESCRIPTION
## Description

Adding a test workflow named on-workflow-dispatch

This is to explore this fork's capabilities in a repo which will be discarded once knowledge if obtained. We will then use this knowledge to create a new independent private repo.