### PR TITLE
fix: Unorphaned res\insights\activity-log-alert module as @donk-msft recently became the owner of this module.

### DIFF
--- a/avm/res/insights/activity-log-alert/ORPHANED.md
+++ b/avm/res/insights/activity-log-alert/ORPHANED.md
@@ -1,4 +1,0 @@
-⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️
-
-- Only security and bug fixes are being handled by the AVM core team at present.
-- If interested in becoming the module owner of this orphaned module (must be Microsoft FTE), please look for the related "orphaned module" GitHub issue [here](https://aka.ms/AVM/OrphanedModules)!

--- a/avm/res/insights/activity-log-alert/README.md
+++ b/avm/res/insights/activity-log-alert/README.md
@@ -1,10 +1,5 @@
 # Activity Log Alerts `[Microsoft.Insights/activityLogAlerts]`
 
-> ⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️
-> 
-> - Only security and bug fixes are being handled by the AVM core team at present.
-> - If interested in becoming the module owner of this orphaned module (must be Microsoft FTE), please look for the related "orphaned module" GitHub issue [here](https://aka.ms/AVM/OrphanedModules)!
-
 This module deploys an Activity Log Alert.
 
 ## Navigation


### PR DESCRIPTION
## Description
New owner to orphaned module changes.
<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.res.insights.activity-log-alert](https://github.com/donk-msft/bicep-registry-modules/actions/workflows/avm.res.insights.activity-log-alert.yml/badge.svg?branch=feat-avm%2Fres%2Finsights%2Factivity-log-alert)](https://github.com/donk-msft/bicep-registry-modules/actions/workflows/avm.res.insights.activity-log-alert.yml)       |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [X] Update to CI Environment or utlities (Non-module effecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
