### PR TITLE
refactor: Make role assignment optional when creating certs 

### DIFF
--- a/modules/deployment-scripts/create-kv-certificate/README.md
+++ b/modules/deployment-scripts/create-kv-certificate/README.md
@@ -34,6 +34,7 @@ This module is based on the `az cli certificate` create command and more informa
 | `isCrossTenant`                            | `bool`         | No       | Override this parameter if using this in cross tenant scenarios                                               |
 | `reuseKey`                                 | `bool`         | No       | The default policy might cause errors about CSR being used before, so set this to false if that happens       |
 | `validity`                                 | `int`          | No       | Optional. Override default validityInMonths 12 value                                                          |
+| `performRoleAssignment`                    | `bool`         | No       | Optional. Override default performRoleAssignment true value to disable rbac role assignment                   |
 
 ## Outputs
 

--- a/modules/deployment-scripts/create-kv-certificate/README.md
+++ b/modules/deployment-scripts/create-kv-certificate/README.md
@@ -38,13 +38,13 @@ This module is based on the `az cli certificate` create command and more informa
 
 ## Outputs
 
-| Name                            | Type  | Description                                        |
-| :------------------------------ | :---: | :------------------------------------------------- |
-| certificateNames                | array | Certificate names                                  |
-| certificateSecretIds            | array | KeyVault secret ids to the created version         |
-| certificateSecretIdUnversioneds | array | KeyVault secret ids which uses the unversioned uri |
-| certificateThumbpints           | array | Certificate Thumbprints                            |
-| certificateThumbprintHexs       | array | Certificate Thumbprints (in hex)                   |
+| Name                              | Type    | Description                                        |
+| :-------------------------------- | :-----: | :------------------------------------------------- |
+| `certificateNames`                | `array` | Certificate names                                  |
+| `certificateSecretIds`            | `array` | KeyVault secret ids to the created version         |
+| `certificateSecretIdUnversioneds` | `array` | KeyVault secret ids which uses the unversioned uri |
+| `certificateThumbpints`           | `array` | Certificate Thumbprints                            |
+| `certificateThumbprintHexs`       | `array` | Certificate Thumbprints (in hex)                   |
 
 ## Examples
 

--- a/modules/deployment-scripts/create-kv-certificate/README.md
+++ b/modules/deployment-scripts/create-kv-certificate/README.md
@@ -34,7 +34,7 @@ This module is based on the `az cli certificate` create command and more informa
 | `isCrossTenant`                            | `bool`         | No       | Override this parameter if using this in cross tenant scenarios                                               |
 | `reuseKey`                                 | `bool`         | No       | The default policy might cause errors about CSR being used before, so set this to false if that happens       |
 | `validity`                                 | `int`          | No       | Optional. Override default validityInMonths 12 value                                                          |
-| `performRoleAssignment`                    | `bool`         | No       | Optional. Override default performRoleAssignment true value to disable rbac role assignment                   |
+| `performRoleAssignment`                    | `bool`         | No       | Set to false to disable role assignments within this module. Default: true                                    |
 
 ## Outputs
 

--- a/modules/deployment-scripts/create-kv-certificate/README.md
+++ b/modules/deployment-scripts/create-kv-certificate/README.md
@@ -57,7 +57,7 @@ param location string = resourceGroup().location
 param akvName string = 'yourAzureKeyVault'
 param certificateName string = 'myapp'
 
-module kvCert 'br/public:deployment-scripts/create-kv-certificate:3.3.1' = {
+module kvCert 'br/public:deployment-scripts/create-kv-certificate:3.4' = {
   name: 'akvCertSingle'
   params: {
     akvName: akvName
@@ -80,7 +80,7 @@ param akvName string =  'yourAzureKeyVault'
 param certificateName string = 'myapp'
 param certificateCommonName string = '${certificateName}.mydomain.local'
 
-module kvCert 'br/public:deployment-scripts/create-kv-certificate:3.3.1' = {
+module kvCert 'br/public:deployment-scripts/create-kv-certificate:3.4' = {
   name: 'akvCertSingle'
   params: {
     akvName: akvName

--- a/modules/deployment-scripts/create-kv-certificate/main.bicep
+++ b/modules/deployment-scripts/create-kv-certificate/main.bicep
@@ -64,6 +64,9 @@ param isCrossTenant bool = false
 @description('The default policy might cause errors about CSR being used before, so set this to false if that happens')
 param reuseKey bool = true
 
+@description('Set to false to disable role assignments within this module. Default: true')
+param performRoleAssignment bool = true
+
 @minValue(1)
 @maxValue(1200)
 @description('Optional. Override default validityInMonths 12 value')
@@ -87,7 +90,7 @@ resource existingDepScriptId 'Microsoft.ManagedIdentity/userAssignedIdentities@2
 
 var delegatedManagedIdentityResourceId = useExistingManagedIdentity ? existingDepScriptId.id : newDepScriptId.id
 
-resource rbacKv 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource rbacKv 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (performRoleAssignment) {
   name: guid(akv.id, rbacRolesNeededOnKV, managedIdentityName, string(useExistingManagedIdentity))
   scope: akv
   properties: {

--- a/modules/deployment-scripts/create-kv-certificate/main.bicep
+++ b/modules/deployment-scripts/create-kv-certificate/main.bicep
@@ -64,13 +64,13 @@ param isCrossTenant bool = false
 @description('The default policy might cause errors about CSR being used before, so set this to false if that happens')
 param reuseKey bool = true
 
-@description('Set to false to disable role assignments within this module. Default: true')
-param performRoleAssignment bool = true
-
 @minValue(1)
 @maxValue(1200)
 @description('Optional. Override default validityInMonths 12 value')
 param validity int = 12
+
+@description('Set to false to disable role assignments within this module. Default: true')
+param performRoleAssignment bool = true
 
 resource akv 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
   name: akvName

--- a/modules/deployment-scripts/create-kv-certificate/main.json
+++ b/modules/deployment-scripts/create-kv-certificate/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.16.2.56959",
-      "templateHash": "11595516812112225013"
+      "version": "0.18.4.5664",
+      "templateHash": "1743315769530624114"
     }
   },
   "parameters": {
@@ -159,6 +159,13 @@
       },
       "maxValue": 1200,
       "minValue": 1
+    },
+    "performRoleAssignment": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Set to false to disable role assignments within this module. Default: true"
+      }
     }
   },
   "variables": {
@@ -177,6 +184,7 @@
       }
     },
     {
+      "condition": "[parameters('performRoleAssignment')]",
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
       "scope": "[format('Microsoft.KeyVault/vaults/{0}', parameters('akvName'))]",

--- a/modules/deployment-scripts/create-kv-certificate/version.json
+++ b/modules/deployment-scripts/create-kv-certificate/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "3.3",
+  "version": "3.4",
   "pathFilters": [
     "./main.json",
     "./metadata.json"


### PR DESCRIPTION
## Description

<!--Why this PR? What is changed? What is the effect? etc.-->

Updating the `deployment-scripts/create-kv-certificate` to add a param that controls the running of the role assignment operation defined in the `rbacKv` resource block. 

This is helpful when using an existing Managed Identity that already has the necessary role assigned to it. Without this param, deploys fail with the "role assignment already exists error". 

## Updating an existing module

<!--Run through the checklist if your PR updates an existing module.-->

- [ ] This is a bug fix:
  - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
  - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
- [x] I have run `brm validate` locally to verify the module files.
- [ ] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](https://github.com/Azure/bicep-registry-modules/blob/main/CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [ ] The PR contains backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
  - [x] The PR contains backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
- [x] I have updated the examples in README with the latest module version number.
