### PR TITLE
fix: storage-account module - fixing `requireInfrastructureEncryption` issue

### DIFF
--- a/avm/res/storage/storage-account/README.md
+++ b/avm/res/storage/storage-account/README.md
@@ -26,9 +26,9 @@ This module deploys a Storage Account.
 | `Microsoft.Storage/storageAccounts/blobServices/containers` | [2022-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2022-09-01/storageAccounts/blobServices/containers) |
 | `Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies` | [2022-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2022-09-01/storageAccounts/blobServices/containers/immutabilityPolicies) |
 | `Microsoft.Storage/storageAccounts/fileServices` | [2021-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2021-09-01/storageAccounts/fileServices) |
-| `Microsoft.Storage/storageAccounts/fileServices/shares` | [2023-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/storageAccounts/fileServices/shares) |
+| `Microsoft.Storage/storageAccounts/fileServices/shares` | [2023-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2023-01-01/storageAccounts/fileServices/shares) |
 | `Microsoft.Storage/storageAccounts/localUsers` | [2022-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2022-05-01/storageAccounts/localUsers) |
-| `Microsoft.Storage/storageAccounts/managementPolicies` | [2023-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/storageAccounts/managementPolicies) |
+| `Microsoft.Storage/storageAccounts/managementPolicies` | [2023-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2023-01-01/storageAccounts/managementPolicies) |
 | `Microsoft.Storage/storageAccounts/queueServices` | [2021-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2021-09-01/storageAccounts/queueServices) |
 | `Microsoft.Storage/storageAccounts/queueServices/queues` | [2021-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2021-09-01/storageAccounts/queueServices/queues) |
 | `Microsoft.Storage/storageAccounts/tableServices` | [2021-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2021-09-01/storageAccounts/tableServices) |

--- a/avm/res/storage/storage-account/blob-service/container/immutability-policy/main.json
+++ b/avm/res/storage/storage-account/blob-service/container/immutability-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.24.24.22086",
-      "templateHash": "15441426428461937893"
+      "version": "0.25.3.34343",
+      "templateHash": "18172078163140627549"
     },
     "name": "Storage Account Blob Container Immutability Policies",
     "description": "This module deploys a Storage Account Blob Container Immutability Policy.",

--- a/avm/res/storage/storage-account/blob-service/container/main.json
+++ b/avm/res/storage/storage-account/blob-service/container/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.24.24.22086",
-      "templateHash": "1429761296615247722"
+      "version": "0.25.3.34343",
+      "templateHash": "4692605911774255516"
     },
     "name": "Storage Account Blob Containers",
     "description": "This module deploys a Storage Account Blob Container.",
@@ -274,8 +274,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.24.24.22086",
-              "templateHash": "15441426428461937893"
+              "version": "0.25.3.34343",
+              "templateHash": "18172078163140627549"
             },
             "name": "Storage Account Blob Container Immutability Policies",
             "description": "This module deploys a Storage Account Blob Container Immutability Policy.",

--- a/avm/res/storage/storage-account/blob-service/main.json
+++ b/avm/res/storage/storage-account/blob-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.24.24.22086",
-      "templateHash": "6670506366627013721"
+      "version": "0.25.3.34343",
+      "templateHash": "1767452448979292347"
     },
     "name": "Storage Account blob Services",
     "description": "This module deploys a Storage Account Blob Service.",
@@ -371,8 +371,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.24.24.22086",
-              "templateHash": "1429761296615247722"
+              "version": "0.25.3.34343",
+              "templateHash": "4692605911774255516"
             },
             "name": "Storage Account Blob Containers",
             "description": "This module deploys a Storage Account Blob Container.",
@@ -640,8 +640,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.24.24.22086",
-                      "templateHash": "15441426428461937893"
+                      "version": "0.25.3.34343",
+                      "templateHash": "18172078163140627549"
                     },
                     "name": "Storage Account Blob Container Immutability Policies",
                     "description": "This module deploys a Storage Account Blob Container Immutability Policy.",

