### PR TITLE
fix: User Assigned Identity - Federated Identity Credential Concurrency

### DIFF
--- a/avm/res/managed-identity/user-assigned-identity/README.md
+++ b/avm/res/managed-identity/user-assigned-identity/README.md
@@ -105,6 +105,14 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
         name: 'test-fed-cred-miuaimax-001'
         subject: 'system:serviceaccount:default:workload-identity-sa'
       }
+      {
+        audiences: [
+          'api://AzureADTokenExchange'
+        ]
+        issuer: '<issuer>'
+        name: 'test-fed-cred-miuaimax-002'
+        subject: 'system:serviceaccount:default:workload-identity-sa'
+      }
     ]
     location: '<location>'
     lock: {
@@ -162,6 +170,14 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
           ],
           "issuer": "<issuer>",
           "name": "test-fed-cred-miuaimax-001",
+          "subject": "system:serviceaccount:default:workload-identity-sa"
+        },
+        {
+          "audiences": [
+            "api://AzureADTokenExchange"
+          ],
+          "issuer": "<issuer>",
+          "name": "test-fed-cred-miuaimax-002",
           "subject": "system:serviceaccount:default:workload-identity-sa"
         }
       ]
@@ -233,6 +249,14 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
         name: 'test-fed-cred-miuaiwaf-001'
         subject: 'system:serviceaccount:default:workload-identity-sa'
       }
+      {
+        audiences: [
+          'api://AzureADTokenExchange'
+        ]
+        issuer: '<issuer>'
+        name: 'test-fed-cred-miuaiwaf-002'
+        subject: 'system:serviceaccount:default:workload-identity-sa'
+      }
     ]
     location: '<location>'
     lock: {
@@ -273,6 +297,14 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
           ],
           "issuer": "<issuer>",
           "name": "test-fed-cred-miuaiwaf-001",
+          "subject": "system:serviceaccount:default:workload-identity-sa"
+        },
+        {
+          "audiences": [
+            "api://AzureADTokenExchange"
+          ],
+          "issuer": "<issuer>",
+          "name": "test-fed-cred-miuaiwaf-002",
           "subject": "system:serviceaccount:default:workload-identity-sa"
         }
       ]

--- a/avm/res/managed-identity/user-assigned-identity/main.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/main.bicep
@@ -82,6 +82,7 @@ resource userAssignedIdentity_lock 'Microsoft.Authorization/locks@2020-05-01' =
     scope: userAssignedIdentity
   }
 
+@batchSize(1)
 module userAssignedIdentity_federatedIdentityCredentials 'federated-identity-credential/main.bicep' = [
   for (federatedIdentityCredential, index) in (federatedIdentityCredentials ?? []): {
     name: '${uniqueString(deployment().name, location)}-UserMSI-FederatedIdentityCredential-${index}'

--- a/avm/res/managed-identity/user-assigned-identity/main.json
+++ b/avm/res/managed-identity/user-assigned-identity/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.54.24096",
-      "templateHash": "8193140269981034553"
+      "templateHash": "7132206622598400364"
     },
     "name": "User Assigned Identities",
     "description": "This module deploys a User Assigned Identity.",
@@ -266,7 +266,9 @@
     "userAssignedIdentity_federatedIdentityCredentials": {
       "copy": {
         "name": "userAssignedIdentity_federatedIdentityCredentials",
-        "count": "[length(coalesce(parameters('federatedIdentityCredentials'), createArray()))]"
+        "count": "[length(coalesce(parameters('federatedIdentityCredentials'), createArray()))]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",

--- a/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
@@ -69,6 +69,14 @@ module testDeployment '../../../main.bicep' = [
           issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}/'
           subject: 'system:serviceaccount:default:workload-identity-sa'
         }
+        {
+          name: 'test-fed-cred-${serviceShort}-002'
+          audiences: [
+            'api://AzureADTokenExchange'
+          ]
+          issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}/'
+          subject: 'system:serviceaccount:default:workload-identity-sa'
+        }
       ]
       roleAssignments: [
         {

--- a/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
@@ -66,7 +66,7 @@ module testDeployment '../../../main.bicep' = [
           audiences: [
             'api://AzureADTokenExchange'
           ]
-          issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}/'
+          issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}01/'
           subject: 'system:serviceaccount:default:workload-identity-sa'
         }
         {
@@ -74,7 +74,7 @@ module testDeployment '../../../main.bicep' = [
           audiences: [
             'api://AzureADTokenExchange'
           ]
-          issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}/'
+          issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}02/'
           subject: 'system:serviceaccount:default:workload-identity-sa'
         }
       ]

--- a/avm/res/managed-identity/user-assigned-identity/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/tests/e2e/waf-aligned/main.test.bicep
@@ -57,7 +57,7 @@ module testDeployment '../../../main.bicep' = [
           audiences: [
             'api://AzureADTokenExchange'
           ]
-          issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}/'
+          issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}01/'
           subject: 'system:serviceaccount:default:workload-identity-sa'
         }
         {
@@ -65,7 +65,7 @@ module testDeployment '../../../main.bicep' = [
           audiences: [
             'api://AzureADTokenExchange'
           ]
-          issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}/'
+          issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}02/'
           subject: 'system:serviceaccount:default:workload-identity-sa'
         }
       ]

--- a/avm/res/managed-identity/user-assigned-identity/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/tests/e2e/waf-aligned/main.test.bicep
@@ -60,6 +60,14 @@ module testDeployment '../../../main.bicep' = [
           issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}/'
           subject: 'system:serviceaccount:default:workload-identity-sa'
         }
+        {
+          name: 'test-fed-cred-${serviceShort}-002'
+          audiences: [
+            'api://AzureADTokenExchange'
+          ]
+          issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}/'
+          subject: 'system:serviceaccount:default:workload-identity-sa'
+        }
       ]
       tags: {
         'hidden-title': 'This is visible in the resource name'


### PR DESCRIPTION
## Description
Fix of following issue:
When deploying with /avm/res/managed-identity/user-assigned-identity/main.bicep, if you specify multiple Federated Identity Credentials, the deployment will fail and produce the below error message

Fixes #1447
Closes #1447

## Pipeline Reference
| Pipeline |
| -------- |
|         [![avm.res.managed-identity.user-assigned-identity](https://github.com/elanzel/bicep-registry-modules/actions/workflows/avm.res.managed-identity.user-assigned-identity.yml/badge.svg?branch=userassignedidentity)](https://github.com/elanzel/bicep-registry-modules/actions/workflows/avm.res.managed-identity.user-assigned-identity.yml) |

## Type of Change
- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
