### PR TITLE
fix: Operational Insights Workspace module - fixed static tests

### DIFF
--- a/avm/res/operational-insights/workspace/README.md
+++ b/avm/res/operational-insights/workspace/README.md
@@ -807,6 +807,16 @@ module workspace 'br/public:avm/res/operational-insights/workspace:<version>' = 
         displayName: 'VMSS Instance Count2'
         name: 'VMSSQueries'
         query: 'Event | where Source == ServiceFabricNodeBootstrapAgent | summarize AggregatedValue = count() by Computer'
+        tags: [
+          {
+            Name: 'Environment'
+            Value: 'Non-Prod'
+          }
+          {
+            Name: 'Role'
+            Value: 'DeploymentValidation'
+          }
+        ]
       }
     ]
     storageInsightsConfigs: [
@@ -1018,7 +1028,17 @@ module workspace 'br/public:avm/res/operational-insights/workspace:<version>' = 
           "category": "VDC Saved Searches",
           "displayName": "VMSS Instance Count2",
           "name": "VMSSQueries",
-          "query": "Event | where Source == ServiceFabricNodeBootstrapAgent | summarize AggregatedValue = count() by Computer"
+          "query": "Event | where Source == ServiceFabricNodeBootstrapAgent | summarize AggregatedValue = count() by Computer",
+          "tags": [
+            {
+              "Name": "Environment",
+              "Value": "Non-Prod"
+            },
+            {
+              "Name": "Role",
+              "Value": "DeploymentValidation"
+            }
+          ]
         }
       ]
     },

--- a/avm/res/operational-insights/workspace/main.bicep
+++ b/avm/res/operational-insights/workspace/main.bicep
@@ -359,7 +359,7 @@ type roleAssignmentType = {
   principalId: string
 
   @description('Optional. The principal type of the assigned principal ID.')
-  principalType: ('ServicePrincipal' | 'Group' | 'User' | 'ForeignGroup' | 'Device' | null)?
+  principalType: ('ServicePrincipal' | 'Group' | 'User' | 'ForeignGroup' | 'Device')?
 
   @description('Optional. The description of the role assignment.')
   description: string?

--- a/avm/res/operational-insights/workspace/main.json
+++ b/avm/res/operational-insights/workspace/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "474198188697109867"
+      "templateHash": "8966393892715059668"
     },
     "name": "Log Analytics Workspaces",
     "description": "This module deploys a Log Analytics Workspace.",
@@ -946,12 +946,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.23.1.45101",
-              "templateHash": "2765164120781162803"
+              "templateHash": "17009532885229273685"
             },
             "name": "Log Analytics Workspace Saved Searches",
             "description": "This module deploys a Log Analytics Workspace Saved Search.",
@@ -990,7 +991,7 @@
             },
             "tags": {
               "type": "array",
-              "defaultValue": [],
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Tags to configure in the resource."
               }
@@ -1024,8 +1025,14 @@
               }
             }
           },
-          "resources": [
-            {
+          "resources": {
+            "workspace": {
+              "existing": true,
+              "type": "Microsoft.OperationalInsights/workspaces",
+              "apiVersion": "2022-10-01",
+              "name": "[parameters('logAnalyticsWorkspaceName')]"
+            },
+            "savedSearch": {
               "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
               "apiVersion": "2020-08-01",
               "name": "[format('{0}/{1}', parameters('logAnalyticsWorkspaceName'), parameters('name'))]",
@@ -1038,9 +1045,12 @@
                 "functionAlias": "[parameters('functionAlias')]",
                 "functionParameters": "[parameters('functionParameters')]",
                 "version": "[parameters('version')]"
-              }
+              },
+              "dependsOn": [
+                "workspace"
+              ]
             }
-          ],
+          },
           "outputs": {
             "resourceId": {
               "type": "string",

--- a/avm/res/operational-insights/workspace/main.json
+++ b/avm/res/operational-insights/workspace/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "8966393892715059668"
+      "templateHash": "18390575590170506674"
     },
     "name": "Log Analytics Workspaces",
     "description": "This module deploys a Log Analytics Workspace.",
@@ -952,7 +952,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.23.1.45101",
-              "templateHash": "17009532885229273685"
+              "templateHash": "15380855553217354458"
             },
             "name": "Log Analytics Workspace Saved Searches",
             "description": "This module deploys a Log Analytics Workspace Saved Search.",
