### PR TITLE
fix: `avm-res-web-serverfarms`

### DIFF
--- a/avm/res/web/serverfarm/README.md
+++ b/avm/res/web/serverfarm/README.md
@@ -54,7 +54,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
       tier: 'Premium'
     }
     // Non-required parameters
-    location: '<location>'
+    location: 'northeurope'
   }
 }
 ```
@@ -86,7 +86,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
     },
     // Non-required parameters
     "location": {
-      "value": "<location>"
+      "value": "northeurope"
     }
   }
 }
@@ -133,7 +133,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
       }
     ]
     kind: 'App'
-    location: '<location>'
+    location: 'northeurope'
     lock: {
       kind: 'CanNotDelete'
       name: 'lock'
@@ -212,7 +212,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
       "value": "App"
     },
     "location": {
-      "value": "<location>"
+      "value": "northeurope"
     },
     "lock": {
       "value": {
@@ -297,7 +297,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
       }
     ]
     kind: 'App'
-    location: '<location>'
+    location: 'northeurope'
     lock: {
       kind: 'CanNotDelete'
       name: 'lock'
@@ -358,7 +358,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
       "value": "App"
     },
     "location": {
-      "value": "<location>"
+      "value": "northeurope"
     },
     "lock": {
       "value": {

--- a/avm/res/web/serverfarm/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/defaults/main.test.bicep
@@ -41,7 +41,7 @@ module testDeployment '../../../main.bicep' = [for iteration in [ 'init', 'idem'
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}-${iteration}'
   params: {
     name: '${namePrefix}${serviceShort}001'
-    location: location
+    location: 'northeurope'
     sku: {
       name: 'P1v3'
       tier: 'Premium'

--- a/avm/res/web/serverfarm/tests/e2e/max/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/max/main.test.bicep
@@ -62,7 +62,7 @@ module testDeployment '../../../main.bicep' = [for iteration in [ 'init', 'idem'
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}-${iteration}'
   params: {
     name: '${namePrefix}${serviceShort}001'
-    location: location
+    location: 'northeurope'
     sku: {
       name: 'P1v3'
       tier: 'Premium'

--- a/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
@@ -53,7 +53,7 @@ module testDeployment '../../../main.bicep' = [for iteration in [ 'init', 'idem'
   name: '${uniqueString(deployment().name, location)}-test-${serviceShort}-${iteration}'
   params: {
     name: '${namePrefix}${serviceShort}001'
-    location: location
+    location: 'northeurope'
     sku: {
       name: 'P1v3'
       tier: 'Premium'


### PR DESCRIPTION
## Description

Following PR #700. Capacity in WestEurope is running low for compute. Qouta limits have been imposed on non priority subscriptions ultimately causing the deployment test to fail. Deployment Test has now been changed to North Europe. And the subscription Quota should be checked before merging.

| Pipeline | 
| -------- | 
| [![avm.res.web.serverfarm](https://github.com/ChrisSidebotham/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml/badge.svg?branch=anchor)](https://github.com/ChrisSidebotham/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml) |