### PR TITLE
feat: Adjust `generate-module-index-data.js` to support AVM 

### DIFF
--- a/scripts/github-actions/generate-module-index-data.js
+++ b/scripts/github-actions/generate-module-index-data.js
@@ -205,7 +205,7 @@ async function generateModuleIndexData({ require, github, context, core }) {
           core,
           path,
           modulePath,
-          (moduleType = "avm-res"),
+          (moduleType = "avm-ptn"),
           tag,
           context
         );

--- a/scripts/github-actions/generate-module-index-data.js
+++ b/scripts/github-actions/generate-module-index-data.js
@@ -16,7 +16,7 @@ async function getModuleDescription(
   tag,
   context
 ) {
-  const allowedModuleRoots = ["brm", "avm/res", "avm/res"];
+  const allowedModuleRoots = ["modules", "avm/res", "avm/res"];
 
   if (!allowedModuleRoots.includes(moduleRoot)) {
     throw new Error(

--- a/scripts/github-actions/generate-module-index-data.js
+++ b/scripts/github-actions/generate-module-index-data.js
@@ -12,15 +12,32 @@ async function getModuleDescription(
   core,
   path,
   modulePath,
+  moduleType = "brm",
   tag,
   context
 ) {
   // Retrieve the main.json file as it existed for the given tag
   const ref = `tags/${modulePath}/${tag}`;
   core.info(`  Retrieving main.json at ref ${ref}`);
-  const mainJsonPath = path
-    .join("modules", modulePath, "main.json")
-    .replace(/\\/g, "/");
+
+  let mainJsonPath;
+  if (moduleType === "brm") {
+    mainJsonPath = path
+      .join("modules", modulePath, "main.json")
+      .replace(/\\/g, "/");
+  } else if (moduleType === "avm-res") {
+    mainJsonPath = path
+      .join("avm/res", modulePath, "main.json")
+      .replace(/\\/g, "/");
+  } else if (moduleType === "avm-ptn") {
+    mainJsonPath = path
+      .join("avm/ptn", modulePath, "main.json")
+      .replace(/\\/g, "/");
+  } else {
+    throw new Error(
+      `Invalid module type provided to getModuleDescription function, permitted type are brm, avm-res, avm-ptn. The module type provided was: ${moduleType}`
+    );
+  }
 
   const response = await github.rest.repos.getContent({
     owner: context.repo.owner,
@@ -52,10 +69,18 @@ async function generateModuleIndexData({ require, github, context, core }) {
   const path = require("path");
   const axios = require("axios").default;
   const moduleGroups = await getSubdirNames(fs, "modules");
+  const moduleGroupsAvmRes = await getSubdirNames(fs, "avm/res");
+  const moduleGroupsAvmPtn = await getSubdirNames(fs, "avm/ptn");
   const modulesWithDescriptions = new Map();
+
+  var allModuleGroups = [];
+  allModuleGroups.push(...moduleGroups);
+  allModuleGroups.push(...moduleGroupsAvmRes);
+  allModuleGroups.push(...moduleGroupsAvmPtn);
 
   var moduleIndexData = [];
 
+  // BRM Modules
   for (const moduleGroup of moduleGroups) {
     const moduleGroupPath = path.join("modules", moduleGroup);
     const moduleNames = await getSubdirNames(fs, moduleGroupPath);
@@ -64,28 +89,30 @@ async function generateModuleIndexData({ require, github, context, core }) {
       const modulePath = `${moduleGroup}/${moduleName}`;
       const versionListUrl = `https://mcr.microsoft.com/v2/bicep/${modulePath}/tags/list`;
 
+      //repeat for avm/res and avm/ptn - might have to be higher up, outside of the loop l.59
       try {
-        core.info(`Processing ${modulePath}:...`);
-        core.info(`  Retrieving  ${versionListUrl}`);
+        core.info(`Processing BRM Module ${modulePath}:...`);
+        core.info(`  Retrieving BRM Module ${versionListUrl}`);
 
         const versionListResponse = await axios.get(versionListUrl);
         const tags = versionListResponse.data.tags.sort();
 
         const properties = {};
-        for (const tag of tags) {
-          var description = await getModuleDescription(
-            github,
-            core,
-            path,
-            modulePath,
-            tag,
-            context
-          );
-          if (description) {
-            properties[tag] = { description };
-            modulesWithDescriptions[modulePath] = true;
-          }
-        }
+        // for (const tag of tags) {
+        //   var description = await getModuleDescription(
+        //     github,
+        //     core,
+        //     path,
+        //     modulePath,
+        //     (moduleType = "brm"),
+        //     tag,
+        //     context
+        //   );
+        //   if (description) {
+        //     properties[tag] = { description };
+        //     modulesWithDescriptions[modulePath] = true;
+        //   }
+        // }
 
         moduleIndexData.push({
           moduleName: modulePath,
@@ -98,13 +125,108 @@ async function generateModuleIndexData({ require, github, context, core }) {
     }
   }
 
+  // AVM Resource Modules
+  for (const moduleGroup of moduleGroupsAvmRes) {
+    const moduleGroupPath = path.join("avm/res", moduleGroup);
+    const moduleNames = await getSubdirNames(fs, moduleGroupPath);
+
+    for (const moduleName of moduleNames) {
+      const modulePath = `${moduleGroup}/${moduleName}`;
+      const versionListUrl = `https://mcr.microsoft.com/v2/bicep/${modulePath}/tags/list`;
+
+      //repeat for avm/res and avm/ptn - might have to be higher up, outside of the loop l.59
+      try {
+        core.info(`Processing AVM Resource Module ${modulePath}:...`);
+        core.info(`  Retrieving AVM Resource Module ${versionListUrl}`);
+
+        const versionListResponse = await axios.get(versionListUrl);
+        const tags = versionListResponse.data.tags.sort();
+
+        const properties = {};
+        // for (const tag of tags) {
+        //   var description = await getModuleDescription(
+        //     github,
+        //     core,
+        //     path,
+        //     modulePath,
+        //     (moduleType = "avm-res"),
+        //     tag,
+        //     context
+        //   );
+        //   if (description) {
+        //     properties[tag] = { description };
+        //     modulesWithDescriptions[modulePath] = true;
+        //   }
+        // }
+
+        moduleIndexData.push({
+          moduleName: modulePath,
+          tags,
+          properties,
+        });
+      } catch (error) {
+        core.setFailed(error);
+      }
+    }
+  }
+
+  // // AVM Pattern Modules
+  // for (const moduleGroup of moduleGroupsAvmPtn) {
+  //   const moduleGroupPath = path.join("avm/ptn", moduleGroup);
+  //   const moduleNames = await getSubdirNames(fs, moduleGroupPath);
+
+  //   for (const moduleName of moduleNames) {
+  //     const modulePath = `${moduleGroup}/${moduleName}`;
+  //     const versionListUrl = `https://mcr.microsoft.com/v2/bicep/${modulePath}/tags/list`;
+
+  //     //repeat for avm/res and avm/ptn - might have to be higher up, outside of the loop l.59
+  //     try {
+  //       core.info(`Processing AVM Pattern Module ${modulePath}:...`);
+  //       core.info(`  Retrieving AVM Pattern Module ${versionListUrl}`);
+
+  //       const versionListResponse = await axios.get(versionListUrl);
+  //       const tags = versionListResponse.data.tags.sort();
+
+  //       const properties = {};
+  //       // for (const tag of tags) {
+  //       //   var description = await getModuleDescription(
+  //       //     github,
+  //       //     core,
+  //       //     path,
+  //       //     modulePath,
+  //       //     (moduleType = "avm-res"),
+  //       //     tag,
+  //       //     context
+  //       //   );
+  //       //   if (description) {
+  //       //     properties[tag] = { description };
+  //       //     modulesWithDescriptions[modulePath] = true;
+  //       //   }
+  //       // }
+
+  //       moduleIndexData.push({
+  //         moduleName: modulePath,
+  //         tags,
+  //         properties,
+  //       });
+  //     } catch (error) {
+  //       core.setFailed(error);
+  //     }
+  //   }
+  // }
+
+  // Remove this as just for testing
+  // for (const module of moduleIndexData) {
+  //   console.log(JSON.stringify(moduleIndexData, null, 2));
+  // }
+
   core.info(`Writing moduleIndex.json`);
   await fs.writeFile(
     "moduleIndex.json",
     JSON.stringify(moduleIndexData, null, 2)
   );
 
-  core.info(`Processed ${moduleGroups.length} modules groups.`);
+  core.info(`Processed ${allModuleGroups.length} modules groups.`);
   core.info(`Processed ${moduleIndexData.length} total modules.`);
   core.info(
     `${
@@ -118,3 +240,6 @@ async function generateModuleIndexData({ require, github, context, core }) {
 }
 
 module.exports = generateModuleIndexData;
+
+// name in json file output needs to be avm-res-network-xxxxxxxx
+// tag will always be folder path avm/res/network/xxxxxxxx

--- a/scripts/github-actions/generate-module-index-data.js
+++ b/scripts/github-actions/generate-module-index-data.js
@@ -65,11 +65,6 @@ async function generateModuleIndexData({ require, github, context, core }) {
   const moduleGroupsAvmPtn = await getSubdirNames(fs, "avm/ptn");
   const modulesWithDescriptions = new Map();
 
-  var allModuleGroups = [];
-  allModuleGroups.push(...moduleGroups);
-  allModuleGroups.push(...moduleGroupsAvmRes);
-  allModuleGroups.push(...moduleGroupsAvmPtn);
-
   var moduleIndexData = [];
 
   // BRM Modules
@@ -95,7 +90,7 @@ async function generateModuleIndexData({ require, github, context, core }) {
             core,
             path,
             modulePath,
-            (moduleRoot = "brm"),
+            (moduleRoot = "modules"),
             tag,
             context
           );
@@ -223,7 +218,13 @@ async function generateModuleIndexData({ require, github, context, core }) {
     JSON.stringify(moduleIndexData, null, 2)
   );
 
-  core.info(`Processed ${allModuleGroups.length} modules groups.`);
+  core.info(
+    `Processed ${
+      moduleGroups.length +
+      moduleGroupsAvmRes.length +
+      moduleGroupsAvmPtn.length
+    } modules groups.`
+  );
   core.info(`Processed ${moduleIndexData.length} total modules.`);
   core.info(
     `${

--- a/scripts/github-actions/generate-module-index-data.js
+++ b/scripts/github-actions/generate-module-index-data.js
@@ -12,32 +12,25 @@ async function getModuleDescription(
   core,
   path,
   modulePath,
-  moduleType = "brm",
+  moduleRoot,
   tag,
   context
 ) {
+  const allowedModuleRoots = ["brm", "avm/res", "avm/res"];
+
+  if (!allowedModuleRoots.includes(moduleRoot)) {
+    throw new Error(
+      `Invalid module type provided to getModuleDescription function, permitted type are brm, avm/res, avm/ptn. The module type provided was: ${moduleRoot}`
+    );
+  }
   // Retrieve the main.json file as it existed for the given tag
   const ref = `tags/${modulePath}/${tag}`;
   core.info(`  Retrieving main.json at ref ${ref}`);
 
   let mainJsonPath;
-  if (moduleType === "brm") {
-    mainJsonPath = path
-      .join("modules", modulePath, "main.json")
-      .replace(/\\/g, "/");
-  } else if (moduleType === "avm-res") {
-    mainJsonPath = path
-      .join("avm/res", modulePath, "main.json")
-      .replace(/\\/g, "/");
-  } else if (moduleType === "avm-ptn") {
-    mainJsonPath = path
-      .join("avm/ptn", modulePath, "main.json")
-      .replace(/\\/g, "/");
-  } else {
-    throw new Error(
-      `Invalid module type provided to getModuleDescription function, permitted type are brm, avm-res, avm-ptn. The module type provided was: ${moduleType}`
-    );
-  }
+  mainJsonPath = path
+    .join(moduleRoot, modulePath, "main.json")
+    .replace(/\\/g, "/");
 
   const response = await github.rest.repos.getContent({
     owner: context.repo.owner,
@@ -103,7 +96,7 @@ async function generateModuleIndexData({ require, github, context, core }) {
             core,
             path,
             modulePath,
-            (moduleType = "brm"),
+            (moduleRoot = "brm"),
             tag,
             context
           );
@@ -156,7 +149,7 @@ async function generateModuleIndexData({ require, github, context, core }) {
             core,
             path,
             modulePath,
-            (moduleType = "avm-res"),
+            (moduleRoot = "avm/res"),
             tag,
             context
           );
@@ -205,7 +198,7 @@ async function generateModuleIndexData({ require, github, context, core }) {
           core,
           path,
           modulePath,
-          (moduleType = "avm-ptn"),
+          (moduleRoot = "avm/ptn"),
           tag,
           context
         );

--- a/scripts/github-actions/generate-module-index-data.js
+++ b/scripts/github-actions/generate-module-index-data.js
@@ -89,7 +89,6 @@ async function generateModuleIndexData({ require, github, context, core }) {
       const modulePath = `${moduleGroup}/${moduleName}`;
       const versionListUrl = `https://mcr.microsoft.com/v2/bicep/${modulePath}/tags/list`;
 
-      //repeat for avm/res and avm/ptn - might have to be higher up, outside of the loop l.59
       try {
         core.info(`Processing BRM Module ${modulePath}:...`);
         core.info(`  Retrieving BRM Module ${versionListUrl}`);
@@ -98,21 +97,21 @@ async function generateModuleIndexData({ require, github, context, core }) {
         const tags = versionListResponse.data.tags.sort();
 
         const properties = {};
-        // for (const tag of tags) {
-        //   var description = await getModuleDescription(
-        //     github,
-        //     core,
-        //     path,
-        //     modulePath,
-        //     (moduleType = "brm"),
-        //     tag,
-        //     context
-        //   );
-        //   if (description) {
-        //     properties[tag] = { description };
-        //     modulesWithDescriptions[modulePath] = true;
-        //   }
-        // }
+        for (const tag of tags) {
+          var description = await getModuleDescription(
+            github,
+            core,
+            path,
+            modulePath,
+            (moduleType = "brm"),
+            tag,
+            context
+          );
+          if (description) {
+            properties[tag] = { description };
+            modulesWithDescriptions[modulePath] = true;
+          }
+        }
 
         moduleIndexData.push({
           moduleName: modulePath,
@@ -131,36 +130,44 @@ async function generateModuleIndexData({ require, github, context, core }) {
     const moduleNames = await getSubdirNames(fs, moduleGroupPath);
 
     for (const moduleName of moduleNames) {
-      const modulePath = `${moduleGroup}/${moduleName}`;
+      const modulePath = `avm/res/${moduleGroup}/${moduleName}`;
       const versionListUrl = `https://mcr.microsoft.com/v2/bicep/${modulePath}/tags/list`;
+      const moduleBicepRegistryRefSplit = modulePath
+        .split(/[\/\\]avm[\/\\]/)
+        .pop();
+      const moduleBicepRegistryRefReplace = moduleBicepRegistryRefSplit
+        .replace(/-/g, "")
+        .replace(/[\/\\]/g, "-");
+      const moduleBicepRegistryRef = moduleBicepRegistryRefReplace;
 
-      //repeat for avm/res and avm/ptn - might have to be higher up, outside of the loop l.59
       try {
         core.info(`Processing AVM Resource Module ${modulePath}:...`);
         core.info(`  Retrieving AVM Resource Module ${versionListUrl}`);
+        core.info(`    Git Tag: ${modulePath}`);
+        core.info(`    BRM Ref: ${moduleBicepRegistryRef}`);
 
         const versionListResponse = await axios.get(versionListUrl);
         const tags = versionListResponse.data.tags.sort();
 
         const properties = {};
-        // for (const tag of tags) {
-        //   var description = await getModuleDescription(
-        //     github,
-        //     core,
-        //     path,
-        //     modulePath,
-        //     (moduleType = "avm-res"),
-        //     tag,
-        //     context
-        //   );
-        //   if (description) {
-        //     properties[tag] = { description };
-        //     modulesWithDescriptions[modulePath] = true;
-        //   }
-        // }
+        for (const tag of tags) {
+          var description = await getModuleDescription(
+            github,
+            core,
+            path,
+            modulePath,
+            (moduleType = "avm-res"),
+            tag,
+            context
+          );
+          if (description) {
+            properties[tag] = { description };
+            modulesWithDescriptions[modulePath] = true;
+          }
+        }
 
         moduleIndexData.push({
-          moduleName: modulePath,
+          moduleName: moduleBicepRegistryRef,
           tags,
           properties,
         });
@@ -170,55 +177,53 @@ async function generateModuleIndexData({ require, github, context, core }) {
     }
   }
 
-  // // AVM Pattern Modules
-  // for (const moduleGroup of moduleGroupsAvmPtn) {
-  //   const moduleGroupPath = path.join("avm/ptn", moduleGroup);
-  //   const moduleNames = await getSubdirNames(fs, moduleGroupPath);
+  // AVM Pattern Modules
+  for (const moduleName of moduleGroupsAvmPtn) {
+    const modulePath = `avm/ptn/${moduleName}`;
+    const versionListUrl = `https://mcr.microsoft.com/v2/bicep/${modulePath}/tags/list`;
+    const moduleBicepRegistryRefSplit = modulePath
+      .split(/[\/\\]avm[\/\\]/)
+      .pop();
+    const moduleBicepRegistryRefReplace = moduleBicepRegistryRefSplit
+      .replace(/-/g, "")
+      .replace(/[\/\\]/g, "-");
+    const moduleBicepRegistryRef = moduleBicepRegistryRefReplace;
 
-  //   for (const moduleName of moduleNames) {
-  //     const modulePath = `${moduleGroup}/${moduleName}`;
-  //     const versionListUrl = `https://mcr.microsoft.com/v2/bicep/${modulePath}/tags/list`;
+    try {
+      core.info(`Processing AVM Pattern Module ${modulePath}:...`);
+      core.info(`  Retrieving AVM Pattern Module ${versionListUrl}`);
+      core.info(`    Git Tag: ${modulePath}`);
+      core.info(`    BRM Ref: ${moduleBicepRegistryRef}`);
 
-  //     //repeat for avm/res and avm/ptn - might have to be higher up, outside of the loop l.59
-  //     try {
-  //       core.info(`Processing AVM Pattern Module ${modulePath}:...`);
-  //       core.info(`  Retrieving AVM Pattern Module ${versionListUrl}`);
+      const versionListResponse = await axios.get(versionListUrl);
+      const tags = versionListResponse.data.tags.sort();
 
-  //       const versionListResponse = await axios.get(versionListUrl);
-  //       const tags = versionListResponse.data.tags.sort();
+      const properties = {};
+      for (const tag of tags) {
+        var description = await getModuleDescription(
+          github,
+          core,
+          path,
+          modulePath,
+          (moduleType = "avm-res"),
+          tag,
+          context
+        );
+        if (description) {
+          properties[tag] = { description };
+          modulesWithDescriptions[modulePath] = true;
+        }
+      }
 
-  //       const properties = {};
-  //       // for (const tag of tags) {
-  //       //   var description = await getModuleDescription(
-  //       //     github,
-  //       //     core,
-  //       //     path,
-  //       //     modulePath,
-  //       //     (moduleType = "avm-res"),
-  //       //     tag,
-  //       //     context
-  //       //   );
-  //       //   if (description) {
-  //       //     properties[tag] = { description };
-  //       //     modulesWithDescriptions[modulePath] = true;
-  //       //   }
-  //       // }
-
-  //       moduleIndexData.push({
-  //         moduleName: modulePath,
-  //         tags,
-  //         properties,
-  //       });
-  //     } catch (error) {
-  //       core.setFailed(error);
-  //     }
-  //   }
-  // }
-
-  // Remove this as just for testing
-  // for (const module of moduleIndexData) {
-  //   console.log(JSON.stringify(moduleIndexData, null, 2));
-  // }
+      moduleIndexData.push({
+        moduleName: moduleBicepRegistryRef,
+        tags,
+        properties,
+      });
+    } catch (error) {
+      core.setFailed(error);
+    }
+  }
 
   core.info(`Writing moduleIndex.json`);
   await fs.writeFile(
@@ -240,6 +245,3 @@ async function generateModuleIndexData({ require, github, context, core }) {
 }
 
 module.exports = generateModuleIndexData;
-
-// name in json file output needs to be avm-res-network-xxxxxxxx
-// tag will always be folder path avm/res/network/xxxxxxxx

--- a/scripts/github-actions/generate-module-index-data.js
+++ b/scripts/github-actions/generate-module-index-data.js
@@ -27,8 +27,7 @@ async function getModuleDescription(
   const ref = `tags/${modulePath}/${tag}`;
   core.info(`  Retrieving main.json at ref ${ref}`);
 
-  let mainJsonPath;
-  mainJsonPath = path
+  const mainJsonPath = path
     .join(moduleRoot, modulePath, "main.json")
     .replace(/\\/g, "/");
 

--- a/scripts/github-actions/generate-module-index-md.js
+++ b/scripts/github-actions/generate-module-index-md.js
@@ -146,6 +146,9 @@ permalink: /
   );
 
   for (const [moduleGroup, modules] of moduleGroups) {
+    if (moduleGroup.includes("avm")) {
+      continue;
+    }
     core.debug(`Generating ${moduleGroup}...`);
 
     const moduleGroupTable = await generateModuleGroupTable(


### PR DESCRIPTION
## Description

This PR updates `generate-module-index-data.js` to add support for the AVM modules.

This will allow the AVM modules to be discovered by the Bicep clients/IDEs using the Bicep IDE extensions.

@shenglol & @StephenWeatherford please review as JavaScript is not my daily driver 👍 
