### PR TITLE
feat: Nullable Changefeed Retention and Public Access Enablement - `avm/res/storage/storage-account`

### DIFF
--- a/avm/res/storage/storage-account/README.md
+++ b/avm/res/storage/storage-account/README.md
@@ -184,7 +184,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
     location: '<location>'
     networkAcls: {
       bypass: 'AzureServices'
-      defaultAction: 'Allow'
+      defaultAction: 'Deny'
     }
   }
 }
@@ -216,7 +216,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
     "networkAcls": {
       "value": {
         "bypass": "AzureServices",
-        "defaultAction": "Allow"
+        "defaultAction": "Deny"
       }
     }
   }

--- a/avm/res/storage/storage-account/README.md
+++ b/avm/res/storage/storage-account/README.md
@@ -45,12 +45,13 @@ The following section provides usage examples for the module, which were used to
 - [Deploying as a Blob Storage](#example-1-deploying-as-a-blob-storage)
 - [Deploying as a Block Blob Storage](#example-2-deploying-as-a-block-blob-storage)
 - [Using only defaults](#example-3-using-only-defaults)
-- [Using large parameter set](#example-4-using-large-parameter-set)
-- [Deploying with a NFS File Share](#example-5-deploying-with-a-nfs-file-share)
-- [Using Customer-Managed-Keys with System-Assigned identity](#example-6-using-customer-managed-keys-with-system-assigned-identity)
-- [Using Customer-Managed-Keys with User-Assigned identity](#example-7-using-customer-managed-keys-with-user-assigned-identity)
-- [Deploying as Storage Account version 1](#example-8-deploying-as-storage-account-version-1)
-- [WAF-aligned](#example-9-waf-aligned)
+- [Using only defaults](#example-4-using-only-defaults)
+- [Using large parameter set](#example-5-using-large-parameter-set)
+- [Deploying with a NFS File Share](#example-6-deploying-with-a-nfs-file-share)
+- [Using Customer-Managed-Keys with System-Assigned identity](#example-7-using-customer-managed-keys-with-system-assigned-identity)
+- [Using Customer-Managed-Keys with User-Assigned identity](#example-8-using-customer-managed-keys-with-user-assigned-identity)
+- [Deploying as Storage Account version 1](#example-9-deploying-as-storage-account-version-1)
+- [WAF-aligned](#example-10-waf-aligned)
 
 ### Example 1: _Deploying as a Blob Storage_
 
@@ -178,6 +179,66 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
   name: 'storageAccountDeployment'
   params: {
     // Required parameters
+    name: 'ssachf001'
+    // Non-required parameters
+    allowBlobPublicAccess: false
+    blobServices: {
+      changeFeedEnabled: true
+    }
+    location: '<location>'
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON Parameter file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "name": {
+      "value": "ssachf001"
+    },
+    // Non-required parameters
+    "allowBlobPublicAccess": {
+      "value": false
+    },
+    "blobServices": {
+      "value": {
+        "changeFeedEnabled": true
+      }
+    },
+    "location": {
+      "value": "<location>"
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+### Example 4: _Using only defaults_
+
+This instance deploys the module with the minimum set of required parameters.
+
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
+  name: 'storageAccountDeployment'
+  params: {
+    // Required parameters
     name: 'ssamin001'
     // Non-required parameters
     allowBlobPublicAccess: false
@@ -226,7 +287,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
 </details>
 <p>
 
-### Example 4: _Using large parameter set_
+### Example 5: _Using large parameter set_
 
 This instance deploys the module with most of its features enabled.
 
@@ -1092,7 +1153,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
 </details>
 <p>
 
-### Example 5: _Deploying with a NFS File Share_
+### Example 6: _Deploying with a NFS File Share_
 
 This instance deploys the module with a NFS File Share.
 
@@ -1166,7 +1227,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
 </details>
 <p>
 
-### Example 6: _Using Customer-Managed-Keys with System-Assigned identity_
+### Example 7: _Using Customer-Managed-Keys with System-Assigned identity_
 
 This instance deploys the module using Customer-Managed-Keys using a System-Assigned Identity. This required the service to be deployed twice, once as a pre-requisite to create the System-Assigned Identity, and once to use it for accessing the Customer-Managed-Key secret.
 
@@ -1270,7 +1331,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
 </details>
 <p>
 
-### Example 7: _Using Customer-Managed-Keys with User-Assigned identity_
+### Example 8: _Using Customer-Managed-Keys with User-Assigned identity_
 
 This instance deploys the module using Customer-Managed-Keys using a User-Assigned Identity to access the Customer-Managed-Key secret.
 
@@ -1390,7 +1451,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
 </details>
 <p>
 
-### Example 8: _Deploying as Storage Account version 1_
+### Example 9: _Deploying as Storage Account version 1_
 
 This instance deploys the module as Storage Account version 1.
 
@@ -1442,7 +1503,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
 </details>
 <p>
 
-### Example 9: _WAF-aligned_
+### Example 10: _WAF-aligned_
 
 This instance deploys the module in alignment with the best-practices of the Azure Well-Architected Framework.
 

--- a/avm/res/storage/storage-account/README.md
+++ b/avm/res/storage/storage-account/README.md
@@ -181,6 +181,11 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
     name: 'ssamin001'
     // Non-required parameters
     allowBlobPublicAccess: false
+    location: '<location>'
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Allow'
+    }
   }
 }
 ```
@@ -204,6 +209,15 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
     // Non-required parameters
     "allowBlobPublicAccess": {
       "value": false
+    },
+    "location": {
+      "value": "<location>"
+    },
+    "networkAcls": {
+      "value": {
+        "bypass": "AzureServices",
+        "defaultAction": "Allow"
+      }
     }
   }
 }
@@ -2052,13 +2066,6 @@ Networks ACLs, this value contains IPs to whitelist and/or Subnet information. I
 
 - Required: No
 - Type: object
-- Default:
-  ```Bicep
-  {
-      bypass: 'AzureServices'
-      defaultAction: 'Deny'
-  }
-  ```
 
 **Required parameters**
 

--- a/avm/res/storage/storage-account/blob-service/README.md
+++ b/avm/res/storage/storage-account/blob-service/README.md
@@ -34,7 +34,7 @@ This module deploys a Storage Account Blob Service.
 | :-- | :-- | :-- |
 | [`automaticSnapshotPolicyEnabled`](#parameter-automaticsnapshotpolicyenabled) | bool | Automatic Snapshot is enabled if set to true. |
 | [`changeFeedEnabled`](#parameter-changefeedenabled) | bool | The blob service properties for change feed events. Indicates whether change feed event logging is enabled for the Blob service. |
-| [`changeFeedRetentionInDays`](#parameter-changefeedretentionindays) | int | Indicates whether change feed event logging is enabled for the Blob service. Indicates the duration of changeFeed retention in days. A "0" value indicates an infinite retention of the change feed. |
+| [`changeFeedRetentionInDays`](#parameter-changefeedretentionindays) | int | Indicates whether change feed event logging is enabled for the Blob service. Indicates the duration of changeFeed retention in days. If left blank, it indicates an infinite retention of the change feed. |
 | [`containerDeleteRetentionPolicyAllowPermanentDelete`](#parameter-containerdeleteretentionpolicyallowpermanentdelete) | bool | This property when set to true allows deletion of the soft deleted blob versions and snapshots. This property cannot be used with blob restore policy. This property only applies to blob service and does not apply to containers or file share. |
 | [`containerDeleteRetentionPolicyDays`](#parameter-containerdeleteretentionpolicydays) | int | Indicates the number of days that the deleted item should be retained. |
 | [`containerDeleteRetentionPolicyEnabled`](#parameter-containerdeleteretentionpolicyenabled) | bool | The blob service properties for container soft delete. Indicates whether DeleteRetentionPolicy is enabled. |
@@ -75,7 +75,7 @@ The blob service properties for change feed events. Indicates whether change fee
 
 ### Parameter: `changeFeedRetentionInDays`
 
-Indicates whether change feed event logging is enabled for the Blob service. Indicates the duration of changeFeed retention in days. A "0" value indicates an infinite retention of the change feed.
+Indicates whether change feed event logging is enabled for the Blob service. Indicates the duration of changeFeed retention in days. If left blank, it indicates an infinite retention of the change feed.
 
 - Required: No
 - Type: int

--- a/avm/res/storage/storage-account/blob-service/main.bicep
+++ b/avm/res/storage/storage-account/blob-service/main.bicep
@@ -78,7 +78,7 @@ resource blobServices 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01
     automaticSnapshotPolicyEnabled: automaticSnapshotPolicyEnabled
     changeFeed: changeFeedEnabled ? {
       enabled: true
-      retentionInDays: changeFeedRetentionInDays
+      retentionInDays: changeFeedRetentionInDays ?? null
     } : null
     containerDeleteRetentionPolicy: {
       enabled: containerDeleteRetentionPolicyEnabled

--- a/avm/res/storage/storage-account/blob-service/main.bicep
+++ b/avm/res/storage/storage-account/blob-service/main.bicep
@@ -12,9 +12,9 @@ param automaticSnapshotPolicyEnabled bool = false
 @description('Optional. The blob service properties for change feed events. Indicates whether change feed event logging is enabled for the Blob service.')
 param changeFeedEnabled bool = false
 
-@minValue(0)
+@minValue(1)
 @maxValue(146000)
-@description('Optional. Indicates whether change feed event logging is enabled for the Blob service. Indicates the duration of changeFeed retention in days. A "0" value indicates an infinite retention of the change feed.')
+@description('Optional. Indicates whether change feed event logging is enabled for the Blob service. Indicates the duration of changeFeed retention in days. If left blank, it indicates an infinite retention of the change feed.')
 param changeFeedRetentionInDays int?
 
 @description('Optional. The blob service properties for container soft delete. Indicates whether DeleteRetentionPolicy is enabled.')

--- a/avm/res/storage/storage-account/blob-service/main.json
+++ b/avm/res/storage/storage-account/blob-service/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.54.24096",
-      "templateHash": "18223201950367023198"
+      "templateHash": "12035585784444075183"
     },
     "name": "Storage Account blob Services",
     "description": "This module deploys a Storage Account Blob Service.",
@@ -284,7 +284,7 @@
       "name": "[format('{0}/{1}', parameters('storageAccountName'), variables('name'))]",
       "properties": {
         "automaticSnapshotPolicyEnabled": "[parameters('automaticSnapshotPolicyEnabled')]",
-        "changeFeed": "[if(parameters('changeFeedEnabled'), createObject('enabled', true(), 'retentionInDays', parameters('changeFeedRetentionInDays')), null())]",
+        "changeFeed": "[if(parameters('changeFeedEnabled'), createObject('enabled', true(), 'retentionInDays', coalesce(parameters('changeFeedRetentionInDays'), null())), null())]",
         "containerDeleteRetentionPolicy": {
           "enabled": "[parameters('containerDeleteRetentionPolicyEnabled')]",
           "days": "[parameters('containerDeleteRetentionPolicyDays')]",

--- a/avm/res/storage/storage-account/blob-service/main.json
+++ b/avm/res/storage/storage-account/blob-service/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.54.24096",
-      "templateHash": "12175020972967228537"
+      "templateHash": "18223201950367023198"
     },
     "name": "Storage Account blob Services",
     "description": "This module deploys a Storage Account Blob Service.",
@@ -159,10 +159,10 @@
     "changeFeedRetentionInDays": {
       "type": "int",
       "nullable": true,
-      "minValue": 0,
+      "minValue": 1,
       "maxValue": 146000,
       "metadata": {
-        "description": "Optional. Indicates whether change feed event logging is enabled for the Blob service. Indicates the duration of changeFeed retention in days. A \"0\" value indicates an infinite retention of the change feed."
+        "description": "Optional. Indicates whether change feed event logging is enabled for the Blob service. Indicates the duration of changeFeed retention in days. If left blank, it indicates an infinite retention of the change feed."
       }
     },
     "containerDeleteRetentionPolicyEnabled": {

--- a/avm/res/storage/storage-account/main.bicep
+++ b/avm/res/storage/storage-account/main.bicep
@@ -677,7 +677,7 @@ type networkAclsType = {
 
     @description('Required. The resource ID of the target service. Can also contain a wildcard, if multiple services e.g. in a resource group should be included.')
     resourceId: string
-  }[]?
+  }[]
 
   @description('Required. Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Possible values are any combination of Logging,Metrics,AzureServices (For example, "Logging, Metrics"), or None to bypass none of those traffics.')
   bypass: (

--- a/avm/res/storage/storage-account/main.bicep
+++ b/avm/res/storage/storage-account/main.bicep
@@ -69,10 +69,7 @@ param privateEndpoints privateEndpointType
 param managementPolicyRules array?
 
 @description('Required. Networks ACLs, this value contains IPs to whitelist and/or Subnet information. If in use, bypass needs to be supplied. For security reasons, it is recommended to set the DefaultAction Deny.')
-param networkAcls networkAclsType = {
-  bypass: 'AzureServices'
-  defaultAction: 'Deny'
-}
+param networkAcls networkAclsType?
 
 @description('Optional. A Boolean indicating whether or not the service applies a secondary layer of encryption with platform managed keys for data at rest. For security reasons, it is recommended to set it to true.')
 param requireInfrastructureEncryption bool = true

--- a/avm/res/storage/storage-account/main.bicep
+++ b/avm/res/storage/storage-account/main.bicep
@@ -69,7 +69,7 @@ param privateEndpoints privateEndpointType
 param managementPolicyRules array?
 
 @description('Required. Networks ACLs, this value contains IPs to whitelist and/or Subnet information. If in use, bypass needs to be supplied. For security reasons, it is recommended to set the DefaultAction Deny.')
-param networkAcls networkAclsType?
+param networkAcls networkAclsType
 
 @description('Optional. A Boolean indicating whether or not the service applies a secondary layer of encryption with platform managed keys for data at rest. For security reasons, it is recommended to set it to true.')
 param requireInfrastructureEncryption bool = true
@@ -393,8 +393,8 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
     networkAcls: !empty(networkAcls)
       ? {
           resourceAccessRules: networkAcls.?resourceAccessRules
-          bypass: networkAcls.?bypass
-          defaultAction: networkAcls.?defaultAction
+          bypass: networkAcls.bypass
+          defaultAction: networkAcls.defaultAction
           virtualNetworkRules: networkAcls.?virtualNetworkRules
           ipRules: networkAcls.?ipRules
         }

--- a/avm/res/storage/storage-account/main.json
+++ b/avm/res/storage/storage-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.54.24096",
-      "templateHash": "13878793352750035767"
+      "templateHash": "527574595623774686"
     },
     "name": "Storage Accounts",
     "description": "This module deploys a Storage Account.",
@@ -194,7 +194,8 @@
             "description": "Required. Specifies the default action of allow or deny when no other rules match."
           }
         }
-      }
+      },
+      "nullable": true
     },
     "privateEndpointType": {
       "type": "array",
@@ -615,10 +616,6 @@
     },
     "networkAcls": {
       "$ref": "#/definitions/networkAclsType",
-      "defaultValue": {
-        "bypass": "AzureServices",
-        "defaultAction": "Deny"
-      },
       "metadata": {
         "description": "Required. Networks ACLs, this value contains IPs to whitelist and/or Subnet information. If in use, bypass needs to be supplied. For security reasons, it is recommended to set the DefaultAction Deny."
       }
@@ -928,7 +925,7 @@
         "isNfsV3Enabled": "[if(parameters('enableNfsV3'), parameters('enableNfsV3'), '')]",
         "largeFileSharesState": "[if(or(equals(parameters('skuName'), 'Standard_LRS'), equals(parameters('skuName'), 'Standard_ZRS')), parameters('largeFileSharesState'), null())]",
         "minimumTlsVersion": "[parameters('minimumTlsVersion')]",
-        "networkAcls": "[if(not(empty(parameters('networkAcls'))), createObject('resourceAccessRules', tryGet(parameters('networkAcls'), 'resourceAccessRules'), 'bypass', tryGet(parameters('networkAcls'), 'bypass'), 'defaultAction', tryGet(parameters('networkAcls'), 'defaultAction'), 'virtualNetworkRules', tryGet(parameters('networkAcls'), 'virtualNetworkRules'), 'ipRules', tryGet(parameters('networkAcls'), 'ipRules')), null())]",
+        "networkAcls": "[if(not(empty(parameters('networkAcls'))), createObject('resourceAccessRules', tryGet(parameters('networkAcls'), 'resourceAccessRules'), 'bypass', parameters('networkAcls').bypass, 'defaultAction', parameters('networkAcls').defaultAction, 'virtualNetworkRules', tryGet(parameters('networkAcls'), 'virtualNetworkRules'), 'ipRules', tryGet(parameters('networkAcls'), 'ipRules')), null())]",
         "allowBlobPublicAccess": "[parameters('allowBlobPublicAccess')]",
         "publicNetworkAccess": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(and(not(empty(parameters('privateEndpoints'))), empty(parameters('networkAcls'))), 'Disabled', null()))]",
         "azureFilesIdentityBasedAuthentication": "[if(not(empty(parameters('azureFilesIdentityBasedAuthentication'))), parameters('azureFilesIdentityBasedAuthentication'), null())]"
@@ -2020,7 +2017,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.26.54.24096",
-              "templateHash": "12175020972967228537"
+              "templateHash": "18223201950367023198"
             },
             "name": "Storage Account blob Services",
             "description": "This module deploys a Storage Account Blob Service.",
@@ -2173,10 +2170,10 @@
             "changeFeedRetentionInDays": {
               "type": "int",
               "nullable": true,
-              "minValue": 0,
+              "minValue": 1,
               "maxValue": 146000,
               "metadata": {
-                "description": "Optional. Indicates whether change feed event logging is enabled for the Blob service. Indicates the duration of changeFeed retention in days. A \"0\" value indicates an infinite retention of the change feed."
+                "description": "Optional. Indicates whether change feed event logging is enabled for the Blob service. Indicates the duration of changeFeed retention in days. If left blank, it indicates an infinite retention of the change feed."
               }
             },
             "containerDeleteRetentionPolicyEnabled": {

--- a/avm/res/storage/storage-account/main.json
+++ b/avm/res/storage/storage-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.54.24096",
-      "templateHash": "527574595623774686"
+      "templateHash": "12435923476453706419"
     },
     "name": "Storage Accounts",
     "description": "This module deploys a Storage Account.",
@@ -2017,7 +2017,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.26.54.24096",
-              "templateHash": "18223201950367023198"
+              "templateHash": "12035585784444075183"
             },
             "name": "Storage Account blob Services",
             "description": "This module deploys a Storage Account Blob Service.",
@@ -2295,7 +2295,7 @@
               "name": "[format('{0}/{1}', parameters('storageAccountName'), variables('name'))]",
               "properties": {
                 "automaticSnapshotPolicyEnabled": "[parameters('automaticSnapshotPolicyEnabled')]",
-                "changeFeed": "[if(parameters('changeFeedEnabled'), createObject('enabled', true(), 'retentionInDays', parameters('changeFeedRetentionInDays')), null())]",
+                "changeFeed": "[if(parameters('changeFeedEnabled'), createObject('enabled', true(), 'retentionInDays', coalesce(parameters('changeFeedRetentionInDays'), null())), null())]",
                 "containerDeleteRetentionPolicy": {
                   "enabled": "[parameters('containerDeleteRetentionPolicyEnabled')]",
                   "days": "[parameters('containerDeleteRetentionPolicyDays')]",

--- a/avm/res/storage/storage-account/tests/e2e/changefeed/main.test.bicep
+++ b/avm/res/storage/storage-account/tests/e2e/changefeed/main.test.bicep
@@ -1,0 +1,52 @@
+targetScope = 'subscription'
+
+metadata name = 'Using only defaults'
+metadata description = 'This instance deploys the module with the minimum set of required parameters.'
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Optional. The name of the resource group to deploy for testing purposes.')
+@maxLength(90)
+param resourceGroupName string = 'dep-${namePrefix}-storage.storageaccounts-${serviceShort}-rg'
+
+@description('Optional. The location to deploy resources to.')
+param resourceLocation string = deployment().location
+
+@description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
+param serviceShort string = 'ssachf'
+
+@description('Optional. A token to inject into the name of each resource.')
+param namePrefix string = '#_namePrefix_#'
+
+// ============ //
+// Dependencies //
+// ============ //
+
+// General resources
+// =================
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: resourceGroupName
+  location: resourceLocation
+}
+
+// ============== //
+// Test Execution //
+// ============== //
+
+@batchSize(1)
+module testDeployment '../../../main.bicep' = [
+  for iteration in ['init', 'idem']: {
+    scope: resourceGroup
+    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
+    params: {
+      name: '${namePrefix}${serviceShort}001'
+      allowBlobPublicAccess: false
+      location: resourceLocation
+      blobServices: {
+        changeFeedEnabled: true
+      }
+    }
+  }
+]

--- a/avm/res/storage/storage-account/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/storage/storage-account/tests/e2e/defaults/main.test.bicep
@@ -45,7 +45,7 @@ module testDeployment '../../../main.bicep' = [
       allowBlobPublicAccess: false
       location: resourceLocation
       networkAcls: {
-        defaultAction: 'Allow'
+        defaultAction: 'Deny'
         bypass: 'AzureServices'
       }
     }

--- a/avm/res/storage/storage-account/version.json
+++ b/avm/res/storage/storage-account/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.8",
+    "version": "0.9",
     "pathFilters": [
         "./main.json"
     ]


### PR DESCRIPTION
## Description
Bugfixes to enable
- Blob Services changefeed retention without a time limit
- Ability to deploy a storage account with fully public access
- Added test case for blob services changefeeds

Fixes #1346
Fixes #1385

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.res.storage.storage-account](https://github.com/fblix/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml/badge.svg?branch=users%2Ffblix%2F1346%2B1385)](https://github.com/fblix/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml)       |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
