### PR TITLE
fix: Update thresholdType to use `Forecasted` instead of `Forecast`

### DIFF
--- a/avm/res/consumption/budget/README.md
+++ b/avm/res/consumption/budget/README.md
@@ -261,7 +261,7 @@ module budget 'br/public:avm/res/consumption/budget:<version>' = {
 | [`amount`](#parameter-amount) | int | The total amount of cost or usage to track with the budget. |
 | [`name`](#parameter-name) | string | The name of the budget. |
 | [`operator`](#parameter-operator) | string | The comparison operator. The operator can be either `EqualTo`, `GreaterThan`, or `GreaterThanOrEqualTo`. |
-| [`thresholdType`](#parameter-thresholdtype) | string | The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecast`. |
+| [`thresholdType`](#parameter-thresholdtype) | string | The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecasted`. |
 
 **Conditional parameters**
 
@@ -317,7 +317,7 @@ The comparison operator. The operator can be either `EqualTo`, `GreaterThan`, or
 
 ### Parameter: `thresholdType`
 
-The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecast`.
+The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecasted`.
 
 - Required: No
 - Type: string
@@ -326,7 +326,7 @@ The type of threshold to use for the budget. The threshold type can be either `A
   ```Bicep
   [
     'Actual'
-    'Forecast'
+    'Forecasted'
   ]
   ```
 

--- a/avm/res/consumption/budget/main.bicep
+++ b/avm/res/consumption/budget/main.bicep
@@ -63,9 +63,9 @@ param actionGroups array?
 
 @allowed([
   'Actual'
-  'Forecast'
+  'Forecasted'
 ])
-@description('Required. The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecast`.')
+@description('Required. The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecasted`.')
 param thresholdType string = 'Actual'
 
 @description('Optional. The filter to use for restricting which resources are considered within the budget.')

--- a/avm/res/consumption/budget/main.json
+++ b/avm/res/consumption/budget/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.54.24096",
-      "templateHash": "9911588770976622603"
+      "templateHash": "14286788088150860765"
     },
     "name": "Consumption Budgets",
     "description": "This module deploys a Consumption Budget for Subscriptions.",
@@ -117,10 +117,10 @@
       "defaultValue": "Actual",
       "allowedValues": [
         "Actual",
-        "Forecast"
+        "Forecasted"
       ],
       "metadata": {
-        "description": "Required. The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecast`."
+        "description": "Required. The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecasted`."
       }
     },
     "filter": {


### PR DESCRIPTION
## Description

Fixes https://github.com/Azure/bicep-registry-modules/issues/1286

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.consumption.budget](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.consumption.budget.yml/badge.svg?branch=segraef%2Fconsumption-budget-fix)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.consumption.budget.yml)      |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
