### PR TITLE
feat: Added User Defined Types to Private Endpoints customDnsConfigs and ipConfigurations properties

### DIFF
--- a/avm/res/network/private-endpoint/README.md
+++ b/avm/res/network/private-endpoint/README.md
@@ -161,7 +161,14 @@ module privateEndpoint 'br/public:avm-res-network-privateendpoint:1.0.0' = {
     applicationSecurityGroupResourceIds: [
       '<applicationSecurityGroupResourceId>'
     ]
-    customDnsConfigs: []
+    customDnsConfigs: [
+      {
+        fqdn: 'abc.keyvault.com'
+        ipAddresses: [
+          '10.0.0.10'
+        ]
+      }
+    ]
     customNetworkInterfaceName: 'npemax001nic'
     ipConfigurations: [
       {
@@ -233,7 +240,14 @@ module privateEndpoint 'br/public:avm-res-network-privateendpoint:1.0.0' = {
       ]
     },
     "customDnsConfigs": {
-      "value": []
+      "value": [
+        {
+          "fqdn": "abc.keyvault.com",
+          "ipAddresses": [
+            "10.0.0.10"
+          ]
+        }
+      ]
     },
     "customNetworkInterfaceName": {
       "value": "npemax001nic"
@@ -490,6 +504,26 @@ Custom DNS configurations.
 - Required: No
 - Type: array
 
+
+| Name | Required | Type | Description |
+| :-- | :-- | :--| :-- |
+| [`fqdn`](#parameter-customdnsconfigsfqdn) | Yes | string | Required. Fqdn that resolves to private endpoint ip address. |
+| [`ipAddresses`](#parameter-customdnsconfigsipaddresses) | Yes | array | Required. A list of private ip addresses of the private endpoint. |
+
+### Parameter: `customDnsConfigs.fqdn`
+
+Required. Fqdn that resolves to private endpoint ip address.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `customDnsConfigs.ipAddresses`
+
+Required. A list of private ip addresses of the private endpoint.
+
+- Required: Yes
+- Type: array
+
 ### Parameter: `customNetworkInterfaceName`
 
 The custom name of the network interface attached to the private endpoint.
@@ -514,6 +548,26 @@ Subtype(s) of the connection to be created. The allowed values depend on the typ
 A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints.
 - Required: No
 - Type: array
+
+
+| Name | Required | Type | Description |
+| :-- | :-- | :--| :-- |
+| [`name`](#parameter-ipconfigurationsname) | Yes | string | Required. The name of the resource that is unique within a resource group. |
+| [`properties`](#parameter-ipconfigurationsproperties) | Yes | object | Required. Properties of private endpoint IP configurations. |
+
+### Parameter: `ipConfigurations.name`
+
+Required. The name of the resource that is unique within a resource group.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `ipConfigurations.properties`
+
+Required. Properties of private endpoint IP configurations.
+
+- Required: Yes
+- Type: object
 
 ### Parameter: `location`
 

--- a/avm/res/network/private-endpoint/README.md
+++ b/avm/res/network/private-endpoint/README.md
@@ -569,6 +569,34 @@ Required. Properties of private endpoint IP configurations.
 - Required: Yes
 - Type: object
 
+| Name | Required | Type | Description |
+| :-- | :-- | :--| :-- |
+| [`groupId`](#parameter-ipconfigurationspropertiesgroupid) | Yes | string | Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. |
+| [`memberName`](#parameter-ipconfigurationspropertiesmembername) | Yes | string | Required. The member name of a group obtained from the remote resource that this private endpoint should connect to. |
+| [`privateIPAddress`](#parameter-ipconfigurationspropertiesprivateipaddress) | Yes | string | Required. A private ip address obtained from the private endpoint's subnet. |
+
+### Parameter: `ipConfigurations.properties.groupId`
+
+Required. The ID of a group obtained from the remote resource that this private endpoint should connect to.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `ipConfigurations.properties.memberName`
+
+Required. The member name of a group obtained from the remote resource that this private endpoint should connect to.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `ipConfigurations.properties.privateIPAddress`
+
+Required. A private ip address obtained from the private endpoint's subnet.
+
+- Required: Yes
+- Type: string
+
+
 ### Parameter: `location`
 
 Location for all Resources.

--- a/avm/res/network/private-endpoint/main.bicep
+++ b/avm/res/network/private-endpoint/main.bicep
@@ -18,7 +18,7 @@ param applicationSecurityGroupResourceIds array?
 param customNetworkInterfaceName string?
 
 @description('Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints.')
-param ipConfigurations ipConfigurationsType?
+param ipConfigurations ipConfigurationsType
 
 @description('Required. Subtype(s) of the connection to be created. The allowed values depend on the type serviceResourceId refers to.')
 param groupIds array
@@ -42,7 +42,7 @@ param roleAssignments roleAssignmentType
 param tags object?
 
 @description('Optional. Custom DNS configurations.')
-param customDnsConfigs customDnsConfigType?
+param customDnsConfigs customDnsConfigType
 
 @description('Optional. Manual PrivateLink Service Connections.')
 param manualPrivateLinkServiceConnections array?

--- a/avm/res/network/private-endpoint/main.bicep
+++ b/avm/res/network/private-endpoint/main.bicep
@@ -18,7 +18,7 @@ param applicationSecurityGroupResourceIds array?
 param customNetworkInterfaceName string?
 
 @description('Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints.')
-param ipConfigurations array?
+param ipConfigurations ipConfigurationsType?
 
 @description('Required. Subtype(s) of the connection to be created. The allowed values depend on the type serviceResourceId refers to.')
 param groupIds array
@@ -42,7 +42,7 @@ param roleAssignments roleAssignmentType
 param tags object?
 
 @description('Optional. Custom DNS configurations.')
-param customDnsConfigs array?
+param customDnsConfigs customDnsConfigType?
 
 @description('Optional. Manual PrivateLink Service Connections.')
 param manualPrivateLinkServiceConnections array?
@@ -187,3 +187,28 @@ type lockType = {
   @description('Optional. Specify the type of lock.')
   kind: ('CanNotDelete' | 'ReadOnly' | 'None')?
 }?
+
+type ipConfigurationsType = {
+  @description('Required. The name of the resource that is unique within a resource group.')
+  name: string
+
+  @description('Required. Properties of private endpoint IP configurations.')
+  properties: {
+    @description('Required. The ID of a group obtained from the remote resource that this private endpoint should connect to.')
+    groupId: string
+
+    @description('Required. The member name of a group obtained from the remote resource that this private endpoint should connect to.')
+    memberName: string
+
+    @description('Required. A private ip address obtained from the private endpoint\'s subnet.')
+    privateIPAddress: string
+  }
+}[]?
+
+type customDnsConfigType = {
+  @description('Required. Fqdn that resolves to private endpoint ip address.')
+  fqdn: string
+
+  @description('Required. A list of private ip addresses of the private endpoint.')
+  ipAddresses: string[]
+}[]?

--- a/avm/res/network/private-endpoint/main.json
+++ b/avm/res/network/private-endpoint/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "2788827530274342759"
+      "templateHash": "1208381918996235289"
     },
     "name": "Private Endpoints",
     "description": "This module deploys a Private Endpoint.",

--- a/avm/res/network/private-endpoint/main.json
+++ b/avm/res/network/private-endpoint/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "1208381918996235289"
+      "templateHash": "13477311172998188302"
     },
     "name": "Private Endpoints",
     "description": "This module deploys a Private Endpoint.",
@@ -205,7 +205,6 @@
     },
     "ipConfigurations": {
       "$ref": "#/definitions/ipConfigurationsType",
-      "nullable": true,
       "metadata": {
         "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
       }
@@ -258,7 +257,6 @@
     },
     "customDnsConfigs": {
       "$ref": "#/definitions/customDnsConfigType",
-      "nullable": true,
       "metadata": {
         "description": "Optional. Custom DNS configurations."
       }

--- a/avm/res/network/private-endpoint/main.json
+++ b/avm/res/network/private-endpoint/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.21.1.54444",
-      "templateHash": "13152465847704433697"
+      "version": "0.22.6.54827",
+      "templateHash": "3825640575007850444"
     },
     "name": "Private Endpoints",
     "description": "This module deploys a Private Endpoint.",
@@ -103,6 +103,71 @@
         }
       },
       "nullable": true
+    },
+    "ipConfigurationsType": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "metadata": {
+              "description": "Required. The name of the resource that is unique within a resource group."
+            }
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "groupId": {
+                "type": "string",
+                "metadata": {
+                  "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to."
+                }
+              },
+              "memberName": {
+                "type": "string",
+                "metadata": {
+                  "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to."
+                }
+              },
+              "privateIPAddress": {
+                "type": "string",
+                "metadata": {
+                  "description": "Required. A private ip address obtained from the private endpoint's subnet."
+                }
+              }
+            },
+            "metadata": {
+              "description": "Required. Properties of private endpoint IP configurations."
+            }
+          }
+        }
+      },
+      "nullable": true
+    },
+    "customDnsConfigType": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "fqdn": {
+            "type": "string",
+            "metadata": {
+              "description": "Required. Fqdn that resolves to private endpoint ip address."
+            }
+          },
+          "ipAddresses": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "metadata": {
+              "description": "Required. A list of private ip addresses of the private endpoint."
+            }
+          }
+        }
+      },
+      "nullable": true
     }
   },
   "parameters": {
@@ -139,7 +204,7 @@
       }
     },
     "ipConfigurations": {
-      "type": "array",
+      "$ref": "#/definitions/ipConfigurationsType",
       "nullable": true,
       "metadata": {
         "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
@@ -192,7 +257,7 @@
       }
     },
     "customDnsConfigs": {
-      "type": "array",
+      "$ref": "#/definitions/customDnsConfigType",
       "nullable": true,
       "metadata": {
         "description": "Optional. Custom DNS configurations."
@@ -345,8 +410,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "1698104586574073002"
+              "version": "0.22.6.54827",
+              "templateHash": "10665671629187108342"
             },
             "name": "Private Endpoint Private DNS Zone Groups",
             "description": "This module deploys a Private Endpoint Private DNS Zone Group.",

--- a/avm/res/network/private-endpoint/private-dns-zone-group/main.json
+++ b/avm/res/network/private-endpoint/private-dns-zone-group/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.21.1.54444",
-      "templateHash": "1698104586574073002"
+      "version": "0.22.6.54827",
+      "templateHash": "10665671629187108342"
     },
     "name": "Private Endpoint Private DNS Zone Groups",
     "description": "This module deploys a Private Endpoint Private DNS Zone Group.",

