### PR TITLE
fix: removed availablityZone from `avm/res/db-for-postgre-sql/flexible-server`

### DIFF
--- a/avm/res/db-for-postgre-sql/flexible-server/README.md
+++ b/avm/res/db-for-postgre-sql/flexible-server/README.md
@@ -392,7 +392,6 @@ module flexibleServer 'br/public:avm/res/db-for-postgre-sql/flexible-server:<ver
         principalType: 'ServicePrincipal'
       }
     ]
-    availabilityZone: '1'
     backupRetentionDays: 20
     configurations: [
       {
@@ -487,9 +486,6 @@ module flexibleServer 'br/public:avm/res/db-for-postgre-sql/flexible-server:<ver
           "principalType": "ServicePrincipal"
         }
       ]
-    },
-    "availabilityZone": {
-      "value": "1"
     },
     "backupRetentionDays": {
       "value": 20

--- a/avm/res/db-for-postgre-sql/flexible-server/tests/e2e/public/main.test.bicep
+++ b/avm/res/db-for-postgre-sql/flexible-server/tests/e2e/public/main.test.bicep
@@ -73,7 +73,6 @@ module testDeployment '../../../main.bicep' = [for iteration in [ 'init', 'idem'
     ]
     skuName: 'Standard_D2s_v3'
     tier: 'GeneralPurpose'
-    availabilityZone: '1'
     backupRetentionDays: 20
     configurations: [
       {


### PR DESCRIPTION
## Description

Removed availablityZone parameter from the `public` test case due to Azure Region capacity restrictions.
