### PR TITLE
fix: Module `avm/res/web/site` array index is out of bounds issue

### DIFF
--- a/avm/res/web/site/config--appsettings/main.bicep
+++ b/avm/res/web/site/config--appsettings/main.bicep
@@ -45,13 +45,13 @@ resource app 'Microsoft.Web/sites@2022-09-01' existing = {
 }
 
 resource appInsight 'Microsoft.Insights/components@2020-02-02' existing = if (!empty(appInsightResourceId)) {
-  name: last(split(appInsightResourceId ?? '', '/'))!
-  scope: resourceGroup(split(appInsightResourceId ?? '', '/')[2], split(appInsightResourceId ?? '', '/')[4])
+  name: last(split(appInsightResourceId ?? 'dummyName', '/'))
+  scope: resourceGroup(split(appInsightResourceId ?? '//', '/')[2], split(appInsightResourceId ?? '////', '/')[4])
 }
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = if (!empty(storageAccountResourceId)) {
-  name: last(split(storageAccountResourceId ?? '', '/'))!
-  scope: resourceGroup(split(storageAccountResourceId ?? '', '/')[2], split(storageAccountResourceId ?? '', '/')[4])
+  name: last(split(storageAccountResourceId ?? 'dummyName', '/'))
+  scope: resourceGroup(split(storageAccountResourceId ?? '//', '/')[2], split(storageAccountResourceId ?? '////', '/')[4])
 }
 
 resource appSettings 'Microsoft.Web/sites/config@2022-09-01' = {

--- a/avm/res/web/site/config--appsettings/main.json
+++ b/avm/res/web/site/config--appsettings/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.24.24.22086",
-      "templateHash": "3735013939266613858"
+      "templateHash": "16772310332668493999"
     },
     "name": "Site App Settings",
     "description": "This module deploys a Site App Setting.",
@@ -73,25 +73,25 @@
       "existing": true,
       "type": "Microsoft.Insights/components",
       "apiVersion": "2020-02-02",
-      "subscriptionId": "[split(coalesce(parameters('appInsightResourceId'), ''), '/')[2]]",
-      "resourceGroup": "[split(coalesce(parameters('appInsightResourceId'), ''), '/')[4]]",
-      "name": "[last(split(coalesce(parameters('appInsightResourceId'), ''), '/'))]"
+      "subscriptionId": "[split(coalesce(parameters('appInsightResourceId'), '//'), '/')[2]]",
+      "resourceGroup": "[split(coalesce(parameters('appInsightResourceId'), '////'), '/')[4]]",
+      "name": "[last(split(coalesce(parameters('appInsightResourceId'), 'dummyName'), '/'))]"
     },
     "storageAccount": {
       "condition": "[not(empty(parameters('storageAccountResourceId')))]",
       "existing": true,
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2023-01-01",
-      "subscriptionId": "[split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2]]",
-      "resourceGroup": "[split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]]",
-      "name": "[last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))]"
+      "subscriptionId": "[split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2]]",
+      "resourceGroup": "[split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]]",
+      "name": "[last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))]"
     },
     "appSettings": {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2022-09-01",
       "name": "[format('{0}/{1}', parameters('appName'), 'appsettings')]",
       "kind": "[parameters('kind')]",
-      "properties": "[union(coalesce(parameters('appSettingsKeyValuePairs'), createObject()), if(not(empty(parameters('storageAccountResourceId'))), union(createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2], split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))), '2023-01-01').keys[0].value)), if(equals(parameters('setAzureWebJobsDashboard'), true()), createObject('AzureWebJobsDashboard', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2], split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))), '2023-01-01').keys[0].value)), createObject())), createObject()), if(not(empty(parameters('appInsightResourceId'))), createObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference('appInsight').InstrumentationKey, 'APPLICATIONINSIGHTS_CONNECTION_STRING', reference('appInsight').ConnectionString), createObject()))]",
+      "properties": "[union(coalesce(parameters('appSettingsKeyValuePairs'), createObject()), if(not(empty(parameters('storageAccountResourceId'))), union(createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), '2023-01-01').keys[0].value)), if(equals(parameters('setAzureWebJobsDashboard'), true()), createObject('AzureWebJobsDashboard', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), '2023-01-01').keys[0].value)), createObject())), createObject()), if(not(empty(parameters('appInsightResourceId'))), createObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference('appInsight').InstrumentationKey, 'APPLICATIONINSIGHTS_CONNECTION_STRING', reference('appInsight').ConnectionString), createObject()))]",
       "dependsOn": [
         "app",
         "appInsight",

--- a/avm/res/web/site/main.json
+++ b/avm/res/web/site/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.24.24.22086",
-      "templateHash": "12442626664527443863"
+      "templateHash": "1531810359747805653"
     },
     "name": "Web/Function Apps",
     "description": "This module deploys a Web or Function App.",
@@ -628,7 +628,7 @@
         "Required"
       ],
       "metadata": {
-        "description": "Optional. This composes with ClientCertEnabled setting.\n- ClientCertEnabled=false means ClientCert is ignored.\n- ClientCertEnabled=true and ClientCertMode=Required means ClientCert is required.\n- ClientCertEnabled=true and ClientCertMode=Optional means ClientCert is optional or accepted.\n"
+        "description": "Optional. This composes with ClientCertEnabled setting.\r\n- ClientCertEnabled=false means ClientCert is ignored.\r\n- ClientCertEnabled=true and ClientCertMode=Required means ClientCert is required.\r\n- ClientCertEnabled=true and ClientCertMode=Optional means ClientCert is optional or accepted.\r\n"
       }
     },
     "cloningInfo": {
@@ -887,7 +887,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.24.24.22086",
-              "templateHash": "3735013939266613858"
+              "templateHash": "16772310332668493999"
             },
             "name": "Site App Settings",
             "description": "This module deploys a Site App Setting.",