--- a/avm/res/storage/storage-account/file-service/README.md
+++ b/avm/res/storage/storage-account/file-service/README.md
@@ -16,7 +16,7 @@ This module deploys a Storage Account File Share Service.
 | :-- | :-- |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.Storage/storageAccounts/fileServices` | [2021-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2021-09-01/storageAccounts/fileServices) |
-| `Microsoft.Storage/storageAccounts/fileServices/shares` | [2023-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/storageAccounts/fileServices/shares) |
+| `Microsoft.Storage/storageAccounts/fileServices/shares` | [2023-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2023-01-01/storageAccounts/fileServices/shares) |
 
 ## Parameters
 

--- a/avm/res/storage/storage-account/file-service/main.json
+++ b/avm/res/storage/storage-account/file-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.24.24.22086",
-      "templateHash": "685043578297461233"
+      "version": "0.25.3.34343",
+      "templateHash": "525431657620027128"
     },
     "name": "Storage Account File Share Services",
     "description": "This module deploys a Storage Account File Share Service.",
@@ -254,8 +254,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.24.24.22086",
-              "templateHash": "11243515252529303304"
+              "version": "0.25.3.34343",
+              "templateHash": "17147893039694736501"
             },
             "name": "Storage Account File Shares",
             "description": "This module deploys a Storage Account File Share.",
@@ -454,8 +454,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.24.24.22086",
-                      "templateHash": "17643632023108067837"
+                      "version": "0.25.3.34343",
+                      "templateHash": "7361754328987495524"
                     }
                   },
                   "parameters": {

--- a/avm/res/storage/storage-account/file-service/share/README.md
+++ b/avm/res/storage/storage-account/file-service/share/README.md
@@ -14,7 +14,7 @@ This module deploys a Storage Account File Share.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Storage/storageAccounts/fileServices/shares` | [2023-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/storageAccounts/fileServices/shares) |
+| `Microsoft.Storage/storageAccounts/fileServices/shares` | [2023-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2023-01-01/storageAccounts/fileServices/shares) |
 
 ## Parameters
 

--- a/avm/res/storage/storage-account/file-service/share/main.json
+++ b/avm/res/storage/storage-account/file-service/share/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.24.24.22086",
-      "templateHash": "11243515252529303304"
+      "version": "0.25.3.34343",
+      "templateHash": "17147893039694736501"
     },
     "name": "Storage Account File Shares",
     "description": "This module deploys a Storage Account File Share.",
@@ -205,8 +205,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.24.24.22086",
-              "templateHash": "17643632023108067837"
+              "version": "0.25.3.34343",
+              "templateHash": "7361754328987495524"
             }
           },
           "parameters": {

--- a/avm/res/storage/storage-account/local-user/main.json
+++ b/avm/res/storage/storage-account/local-user/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.24.24.22086",
-      "templateHash": "414567084253124464"
+      "version": "0.25.3.34343",
+      "templateHash": "10424013943333306181"
     },
     "name": "Storage Account Local Users",
     "description": "This module deploys a Storage Account Local User, which is used for SFTP authentication.",

--- a/avm/res/storage/storage-account/main.json
+++ b/avm/res/storage/storage-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.25.3.34343",
-      "templateHash": "631937264961119905"
+      "templateHash": "11481386241542947145"
     },
     "name": "Storage Accounts",
     "description": "This module deploys a Storage Account.",
@@ -887,24 +887,7 @@
         },
         "dnsEndpointType": "[if(not(empty(parameters('dnsEndpointType'))), parameters('dnsEndpointType'), null())]",
         "isLocalUserEnabled": "[parameters('isLocalUserEnabled')]",
-        "encryption": {
-          "keySource": "[if(not(empty(parameters('customerManagedKey'))), 'Microsoft.Keyvault', 'Microsoft.Storage')]",
-          "services": {
-            "blob": "[if(variables('supportsBlobService'), createObject('enabled', true()), null())]",
-            "file": "[if(variables('supportsFileService'), createObject('enabled', true()), null())]",
-            "table": {
-              "enabled": true
-            },
-            "queue": {
-              "enabled": true
-            }
-          },
-          "requireInfrastructureEncryption": "[if(not(equals(parameters('kind'), 'Storage')), parameters('requireInfrastructureEncryption'), null())]",
-          "keyvaultproperties": "[if(not(empty(parameters('customerManagedKey'))), createObject('keyname', parameters('customerManagedKey').keyName, 'keyvaulturi', reference('cMKKeyVault').vaultUri, 'keyversion', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'keyVersion'), ''))), parameters('customerManagedKey').keyVersion, last(split(reference('cMKKeyVault::cMKKey').keyUriWithVersion, '/')))), null())]",
-          "identity": {
-            "userAssignedIdentity": "[if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2], split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/'))), null())]"
-          }
-        },
+        "encryption": "[union(createObject('keySource', if(not(empty(parameters('customerManagedKey'))), 'Microsoft.Keyvault', 'Microsoft.Storage'), 'services', createObject('blob', if(variables('supportsBlobService'), createObject('enabled', true()), null()), 'file', if(variables('supportsFileService'), createObject('enabled', true()), null()), 'table', createObject('enabled', true()), 'queue', createObject('enabled', true())), 'keyvaultproperties', if(not(empty(parameters('customerManagedKey'))), createObject('keyname', parameters('customerManagedKey').keyName, 'keyvaulturi', reference('cMKKeyVault').vaultUri, 'keyversion', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'keyVersion'), ''))), parameters('customerManagedKey').keyVersion, last(split(reference('cMKKeyVault::cMKKey').keyUriWithVersion, '/')))), null()), 'identity', createObject('userAssignedIdentity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2], split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/'))), null()))), if(parameters('requireInfrastructureEncryption'), createObject('requireInfrastructureEncryption', if(not(equals(parameters('kind'), 'Storage')), parameters('requireInfrastructureEncryption'), null())), createObject()))]",
         "accessTier": "[if(not(equals(parameters('kind'), 'Storage')), parameters('accessTier'), null())]",
         "sasPolicy": "[if(not(empty(parameters('sasExpirationPeriod'))), createObject('expirationAction', 'Log', 'sasExpirationPeriod', parameters('sasExpirationPeriod')), null())]",
         "supportsHttpsTrafficOnly": "[parameters('supportsHttpsTrafficOnly')]",

