### PR TITLE
fix: Resolve transition to read-only GH TOKEN

### DIFF
--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -31,6 +30,10 @@ on:
       - "avm/res/analysis-services/server/**"
       - "avm/utilities/pipelines/**"
       - "!*/**/README.md"
+
+permissions:
+  id-token: write # For OIDC
+  contents: write # For release tags
 
 env:
   modulePath: "avm/res/analysis-services/server"

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -31,10 +31,6 @@ on:
       - "avm/utilities/pipelines/**"
       - "!*/**/README.md"
 
-permissions:
-  id-token: write # For OIDC
-  contents: write # For release tags
-
 env:
   modulePath: "avm/res/analysis-services/server"
   workflowPath: ".github/workflows/avm.res.analysis-services.server.yml"

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -71,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.api-management.service.yml
+++ b/.github/workflows/avm.res.api-management.service.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.app.container-app.yml
+++ b/.github/workflows/avm.res.app.container-app.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -71,7 +70,10 @@ jobs:
   #   Call reusable workflow   #
   ##############################
   call-workflow-passing-data:
-    name: "Module"
+    name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.app.managed-environment.yml
+++ b/.github/workflows/avm.res.app.managed-environment.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -71,7 +70,10 @@ jobs:
   #   Call reusable workflow   #
   ##############################
   call-workflow-passing-data:
-    name: "Module"
+    name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.automation.automation-account.yml
+++ b/.github/workflows/avm.res.automation.automation-account.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.batch.batch-account.yml
+++ b/.github/workflows/avm.res.batch.batch-account.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.cache.redis.yml
+++ b/.github/workflows/avm.res.cache.redis.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.cognitive-services.account.yml
+++ b/.github/workflows/avm.res.cognitive-services.account.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.compute.availability-set.yml
+++ b/.github/workflows/avm.res.compute.availability-set.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.compute.disk-encryption-set.yml
+++ b/.github/workflows/avm.res.compute.disk-encryption-set.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.compute.disk.yml
+++ b/.github/workflows/avm.res.compute.disk.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.compute.gallery.yml
+++ b/.github/workflows/avm.res.compute.gallery.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.compute.image.yml
+++ b/.github/workflows/avm.res.compute.image.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.compute.proximity-placement-group.yml
+++ b/.github/workflows/avm.res.compute.proximity-placement-group.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.compute.ssh-public-key.yml
+++ b/.github/workflows/avm.res.compute.ssh-public-key.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.compute.virtual-machine.yml
+++ b/.github/workflows/avm.res.compute.virtual-machine.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.consumption.budget.yml
+++ b/.github/workflows/avm.res.consumption.budget.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.container-registry.registry.yml
+++ b/.github/workflows/avm.res.container-registry.registry.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.container-service.managed-cluster.yml
+++ b/.github/workflows/avm.res.container-service.managed-cluster.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -71,7 +70,10 @@ jobs:
   #   Call reusable workflow   #
   ##############################
   call-workflow-passing-data:
