### PR TITLE
fix: 1341 IR description passthrough

### DIFF
--- a/avm/res/data-factory/factory/main.bicep
+++ b/avm/res/data-factory/factory/main.bicep
@@ -172,6 +172,7 @@ module dataFactory_integrationRuntimes 'integration-runtime/main.bicep' = [for (
     dataFactoryName: dataFactory.name
     name: integrationRuntime.name
     type: integrationRuntime.type
+    interagrationRuntimeCustomDescription: integrationRuntime.?interagrationRuntimeCustomDescription ?? 'Managed Integration Runtime created by avm-res-datafactory-factories'
     managedVirtualNetworkName: contains(integrationRuntime, 'managedVirtualNetworkName') ? integrationRuntime.managedVirtualNetworkName : ''
     typeProperties: contains(integrationRuntime, 'typeProperties') ? integrationRuntime.typeProperties : {}
   }

--- a/avm/res/data-factory/factory/main.json
+++ b/avm/res/data-factory/factory/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.54.24096",
-      "templateHash": "17591619092727607098"
+      "templateHash": "18305717161046402755"
     },
     "name": "Data Factories",
     "description": "This module deploys a Data Factory.",
@@ -1025,6 +1025,9 @@
           },
           "type": {
             "value": "[parameters('integrationRuntimes')[copyIndex()].type]"
+          },
+          "interagrationRuntimeCustomDescription": {
+            "value": "[coalesce(tryGet(parameters('integrationRuntimes')[copyIndex()], 'interagrationRuntimeCustomDescription'), 'Managed Integration Runtime created by avm-res-datafactory-factories')]"
           },
           "managedVirtualNetworkName": "[if(contains(parameters('integrationRuntimes')[copyIndex()], 'managedVirtualNetworkName'), createObject('value', parameters('integrationRuntimes')[copyIndex()].managedVirtualNetworkName), createObject('value', ''))]",
           "typeProperties": "[if(contains(parameters('integrationRuntimes')[copyIndex()], 'typeProperties'), createObject('value', parameters('integrationRuntimes')[copyIndex()].typeProperties), createObject('value', createObject()))]"


### PR DESCRIPTION
## Description

The IR description was left out of the main parent bicep file

Fixes #1341 
Closes #1341
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.res.data-factory.factory](https://github.com/clintgrove/bicep-registry-modules/actions/workflows/avm.res.data-factory.factory.yml/badge.svg?branch=irdescpassthrough)](https://github.com/clintgrove/bicep-registry-modules/actions/workflows/avm.res.data-factory.factory.yml)       |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
