### PR TITLE
fix: firewall-policy module: Added missing 'Basic' tier value

### DIFF
--- a/avm/res/network/firewall-policy/README.md
+++ b/avm/res/network/firewall-policy/README.md
@@ -307,6 +307,7 @@ module firewallPolicy 'br/public:avm/res/network/firewall-policy:<version>' = {
       Role: 'DeploymentValidation'
     }
     threatIntelMode: 'Deny'
+    tier: 'Basic'
   }
 }
 ```
@@ -386,6 +387,9 @@ module firewallPolicy 'br/public:avm/res/network/firewall-policy:<version>' = {
     },
     "threatIntelMode": {
       "value": "Deny"
+    },
+    "tier": {
+      "value": "Basic"
     }
   }
 }
@@ -649,6 +653,7 @@ Tier of Firewall Policy.
 - Allowed:
   ```Bicep
   [
+    'Basic'
     'Premium'
     'Standard'
   ]

--- a/avm/res/network/firewall-policy/README.md
+++ b/avm/res/network/firewall-policy/README.md
@@ -307,7 +307,6 @@ module firewallPolicy 'br/public:avm/res/network/firewall-policy:<version>' = {
       Role: 'DeploymentValidation'
     }
     threatIntelMode: 'Deny'
-    tier: 'Basic'
   }
 }
 ```
@@ -387,9 +386,6 @@ module firewallPolicy 'br/public:avm/res/network/firewall-policy:<version>' = {
     },
     "threatIntelMode": {
       "value": "Deny"
-    },
-    "tier": {
-      "value": "Basic"
     }
   }
 }

--- a/avm/res/network/firewall-policy/main.bicep
+++ b/avm/res/network/firewall-policy/main.bicep
@@ -53,6 +53,7 @@ param mode string = 'Off'
 @allowed([
   'Premium'
   'Standard'
+  'Basic'
 ])
 param tier string = 'Standard'
 

--- a/avm/res/network/firewall-policy/main.json
+++ b/avm/res/network/firewall-policy/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.25.53.49325",
-      "templateHash": "18010679319561930400"
+      "templateHash": "8352567375549268667"
     },
     "name": "Firewall Policies",
     "description": "This module deploys a Firewall Policy.",
@@ -136,7 +136,8 @@
       "defaultValue": "Standard",
       "allowedValues": [
         "Premium",
-        "Standard"
+        "Standard",
+        "Basic"
       ],
       "metadata": {
         "description": "Optional. Tier of Firewall Policy."

--- a/avm/res/network/firewall-policy/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/firewall-policy/tests/e2e/waf-aligned/main.test.bicep
@@ -42,7 +42,6 @@ module testDeployment '../../../main.bicep' = [for iteration in [ 'init', 'idem'
   params: {
     name: '${namePrefix}${serviceShort}001'
     location: resourceLocation
-    tier: 'Basic'
     ruleCollectionGroups: [
       {
         name: '${namePrefix}-rule-001'

--- a/avm/res/network/firewall-policy/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/firewall-policy/tests/e2e/waf-aligned/main.test.bicep
@@ -42,6 +42,7 @@ module testDeployment '../../../main.bicep' = [for iteration in [ 'init', 'idem'
   params: {
     name: '${namePrefix}${serviceShort}001'
     location: resourceLocation
+    tier: 'Basic'
     ruleCollectionGroups: [
       {
         name: '${namePrefix}-rule-001'


### PR DESCRIPTION
## Description

- Added missing value `'Basic'` to allowed values of the parameter `tier`

Resolves #1063 

| Pipeline |
| - |
| [![avm.res.network.firewall-policy](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.network.firewall-policy.yml/badge.svg?branch=users%2Fkrbar%2F1063_fwPolicyFix)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.network.firewall-policy.yml) |

## Updating an existing module

<!--Run through the checklist if your PR updates an existing module.-->

- [x] This is a bug fix:
  - [x] Someone has opened a bug report issue, and I have included "Closes #1063" in the PR description.
  - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
- [ ] I have run `brm validate` locally to verify the module files.
- [x] I have run deployment tests locally to ensure the module is deployable.
- [x] I have read the [Updating an existing module](https://github.com/Azure/bicep-registry-modules/blob/main/CONTRIBUTING.md#updating-an-existing-module) section in the contributing guide and updated the `version.json` file properly:
  - [x] The PR contains backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
  - [ ] The PR contains backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] The PR contains breaking changes, and I have bumped the MAJOR version in `version.json`.
- [ ] I have updated the examples in README with the latest module version number.
