### PR TITLE
feat: Publish module index on publish module

### DIFF
--- a/.github/workflows/publish-module.yml
+++ b/.github/workflows/publish-module.yml
@@ -71,3 +71,11 @@ jobs:
 
       - name: Publish module
         run: bicep publish "modules/${{ steps.parse-tag.outputs.module_path }}/main.json" --target "br:${{ secrets.PUBLISH_REGISTRY_SERVER }}/public/bicep/${{ steps.parse-tag.outputs.module_path }}:${{ steps.parse-tag.outputs.version }}" --documentationUri "${{ steps.parse-tag.outputs.documentation_uri }}" --force
+
+  publish-module-index:
+    needs: main
+    uses: ./.github/workflows/publish-module-index.yml
+    secrets:
+      PUBLISH_CLIENT_ID: ${{ secrets.PUBLISH_CLIENT_ID }}
+      PUBLISH_TENANT_ID: ${{ secrets.PUBLISH_TENANT_ID }}
+      PUBLISH_SUBSCRIPTION_ID: ${{ secrets.PUBLISH_SUBSCRIPTION_ID }}


### PR DESCRIPTION
@shenglol I haven't actually tested this, just modeled it after publish-module-index in on-push-main. Does it makes sense for me to set this up and test in a forked branch first?