### PR TITLE
fix: Update to Condition for required Parameters in Set-ModuleReadMe.ps1

### DIFF
--- a/avm/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
+++ b/avm/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
@@ -1095,7 +1095,7 @@ function Set-UsageExamplesSection {
         $isUserDefinedType = $TemplateFileContent.parameters[$_].Keys -contains '$ref'
         $isNullable = $TemplateFileContent.parameters[$_]['nullable']
         $isNullableInRef = $TemplateFileContent.parameters[$_].Keys -contains '$ref' ? $TemplateFileContent.definitions[(Split-Path $TemplateFileContent.parameters[$_].'$ref' -Leaf)]['nullable'] : $false
-        (($hasNoDefaultValue -and -not $isUserDefinedType -and -not $isNullable) -or ($isUserDefinedType -and -not $isNullableInRef))
+        (($hasNoDefaultValue -and -not $isUserDefinedType -and -not $isNullable) -or ($isUserDefinedType -and -not $isNullableInRef -and -not $isNullable))
     } | Sort-Object
 
     ############################


### PR DESCRIPTION
## Description

Fixing issue where set module readme condition does not balance out with nullable parameters for user defined types, Causing nullable user defined types to appear as required params when they are optional. 

Note: This is the same change in #552 without autoformatting enabled!