-    name: "Module"
+    name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.data-factory.factory.yml
+++ b/.github/workflows/avm.res.data-factory.factory.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.data-protection.backup-vault.yml
+++ b/.github/workflows/avm.res.data-protection.backup-vault.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.databricks.access-connector.yml
+++ b/.github/workflows/avm.res.databricks.access-connector.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.databricks.workspace.yml
+++ b/.github/workflows/avm.res.databricks.workspace.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.db-for-my-sql.flexible-server.yml
+++ b/.github/workflows/avm.res.db-for-my-sql.flexible-server.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.db-for-postgre-sql.flexible-server.yml
+++ b/.github/workflows/avm.res.db-for-postgre-sql.flexible-server.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.desktop-virtualization.application-group.yml
+++ b/.github/workflows/avm.res.desktop-virtualization.application-group.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.desktop-virtualization.scaling-plan.yml
+++ b/.github/workflows/avm.res.desktop-virtualization.scaling-plan.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.document-db.database-account.yml
+++ b/.github/workflows/avm.res.document-db.database-account.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.event-grid.domain.yml
+++ b/.github/workflows/avm.res.event-grid.domain.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.event-grid.system-topic.yml
+++ b/.github/workflows/avm.res.event-grid.system-topic.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.event-grid.topic.yml
+++ b/.github/workflows/avm.res.event-grid.topic.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.health-bot.health-bot.yml
+++ b/.github/workflows/avm.res.health-bot.health-bot.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.insights.action-group.yml
+++ b/.github/workflows/avm.res.insights.action-group.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.insights.activity-log-alert.yml
+++ b/.github/workflows/avm.res.insights.activity-log-alert.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.insights.component.yml
+++ b/.github/workflows/avm.res.insights.component.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.insights.data-collection-endpoint.yml
+++ b/.github/workflows/avm.res.insights.data-collection-endpoint.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.insights.data-collection-rule.yml
+++ b/.github/workflows/avm.res.insights.data-collection-rule.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.insights.diagnostic-setting.yml
+++ b/.github/workflows/avm.res.insights.diagnostic-setting.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.insights.metric-alert.yml
+++ b/.github/workflows/avm.res.insights.metric-alert.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.insights.scheduled-query-rule.yml
+++ b/.github/workflows/avm.res.insights.scheduled-query-rule.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.insights.webtest.yml
+++ b/.github/workflows/avm.res.insights.webtest.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.key-vault.vault.yml
+++ b/.github/workflows/avm.res.key-vault.vault.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.kubernetes-configuration.extension.yml
+++ b/.github/workflows/avm.res.kubernetes-configuration.extension.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.kubernetes-configuration.flux-configuration.yml
+++ b/.github/workflows/avm.res.kubernetes-configuration.flux-configuration.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.logic.workflow.yml
+++ b/.github/workflows/avm.res.logic.workflow.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.maintenance.maintenance-configuration.yml
+++ b/.github/workflows/avm.res.maintenance.maintenance-configuration.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.managed-identity.user-assigned-identity.yml
+++ b/.github/workflows/avm.res.managed-identity.user-assigned-identity.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.net-app.net-app-account.yml
+++ b/.github/workflows/avm.res.net-app.net-app-account.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.application-security-group.yml
+++ b/.github/workflows/avm.res.network.application-security-group.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.bastion-host.yml
+++ b/.github/workflows/avm.res.network.bastion-host.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.connection.yml
+++ b/.github/workflows/avm.res.network.connection.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.ddos-protection-plan.yml
+++ b/.github/workflows/avm.res.network.ddos-protection-plan.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.dns-forwarding-ruleset.yml
+++ b/.github/workflows/avm.res.network.dns-forwarding-ruleset.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.dns-resolver.yml
+++ b/.github/workflows/avm.res.network.dns-resolver.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.dns-zone.yml
+++ b/.github/workflows/avm.res.network.dns-zone.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.express-route-circuit.yml
+++ b/.github/workflows/avm.res.network.express-route-circuit.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.express-route-gateway.yml
+++ b/.github/workflows/avm.res.network.express-route-gateway.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.firewall-policy.yml
+++ b/.github/workflows/avm.res.network.firewall-policy.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.front-door-web-application-firewall-policy.yml
+++ b/.github/workflows/avm.res.network.front-door-web-application-firewall-policy.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.front-door.yml
+++ b/.github/workflows/avm.res.network.front-door.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.load-balancer.yml
+++ b/.github/workflows/avm.res.network.load-balancer.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.local-network-gateway.yml
+++ b/.github/workflows/avm.res.network.local-network-gateway.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.nat-gateway.yml
+++ b/.github/workflows/avm.res.network.nat-gateway.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -71,7 +70,10 @@ jobs:
   #   Call reusable workflow   #
   ##############################
   call-workflow-passing-data:
-    name: "Module"
+    name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.network-interface.yml
+++ b/.github/workflows/avm.res.network.network-interface.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.network-security-group.yml
+++ b/.github/workflows/avm.res.network.network-security-group.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.private-dns-zone.yml
+++ b/.github/workflows/avm.res.network.private-dns-zone.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.private-endpoint.yml
+++ b/.github/workflows/avm.res.network.private-endpoint.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.private-endpoint.yml
+++ b/.github/workflows/avm.res.network.private-endpoint.yml
@@ -32,10 +32,6 @@ on:
       - "avm/utilities/pipelines/**"
       - "!*/**/README.md"
 
-permissions:
-  id-token: write # For OIDC
-  # contents: write # For release tags
-
 env:
   modulePath: "avm/res/network/private-endpoint"
   workflowPath: ".github/workflows/avm.res.network.private-endpoint.yml"

--- a/.github/workflows/avm.res.network.private-endpoint.yml
+++ b/.github/workflows/avm.res.network.private-endpoint.yml
@@ -32,6 +32,10 @@ on:
       - "avm/utilities/pipelines/**"
       - "!*/**/README.md"
 
+permissions:
+  id-token: write # For OIDC
+  # contents: write # For release tags
+
 env:
   modulePath: "avm/res/network/private-endpoint"
   workflowPath: ".github/workflows/avm.res.network.private-endpoint.yml"

--- a/.github/workflows/avm.res.network.public-ip-address.yml
+++ b/.github/workflows/avm.res.network.public-ip-address.yml
@@ -23,7 +23,6 @@ on:
   push:
     branches:
       - main
-      - fix/eriqua/gh-token
     paths:
       - ".github/actions/templates/avm-**"
       - ".github/workflows/avm.template.module.yml"

