### PR TITLE
Added `avm/` to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+avm/
 modules/
 package-lock.json
 docs/jekyll


### PR DESCRIPTION
## Description

Added `avm/` to .prettierignore as it conflicts with its `main.json` & `readme.md` module files
