### PR TITLE
feat: Adjust `generate-module-index-data.js` `moduleJsonPath` for AVM modules

### DIFF
--- a/scripts/github-actions/generate-module-index-data.js
+++ b/scripts/github-actions/generate-module-index-data.js
@@ -27,10 +27,19 @@ async function getModuleDescription(
   const ref = `tags/${modulePath}/${tag}`;
   core.info(`  Retrieving main.json at ref ${ref}`);
 
-  const mainJsonPath = path
+  let mainJsonPath = path
     .join(moduleRoot, modulePath, "main.json")
     .replace(/\\/g, "/");
 
+  // if mainJsonPath starts with avm/res/avm/res then remove the first avm/res
+  if (mainJsonPath.startsWith("avm/res/avm/res")) {
+    mainJsonPath = mainJsonPath.replace("avm/res/", "");
+  }
+
+  // if mainJsonPath starts with avm/ptn/avm/ptn then remove the first avm/ptn
+  if (mainJsonPath.startsWith("avm/ptn/avm/ptn")) {
+    mainJsonPath = mainJsonPath.replace("avm/ptn/", "");
+  }
   const response = await github.rest.repos.getContent({
     owner: context.repo.owner,
     repo: context.repo.repo,

--- a/scripts/github-actions/generate-module-index-data.js
+++ b/scripts/github-actions/generate-module-index-data.js
@@ -16,7 +16,7 @@ async function getModuleDescription(
   tag,
   context
 ) {
-  const allowedModuleRoots = ["modules", "avm/res", "avm/res"];
+  const allowedModuleRoots = ["modules", "avm/res", "avm/ptn"];
 
   if (!allowedModuleRoots.includes(moduleRoot)) {
     throw new Error(
@@ -40,6 +40,7 @@ async function getModuleDescription(
   if (mainJsonPath.startsWith("avm/ptn/avm/ptn")) {
     mainJsonPath = mainJsonPath.replace("avm/ptn/", "");
   }
+
   const response = await github.rest.repos.getContent({
     owner: context.repo.owner,
     repo: context.repo.repo,


### PR DESCRIPTION
## Description

Adjust `generate-module-index-data.js` `moduleJsonPath` for AVM modules to remove double `avm/res/avm/res` or `avm/ptn/avm/ptn` paths to main.json

Testing of API manually works as expected: https://api.github.com/repos/Azure/bicep-registry-modules/contents/avm/res/network/private-endpoint/main.json?ref=tags/avm/res/network/private-endpoint/0.1.0

And have tested logic in output