### PR TITLE
fix: pwsh publish module index

### DIFF
--- a/.github/workflows/avm.platform.publish-module-index-json.yml
+++ b/.github/workflows/avm.platform.publish-module-index-json.yml
@@ -51,7 +51,7 @@ jobs:
           Write-Verbose "Invoke task with" -Verbose
           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-          if(-not (Invoke-AvmJsonModuleIndexGeneration @functionInput -Force)) {
+          if(-not (Invoke-AvmJsonModuleIndexGeneration @functionInput)) {
             Write-Output ('{0}={1}' -f 'anyErrorsOccurred', $true) >> $env:GITHUB_ENV
           }
 

--- a/avm/utilities/pipelines/platform/Invoke-AvmJsonModuleIndexGeneration.ps1
+++ b/avm/utilities/pipelines/platform/Invoke-AvmJsonModuleIndexGeneration.ps1
@@ -40,7 +40,6 @@ The function requires Azure PowerShell Storage Module (Az.Storage) to be install
 #>
 
 function Invoke-AvmJsonModuleIndexGeneration {
-  [CmdletBinding(SupportsShouldProcess)]
   param (
     [Parameter(Mandatory = $false)]
     [string] $storageAccountName = 'biceplivedatasaprod',


### PR DESCRIPTION
## Description

Removing an unnecessary `-Force` and unrequired `SupportsShouldProcess` from the `Invoke-AvmJsonModuleIndexGeneration.ps1`

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utlities (Non-module effecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
