### PR TITLE
fix: demoloyment-scripts/aks-run-helm needs 'rbacRolesNeeded' parameter option

### DIFF
--- a/modules/deployment-scripts/aks-run-helm/README.md
+++ b/modules/deployment-scripts/aks-run-helm/README.md
@@ -17,6 +17,7 @@ More information about using Helm on Azure can be found [here](https://docs.micr
 | `aksName`                                  | `string` | Yes      | The name of the Azure Kubernetes Service                                        |
 | `location`                                 | `string` | No       | The location to deploy the resources to                                         |
 | `forceUpdateTag`                           | `string` | No       | How the deployment script should be forced to execute                           |
+| `rbacRolesNeeded`                          | `array`  | No       | An array of Azure RoleIds that are required for the DeploymentScript resource   |
 | `useExistingManagedIdentity`               | `bool`   | No       | Does the Managed Identity already exists, or should be created                  |
 | `managedIdentityName`                      | `string` | No       | Name of the Managed Identity resource                                           |
 | `existingManagedIdentitySubId`             | `string` | No       | For an existing Managed Identity, the Subscription Id it is located in          |

--- a/modules/deployment-scripts/aks-run-helm/main.json
+++ b/modules/deployment-scripts/aks-run-helm/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.19.5.34762",
-      "templateHash": "13146146605378120228"
+      "version": "0.24.24.22086",
+      "templateHash": "17747110168699216519"
     },
     "name": "AKS Run Helm Script",
     "description": "An Azure CLI Deployment Script that allows you to run a Helm command at a Kubernetes cluster.",
@@ -30,6 +30,16 @@
       "defaultValue": "[utcNow()]",
       "metadata": {
         "description": "How the deployment script should be forced to execute"
+      }
+    },
+    "rbacRolesNeeded": {
+      "type": "array",
+      "defaultValue": [
+        "b24988ac-6180-42a0-ab88-20f7382dd24c",
+        "7f6c6a51-bcf8-42ba-9220-52d62157d7db"
+      ],
+      "metadata": {
+        "description": "An array of Azure RoleIds that are required for the DeploymentScript resource"
       }
     },
     "useExistingManagedIdentity": {
@@ -84,14 +94,14 @@
     "cleanupPreference": {
       "type": "string",
       "defaultValue": "OnSuccess",
-      "metadata": {
-        "description": "When the script resource is cleaned up"
-      },
       "allowedValues": [
         "OnSuccess",
         "OnExpiration",
         "Always"
-      ]
+      ],
+      "metadata": {
+        "description": "When the script resource is cleaned up"
+      }
     }
   },
   "resources": [
@@ -123,9 +133,10 @@
           "forceUpdateTag": {
             "value": "[parameters('forceUpdateTag')]"
           },
-          "useExistingManagedIdentity": {
-            "value": "[parameters('useExistingManagedIdentity')]"
+          "rbacRolesNeeded": {
+            "value": "[parameters('rbacRolesNeeded')]"
           },
+          "newOrExistingManagedIdentity": "[if(parameters('useExistingManagedIdentity'), createObject('value', 'existing'), createObject('value', 'new'))]",
           "managedIdentityName": {
             "value": "[parameters('managedIdentityName')]"
           },
@@ -145,9 +156,12 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.5.6.12127",
-              "templateHash": "25989803949072927"
-            }
+              "version": "0.19.5.34762",
+              "templateHash": "14134297598922776972"
+            },
+            "name": "AKS Run Command Script",
+            "description": "An Azure CLI Deployment Script that allows you to run a command on a Kubernetes cluster.",
+            "owner": "Aks-Bicep-Accelerator-Maintainers"
           },
           "parameters": {
             "aksName": {
@@ -158,7 +172,6 @@
             },
             "location": {
               "type": "string",
-              "defaultValue": "[resourceGroup().location]",
               "metadata": {
                 "description": "The location to deploy the resources to"
               }
@@ -180,16 +193,20 @@
                 "description": "An array of Azure RoleIds that are required for the DeploymentScript resource"
               }
             },