@@ -954,25 +954,25 @@
               "existing": true,
               "type": "Microsoft.Insights/components",
               "apiVersion": "2020-02-02",
-              "subscriptionId": "[split(coalesce(parameters('appInsightResourceId'), ''), '/')[2]]",
-              "resourceGroup": "[split(coalesce(parameters('appInsightResourceId'), ''), '/')[4]]",
-              "name": "[last(split(coalesce(parameters('appInsightResourceId'), ''), '/'))]"
+              "subscriptionId": "[split(coalesce(parameters('appInsightResourceId'), '//'), '/')[2]]",
+              "resourceGroup": "[split(coalesce(parameters('appInsightResourceId'), '////'), '/')[4]]",
+              "name": "[last(split(coalesce(parameters('appInsightResourceId'), 'dummyName'), '/'))]"
             },
             "storageAccount": {
               "condition": "[not(empty(parameters('storageAccountResourceId')))]",
               "existing": true,
               "type": "Microsoft.Storage/storageAccounts",
               "apiVersion": "2023-01-01",
-              "subscriptionId": "[split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2]]",
-              "resourceGroup": "[split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]]",
-              "name": "[last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))]"
+              "subscriptionId": "[split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2]]",
+              "resourceGroup": "[split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]]",
+              "name": "[last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))]"
             },
             "appSettings": {
               "type": "Microsoft.Web/sites/config",
               "apiVersion": "2022-09-01",
               "name": "[format('{0}/{1}', parameters('appName'), 'appsettings')]",
               "kind": "[parameters('kind')]",
-              "properties": "[union(coalesce(parameters('appSettingsKeyValuePairs'), createObject()), if(not(empty(parameters('storageAccountResourceId'))), union(createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2], split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))), '2023-01-01').keys[0].value)), if(equals(parameters('setAzureWebJobsDashboard'), true()), createObject('AzureWebJobsDashboard', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2], split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))), '2023-01-01').keys[0].value)), createObject())), createObject()), if(not(empty(parameters('appInsightResourceId'))), createObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference('appInsight').InstrumentationKey, 'APPLICATIONINSIGHTS_CONNECTION_STRING', reference('appInsight').ConnectionString), createObject()))]",
+              "properties": "[union(coalesce(parameters('appSettingsKeyValuePairs'), createObject()), if(not(empty(parameters('storageAccountResourceId'))), union(createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), '2023-01-01').keys[0].value)), if(equals(parameters('setAzureWebJobsDashboard'), true()), createObject('AzureWebJobsDashboard', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), '2023-01-01').keys[0].value)), createObject())), createObject()), if(not(empty(parameters('appInsightResourceId'))), createObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference('appInsight').InstrumentationKey, 'APPLICATIONINSIGHTS_CONNECTION_STRING', reference('appInsight').ConnectionString), createObject()))]",
               "dependsOn": [
                 "app",
                 "appInsight",
@@ -1256,7 +1256,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.24.24.22086",
-              "templateHash": "13458641455647274431"
+              "templateHash": "14287529092911845504"
             },
             "name": "Web/Function App Deployment Slots",
             "description": "This module deploys a Web or Function App Deployment Slot.",
@@ -2121,7 +2121,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.24.24.22086",
-                      "templateHash": "10616094367902686039"
+                      "templateHash": "9605115891306784861"
                     },
                     "name": "Site Slot App Settings",
                     "description": "This module deploys a Site Slot App Setting.",