--- a/avm/res/network/private-endpoint/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/private-endpoint/tests/e2e/max/main.test.bicep
@@ -83,6 +83,14 @@ module testDeployment '../../../main.bicep' = [for iteration in [ 'init', 'idem'
         }
       }
     ]
+    customDnsConfigs: [
+      {
+        fqdn: 'abc.keyvault.com'
+        ipAddresses: [
+          '10.0.0.10'
+        ]
+      }
+    ]
     customNetworkInterfaceName: '${namePrefix}${serviceShort}001nic'
     applicationSecurityGroupResourceIds: [
       nestedDependencies.outputs.applicationSecurityGroupResourceId
@@ -94,7 +102,6 @@ module testDeployment '../../../main.bicep' = [for iteration in [ 'init', 'idem'
     }
     // Workaround for PSRule
     privateDnsZoneGroupName: 'default'
-    customDnsConfigs: []
     manualPrivateLinkServiceConnections: []
   }
 }]

--- a/avm/res/network/private-endpoint/version.json
+++ b/avm/res/network/private-endpoint/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.1",
+    "version": "0.2",
     "pathFilters": [
         "./main.json"
     ]

--- a/avm/res/network/private-endpoint/version.json
+++ b/avm/res/network/private-endpoint/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.2",
+    "version": "0.1",
     "pathFilters": [
         "./main.json"
     ]


### PR DESCRIPTION
## Description

This enables User defined types for two properties of the Private Endpoints module: 
- `ipConfigurations`
- `customDnsConfigs`

Why?

Other modules that rely on the Private endpoints (i.e. Key Vault) will fail to deploy private endpoints if static IPs are to be used for the PE. 

Merging this PR requires also updating modules that use the PE to add test cases for these two new properties. Currently they are not working and would fail if static IPs are used.

## Updating an existing module

[![avm.res.network.private-endpoint](https://github.com/ahmadabdalla/bicep-registry-modules/actions/workflows/avm.res.network.private-endpoint.yml/badge.svg?branch=users%2Fahmad%2FPE_Updates)](https://github.com/ahmadabdalla/bicep-registry-modules/actions/workflows/avm.res.network.private-endpoint.yml)

- [ ] This is a bug fix:
  - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
  - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
- [ ] I have run `brm validate` locally to verify the module files.
- [x] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](https://github.com/Azure/bicep-registry-modules/blob/main/CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [x] The PR contains backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
  - [ ] The PR contains backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
- [ ] I have updated the examples in README with the latest module version number.
