### PR TITLE
Add PSRule analysis for WAF Reliability Pillar for module defaults

### DIFF
--- a/.github/actions/templates/avm-getModuleTestFiles/action.yml
+++ b/.github/actions/templates/avm-getModuleTestFiles/action.yml
@@ -68,13 +68,16 @@ runs:
 
         # Output values to be accessed by next jobs
         $psRuleCompressedOutput = $psRuleTestFilePaths | ForEach-Object {
-          @{
-            path = $_
-            name = if ((Split-Path (Split-Path $_) -Leaf) -eq ($moduleFolderPath.Split('/')[-1]) ) {
-              "module-bicep-file"
+          if ((Split-Path (Split-Path $_) -Leaf) -eq ($moduleFolderPath.Split('/')[-1])) {
+            @{
+              path = $_
+              name = "module-bicep-file"
             }
-            else {
-              Split-Path (Split-Path $_) -Leaf
+          }
+          else {
+            @{
+              path = $_
+              name = Split-Path (Split-Path $_) -Leaf
             }
           }
         } | ConvertTo-Json -Compress

--- a/.github/actions/templates/avm-getModuleTestFiles/action.yml
+++ b/.github/actions/templates/avm-getModuleTestFiles/action.yml
@@ -57,6 +57,7 @@ runs:
         Write-Output '::endgroup::'
 
         Write-Output '::group::Get PSRule test files'
+        $testFilePaths = (Get-ChildItem -Path $moduleFolderPath -Recurse -Include 'main.test.bicep', 'main.bicep').FullName | Sort-Object
         $psRuleTestFilePaths = $testFilePaths | Where-Object { $_ -match '${{ inputs.psRuleFilterRegex }}' }
 
         Write-Output $psRuleTestFilePaths

--- a/.github/actions/templates/avm-getModuleTestFiles/action.yml
+++ b/.github/actions/templates/avm-getModuleTestFiles/action.yml
@@ -59,8 +59,12 @@ runs:
         Write-Output '::group::Get PSRule test files'
         $psRuleTestFilePaths = $testFilePaths | Where-Object { $_ -match '${{ inputs.psRuleFilterRegex }}' }
 
+        Write-Output $psRuleTestFilePaths
+
         Write-Verbose 'Found PSRule module test files' -Verbose
         $psRuleTestFilePaths | ForEach-Object { Write-Verbose "- [$_]" -Verbose }
+
+        Write-Output $psRuleTestFilePaths
 
         # Output values to be accessed by next jobs
         $psRuleCompressedOutput = $psRuleTestFilePaths | ForEach-Object {

--- a/.github/actions/templates/avm-getModuleTestFiles/action.yml
+++ b/.github/actions/templates/avm-getModuleTestFiles/action.yml
@@ -68,7 +68,7 @@ runs:
 
         # Output values to be accessed by next jobs
         $psRuleCompressedOutput = $psRuleTestFilePaths | ForEach-Object {
-          if ((Split-Path (Split-Path $_) -Leaf) -eq ($moduleFolderPath.Split('/')[-1])) {
+          if ((Split-Path (Split-Path $_) -Leaf) -eq (Split-Path $moduleFolderPath -Leaf)) {
             @{
               path = $_
               name = "module-bicep-file"

--- a/.github/actions/templates/avm-getModuleTestFiles/action.yml
+++ b/.github/actions/templates/avm-getModuleTestFiles/action.yml
@@ -8,7 +8,7 @@ inputs:
   psRuleFilterRegex:
     description: "The regex used to filter PSRule compliant files"
     required: true
-    default: "(defaults|waf-aligned)"
+    default: "(main.bicep|defaults|waf-aligned)"
 
 outputs:
   moduleTestFilePaths:
@@ -31,7 +31,7 @@ runs:
         # Get the list of parameter file paths
         $moduleFolderPath = Join-Path $env:GITHUB_WORKSPACE '${{ inputs.modulePath }}'
 
-        $testFilePaths = (Get-ChildItem -Path $moduleFolderPath -Recurse -Filter 'main.test.bicep').FullName | Sort-Object
+        $testFilePaths = (Get-ChildItem -Path $moduleFolderPath -Recurse -Include 'main.test.bicep', 'main.bicep').FullName | Sort-Object
         $testFilePaths = $testFilePaths | ForEach-Object {
           $_.Replace($moduleFolderPath, '').Trim('\').Trim('/')
         }
@@ -40,7 +40,7 @@ runs:
         $testFilePaths | ForEach-Object { Write-Verbose "- [$_]" -Verbose }
 
         # Output values to be accessed by next jobs
-        $deployCompressedOutput = $testFilePaths | ForEach-Object {
+        $deployCompressedOutput = $testFilePaths | Where-Object { $_ -notmatch '(main.bicep)' } | ForEach-Object {
           @{
             path = $_
             name = Split-Path (Split-Path $_) -Leaf
@@ -66,7 +66,12 @@ runs:
         $psRuleCompressedOutput = $psRuleTestFilePaths | ForEach-Object {
           @{
             path = $_
-            name = Split-Path (Split-Path $_) -Leaf
+            name = if ((Split-Path (Split-Path $_) -Leaf) -eq ($moduleFolderPath.Split('/')[-1]) ) {
+              "module-bicep-file"
+            }
+            else {
+              Split-Path (Split-Path $_) -Leaf
+            }
           }
         } | ConvertTo-Json -Compress
 

--- a/.github/actions/templates/avm-validateModulePSRule/action.yml
+++ b/.github/actions/templates/avm-validateModulePSRule/action.yml
@@ -109,7 +109,65 @@ runs:
 
     # [PSRule validation] task(s)
     #-----------------------------
-    - name: Run PSRule analysis
+    - name: Run PSRule analysis - WAF Reliability Pillar
+      uses: microsoft/ps-rule@v2.9.0
+      continue-on-error: true # Setting this whilst PSRule gets bedded in, in this project
+      with:
+        modules: "PSRule.Rules.Azure"
+        baseline: "Azure.Pillar.Reliability"
+        inputPath: "${{ inputs.templateFilePath}}"
+        outputFormat: Csv
+        outputPath: "${{ inputs.templateFilePath}}-PSRule-output-waf-reliability.csv"
+        option: "${{ github.workspace }}/${{ inputs.psrulePath}}/ps-rule-waf-reliability.yaml" # Path to PSRule configuration options file
+        source: "${{ inputs.psrulePath}}/.ps-rule/" # Path to folder containing suppression rules to use for analysis.
+        summary: false # Disabling as taken care in customized task
+
+    - name: "Parse CSV content - WAF Reliability Pillar"
+      if: always()
+      uses: azure/powershell@v1
+      with:
+        azPSVersion: "latest"
+        inlineScript: |
+          # Grouping task logs
+          Write-Output '::group::Parse CSV content'
+
+          # Load used functions
+          . (Join-Path $env:GITHUB_WORKSPACE 'avm' 'utilities' 'pipelines' 'staticValidation' 'psrule' 'Set-PSRuleGitHubOutput.ps1')
+
+          # Populate parameter input
+          $ParameterInput = @{
+            inputFilePath           = '${{ inputs.templateFilePath}}-PSRule-output-waf-reliability.csv'
+            outputFilePath          = '${{ inputs.templateFilePath}}-PSRule-output-waf-reliability.md'
+            skipPassedRulesReport   = $false
+          }
+
+          Write-Verbose ('Set PS Rule WAF Reliability Output with following parameters:`n{0}' -f (ConvertTo-Json $ParameterInput -Depth 10)) -Verbose
+
+          # Invoke Set PSRule Output Functionality
+          $null = Set-PSRuleGitHubOutput @ParameterInput
+
+          Write-Output '::endgroup::'
+
+    - name: "Output to GitHub job summaries - WAF Reliability Pillar"
+      if: always()
+      shell: pwsh
+      run: |
+        # Grouping task logs
+        Write-Output '::group::Output to GitHub job summaries'
+
+        $mdPSRuleOutputFilePath = Join-Path $env:GITHUB_WORKSPACE '${{ inputs.templateFilePath}}-PSRule-output-waf-reliability.md'
+
+        if (-not (Test-Path $mdPSRuleOutputFilePath)) {
+          Write-Warning ('Input file [{0}] not found. Please check if the previous task threw an error and try again.' -f $mdPSRuleOutputFilePath)
+          return ''
+        } else {
+          Get-Content $mdPSRuleOutputFilePath >> $env:GITHUB_STEP_SUMMARY
+          Write-Verbose ('Successfully printed out file [{0}] to Job Summaries' -f $mdPSRuleOutputFilePath) -Verbose
+        }
+
+        Write-Output '::endgroup::'
+
+    - name: Run PSRule analysis - All Pillars
       uses: microsoft/ps-rule@v2.9.0
       continue-on-error: true # Setting this whilst PSRule gets bedded in, in this project
       with:

--- a/avm/utilities/pipelines/staticValidation/psrule/ps-rule-waf-reliability.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/ps-rule-waf-reliability.yaml
@@ -1,0 +1,80 @@
+#
+# PSRule for Azure configuration
+#
+
+# Please see the documentation for all configuration options:
+# https://aka.ms/ps-rule/options
+# https://aka.ms/ps-rule-azure/options
+
+# Configure binding for local rules.
+binding:
+  preferTargetInfo: true
+  targetType:
+    - type
+    - resourceType
+
+# Require minimum versions of modules.
+requires:
+  PSRule: "@pre >=2.9.0"
+  PSRule.Rules.Azure: ">=1.29.0"
+
+# Use PSRule for Azure.
+include:
+  module:
+    - PSRule.Rules.Azure
+
+execution:
+  ruleSuppressed: Debug
+  unprocessedObject: Debug
+
+output:
+  culture:
+    - "en-US"
+
+input:
+  pathIgnore:
+    # Exclude all files.
+    - "*"
+    # Only process module default bicep files.
+    - "!avm/**/main.bicep"
+
+configuration:
+  # Enable automatic expansion of Azure parameter files.
+  AZURE_PARAMETER_FILE_EXPANSION: false
+
+  # Enable automatic expansion of Azure Bicep source files.
+  AZURE_BICEP_FILE_EXPANSION: true
+
+  # Configures the number of seconds to wait for build Bicep files.
+  AZURE_BICEP_FILE_EXPANSION_TIMEOUT: 10
+
+  # Custom non-sensitive parameters' names
+  AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES:
+    [
+      "sasTokenValidityLength",
+      "passwordlength",
+      "secretname",
+      "secreturl",
+      "secreturi",
+      "secretrotation",
+      "secretinterval",
+      "secretprovider",
+      "secretsprovider",
+      "secretref",
+      "secretid",
+      "disablepassword",
+      "sync*passwords",
+      "sqlAdministratorLogin",
+      "tokenname",
+      "ssoClientSecretKeyVaultPath",
+      "ssoSecretType",
+      "tokenValidityLength",
+    ]
+
+rule:
+  # Enable custom rules that don't exist in the baseline
+  includeLocal: false
+  exclude:
+    # Ignore the following rules for all resources
+    - Azure.KeyVault.PurgeProtect
+    - Azure.VM.UseHybridUseBenefit


### PR DESCRIPTION
## Description

Add PSRule analysis for WAF Reliability Pillar for module defaults

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
