### PR TITLE
fix: Global Resources in Region Selection

### DIFF
--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -83,7 +83,7 @@ runs:
           Write-Verbose "Invoke function with" -Verbose
           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-          $resourceLocation = Get-AzAvailableResourceLocation @functionInput
+          $resourceLocation = Get-AzAvailableResourceLocation @functionInput -Verbose
 
           $deploymentLocation = @{}
           Write-Verbose ('{0}-{1}' -f 'resourceLocation', $resourceLocation) -Verbose

--- a/avm/utilities/pipelines/e2eValidation/regionSelector/Get-AzAvailableResourceLocation.ps1
+++ b/avm/utilities/pipelines/e2eValidation/regionSelector/Get-AzAvailableResourceLocation.ps1
@@ -67,7 +67,7 @@ function Get-AzAvailableResourceLocation {
 
   if ($resourceRegionList -eq "global") {
     Write-Verbose "Resource is global, no region selection required"
-    $location = "global"
+    $location = "westeurope" # Using West Europe for resource group location. GLobabl resources should have hardocded location in `main.bicep`
   }
   else {
 

--- a/avm/utilities/pipelines/e2eValidation/regionSelector/Get-AzAvailableResourceLocation.ps1
+++ b/avm/utilities/pipelines/e2eValidation/regionSelector/Get-AzAvailableResourceLocation.ps1
@@ -66,7 +66,7 @@ function Get-AzAvailableResourceLocation {
   Write-Verbose "Region list: $($resourceRegionList | ConvertTo-Json)"
 
   if ($resourceRegionList -eq "global") {
-    Write-Verbose "Resource is global, no region selection required"
+    Write-Verbose "Resource is global, default region [West Europe] will be used for resource group creation"
     $location = "westeurope" # Using West Europe for resource group location. GLobabl resources should have hardocded location in `main.bicep`
   }
   else {

--- a/avm/utilities/pipelines/e2eValidation/regionSelector/Get-AzAvailableResourceLocation.ps1
+++ b/avm/utilities/pipelines/e2eValidation/regionSelector/Get-AzAvailableResourceLocation.ps1
@@ -65,19 +65,27 @@ function Get-AzAvailableResourceLocation {
   $ResourceRegionList = (Get-AzResourceProvider | Where-Object { $_.ProviderNamespace -eq $formattedResourceProvider }).ResourceTypes | Where-Object { $_.ResourceTypeName -eq $formattedServiceName } | Select-Object -ExpandProperty Locations
   Write-Verbose "Region list: $($resourceRegionList | ConvertTo-Json)"
 
-  $locations = Get-AzLocation | Where-Object {
-    $_.DisplayName -in $ResourceRegionList -and
-    $_.Location -notin $ExcludedRegions -and
-    $_.PairedRegion -ne "{}" -and
-    $_.RegionCategory -eq "Recommended"
-  } |  Select-Object -ExpandProperty Location
-  Write-Verbose "Available Locations: $($locations | ConvertTo-Json)"
+  if ($resourceRegionList -eq "global") {
+    Write-Verbose "Resource is global, no region selection required"
+    $location = "global"
+  }
+  else {
+
+    $locations = Get-AzLocation | Where-Object {
+      $_.DisplayName -in $ResourceRegionList -and
+      $_.Location -notin $ExcludedRegions -and
+      $_.PairedRegion -ne "{}" -and
+      $_.RegionCategory -eq "Recommended"
+    } |  Select-Object -ExpandProperty Location
+    Write-Verbose "Available Locations: $($locations | ConvertTo-Json)"
 
 
-  $index = Get-Random -Maximum ($locations.Count)
-  Write-Verbose "Generated random index [$index]"
+    $index = Get-Random -Maximum ($locations.Count)
+    Write-Verbose "Generated random index [$index]"
 
-  $location = $locations[$index]
+    $location = $locations[$index]
+
+  }
   Write-Verbose "Selected location [$location]" -Verbose
 
   return $location


### PR DESCRIPTION
## Description 

Global Resources was being filtered out due to a missing condition as 'Global' is not recognised by Get-AzLocation

## Tests

[![avm.res.resource-graph.query](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resource-graph.query.yml/badge.svg)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resource-graph.query.yml)
