### PR TITLE
fixed virtual network subnet module not to ask for optional subnet-name… `avm/res/network/virtual-network/`

### DIFF
--- a/avm/res/network/virtual-network/subnet/main.bicep
+++ b/avm/res/network/virtual-network/subnet/main.bicep
@@ -3,7 +3,7 @@ metadata description = 'This module deploys a Virtual Network Subnet.'
 metadata owner = 'Azure/module-maintainers'
 
 @description('Optional. The Name of the subnet resource.')
-param name string
+param name string = ''
 
 @description('Conditional. The name of the parent virtual network. Required if the template is used in a standalone deployment.')
 param virtualNetworkName string


### PR DESCRIPTION
… input in run

## Description

Not reported as an issues
This fixes the subnet module asking for name input on run, if you run the subnet as a seperate module.

## Pipeline Reference


## Type of Change

added default string for optional parameters. 

## Checklist

No other issues have been reported on this
