### PR TITLE
fix: Set-AVMModule - Wrong 'defaults' test case path in folder creation mode

### DIFF
--- a/avm/utilities/tools/helper/Set-ModuleFileAndFolderSetup.ps1
+++ b/avm/utilities/tools/helper/Set-ModuleFileAndFolderSetup.ps1
@@ -19,7 +19,7 @@ Set-ModuleFileAndFolderSetup -FullModuleFolderPath '<repoPath>\avm\res\storage\s
 Results into:
 - Added file [<repoPath>\avm\res\storage\storage-account\main.bicep]
 - Added file [<repoPath>\avm\res\storage\storage-account\version.json]
-- Added file [<repoPath>\avm\res\storage\storage-account\tests\e2e\default\main.test.bicep]
+- Added file [<repoPath>\avm\res\storage\storage-account\tests\e2e\defaults\main.test.bicep]
 - Added file [<repoPath>\avm\res\storage\storage-account\tests\e2e\waf-aligned\main.test.bicep]
 - Added file [<repoPath>\avm\res\storage\storage-account\blob-service\main.bicep]
 - Added file [<repoPath>\avm\res\storage\storage-account\blob-service\container\main.bicep]
@@ -30,7 +30,7 @@ Set-ModuleFileAndFolderSetup -FullModuleFolderPath '<repoPath>\avm\res\storage\s
 Results into:
 - Added file [<repoPath>\avm\res\storage\storage-account\main.bicep]
 - Added file [<repoPath>\avm\res\storage\storage-account\version.json]
-- Added file [<repoPath>\avm\res\storage\storage-account\tests\e2e\default\main.test.bicep]
+- Added file [<repoPath>\avm\res\storage\storage-account\tests\e2e\defaults\main.test.bicep]
 - Added file [<repoPath>\avm\res\storage\storage-account\tests\e2e\waf-aligned\main.test.bicep]
 
 #>
@@ -102,13 +102,13 @@ function Set-ModuleFileAndFolderSetup {
             Write-Verbose "Added file [$versionFilePath]" -Verbose
         }
 
-        # Default test file
+        # Defaults test file
         # -----------------
         $testCasesPath = Join-Path $CurrentLevelFolderPath 'tests' 'e2e'
         $currentTestFolders = Get-ChildItem -Path $testCasesPath -Directory | ForEach-Object { $_.Name }
 
         if (($currentTestFolders -match '.*defaults').count -eq 0) {
-            $defaultTestFilePath = Join-Path $testCasesPath 'default' 'main.test.bicep'
+            $defaultTestFilePath = Join-Path $testCasesPath 'defaults' 'main.test.bicep'
             if ($PSCmdlet.ShouldProcess("file [$defaultTestFilePath]", 'Add')) {
                 $null = New-Item -Path $defaultTestFilePath -ItemType 'File' -Force
             }


### PR DESCRIPTION
## Description

PR fixes a wrong path, when Set-AVMModule creates files and folders. The script created a path `<modulePath>\tests\e2e\default\main.test.bicep`, but should create `<modulePath>\tests\e2e\defaults\main.test.bicep`.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utlities (Non-module effecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
