### PR TITLE
fix: unorphaned `avm/res/db-for-postgre-sql/flexible-server`

### DIFF
--- a/avm/res/db-for-postgre-sql/flexible-server/ORPHANED.md
+++ b/avm/res/db-for-postgre-sql/flexible-server/ORPHANED.md
@@ -1,4 +1,0 @@
-⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️
-
-- Only security and bug fixes are being handled by the AVM core team at present.
-- If interested in becoming the module owner of this orphaned module (must be Microsoft FTE), please look for the related "orphaned module" GitHub issue [here](https://aka.ms/AVM/OrphanedModules)!

--- a/avm/res/db-for-postgre-sql/flexible-server/README.md
+++ b/avm/res/db-for-postgre-sql/flexible-server/README.md
@@ -1,10 +1,5 @@
 # DBforPostgreSQL Flexible Servers `[Microsoft.DBforPostgreSQL/flexibleServers]`
 
-> ⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️
-> 
-> - Only security and bug fixes are being handled by the AVM core team at present.
-> - If interested in becoming the module owner of this orphaned module (must be Microsoft FTE), please look for the related "orphaned module" GitHub issue [here](https://aka.ms/AVM/OrphanedModules)!
-
 This module deploys a DBforPostgreSQL Flexible Server.
 
 ## Navigation


### PR DESCRIPTION
## Description

Unorphaned `avm/res/db-for-postgre-sql/flexible-server` as @joaria became the owner of the module.
