### PR TITLE
fix: Add batchSize to deployments

### DIFF
--- a/modules/ai/cognitiveservices/main.bicep
+++ b/modules/ai/cognitiveservices/main.bicep
@@ -135,6 +135,7 @@ resource cognitiveService 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   }
 }
 
+@batchSize(1)
 resource cognitiveServiceDeployment 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01' = [for (deployment, index) in deployments: {
   name: '${name}-deploy-${index}'
   parent: cognitiveService
@@ -161,9 +162,6 @@ module cognitiveServicePrivateEndpoint 'modules/privateEndpoint.bicep' = if (pri
     privateEndpoints: varPrivateEndpoints
     tags: tags
   }
-  dependsOn: [
-    cognitiveService
-  ]
 }
 
 resource cognitiveServiceLock 'Microsoft.Authorization/locks@2020-05-01' = if (lock != 'NotSpecified') {

--- a/modules/ai/cognitiveservices/main.json
+++ b/modules/ai/cognitiveservices/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.20.4.51522",
-      "templateHash": "12705091931520921510"
+      "templateHash": "4658231277982806422"
     },
     "name": "CognitiveServices",
     "description": "This module deploys CognitiveServices (Microsoft.CognitiveServices/accounts) and optionally available integrations.",
@@ -278,7 +278,9 @@
     {
       "copy": {
         "name": "cognitiveServiceDeployment",
-        "count": "[length(parameters('deployments'))]"
+        "count": "[length(parameters('deployments'))]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "type": "Microsoft.CognitiveServices/accounts/deployments",
       "apiVersion": "2023-05-01",


### PR DESCRIPTION
## Description

<!--Why this PR? What is changed? What is the effect? etc.-->


The AI module was doing deployments in a loop, but the resource only handles one at a time, so I put batchSize(1) for each.

## Adding a new module

<!--Run through the checklist if your PR adds a new module.-->

- [ ] A proposal has been submitted and approved.
- [ ] I have included "Closes #{module_proposal_issue_number}" in the PR description.
- [ ] I have run `brm validate` locally to verify the module files.
- [ ] I have run deployment tests locally to ensure the module is deployable.

## Updating an existing module

<!--Run through the checklist if your PR updates an existing module.-->

- [ x] This is a bug fix:
  - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
  - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
- [ ] I have run `brm validate` locally to verify the module files.
- [ ] I have run deployment tests locally to ensure the module is deployable.
- [ ] I have read the [Updating an existing module](https://github.com/Azure/bicep-registry-modules/blob/main/CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [ ] The PR contains backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
  - [ ] The PR contains backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
- [ ] I have updated the examples in README with the latest module version number.