@@ -2203,25 +2203,25 @@
                       "existing": true,
                       "type": "Microsoft.Insights/components",
                       "apiVersion": "2020-02-02",
-                      "subscriptionId": "[split(coalesce(parameters('appInsightResourceId'), ''), '/')[2]]",
-                      "resourceGroup": "[split(coalesce(parameters('appInsightResourceId'), ''), '/')[4]]",
-                      "name": "[last(split(coalesce(parameters('appInsightResourceId'), ''), '/'))]"
+                      "subscriptionId": "[split(coalesce(parameters('appInsightResourceId'), '//'), '/')[2]]",
+                      "resourceGroup": "[split(coalesce(parameters('appInsightResourceId'), '////'), '/')[4]]",
+                      "name": "[last(split(coalesce(parameters('appInsightResourceId'), 'dummyName'), '/'))]"
                     },
                     "storageAccount": {
                       "condition": "[not(empty(parameters('storageAccountResourceId')))]",
                       "existing": true,
                       "type": "Microsoft.Storage/storageAccounts",
                       "apiVersion": "2023-01-01",
-                      "subscriptionId": "[split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2]]",
-                      "resourceGroup": "[split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]]",
-                      "name": "[last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))]"
+                      "subscriptionId": "[split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2]]",
+                      "resourceGroup": "[split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]]",
+                      "name": "[last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))]"
                     },
                     "slotSettings": {
                       "type": "Microsoft.Web/sites/slots/config",
                       "apiVersion": "2022-09-01",
                       "name": "[format('{0}/{1}/{2}', parameters('appName'), parameters('slotName'), 'appsettings')]",
                       "kind": "[parameters('kind')]",
-                      "properties": "[union(coalesce(parameters('appSettingsKeyValuePairs'), createObject()), if(not(empty(parameters('storageAccountResourceId'))), union(createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2], split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))), '2023-01-01').keys[0].value)), if(equals(parameters('setAzureWebJobsDashboard'), true()), createObject('AzureWebJobsDashboard', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2], split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))), '2023-01-01').keys[0].value)), createObject())), createObject()), if(not(empty(parameters('appInsightResourceId'))), createObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference('appInsight').InstrumentationKey, 'APPLICATIONINSIGHTS_CONNECTION_STRING', reference('appInsight').ConnectionString), createObject()))]",
+                      "properties": "[union(coalesce(parameters('appSettingsKeyValuePairs'), createObject()), if(not(empty(parameters('storageAccountResourceId'))), union(createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), '2023-01-01').keys[0].value)), if(equals(parameters('setAzureWebJobsDashboard'), true()), createObject('AzureWebJobsDashboard', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), '2023-01-01').keys[0].value)), createObject())), createObject()), if(not(empty(parameters('appInsightResourceId'))), createObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference('appInsight').InstrumentationKey, 'APPLICATIONINSIGHTS_CONNECTION_STRING', reference('appInsight').ConnectionString), createObject()))]",
                       "dependsOn": [
                         "appInsight",
                         "app::slot",

--- a/avm/res/web/site/main.json
+++ b/avm/res/web/site/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.24.24.22086",
-      "templateHash": "1531810359747805653"
+      "templateHash": "6827854649814438473"
     },
     "name": "Web/Function Apps",
     "description": "This module deploys a Web or Function App.",
@@ -628,7 +628,7 @@
         "Required"
       ],
       "metadata": {
-        "description": "Optional. This composes with ClientCertEnabled setting.\r\n- ClientCertEnabled=false means ClientCert is ignored.\r\n- ClientCertEnabled=true and ClientCertMode=Required means ClientCert is required.\r\n- ClientCertEnabled=true and ClientCertMode=Optional means ClientCert is optional or accepted.\r\n"
+        "description": "Optional. This composes with ClientCertEnabled setting.\n- ClientCertEnabled=false means ClientCert is ignored.\n- ClientCertEnabled=true and ClientCertMode=Required means ClientCert is required.\n- ClientCertEnabled=true and ClientCertMode=Optional means ClientCert is optional or accepted.\n"
       }
     },
     "cloningInfo": {

--- a/avm/res/web/site/slot/config--appsettings/main.bicep
+++ b/avm/res/web/site/slot/config--appsettings/main.bicep
@@ -52,13 +52,13 @@ resource app 'Microsoft.Web/sites@2022-09-01' existing = {
 }
 
 resource appInsight 'Microsoft.Insights/components@2020-02-02' existing = if (!empty(appInsightResourceId)) {
-  name: last(split(appInsightResourceId ?? '', '/'))!
-  scope: resourceGroup(split(appInsightResourceId ?? '', '/')[2], split(appInsightResourceId ?? '', '/')[4])
+  name: last(split(appInsightResourceId ?? 'dummyName', '/'))
+  scope: resourceGroup(split(appInsightResourceId ?? '//', '/')[2], split(appInsightResourceId ?? '////', '/')[4])
 }
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = if (!empty(storageAccountResourceId)) {
-  name: last(split(storageAccountResourceId ?? '', '/'))!
-  scope: resourceGroup(split(storageAccountResourceId ?? '', '/')[2], split(storageAccountResourceId ?? '', '/')[4])
+  name: last(split(storageAccountResourceId ?? 'dummyName', '/'))!
+  scope: resourceGroup(split(storageAccountResourceId ?? '//', '/')[2], split(storageAccountResourceId ?? '////', '/')[4])
 }
 
 resource slotSettings 'Microsoft.Web/sites/slots/config@2022-09-01' = {

--- a/avm/res/web/site/slot/config--appsettings/main.json
+++ b/avm/res/web/site/slot/config--appsettings/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.24.24.22086",
-      "templateHash": "10616094367902686039"
+      "templateHash": "9605115891306784861"
     },
     "name": "Site Slot App Settings",
     "description": "This module deploys a Site Slot App Setting.",
@@ -88,25 +88,25 @@
       "existing": true,
       "type": "Microsoft.Insights/components",
       "apiVersion": "2020-02-02",
-      "subscriptionId": "[split(coalesce(parameters('appInsightResourceId'), ''), '/')[2]]",
-      "resourceGroup": "[split(coalesce(parameters('appInsightResourceId'), ''), '/')[4]]",
-      "name": "[last(split(coalesce(parameters('appInsightResourceId'), ''), '/'))]"
+      "subscriptionId": "[split(coalesce(parameters('appInsightResourceId'), '//'), '/')[2]]",
+      "resourceGroup": "[split(coalesce(parameters('appInsightResourceId'), '////'), '/')[4]]",
+      "name": "[last(split(coalesce(parameters('appInsightResourceId'), 'dummyName'), '/'))]"
     },
     "storageAccount": {
       "condition": "[not(empty(parameters('storageAccountResourceId')))]",
       "existing": true,
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2023-01-01",
-      "subscriptionId": "[split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2]]",
-      "resourceGroup": "[split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]]",
-      "name": "[last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))]"
+      "subscriptionId": "[split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2]]",
+      "resourceGroup": "[split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]]",
+      "name": "[last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))]"
     },
     "slotSettings": {
       "type": "Microsoft.Web/sites/slots/config",
       "apiVersion": "2022-09-01",
       "name": "[format('{0}/{1}/{2}', parameters('appName'), parameters('slotName'), 'appsettings')]",
       "kind": "[parameters('kind')]",
-      "properties": "[union(coalesce(parameters('appSettingsKeyValuePairs'), createObject()), if(not(empty(parameters('storageAccountResourceId'))), union(createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2], split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))), '2023-01-01').keys[0].value)), if(equals(parameters('setAzureWebJobsDashboard'), true()), createObject('AzureWebJobsDashboard', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2], split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))), '2023-01-01').keys[0].value)), createObject())), createObject()), if(not(empty(parameters('appInsightResourceId'))), createObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference('appInsight').InstrumentationKey, 'APPLICATIONINSIGHTS_CONNECTION_STRING', reference('appInsight').ConnectionString), createObject()))]",
+      "properties": "[union(coalesce(parameters('appSettingsKeyValuePairs'), createObject()), if(not(empty(parameters('storageAccountResourceId'))), union(createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), '2023-01-01').keys[0].value)), if(equals(parameters('setAzureWebJobsDashboard'), true()), createObject('AzureWebJobsDashboard', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), '2023-01-01').keys[0].value)), createObject())), createObject()), if(not(empty(parameters('appInsightResourceId'))), createObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference('appInsight').InstrumentationKey, 'APPLICATIONINSIGHTS_CONNECTION_STRING', reference('appInsight').ConnectionString), createObject()))]",
       "dependsOn": [
         "appInsight",
         "app::slot",

--- a/avm/res/web/site/slot/main.json
+++ b/avm/res/web/site/slot/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.24.24.22086",
-      "templateHash": "13458641455647274431"
+      "templateHash": "14287529092911845504"
     },
     "name": "Web/Function App Deployment Slots",
     "description": "This module deploys a Web or Function App Deployment Slot.",
@@ -871,7 +871,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.24.24.22086",
-              "templateHash": "10616094367902686039"
+              "templateHash": "9605115891306784861"
             },
             "name": "Site Slot App Settings",
             "description": "This module deploys a Site Slot App Setting.",
