### PR TITLE
feat: add AZ parameter checks for zonal resources

### DIFF
--- a/avm/res/network/nat-gateway/tests/unit/avm.core.team.tests.ps1
+++ b/avm/res/network/nat-gateway/tests/unit/avm.core.team.tests.ps1
@@ -1,0 +1,40 @@
+<#
+.SYNOPSIS
+This file contains Pester tests that the AVM Core Team has written for the module. Any additions or changes to these tests will need to be reviewed by the AVM Core Team, this is handled by CODEOWNERS.
+
+If you wish to add your own Pester tests for you module create a new <something>.tests.ps1 file in the /tests/unit folder of your module.
+#>
+
+param (
+  [Parameter(Mandatory = $false)]
+  [array] $moduleFolderPaths,
+
+  [Parameter(Mandatory = $false)]
+  [string] $repoRootPath
+)
+
+BeforeAll {
+  . (Join-Path $RepoRootPath 'avm' 'utilities' 'pipelines' 'sharedScripts' 'helper' 'Get-IsParameterRequired.ps1')
+
+  if ($moduleFolderPaths.Count -gt 1) {
+    $topLevelModuleTemplatePath = $moduleFolderPaths | Sort-Object | Select-Object -First 1
+  }
+  else {
+    $topLevelModuleTemplatePath = $moduleFolderPaths
+  }
+
+  $moduleJsonContentHashtable = Get-Content -Path (Join-Path $topLevelModuleTemplatePath 'main.json') | ConvertFrom-Json -AsHashtable
+}
+
+Describe 'AVM Core Team Module Specific Tests' {
+
+  Context 'WAF - Reliability Pillar - Parameter Tests' {
+
+    It 'NAT Gateway Module Availability Zone Parameter Should Not Have A Default Value Set' {
+      $isRequired = Get-IsParameterRequired -TemplateFileContent $moduleJsonContentHashtable -Parameter $moduleJsonContentHashtable.parameters.zones
+      $isRequired | Should -Be $true
+    }
+
+  }
+
+}


### PR DESCRIPTION
## Description

Adding AZ parameter checks for zonal resoruces.

Only NAT GW Module is the one to have tests added at this time.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.network.nat-gateways](https://github.com/jtracey93/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml/badge.svg)](https://github.com/jtracey93/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml)     |

> Failure is expected as the module is not compliant

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utlities (Non-module effecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
