### PR TITLE
ci: Disable PR merging with certain labels

### DIFF
--- a/.github/workflows/on-pull-request-check-labels.yml
+++ b/.github/workflows/on-pull-request-check-labels.yml
@@ -1,0 +1,32 @@
+name: Check Labels
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+
+jobs:
+  label-check:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 0
+          labels: "Awaiting Module Path Assignment"
+          add_comment: true
+          message: "This PR is being prevented from merging because it is pending on module path assignment."
+
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 0
+          labels: "Awaiting MCR Manifest Onboarding"
+          add_comment: true
+          message: "This PR is being prevented from merging because it is pending on MCR manifest update."

--- a/.github/workflows/on-pull-request-check-labels.yml
+++ b/.github/workflows/on-pull-request-check-labels.yml
@@ -11,6 +11,11 @@ on:
 jobs:
   label-check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        labels:
+          - "Awaiting Module Path Assignment"
+          - "Awaiting MCR Manifest Onboarding"
     permissions:
       issues: write
       pull-requests: write
@@ -19,14 +24,6 @@ jobs:
         with:
           mode: exactly
           count: 0
-          labels: "Awaiting Module Path Assignment"
+          labels: ${{ matrix.labels }}
           add_comment: true
-          message: "This PR is being prevented from merging because it is pending on module path assignment."
-
-      - uses: mheap/github-action-required-labels@v5
-        with:
-          mode: exactly
-          count: 0
-          labels: "Awaiting MCR Manifest Onboarding"
-          add_comment: true
-          message: "This PR is being prevented from merging because it is pending on MCR manifest update."
+          message: "This PR is being prevented from merging because it is pending on label: ${{ matrix.labels }}."


### PR DESCRIPTION
We should prevent PRs from merging if they have one of the following labels:

![image](https://github.com/Azure/bicep-registry-modules/assets/16367959/139f28ce-811a-49d7-958d-60b18ab263a6)