-            "useExistingManagedIdentity": {
-              "type": "bool",
-              "defaultValue": false,
+            "newOrExistingManagedIdentity": {
+              "type": "string",
+              "defaultValue": "new",
+              "allowedValues": [
+                "new",
+                "existing"
+              ],
               "metadata": {
-                "description": "Does the Managed Identity already exists, or should be created"
+                "description": "Create \"new\" or use \"existing\" Managed Identity. Default: new"
               }
             },
             "managedIdentityName": {
               "type": "string",
-              "defaultValue": "id-AksRunCommandProxy",
+              "defaultValue": "[format('id-AksRunCommandProxy-{0}', parameters('location'))]",
               "metadata": {
                 "description": "Name of the Managed Identity resource"
               }
@@ -232,13 +249,25 @@
                 "OnExpiration",
                 "Always"
               ]
+            },
+            "isCrossTenant": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Set to true when deploying template across tenants"
+              }
             }
+          },
+          "variables": {
+            "$fxv#0": "#!/bin/bash\n\nset -e +H\n# -e to exit on error\n# +H to prevent history expansion\n\nif [ \"$loopIndex\" == \"0\" ] && [ \"$initialDelay\" != \"0\" ]\nthen\n    echo \"Waiting on RBAC replication ($initialDelay)\"\n    sleep $initialDelay\n\n    #Force RBAC refresh\n    az logout\n    az login --identity\nfi\n\necho \"Sending command $command to AKS Cluster $aksName in $RG\"\ncmdOut=$(az aks command invoke -g $RG -n $aksName -o json --command \"${command}\")\necho $cmdOut\n\njsonOutputString=$cmdOut\necho $jsonOutputString > $AZ_SCRIPTS_OUTPUT_PATH\n",
+            "useExistingManagedIdentity": "[equals(parameters('newOrExistingManagedIdentity'), 'existing')]",
+            "delegatedManagedIdentityResourceId": "[if(variables('useExistingManagedIdentity'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('existingManagedIdentitySubId'), parameters('existingManagedIdentityResourceGroupName')), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')))]"
           },
           "resources": [
             {
-              "condition": "[not(parameters('useExistingManagedIdentity'))]",
+              "condition": "[not(variables('useExistingManagedIdentity'))]",
               "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
-              "apiVersion": "2018-11-30",
+              "apiVersion": "2023-01-31",
               "name": "[parameters('managedIdentityName')]",
               "location": "[parameters('location')]"
             },
@@ -248,13 +277,14 @@
                 "count": "[length(parameters('rbacRolesNeeded'))]"
               },
               "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2020-08-01-preview",
+              "apiVersion": "2022-04-01",
               "scope": "[format('Microsoft.ContainerService/managedClusters/{0}', parameters('aksName'))]",
-              "name": "[guid(resourceId('Microsoft.ContainerService/managedClusters', parameters('aksName')), parameters('rbacRolesNeeded')[copyIndex()], if(parameters('useExistingManagedIdentity'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('existingManagedIdentitySubId'), parameters('existingManagedIdentityResourceGroupName')), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName'))))]",
+              "name": "[guid(resourceId('Microsoft.ContainerService/managedClusters', parameters('aksName')), parameters('rbacRolesNeeded')[copyIndex()], if(variables('useExistingManagedIdentity'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('existingManagedIdentitySubId'), parameters('existingManagedIdentityResourceGroupName')), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName'))))]",
               "properties": {
-                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', parameters('rbacRolesNeeded')[copyIndex()])]",
-                "principalId": "[if(parameters('useExistingManagedIdentity'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('existingManagedIdentitySubId'), parameters('existingManagedIdentityResourceGroupName')), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), '2018-11-30').principalId, reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), '2018-11-30').principalId)]",
-                "principalType": "ServicePrincipal"
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', parameters('rbacRolesNeeded')[copyIndex()])]",
+                "principalId": "[if(variables('useExistingManagedIdentity'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('existingManagedIdentitySubId'), parameters('existingManagedIdentityResourceGroupName')), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), '2023-01-31').principalId, reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), '2023-01-31').principalId)]",
+                "principalType": "ServicePrincipal",
+                "delegatedManagedIdentityResourceId": "[if(parameters('isCrossTenant'), variables('delegatedManagedIdentityResourceId'), null())]"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName'))]"
@@ -274,7 +304,7 @@
               "identity": {
                 "type": "UserAssigned",
                 "userAssignedIdentities": {
-                  "[format('{0}', if(parameters('useExistingManagedIdentity'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('existingManagedIdentitySubId'), parameters('existingManagedIdentityResourceGroupName')), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName'))))]": {}
+                  "[format('{0}', if(variables('useExistingManagedIdentity'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('existingManagedIdentitySubId'), parameters('existingManagedIdentityResourceGroupName')), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName'))))]": {}
                 }
               },
               "kind": "AzureCLI",
@@ -305,7 +335,7 @@
                     "value": "[string(copyIndex())]"
                   }
                 ],
