### PR TITLE
fix: Update CODEOWNERS to admin group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-/.github/ @Azure/bicep-admins @Azure/avm-core-team
-/scripts/ @Azure/bicep-admins @Azure/avm-core-team
-/avm @Azure/avm-core-team
+/.github/ @Azure/bicep-admins @Azure/avm-core-team-technical
+/scripts/ @Azure/bicep-admins @Azure/avm-core-team-technical
+/avm @Azure/avm-core-team-technical


### PR DESCRIPTION
## Description

<!--Why this PR? What is changed? What is the effect? etc.-->

Updated codeowners with @Azure/avm-core-team-technical team, which is the one having Write access to the repository.
