### PR TITLE
fix: file and folder setup fixes in Set-AVMModule

### DIFF
--- a/avm/utilities/tools/helper/Set-ModuleFileAndFolderSetup.ps1
+++ b/avm/utilities/tools/helper/Set-ModuleFileAndFolderSetup.ps1
@@ -134,7 +134,7 @@ function Set-ModuleFileAndFolderSetup {
         # WAF-aligned test file
         # ---------------------
         if (($currentTestFolders -match '.*waf-aligned').count -eq 0) {
-            $wafTestFilePath = = Join-Path $testCasesPath 'waf-aligned' 'main.test.bicep'
+            $wafTestFilePath = Join-Path $testCasesPath 'waf-aligned' 'main.test.bicep'
             if ($PSCmdlet.ShouldProcess("file [$wafTestFilePath]", "Add")) {
                 $null = New-Item -Path $wafTestFilePath -ItemType 'File' -Force
             }

--- a/avm/utilities/tools/helper/src/src.child.main.bicep
+++ b/avm/utilities/tools/helper/src/src.child.main.bicep
@@ -5,9 +5,6 @@ metadata owner = 'Azure/module-maintainers'
 @description('Required. Name of the resource to create.')
 param name string
 
-@description('Optional. Location for all Resources.')
-param location string = resourceGroup().location
-
 //
 // Add your parameters here
 //
@@ -32,8 +29,8 @@ param location string = resourceGroup().location
 // @description('The name of the resource.')
 // output name string = <Resource>.name
 
-// @description('The location the resource was deployed into.')
-// output location string = <Resource>.location
+// @description('The name of the resource group the resource was created in.')
+// output resourceGroupName string = resourceGroup().name
 
 // ================ //
 // Definitions      //

--- a/avm/utilities/tools/helper/src/src.main.test.bicep
+++ b/avm/utilities/tools/helper/src/src.main.test.bicep
@@ -41,5 +41,6 @@ module testDeployment '../../../main.bicep' = [for iteration in [ 'init', 'idem'
   params: {
     // You parameters go here
     name: '${namePrefix}${serviceShort}001'
+    location: resourceLocation
   }
 }]

--- a/avm/utilities/tools/helper/src/src.main.test.bicep
+++ b/avm/utilities/tools/helper/src/src.main.test.bicep
@@ -10,7 +10,7 @@ targetScope = 'subscription'
 param resourceGroupName string = 'dep-${namePrefix}-<provider>-<resourceType>-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
-param location string = deployment().location
+param resourceLocation string = deployment().location
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 // e.g., for a module 'network/private-endpoint' you could use 'npe' as a prefix and then 'waf' as a suffix for the waf-aligned test
@@ -27,7 +27,7 @@ param namePrefix string = '#_namePrefix_#'
 // =================
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: resourceGroupName
-  location: location
+  location: resourceLocation
 }
 
 // ============== //
@@ -37,7 +37,7 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
 @batchSize(1)
 module testDeployment '../../../main.bicep' = [for iteration in [ 'init', 'idem' ]: {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, location)}-test-${serviceShort}-${iteration}'
+  name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
   params: {
     // You parameters go here
     name: '${namePrefix}${serviceShort}001'


### PR DESCRIPTION
## Description

Fixes to `Set-AVMModule` when creating missing files:
- fixed typo in `Set-ModuleFileAndFolderSetup.ps1` preventing it from creation of the `waf-aligned` test case
- update to the child module template source: 
  - removed `location` parameter and output as unusual in child resources
  - added `resourceGroupName` output
- update to the test case template source
  - replaced `location` with `resourceLocation` to reflect the current format

## Pipeline Reference

| Pipeline |
| -------- |
| `<none>`  |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utlities (Non-module effecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