-                "scriptContent": "      #!/bin/bash\n      set -e\n\n      if [ \"$loopIndex\" == \"0\" ] && [ \"$initialDelay\" != \"0\" ]\n      then\n        echo \"Waiting on RBAC replication ($initialDelay)\"\n        sleep $initialDelay\n\n        #Force RBAC refresh\n        az logout\n        az login --identity\n      fi\n\n      echo \"Sending command $command to AKS Cluster $aksName in $RG\"\n      cmdOut=$(az aks command invoke -g $RG -n $aksName -o json --command \"${command}\")\n      echo $cmdOut\n\n      jsonOutputString=$cmdOut\n      echo $jsonOutputString > $AZ_SCRIPTS_OUTPUT_PATH\n    ",
+                "scriptContent": "[variables('$fxv#0')]",
                 "cleanupPreference": "[parameters('cleanupPreference')]"
               },
               "dependsOn": [
@@ -317,16 +347,16 @@
           "outputs": {
             "commandOutput": {
               "type": "array",
+              "metadata": {
+                "description": "Array of command output from each Deployment Script AKS run command"
+              },
               "copy": {
                 "count": "[length(parameters('commands'))]",
                 "input": {
                   "Index": "[copyIndex()]",
                   "Name": "[format('AKS-Run-{0}-{1}-{2}', parameters('aksName'), deployment().name, copyIndex())]",
-                  "CommandOutput": "[reference(resourceId('Microsoft.Resources/deploymentScripts', format('AKS-Run-{0}-{1}-{2}', parameters('aksName'), deployment().name, copyIndex()))).outputs]"
+                  "CommandOutput": "[reference(resourceId('Microsoft.Resources/deploymentScripts', format('AKS-Run-{0}-{1}-{2}', parameters('aksName'), deployment().name, copyIndex())), '2020-10-01').outputs]"
                 }
-              },
-              "metadata": {
-                "description": "Array of command output from each Deployment Script AKS run command"
               }
             }
           }

--- a/modules/deployment-scripts/aks-run-helm/version.json
+++ b/modules/deployment-scripts/aks-run-helm/version.json
@@ -2,7 +2,6 @@
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
   "version": "v2.0",
   "pathFilters": [
-    "./main.json",
-    "./metadata.json"
+    "./main.json"
   ]
 }


### PR DESCRIPTION
fixes #776


## Description

I added this param because aks-run-helm can't install charts propery because of insufficent roles assignments.
And test template were also failed becaose of same reason.

I also fixed the test case bacause
- typo of helm option
- update the chart version

fixes #776 

## Updating an existing module

<!--Run through the checklist if your PR updates an existing module.-->

- [x] This is a bug fix:
  - [x] Someone has opened a bug report issue, and I have included "Closes #776" in the PR description.
  - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.  
- [x] I have run `brm validate` locally to verify the module files.
- [x] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](https://github.com/Azure/bicep-registry-modules/blob/main/CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [x] The PR contains backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
  - [ ] The PR contains backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
- [x] I have updated the examples in README with the latest module version number.