--- a/.github/workflows/avm.res.network.public-ip-address.yml
+++ b/.github/workflows/avm.res.network.public-ip-address.yml
@@ -23,6 +23,7 @@ on:
   push:
     branches:
       - main
+      - fix/eriqua/gh-token
     paths:
       - ".github/actions/templates/avm-**"
       - ".github/workflows/avm.template.module.yml"

--- a/.github/workflows/avm.res.network.public-ip-address.yml
+++ b/.github/workflows/avm.res.network.public-ip-address.yml
@@ -72,6 +72,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.public-ip-address.yml
+++ b/.github/workflows/avm.res.network.public-ip-address.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main

--- a/.github/workflows/avm.res.network.public-ip-prefix.yml
+++ b/.github/workflows/avm.res.network.public-ip-prefix.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.route-table.yml
+++ b/.github/workflows/avm.res.network.route-table.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.trafficmanagerprofile.yml
+++ b/.github/workflows/avm.res.network.trafficmanagerprofile.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.virtual-network-gateway.yml
+++ b/.github/workflows/avm.res.network.virtual-network-gateway.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.virtual-network.yml
+++ b/.github/workflows/avm.res.network.virtual-network.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.vpn-gateway.yml
+++ b/.github/workflows/avm.res.network.vpn-gateway.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.network.vpn-site.yml
+++ b/.github/workflows/avm.res.network.vpn-site.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.operational-insights.workspace.yml
+++ b/.github/workflows/avm.res.operational-insights.workspace.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.operations-management.solution.yml
+++ b/.github/workflows/avm.res.operations-management.solution.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.power-bi-dedicated.capacity.yml
+++ b/.github/workflows/avm.res.power-bi-dedicated.capacity.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.resource-graph.query.yml
+++ b/.github/workflows/avm.res.resource-graph.query.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.resources.deployment-script.yml
+++ b/.github/workflows/avm.res.resources.deployment-script.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.resources.resource-group.yml
+++ b/.github/workflows/avm.res.resources.resource-group.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.search.search-service.yml
+++ b/.github/workflows/avm.res.search.search-service.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.service-bus.namespace.yml
+++ b/.github/workflows/avm.res.service-bus.namespace.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.sql.server.yml
+++ b/.github/workflows/avm.res.sql.server.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.storage.storage-account.yml
+++ b/.github/workflows/avm.res.storage.storage-account.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.web.serverfarm.yml
+++ b/.github/workflows/avm.res.web.serverfarm.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.web.site.yml
+++ b/.github/workflows/avm.res.web.site.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.web.static-site.yml
+++ b/.github/workflows/avm.res.web.static-site.yml
@@ -20,7 +20,6 @@ on:
         description: "Remove deployed module"
         required: false
         default: true
-
   push:
     branches:
       - main
@@ -72,6 +71,9 @@ jobs:
   ##############################
   call-workflow-passing-data:
     name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.template.module.yml
+++ b/.github/workflows/avm.template.module.yml
@@ -116,6 +116,9 @@ jobs:
   job_publish_module: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
     name: "Publishing"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
     if: github.ref == 'refs/heads/main' && success()
     needs:
       - job_module_deploy_validation

--- a/.github/workflows/avm.template.module.yml
+++ b/.github/workflows/avm.template.module.yml
@@ -20,10 +20,6 @@ on:
         description: "Relative path to the module folder"
         required: true
 
-# permissions:
-#   id-token: write # For OIDC
-#   contents: write # For release tags
-
 env:
   ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
   ARM_MGMTGROUP_ID: "${{ secrets.ARM_MGMTGROUP_ID }}"

--- a/.github/workflows/avm.template.module.yml
+++ b/.github/workflows/avm.template.module.yml
@@ -20,9 +20,9 @@ on:
         description: "Relative path to the module folder"
         required: true
 
-permissions:
-  id-token: write # For OIDC
-  contents: write # For release tags
+# permissions:
+#   id-token: write # For OIDC
+#   contents: write # For release tags
 
 env:
   ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"

--- a/.github/workflows/avm.template.module.yml
+++ b/.github/workflows/avm.template.module.yml
@@ -116,9 +116,6 @@ jobs:
   job_publish_module: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
     name: "Publishing"
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write # For OIDC
-      contents: write # For release tags
     if: github.ref == 'refs/heads/main' && success()
     needs:
       - job_module_deploy_validation


### PR DESCRIPTION
## Description

Closes #917 
Resolve transition to read-only GH TOKEN
Minor: renaming a few callers to reusable workflows to `"Run"` from "Module"

[![avm.res.network.public-ip-address](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml/badge.svg?branch=fix%2Feriqua%2Fgh-token)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml)
[![avm.res.analysis-services.server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml/badge.svg?branch=fix%2Feriqua%2Fgh-token)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml)