### PR TITLE
fix: Gracefully handle empty subnet properties - `avm/res/network/virtual-network`

### DIFF
--- a/avm/res/network/virtual-network/README.md
+++ b/avm/res/network/virtual-network/README.md
@@ -4,13 +4,13 @@ This module deploys a Virtual Network (vNet).
 
 ## Navigation
 
-- [Resource Types](#Resource-Types)
-- [Usage examples](#Usage-examples)
-- [Parameters](#Parameters)
-- [Outputs](#Outputs)
-- [Cross-referenced modules](#Cross-referenced-modules)
-- [Notes](#Notes)
-- [Data Collection](#Data-Collection)
+- [Resource Types](#resource-types)
+- [Usage examples](#usage-examples)
+- [Parameters](#parameters)
+- [Outputs](#outputs)
+- [Cross-referenced modules](#cross-referenced-modules)
+- [Notes](#notes)
+- [Data Collection](#data-collection)
 
 ## Resource Types
 

--- a/avm/res/network/virtual-network/main.bicep
+++ b/avm/res/network/virtual-network/main.bicep
@@ -111,23 +111,23 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
       name: subnet.name
       properties: {
         addressPrefix: subnet.addressPrefix
-        addressPrefixes: contains(subnet, 'addressPrefixes') ? subnet.addressPrefixes : []
-        applicationGatewayIPConfigurations: contains(subnet, 'applicationGatewayIPConfigurations') ? subnet.applicationGatewayIPConfigurations : []
-        delegations: contains(subnet, 'delegations') ? subnet.delegations : []
-        ipAllocations: contains(subnet, 'ipAllocations') ? subnet.ipAllocations : []
-        natGateway: contains(subnet, 'natGatewayResourceId') ? {
+        addressPrefixes: contains(subnet, 'addressPrefixes') && !empty(subnet.addressPrefixes) ? subnet.addressPrefixes : []
+        applicationGatewayIPConfigurations: contains(subnet, 'applicationGatewayIPConfigurations') && !empty(subnet.applicationGatewayIPConfigurations) ? subnet.applicationGatewayIPConfigurations : []
+        delegations: contains(subnet, 'delegations') && !empty(subnet.delegations) ? subnet.delegations : []
+        ipAllocations: contains(subnet, 'ipAllocations') && !empty(subnet.ipAllocations) ? subnet.ipAllocations : []
+        natGateway: contains(subnet, 'natGatewayResourceId') && !empty(subnet.natGatewayResourceId) ? {
           id: subnet.natGatewayResourceId
         } : null
-        networkSecurityGroup: contains(subnet, 'networkSecurityGroupResourceId') ? {
+        networkSecurityGroup: contains(subnet, 'networkSecurityGroupResourceId') && !empty(subnet.networkSecurityGroupResourceId) ? {
           id: subnet.networkSecurityGroupResourceId
         } : null
-        privateEndpointNetworkPolicies: contains(subnet, 'privateEndpointNetworkPolicies') ? subnet.privateEndpointNetworkPolicies : null
-        privateLinkServiceNetworkPolicies: contains(subnet, 'privateLinkServiceNetworkPolicies') ? subnet.privateLinkServiceNetworkPolicies : null
-        routeTable: contains(subnet, 'routeTableResourceId') ? {
+        privateEndpointNetworkPolicies: contains(subnet, 'privateEndpointNetworkPolicies') && !empty(subnet.privateEndpointNetworkPolicies) ? subnet.privateEndpointNetworkPolicies : null
+        privateLinkServiceNetworkPolicies: contains(subnet, 'privateLinkServiceNetworkPolicies') && !empty(subnet.privateLinkServiceNetworkPolicies) ? subnet.privateLinkServiceNetworkPolicies : null
+        routeTable: contains(subnet, 'routeTableResourceId') && !empty(subnet.routeTableResourceId) ? {
           id: subnet.routeTableResourceId
         } : null
-        serviceEndpoints: contains(subnet, 'serviceEndpoints') ? subnet.serviceEndpoints : []
-        serviceEndpointPolicies: contains(subnet, 'serviceEndpointPolicies') ? subnet.serviceEndpointPolicies : []
+        serviceEndpoints: contains(subnet, 'serviceEndpoints') && !empty(subnet.serviceEndpoints) ? subnet.serviceEndpoints : []
+        serviceEndpointPolicies: contains(subnet, 'serviceEndpointPolicies') && !empty(subnet.serviceEndpointPolicies) ? subnet.serviceEndpointPolicies : []
       }
     }]
   }


### PR DESCRIPTION
## Description

Closes #1026

## Updating an existing module

- [x] This is a bug fix:
  - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
  - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
- [ ] I have run `brm validate` locally to verify the module files.
- [x] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](https://github.com/Azure/bicep-registry-modules/blob/main/CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [x] The PR contains backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
  - [ ] The PR contains backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
- [x] I have updated the examples in README with the latest module version number.
