### PR TITLE
feat: Add AVM note to index site and contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@
 
 The following instructions are created to help with the development of Bicep public registry modules.
 
+> **NOTE:** If you are looking to contribute to an [Azure Verified Module (AVM)](https://aka.ms/avm) then please visit the AVM site for specific [contribution guidance](https://aka.ms/avm/contribute).
+
 ## Prerequisite
 
 - Create a fork of the [Azure/bicep-registry-modules](https://github.com/Azure/bicep-registry-modules) repository and clone the fork to your local machine.

--- a/scripts/github-actions/generate-module-index-md.js
+++ b/scripts/github-actions/generate-module-index-md.js
@@ -130,6 +130,16 @@ permalink: /
 
 ---
 
+{: .note-title }
+> Azure Verified Modules (AVM) - Module Indexes
+>
+> The [Azure Verified Modules (AVM)](https://aka.ms/avm) module indexes are located over on the AVM website. You can find them here for:
+>
+> - [Resource Modules](https://aka.ms/avm/index/bicep/res)
+> - [Pattern Modules](https://aka.ms/avm/index/bicep/ptn)
+
+---
+
 `;
 
   const moduleIndexDataContent = await fs.readFile("moduleIndex.json", {


### PR DESCRIPTION
This PR adds a note to the BRM index static site and contribution guide about AVM modules as discussed with @shenglol as we are keeping the AVM indexes and contribution guidance separate, for now 👍 

Adding a "callout" following just the docs site configuration [here](https://just-the-docs.com/docs/ui-components/callouts/#a-single-paragraph-callout)

Ran the `scripts\github-actions\runlocally\run-generate-module-index.bat` local testing script and completed fine with no errors.