### PR TITLE
fix: module `avm/res/network/nat-gateway`

### DIFF
--- a/avm/res/network/nat-gateway/tests/unit/avm.core.team.tests.ps1
+++ b/avm/res/network/nat-gateway/tests/unit/avm.core.team.tests.ps1
@@ -30,7 +30,7 @@ Describe 'AVM Core Team Module Specific Tests' {
   Context 'WAF - Reliability Pillar - Parameter Tests' {
 
     It 'NAT Gateway Module Availability Zone Parameter Should Not Have A Default Value Set' {
-      $isRequired = Get-IsParameterRequired -TemplateFileContent $moduleJsonContentHashtable -Parameter $moduleJsonContentHashtable.parameters.zones
+      $isRequired = Get-IsParameterRequired -TemplateFileContent $moduleJsonContentHashtable -Parameter $moduleJsonContentHashtable.parameters.zone
       $isRequired | Should -Be $true
     }
 


### PR DESCRIPTION
## Description

The Static Validation fals because the av.core.tem.test.ps1 should match the new name for single zone "zone" instead of "zones"

Fixes #1501 
Closes #1501 



## Pipeline Reference

[![avm.res.network.nat-gateways](https://github.com/fabmas/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml/badge.svg?branch=nat-gw)](https://github.com/fabmas/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml)

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
