### PR TITLE
feat: mysql single server: Enable publishSource experimental feature

### DIFF
--- a/modules/storage/mysql-single-server/README.md
+++ b/modules/storage/mysql-single-server/README.md
@@ -65,7 +65,7 @@ This module requires the namespace 'Microsoft.DBforMySQL' to be registered  for 
 This example deploys a MySQL Single Server database.
 
 ```bicep
-module test01 'br/public:database/mysql-single-server:1.0.2' = {
+module test01 'br/public:database/mysql-single-server:1.0.3' = {
   name: 'test01-${serverName}'
   params: {
     prefix: 'mysql-test01'
@@ -81,7 +81,7 @@ module test01 'br/public:database/mysql-single-server:1.0.2' = {
 This example deploys a MySQL Single Server database with login and password with the sku name and firewall rules , server configurations and private endpoints.
 
 ```bicep
-module test02 'br/public:database/mysql-single-server:1.0.2' = {
+module test02 'br/public:database/mysql-single-server:1.0.3' = {
   name: 'mysqldb-${uniqueString(deployment().name, location)}-deployment'
   params: {
     prefix: 'mysql-test02'
@@ -131,7 +131,7 @@ module test02 'br/public:database/mysql-single-server:1.0.2' = {
 This example deploys a MySQL Single Server database with Role Assignments.
 
 ```bicep
-module test03 'br/public:database/mysql-single-server:1.0.2' = {
+module test03 'br/public:database/mysql-single-server:1.0.3' = {
   name: 'mysqldb-${uniqueString(deployment().name, location)}-deployment'
   params: {
     prefix: 'mysql-test04'

--- a/modules/storage/mysql-single-server/bicepconfig.json
+++ b/modules/storage/mysql-single-server/bicepconfig.json
@@ -1,5 +1,6 @@
 {
   "experimentalFeaturesEnabled": {
-    "userDefinedTypes": true
+    "userDefinedTypes": true,
+    "publishSource": true
   }
 }

--- a/modules/storage/mysql-single-server/main.json
+++ b/modules/storage/mysql-single-server/main.json
@@ -1,13 +1,12 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "languageVersion": "1.10-experimental",
+  "languageVersion": "2.0",
   "contentVersion": "1.0.0.0",
   "metadata": {
-    "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
     "_generator": {
       "name": "bicep",
-      "version": "0.19.5.34762",
-      "templateHash": "595293575967895786"
+      "version": "0.25.53.49325",
+      "templateHash": "1984152061229242648"
     },
     "name": "mysql-single-server",
     "description": "This Bicep Module is used for the deployment of MySQL DB  Single Server with reusable set of parameters and resources.",
@@ -193,11 +192,11 @@
       "properties": {
         "name": {
           "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
           "metadata": {
             "description": "The resource name."
-          },
-          "maxLength": 128,
-          "minLength": 1
+          }
         },
         "startIpAddress": {
           "type": "string",
@@ -218,11 +217,11 @@
       "properties": {
         "name": {
           "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
           "metadata": {
             "description": "The resource name."
-          },
-          "maxLength": 128,
-          "minLength": 1
+          }
         },
         "ignoreMissingVnetServiceEndpoint": {
           "type": "bool",
@@ -323,8 +322,8 @@
     "backupRetentionDays": {
       "type": "int",
       "defaultValue": 35,
-      "maxValue": 35,
       "minValue": 7,
+      "maxValue": 35,
       "metadata": {
         "description": "Optional. The number of days a backup is retained."
       }
@@ -711,14 +710,12 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "languageVersion": "1.10-experimental",
           "contentVersion": "1.0.0.0",
           "metadata": {
-            "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
             "_generator": {
               "name": "bicep",
-              "version": "0.19.5.34762",
-              "templateHash": "5901804176008778240"
+              "version": "0.25.53.49325",
+              "templateHash": "15457746991884040283"
             }
           },
           "parameters": {
@@ -761,14 +758,8 @@
             },
             "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', if(contains(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName')))]"
           },
-          "resources": {
-            "mysqlServer": {
-              "existing": true,
-              "type": "Microsoft.DBforMySQL/servers",
-              "apiVersion": "2017-12-01",
-              "name": "[parameters('serverName')]"
-            },
-            "roleAssignment": {
+          "resources": [
+            {
               "copy": {
                 "name": "roleAssignment",
                 "count": "[length(parameters('principalIds'))]"
@@ -784,7 +775,7 @@
                 "principalType": "[if(not(empty(parameters('principalType'))), parameters('principalType'), null())]"
               }
             }
-          }
+          ]
         }
       },
       "dependsOn": [
@@ -813,14 +804,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "languageVersion": "1.10-experimental",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
-            "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
             "_generator": {
               "name": "bicep",
-              "version": "0.19.5.34762",
-              "templateHash": "17584855190782240496"
+              "version": "0.25.53.49325",
+              "templateHash": "15210835296193665604"
             }
           },
           "definitions": {

--- a/modules/storage/mysql-single-server/test/main.test.bicep
+++ b/modules/storage/mysql-single-server/test/main.test.bicep
@@ -205,7 +205,7 @@ module test06 '../main.bicep' = {
         enabled: true
         retentionPolicy: {
           days: 2
-          enabled: true
+          enabled: false
         }
       }]
       diagnosticReceivers: {

--- a/modules/storage/mysql-single-server/version.json
+++ b/modules/storage/mysql-single-server/version.json
@@ -2,7 +2,6 @@
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
   "version": "1.0",
   "pathFilters": [
-    "./main.json",
-    "./metadata.json"
+    "./main.json"
   ]
 }


### PR DESCRIPTION
## Description

Enable publishSource experimental feature
In preparation for --with-source

## Updating an existing module

- [ ] This is a bug fix:
  - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
  - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
- [x] I have run `brm validate` locally to verify the module files.
- [ ] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](https://github.com/Azure/bicep-registry-modules/blob/main/CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [x] The PR contains backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
  - [ ] The PR contains backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
- [x] I have updated the examples in README with the latest module version number.
