### PR TITLE
fix: `avm/res/operational-insights/workspace/saved-search` - suppressing false positive bicep warning

### DIFF
--- a/avm/res/operational-insights/workspace/saved-search/main.bicep
+++ b/avm/res/operational-insights/workspace/saved-search/main.bicep
@@ -41,6 +41,7 @@ resource savedSearch 'Microsoft.OperationalInsights/workspaces/savedSearches@202
   parent: workspace
   //etag: etag // According to API, the variable should be here, but it doesn't work here.
   properties: {
+    #disable-next-line BCP037 // This is a false positive, the 'etag' property works here even if the documentation suggests that it sohuld be placed one leve higher.
     etag: etag
     tags: tags ?? []
     displayName: displayName


### PR DESCRIPTION
## Description

Suppressed an inaccurate bicep warning: 
`The property "etag" is not allowed on objects of type "SavedSearchProperties". No other properties are allowed. If this is an inaccuracy in the documentation, please report it to the Bicep Team.`

Some additional context: https://github.com/Azure/ResourceModules/issues/1570

| Pipeline |
| - |
| [![avm.res.operational-insights.workspace](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml/badge.svg?branch=users%2Fkrbar%2FlawNoWarning)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml) |