### PR TITLE
fix: Platform scripts trigger exclusion missing in a few module validation workflows

### DIFF
--- a/.github/workflows/avm.res.aad.domain-service.yml
+++ b/.github/workflows/avm.res.aad.domain-service.yml
@@ -29,6 +29,7 @@ on:
       - ".github/workflows/avm.res.aad.domain-service.yml"
       - "avm/res/aad/domain-service/**"
       - "avm/utilities/pipelines/**"
+      - "!avm/utilities/pipelines/platform/**"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.container-instance.container-group.yml
+++ b/.github/workflows/avm.res.container-instance.container-group.yml
@@ -29,6 +29,7 @@ on:
       - ".github/workflows/avm.res.container-instance.container-group.yml"
       - "avm/res/container-instance/container-group/**"
       - "avm/utilities/pipelines/**"
+      - "!avm/utilities/pipelines/platform/**"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.digital-twins.digital-twins-instance.yml
+++ b/.github/workflows/avm.res.digital-twins.digital-twins-instance.yml
@@ -29,6 +29,7 @@ on:
       - ".github/workflows/avm.res.digital-twins.digital-twins-instance.yml"
       - "avm/res/digital-twins/digital-twins-instance/**"
       - "avm/utilities/pipelines/**"
+      - "!avm/utilities/pipelines/platform/**"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.service-endpoint-policy.yml
+++ b/.github/workflows/avm.res.network.service-endpoint-policy.yml
@@ -29,6 +29,7 @@ on:
       - ".github/workflows/avm.res.network.service-endpoint-policy.yml"
       - "avm/res/network/service-endpoint-policy/**"
       - "avm/utilities/pipelines/**"
+      - "!avm/utilities/pipelines/platform/**"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.recovery-services.vault.yml
+++ b/.github/workflows/avm.res.recovery-services.vault.yml
@@ -29,6 +29,7 @@ on:
       - ".github/workflows/avm.res.recovery-services.vault.yml"
       - "avm/res/recovery-services/vault/**"
       - "avm/utilities/pipelines/**"
+      - "!avm/utilities/pipelines/platform/**"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.service-fabric.cluster.yml
+++ b/.github/workflows/avm.res.service-fabric.cluster.yml
@@ -29,6 +29,7 @@ on:
       - ".github/workflows/avm.res.service-fabric.cluster.yml"
       - "avm/res/service-fabric/cluster/**"
       - "avm/utilities/pipelines/**"
+      - "!avm/utilities/pipelines/platform/**"
       - "!*/**/README.md"
 
 env:


### PR DESCRIPTION
## Description

Platform scripts trigger exclusion missing in a few module validation workflows

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| N/A |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utlities (Non-module effecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