@@ -953,25 +953,25 @@
               "existing": true,
               "type": "Microsoft.Insights/components",
               "apiVersion": "2020-02-02",
-              "subscriptionId": "[split(coalesce(parameters('appInsightResourceId'), ''), '/')[2]]",
-              "resourceGroup": "[split(coalesce(parameters('appInsightResourceId'), ''), '/')[4]]",
-              "name": "[last(split(coalesce(parameters('appInsightResourceId'), ''), '/'))]"
+              "subscriptionId": "[split(coalesce(parameters('appInsightResourceId'), '//'), '/')[2]]",
+              "resourceGroup": "[split(coalesce(parameters('appInsightResourceId'), '////'), '/')[4]]",
+              "name": "[last(split(coalesce(parameters('appInsightResourceId'), 'dummyName'), '/'))]"
             },
             "storageAccount": {
               "condition": "[not(empty(parameters('storageAccountResourceId')))]",
               "existing": true,
               "type": "Microsoft.Storage/storageAccounts",
               "apiVersion": "2023-01-01",
-              "subscriptionId": "[split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2]]",
-              "resourceGroup": "[split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]]",
-              "name": "[last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))]"
+              "subscriptionId": "[split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2]]",
+              "resourceGroup": "[split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]]",
+              "name": "[last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))]"
             },
             "slotSettings": {
               "type": "Microsoft.Web/sites/slots/config",
               "apiVersion": "2022-09-01",
               "name": "[format('{0}/{1}/{2}', parameters('appName'), parameters('slotName'), 'appsettings')]",
               "kind": "[parameters('kind')]",
-              "properties": "[union(coalesce(parameters('appSettingsKeyValuePairs'), createObject()), if(not(empty(parameters('storageAccountResourceId'))), union(createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2], split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))), '2023-01-01').keys[0].value)), if(equals(parameters('setAzureWebJobsDashboard'), true()), createObject('AzureWebJobsDashboard', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), ''), '/')[2], split(coalesce(parameters('storageAccountResourceId'), ''), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), ''), '/'))), '2023-01-01').keys[0].value)), createObject())), createObject()), if(not(empty(parameters('appInsightResourceId'))), createObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference('appInsight').InstrumentationKey, 'APPLICATIONINSIGHTS_CONNECTION_STRING', reference('appInsight').ConnectionString), createObject()))]",
+              "properties": "[union(coalesce(parameters('appSettingsKeyValuePairs'), createObject()), if(not(empty(parameters('storageAccountResourceId'))), union(createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), '2023-01-01').keys[0].value)), if(equals(parameters('setAzureWebJobsDashboard'), true()), createObject('AzureWebJobsDashboard', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/')), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('storageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('storageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('storageAccountResourceId'), 'dummyName'), '/'))), '2023-01-01').keys[0].value)), createObject())), createObject()), if(not(empty(parameters('appInsightResourceId'))), createObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference('appInsight').InstrumentationKey, 'APPLICATIONINSIGHTS_CONNECTION_STRING', reference('appInsight').ConnectionString), createObject()))]",
               "dependsOn": [
                 "appInsight",
                 "app::slot",

--- a/avm/res/web/site/version.json
+++ b/avm/res/web/site/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.1",
+    "version": "0.2",
     "pathFilters": [
         "./main.json"
     ]


### PR DESCRIPTION
## Description

Fixing the `The language expression property array index '2' is out of bounds..` issue in the module `avm/res/web/site`. The issue occurs in a specific scenario: when `appSettingsKeyValuePairs` parameter is not empty, but at the same time the `appInsightResourceId` or `storageAccountResourceId` is not provided.

## Pipeline references

| Pipeline |
| - |
| [![avm.res.web.site](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.web.site.yml/badge.svg?branch=users%2Fkrbar%2FwebSiteArrayFix)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.web.site.yml) |
