### PR TITLE
feat: postgres single server: Enable publishSource experimental feature

### DIFF
--- a/modules/storage/postgresql-single-server/README.md
+++ b/modules/storage/postgresql-single-server/README.md
@@ -61,7 +61,7 @@ Deploy a Postgresql Single Server with minimal parameters
 @secure
 param administratorLoginPassword string
 
-module postgresqlSingleServer 'br/public:storage/postgresql-single-server:1.1.2' = {
+module postgresqlSingleServer 'br/public:storage/postgresql-single-server:1.1.3' = {
   name: 'postgresqlSingleServer'
   params: {
     prefix: 'postgresql-test01'
@@ -79,7 +79,7 @@ Deploy a Postgresql Single Server primary + replica set
 @secure
 param administratorLoginPassword string
 
-module primaryPostgresqlServer 'br/public:storage/postgresql-single-server:1.1.2' = {
+module primaryPostgresqlServer 'br/public:storage/postgresql-single-server:1.1.3' = {
   name: 'primary-server'
   params: {
     prefix: 'primary-server'
@@ -89,7 +89,7 @@ module primaryPostgresqlServer 'br/public:storage/postgresql-single-server:1.1.2
   }
 }
 
-module replicaPostgresqlServer 'br/public:storage/postgresql-single-server:1.1.2' = {
+module replicaPostgresqlServer 'br/public:storage/postgresql-single-server:1.1.3' = {
   name: 'replica-server'
   dependsOn: [
     primaryPostgresqlServer
@@ -154,7 +154,7 @@ var serverConfigurations = [
   }
 ]
 
-module postgresqlSingleServer 'br/public:storage/postgresql-single-server:1.1.2' = {
+module postgresqlSingleServer 'br/public:storage/postgresql-single-server:1.1.3' = {
   name: 'postgresqlSingleServer'
   params: {
     prefix: 'postgresql-test02'

--- a/modules/storage/postgresql-single-server/bicepconfig.json
+++ b/modules/storage/postgresql-single-server/bicepconfig.json
@@ -1,5 +1,6 @@
 {
   "experimentalFeaturesEnabled": {
-    "userDefinedTypes": true
+    "userDefinedTypes": true,
+    "publishSource": true
   }
 }

--- a/modules/storage/postgresql-single-server/main.json
+++ b/modules/storage/postgresql-single-server/main.json
@@ -1,13 +1,12 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "languageVersion": "1.10-experimental",
+  "languageVersion": "2.0",
   "contentVersion": "1.0.0.0",
   "metadata": {
-    "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
     "_generator": {
       "name": "bicep",
-      "version": "0.19.5.34762",
-      "templateHash": "16855669211188020065"
+      "version": "0.25.53.49325",
+      "templateHash": "1662678431898818602"
     },
     "name": "PostgreSQL Single Server",
     "description": "This module deploys PostgreSQL Single Server (Microsoft.DBforPostgreSQL/servers) and optionally available integrations.",
@@ -199,11 +198,11 @@
       "properties": {
         "name": {
           "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
           "metadata": {
             "description": "The resource name."
-          },
-          "maxLength": 128,
-          "minLength": 1
+          }
         },
         "startIpAddress": {
           "type": "string",
@@ -224,11 +223,11 @@
       "properties": {
         "name": {
           "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
           "metadata": {
             "description": "The resource name."
-          },
-          "maxLength": 128,
-          "minLength": 1
+          }
         },
         "ignoreMissingVnetServiceEndpoint": {
           "type": "bool",
@@ -289,11 +288,11 @@
     "serverName": {
       "type": "string",
       "defaultValue": "[parameters('name')]",
+      "minLength": 3,
+      "maxLength": 63,
       "metadata": {
         "description": "Optional. Override the name of the server."
-      },
-      "maxLength": 63,
-      "minLength": 3
+      }
     },
     "tags": {
       "type": "object",
@@ -310,17 +309,17 @@
     },
     "administratorLoginPassword": {
       "type": "securestring",
+      "minLength": 8,
+      "maxLength": 128,
       "metadata": {
         "description": "Required. The administrator login password for the SQL server. Can only be specified when the server is being created."
-      },
-      "maxLength": 128,
-      "minLength": 8
+      }
     },
     "backupRetentionDays": {
       "type": "int",
       "defaultValue": 35,
-      "maxValue": 35,
       "minValue": 7,
+      "maxValue": 35,
       "metadata": {
         "description": "Optional. The number of days a backup is retained."
       }
@@ -707,14 +706,12 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "languageVersion": "1.10-experimental",
           "contentVersion": "1.0.0.0",
           "metadata": {
-            "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
             "_generator": {
               "name": "bicep",
-              "version": "0.19.5.34762",
-              "templateHash": "12308055348995252367"
+              "version": "0.25.53.49325",
+              "templateHash": "7758610775852434142"
             }
           },
           "parameters": {
@@ -757,14 +754,8 @@
             },
             "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', if(contains(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName')))]"
           },
-          "resources": {
-            "postgresServer": {
-              "existing": true,
-              "type": "Microsoft.DBforPostgreSQL/servers",
-              "apiVersion": "2017-12-01",
-              "name": "[parameters('serverName')]"
-            },
-            "roleAssignment": {
+          "resources": [
+            {
               "copy": {
                 "name": "roleAssignment",
                 "count": "[length(parameters('principalIds'))]"
@@ -780,7 +771,7 @@
                 "principalType": "[if(not(empty(parameters('principalType'))), parameters('principalType'), null())]"
               }
             }
-          }
+          ]
         }
       },
       "dependsOn": [
@@ -809,14 +800,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "languageVersion": "1.10-experimental",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
-            "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
             "_generator": {
               "name": "bicep",
-              "version": "0.19.5.34762",
-              "templateHash": "17584855190782240496"
+              "version": "0.25.53.49325",
+              "templateHash": "15210835296193665604"
             }
           },
           "definitions": {

--- a/modules/storage/postgresql-single-server/test/main.test.bicep
+++ b/modules/storage/postgresql-single-server/test/main.test.bicep
@@ -198,7 +198,7 @@ module test06 '../main.bicep' = {
         enabled: true
         retentionPolicy: {
           days: 2
-          enabled: true
+          enabled: false
         }
       }]
       diagnosticReceivers: {

--- a/modules/storage/postgresql-single-server/version.json
+++ b/modules/storage/postgresql-single-server/version.json
@@ -2,7 +2,6 @@
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
   "version": "1.1",
   "pathFilters": [
-    "./main.json",
-    "./metadata.json"
+    "./main.json"
   ]
 }


### PR DESCRIPTION
## Description

Enable publishSource experimental feature
In preparation for --with-source

## Updating an existing module

- [ ] This is a bug fix:
  - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
  - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
- [x] I have run `brm validate` locally to verify the module files.
- [ ] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](https://github.com/Azure/bicep-registry-modules/blob/main/CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [x] The PR contains backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
  - [ ] The PR contains backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
- [x] I have updated the examples in README with the latest module version number.
