### PR TITLE
fix: Namefix for integration runtime `/avm/res/data-factory/factory /integration-runtime/`

### DIFF
--- a/avm/res/data-factory/factory/integration-runtime/README.md
+++ b/avm/res/data-factory/factory/integration-runtime/README.md
@@ -36,7 +36,7 @@ This module deploys a Data Factory Managed or Self-Hosted Integration Runtime.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`interagrationRuntimeCustomDescription`](#parameter-interagrationruntimecustomdescription) | string | The description of the Integration Runtime. |
+| [`integrationRuntimeCustomDescription`](#parameter-integrationruntimecustomdescription) | string | The description of the Integration Runtime. |
 | [`managedVirtualNetworkName`](#parameter-managedvirtualnetworkname) | string | The name of the Managed Virtual Network if using type "Managed" . |
 | [`typeProperties`](#parameter-typeproperties) | object | Integration Runtime type properties. Required if type is "Managed". |
 
@@ -68,7 +68,7 @@ The name of the parent Azure Data Factory. Required if the template is used in a
 - Required: Yes
 - Type: string
 
-### Parameter: `interagrationRuntimeCustomDescription`
+### Parameter: `integrationRuntimeCustomDescription`
 
 The description of the Integration Runtime.
 

--- a/avm/res/data-factory/factory/integration-runtime/main.bicep
+++ b/avm/res/data-factory/factory/integration-runtime/main.bicep
@@ -22,7 +22,7 @@ param managedVirtualNetworkName string = ''
 param typeProperties object = {}
 
 @description('Optional. The description of the Integration Runtime.')
-param interagrationRuntimeCustomDescription string = 'Managed Integration Runtime created by avm-res-datafactory-factories'
+param integrationRuntimeCustomDescription string = 'Managed Integration Runtime created by avm-res-datafactory-factories'
 
 var managedVirtualNetworkVar = {
   referenceName: type == 'Managed' ? managedVirtualNetworkName : null
@@ -36,14 +36,16 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
 resource integrationRuntime 'Microsoft.DataFactory/factories/integrationRuntimes@2018-06-01' = {
   name: name
   parent: dataFactory
-  properties: type == 'Managed' ? {
-    description: interagrationRuntimeCustomDescription
-    type: type
-    managedVirtualNetwork: managedVirtualNetworkVar
-    typeProperties: typeProperties
-  } : {
-    type: type
-  }
+  properties: type == 'Managed'
+    ? {
+        description: integrationRuntimeCustomDescription
+        type: type
+        managedVirtualNetwork: managedVirtualNetworkVar
+        typeProperties: typeProperties
+      }
+    : {
+        type: type
+      }
 }
 
 @description('The name of the Resource Group the Integration Runtime was created in.')

--- a/avm/res/data-factory/factory/integration-runtime/main.json
+++ b/avm/res/data-factory/factory/integration-runtime/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.54.24096",
-      "templateHash": "5995255380692588407"
+      "templateHash": "6019779622358376532"
     },
     "name": "Data Factory Integration RunTimes",
     "description": "This module deploys a Data Factory Managed or Self-Hosted Integration Runtime.",
@@ -48,7 +48,7 @@
         "description": "Optional. Integration Runtime type properties. Required if type is \"Managed\"."
       }
     },
-    "interagrationRuntimeCustomDescription": {
+    "integrationRuntimeCustomDescription": {
       "type": "string",
       "defaultValue": "Managed Integration Runtime created by avm-res-datafactory-factories",
       "metadata": {
@@ -67,7 +67,7 @@
       "type": "Microsoft.DataFactory/factories/integrationRuntimes",
       "apiVersion": "2018-06-01",
       "name": "[format('{0}/{1}', parameters('dataFactoryName'), parameters('name'))]",
-      "properties": "[if(equals(parameters('type'), 'Managed'), createObject('description', parameters('interagrationRuntimeCustomDescription'), 'type', parameters('type'), 'managedVirtualNetwork', variables('managedVirtualNetworkVar'), 'typeProperties', parameters('typeProperties')), createObject('type', parameters('type')))]"
+      "properties": "[if(equals(parameters('type'), 'Managed'), createObject('description', parameters('integrationRuntimeCustomDescription'), 'type', parameters('type'), 'managedVirtualNetwork', variables('managedVirtualNetworkVar'), 'typeProperties', parameters('typeProperties')), createObject('type', parameters('type')))]"
     }
   ],
   "outputs": {

--- a/avm/res/data-factory/factory/main.bicep
+++ b/avm/res/data-factory/factory/main.bicep
@@ -217,7 +217,7 @@ module dataFactory_integrationRuntimes 'integration-runtime/main.bicep' = [
       dataFactoryName: dataFactory.name
       name: integrationRuntime.name
       type: integrationRuntime.type
-      interagrationRuntimeCustomDescription: integrationRuntime.?interagrationRuntimeCustomDescription ?? 'Managed Integration Runtime created by avm-res-datafactory-factories'
+      integrationRuntimeCustomDescription: integrationRuntime.?integrationRuntimeCustomDescription ?? 'Managed Integration Runtime created by avm-res-datafactory-factories'
       managedVirtualNetworkName: contains(integrationRuntime, 'managedVirtualNetworkName')
         ? integrationRuntime.managedVirtualNetworkName
         : ''

--- a/avm/res/data-factory/factory/main.json
+++ b/avm/res/data-factory/factory/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.54.24096",
-      "templateHash": "13420826412692086400"
+      "templateHash": "14187397977187427796"
     },
     "name": "Data Factories",
     "description": "This module deploys a Data Factory.",
@@ -1033,8 +1033,8 @@
           "type": {
             "value": "[parameters('integrationRuntimes')[copyIndex()].type]"
           },
-          "interagrationRuntimeCustomDescription": {
-            "value": "[coalesce(tryGet(parameters('integrationRuntimes')[copyIndex()], 'interagrationRuntimeCustomDescription'), 'Managed Integration Runtime created by avm-res-datafactory-factories')]"
+          "integrationRuntimeCustomDescription": {
+            "value": "[coalesce(tryGet(parameters('integrationRuntimes')[copyIndex()], 'integrationRuntimeCustomDescription'), 'Managed Integration Runtime created by avm-res-datafactory-factories')]"
           },
           "managedVirtualNetworkName": "[if(contains(parameters('integrationRuntimes')[copyIndex()], 'managedVirtualNetworkName'), createObject('value', parameters('integrationRuntimes')[copyIndex()].managedVirtualNetworkName), createObject('value', ''))]",
           "typeProperties": "[if(contains(parameters('integrationRuntimes')[copyIndex()], 'typeProperties'), createObject('value', parameters('integrationRuntimes')[copyIndex()].typeProperties), createObject('value', createObject()))]"
@@ -1046,7 +1046,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.26.54.24096",
-              "templateHash": "5995255380692588407"
+              "templateHash": "6019779622358376532"
             },
             "name": "Data Factory Integration RunTimes",
             "description": "This module deploys a Data Factory Managed or Self-Hosted Integration Runtime.",
@@ -1089,7 +1089,7 @@
                 "description": "Optional. Integration Runtime type properties. Required if type is \"Managed\"."
               }
             },
-            "interagrationRuntimeCustomDescription": {
+            "integrationRuntimeCustomDescription": {
               "type": "string",
               "defaultValue": "Managed Integration Runtime created by avm-res-datafactory-factories",
               "metadata": {
@@ -1108,7 +1108,7 @@
               "type": "Microsoft.DataFactory/factories/integrationRuntimes",
               "apiVersion": "2018-06-01",
               "name": "[format('{0}/{1}', parameters('dataFactoryName'), parameters('name'))]",
-              "properties": "[if(equals(parameters('type'), 'Managed'), createObject('description', parameters('interagrationRuntimeCustomDescription'), 'type', parameters('type'), 'managedVirtualNetwork', variables('managedVirtualNetworkVar'), 'typeProperties', parameters('typeProperties')), createObject('type', parameters('type')))]"
+              "properties": "[if(equals(parameters('type'), 'Managed'), createObject('description', parameters('integrationRuntimeCustomDescription'), 'type', parameters('type'), 'managedVirtualNetwork', variables('managedVirtualNetworkVar'), 'typeProperties', parameters('typeProperties')), createObject('type', parameters('type')))]"
             }
           ],
           "outputs": {


### PR DESCRIPTION
## Description
a Simple name correction in spelling of the Integration Runtime passthrough parameter


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.data-factory.factory](https://github.com/clintgrove/bicep-registry-modules/actions/workflows/avm.res.data-factory.factory.yml/badge.svg?branch=integrationRuntime-namefix)](https://github.com/clintgrove/bicep-registry-modules/actions/workflows/avm.res.data-factory.factory.yml)     |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