@@ -1038,7 +1038,7 @@
               "name": "[format('{0}/{1}', parameters('logAnalyticsWorkspaceName'), parameters('name'))]",
               "properties": {
                 "etag": "[parameters('etag')]",
-                "tags": "[parameters('tags')]",
+                "tags": "[coalesce(parameters('tags'), createArray())]",
                 "displayName": "[parameters('displayName')]",
                 "category": "[parameters('category')]",
                 "query": "[parameters('query')]",

--- a/avm/res/operational-insights/workspace/saved-search/README.md
+++ b/avm/res/operational-insights/workspace/saved-search/README.md
@@ -98,7 +98,6 @@ Kusto Query to be stored.
 Tags to configure in the resource.
 - Required: No
 - Type: array
-- Default: `[]`
 
 ### Parameter: `version`
 

--- a/avm/res/operational-insights/workspace/saved-search/main.bicep
+++ b/avm/res/operational-insights/workspace/saved-search/main.bicep
@@ -42,7 +42,7 @@ resource savedSearch 'Microsoft.OperationalInsights/workspaces/savedSearches@202
   //etag: etag // According to API, the variable should be here, but it doesn't work here.
   properties: {
     etag: etag
-    tags: tags
+    tags: tags ?? []
     displayName: displayName
     category: category
     query: query

--- a/avm/res/operational-insights/workspace/saved-search/main.bicep
+++ b/avm/res/operational-insights/workspace/saved-search/main.bicep
@@ -18,7 +18,7 @@ param category string
 param query string
 
 @description('Optional. Tags to configure in the resource.')
-param tags array = []
+param tags array?
 
 @description('Optional. The function alias if query serves as a function.')
 param functionAlias string = ''

--- a/avm/res/operational-insights/workspace/saved-search/main.json
+++ b/avm/res/operational-insights/workspace/saved-search/main.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
   "contentVersion": "1.0.0.0",
   "metadata": {
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "2765164120781162803"
+      "templateHash": "17009532885229273685"
     },
     "name": "Log Analytics Workspace Saved Searches",
     "description": "This module deploys a Log Analytics Workspace Saved Search.",
@@ -44,7 +45,7 @@
     },
     "tags": {
       "type": "array",
-      "defaultValue": [],
+      "nullable": true,
       "metadata": {
         "description": "Optional. Tags to configure in the resource."
       }
@@ -78,8 +79,14 @@
       }
     }
   },
-  "resources": [
-    {
+  "resources": {
+    "workspace": {
+      "existing": true,
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2022-10-01",
+      "name": "[parameters('logAnalyticsWorkspaceName')]"
+    },
+    "savedSearch": {
       "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
       "apiVersion": "2020-08-01",
       "name": "[format('{0}/{1}', parameters('logAnalyticsWorkspaceName'), parameters('name'))]",
@@ -92,9 +99,12 @@
         "functionAlias": "[parameters('functionAlias')]",
         "functionParameters": "[parameters('functionParameters')]",
         "version": "[parameters('version')]"
-      }
+      },
+      "dependsOn": [
+        "workspace"
+      ]
     }
-  ],
+  },
   "outputs": {
     "resourceId": {
       "type": "string",

--- a/avm/res/operational-insights/workspace/saved-search/main.json
+++ b/avm/res/operational-insights/workspace/saved-search/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "17009532885229273685"
+      "templateHash": "15380855553217354458"
     },
     "name": "Log Analytics Workspace Saved Searches",
     "description": "This module deploys a Log Analytics Workspace Saved Search.",
@@ -92,7 +92,7 @@
       "name": "[format('{0}/{1}', parameters('logAnalyticsWorkspaceName'), parameters('name'))]",
       "properties": {
         "etag": "[parameters('etag')]",
-        "tags": "[parameters('tags')]",
+        "tags": "[coalesce(parameters('tags'), createArray())]",
         "displayName": "[parameters('displayName')]",
         "category": "[parameters('category')]",
         "query": "[parameters('query')]",

--- a/avm/res/operational-insights/workspace/tests/e2e/max/main.test.bicep
+++ b/avm/res/operational-insights/workspace/tests/e2e/max/main.test.bicep
@@ -203,6 +203,16 @@ module testDeployment '../../../main.bicep' = [for iteration in [ 'init', 'idem'
         displayName: 'VMSS Instance Count2'
         name: 'VMSSQueries'
         query: 'Event | where Source == ServiceFabricNodeBootstrapAgent | summarize AggregatedValue = count() by Computer'
+        tags: [
+          {
+            Name: 'Environment'
+            Value: 'Non-Prod'
+          }
+          {
+            Name: 'Role'
+            Value: 'DeploymentValidation'
+          }
+        ]
       }
     ]
     storageInsightsConfigs: [


### PR DESCRIPTION
## Description

PR contains following fixes of the Log Analytics Workspace module:
- fixed static tests by changing the parameter to nullable
- Updated definition of the Role Assignment UDT to the newest version
- Added test of tags in the saved-search child module. Now one of the test deploys tags, the other not.

## Pipeline references

| Pipeline |
| - |
| [![avm.res.operational-insights.workspace](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml/badge.svg?branch=users%2Fkrbar%2FlogAnalyticsFixes)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml) |
