### PR TITLE
fix: `avm-res-network-privatednszone` Update to readme to fix build error

### DIFF
--- a/avm/res/network/private-dns-zone/README.md
+++ b/avm/res/network/private-dns-zone/README.md
@@ -574,12 +574,6 @@ module privateDnsZone 'br/public:avm-res-network-privatednszone:1.0.0' = {
       Role: 'DeploymentValidation'
     }
     txt: []
-    virtualNetworkLinks: [
-      {
-        registrationEnabled: true
-        virtualNetworkResourceId: '<virtualNetworkResourceId>'
-      }
-    ]
   }
 }
 ```
@@ -643,14 +637,6 @@ module privateDnsZone 'br/public:avm-res-network-privatednszone:1.0.0' = {
     },
     "txt": {
       "value": []
-    },
-    "virtualNetworkLinks": {
-      "value": [
-        {
-          "registrationEnabled": true,
-          "virtualNetworkResourceId": "<virtualNetworkResourceId>"
-        }
-      ]
     }
   }
 }


### PR DESCRIPTION
## Description

| Pipeline |
| --------- | 
| [![avm.res.network.private-dns-zone](https://github.com/ChrisSidebotham/bicep-registry-modules/actions/workflows/avm.res.network.private-dns-zone.yml/badge.svg?branch=avm-res-network-privatednszone-patch1)](https://github.com/ChrisSidebotham/bicep-registry-modules/actions/workflows/avm.res.network.private-dns-zone.yml) |

Error caused by #590 due to misplaced commits 