### PR TITLE
feat: added `connectionString` output to the Application Insights module

### DIFF
--- a/avm/res/insights/component/README.md
+++ b/avm/res/insights/component/README.md
@@ -747,6 +747,7 @@ Tags of the resource.
 | Output | Type | Description |
 | :-- | :-- | :-- |
 | `applicationId` | string | The application ID of the application insights component. |
+| `connectionString` | string | Application Insights Connection String. |
 | `instrumentationKey` | string | Application Insights Instrumentation key. A read-only value that applications can use to identify the destination for all telemetry sent to Azure Application Insights. This value will be supplied upon construction of each new Application Insights component. |
 | `location` | string | The location the resource was deployed into. |
 | `name` | string | The name of the application insights component. |

--- a/avm/res/insights/component/main.bicep
+++ b/avm/res/insights/component/main.bicep
@@ -185,6 +185,9 @@ output location string = appInsights.location
 @description('Application Insights Instrumentation key. A read-only value that applications can use to identify the destination for all telemetry sent to Azure Application Insights. This value will be supplied upon construction of each new Application Insights component.')
 output instrumentationKey string = appInsights.properties.InstrumentationKey
 
+@description('Application Insights Connection String.')
+output connectionString string = appInsights.properties.ConnectionString
+
 // =============== //
 //   Definitions   //
 // =============== //

--- a/avm/res/insights/component/main.json
+++ b/avm/res/insights/component/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.25.53.49325",
-      "templateHash": "9561238160025481382"
+      "templateHash": "2927135998555920691"
     },
     "name": "Application Insights",
     "description": "This component deploys an Application Insights instance.",
@@ -581,6 +581,13 @@
         "description": "Application Insights Instrumentation key. A read-only value that applications can use to identify the destination for all telemetry sent to Azure Application Insights. This value will be supplied upon construction of each new Application Insights component."
       },
       "value": "[reference('appInsights').InstrumentationKey]"
+    },
+    "connectionString": {
+      "type": "string",
+      "metadata": {
+        "description": "Application Insights Connection String."
+      },
+      "value": "[reference('appInsights').ConnectionString]"
     }
   }
 }

--- a/avm/res/insights/component/version.json
+++ b/avm/res/insights/component/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.2",
+  "version": "0.3",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
## Description

Added a new output `connectionString` to the App Insights module.

This change has been requested via #1130 , however the issue contains one more request, therefore not closing the issue automatically from here.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|  [![avm.res.insights.component](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.insights.component.yml/badge.svg?branch=users%2Fkrbar%2F1130_appInsightsOutput)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.insights.component.yml)  |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
