### PR TITLE
ci: Fix avm ptn module path

### DIFF
--- a/scripts/github-actions/generate-module-index-data.js
+++ b/scripts/github-actions/generate-module-index-data.js
@@ -98,8 +98,13 @@ async function generateModuleIndexData({ require, github, context, core }) {
     numberOfModuleGroupsProcessed++;
   }
 
-  for (const avmModuleRoot of ["avm/res", "avm/ptn"]) {
-    const avmModuleGroups = await getSubdirNames(fs, avmModuleRoot);
+  for (const avmModuleRoot of ["avm/res", "avm"]) {
+    // Resource module path pattern: `avm/res/${moduleGroup}/${moduleName}`
+    // Pattern module path pattern: `avm/ptn/${moduleName}` (no nested module group)
+    const avmModuleGroups =
+      avmModuleRoot === "avm/res"
+        ? await getSubdirNames(fs, avmModuleRoot)
+        : ["ptn"];
 
     for (const moduleGroup of avmModuleGroups) {
       const moduleGroupPath = `${avmModuleRoot}/${moduleGroup}`;


### PR DESCRIPTION
@jtracey93 I read your [comment ](https://github.com/Azure/bicep-registry-modules/pull/576#discussion_r1365378127) again and realized I misunderstood module path for avm ptn modules (unlike res modules, there is no nested module groups). The PR fixes it.