### PR TITLE
fix: bump Azure login from v1 to v2 in GH actions

### DIFF
--- a/.github/actions/templates/avm-publishModule/action.yml
+++ b/.github/actions/templates/avm-publishModule/action.yml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: Log in to Azure
-      uses: azure/login@v1
+      uses: azure/login@v2
       with:
         client-id: ${{ env.PUBLISH_CLIENT_ID }}
         tenant-id: ${{ env.PUBLISH_TENANT_ID }}

--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -56,7 +56,7 @@ runs:
   using: "composite"
   steps:
     - name: Azure Login
-      uses: Azure/login@v1
+      uses: azure/login@v2
       with:
         creds: ${{ env.AZURE_CREDENTIALS }}
         enable-AzPSSession: true


### PR DESCRIPTION
## Description

Solves Node.js warnings like 
![image](https://github.com/Azure/bicep-registry-modules/assets/56914614/5bc9fe64-56e9-433f-837e-7c883b4d67ab)


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.key-vault.vault](https://github.com/eriqua/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml/badge.svg?branch=fix%2Fbump-action-login)](https://github.com/eriqua/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml) |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