--- a/avm/res/storage/storage-account/management-policy/README.md
+++ b/avm/res/storage/storage-account/management-policy/README.md
@@ -14,7 +14,7 @@ This module deploys a Storage Account Management Policy.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Storage/storageAccounts/managementPolicies` | [2023-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/storageAccounts/managementPolicies) |
+| `Microsoft.Storage/storageAccounts/managementPolicies` | [2023-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2023-01-01/storageAccounts/managementPolicies) |
 
 ## Parameters
 

--- a/avm/res/storage/storage-account/management-policy/main.json
+++ b/avm/res/storage/storage-account/management-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.24.24.22086",
-      "templateHash": "17360500138014235250"
+      "version": "0.25.3.34343",
+      "templateHash": "3500765950730474634"
     },
     "name": "Storage Account Management Policies",
     "description": "This module deploys a Storage Account Management Policy.",

--- a/avm/res/storage/storage-account/queue-service/main.json
+++ b/avm/res/storage/storage-account/queue-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.24.24.22086",
-      "templateHash": "9901414791831714811"
+      "version": "0.25.3.34343",
+      "templateHash": "4596144758979274883"
     },
     "name": "Storage Account Queue Services",
     "description": "This module deploys a Storage Account Queue Service.",
@@ -218,8 +218,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.24.24.22086",
-              "templateHash": "11104056744955032379"
+              "version": "0.25.3.34343",
+              "templateHash": "15723904499918946832"
             },
             "name": "Storage Account Queues",
             "description": "This module deploys a Storage Account Queue.",

--- a/avm/res/storage/storage-account/queue-service/queue/main.json
+++ b/avm/res/storage/storage-account/queue-service/queue/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.24.24.22086",
-      "templateHash": "11104056744955032379"
+      "version": "0.25.3.34343",
+      "templateHash": "15723904499918946832"
     },
     "name": "Storage Account Queues",
     "description": "This module deploys a Storage Account Queue.",

--- a/avm/res/storage/storage-account/table-service/main.json
+++ b/avm/res/storage/storage-account/table-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.24.24.22086",
-      "templateHash": "4432761872900647010"
+      "version": "0.25.3.34343",
+      "templateHash": "11627405660929516603"
     },
     "name": "Storage Account Table Services",
     "description": "This module deploys a Storage Account Table Service.",
@@ -215,8 +215,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.24.24.22086",
-              "templateHash": "981180809348713884"
+              "version": "0.25.3.34343",
+              "templateHash": "1839032011015561279"
             },
             "name": "Storage Account Table",
             "description": "This module deploys a Storage Account Table.",

--- a/avm/res/storage/storage-account/table-service/table/main.json
+++ b/avm/res/storage/storage-account/table-service/table/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.24.24.22086",
-      "templateHash": "981180809348713884"
+      "version": "0.25.3.34343",
+      "templateHash": "1839032011015561279"
     },
     "name": "Storage Account Table",
     "description": "This module deploys a Storage Account Table.",

--- a/avm/res/storage/storage-account/version.json
+++ b/avm/res/storage/storage-account/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.6",
+    "version": "0.7",
     "pathFilters": [
         "./main.json"
     ]

--- a/avm/res/storage/storage-account/version.json
+++ b/avm/res/storage/storage-account/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.7",
+    "version": "0.6",
     "pathFilters": [
         "./main.json"
     ]


### PR DESCRIPTION
## Description

Resolves #846 

| Pipeline |
| - |
| [![avm.res.storage.storage-account](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml/badge.svg?branch=users%2Fkrbar%2F846_storageFix)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml) |

## Updating an existing module

<!--Run through the checklist if your PR updates an existing module.-->

- [x] This is a bug fix:
  - [x] Someone has opened a bug report issue, and I have included "Closes #846" in the PR description.
  - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
- [ ] I have run `brm validate` locally to verify the module files.
- [x] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](https://github.com/Azure/bicep-registry-modules/blob/main/CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [x] The PR contains backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
  - [ ] The PR contains backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
- [ ] I have updated the examples in README with the latest module version number.
