### PR TITLE
fix: Failing Pipeline: Nullable types are not allowed

### DIFF
--- a/avm/res/storage/storage-account/README.md
+++ b/avm/res/storage/storage-account/README.md
@@ -181,6 +181,11 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
     name: 'ssamin001'
     // Non-required parameters
     allowBlobPublicAccess: false
+    location: '<location>'
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Allow'
+    }
   }
 }
 ```
@@ -204,6 +209,15 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
     // Non-required parameters
     "allowBlobPublicAccess": {
       "value": false
+    },
+    "location": {
+      "value": "<location>"
+    },
+    "networkAcls": {
+      "value": {
+        "bypass": "AzureServices",
+        "defaultAction": "Allow"
+      }
     }
   }
 }

--- a/avm/res/storage/storage-account/README.md
+++ b/avm/res/storage/storage-account/README.md
@@ -184,7 +184,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
     location: '<location>'
     networkAcls: {
       bypass: 'AzureServices'
-      defaultAction: 'Allow'
+      defaultAction: 'Deny'
     }
   }
 }
@@ -216,7 +216,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:<version>' = {
     "networkAcls": {
       "value": {
         "bypass": "AzureServices",
-        "defaultAction": "Allow"
+        "defaultAction": "Deny"
       }
     }
   }

--- a/avm/res/storage/storage-account/blob-service/container/immutability-policy/main.json
+++ b/avm/res/storage/storage-account/blob-service/container/immutability-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "2429139364933838439"
+      "version": "0.26.170.59819",
+      "templateHash": "12849754295459852309"
     },
     "name": "Storage Account Blob Container Immutability Policies",
     "description": "This module deploys a Storage Account Blob Container Immutability Policy.",

--- a/avm/res/storage/storage-account/blob-service/container/main.json
+++ b/avm/res/storage/storage-account/blob-service/container/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "3297137219061666309"
+      "version": "0.26.170.59819",
+      "templateHash": "3805384021483033369"
     },
     "name": "Storage Account Blob Containers",
     "description": "This module deploys a Storage Account Blob Container.",
@@ -274,8 +274,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "2429139364933838439"
+              "version": "0.26.170.59819",
+              "templateHash": "12849754295459852309"
             },
             "name": "Storage Account Blob Container Immutability Policies",
             "description": "This module deploys a Storage Account Blob Container Immutability Policy.",

--- a/avm/res/storage/storage-account/blob-service/main.json
+++ b/avm/res/storage/storage-account/blob-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "12175020972967228537"
+      "version": "0.26.170.59819",
+      "templateHash": "7278814029590745003"
     },
     "name": "Storage Account blob Services",
     "description": "This module deploys a Storage Account Blob Service.",
@@ -403,8 +403,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "3297137219061666309"
+              "version": "0.26.170.59819",
+              "templateHash": "3805384021483033369"
             },
             "name": "Storage Account Blob Containers",
             "description": "This module deploys a Storage Account Blob Container.",
@@ -672,8 +672,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.26.54.24096",
-                      "templateHash": "2429139364933838439"
+                      "version": "0.26.170.59819",
+                      "templateHash": "12849754295459852309"
                     },
                     "name": "Storage Account Blob Container Immutability Policies",
                     "description": "This module deploys a Storage Account Blob Container Immutability Policy.",

--- a/avm/res/storage/storage-account/file-service/main.json
+++ b/avm/res/storage/storage-account/file-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "13860799899517512764"
+      "version": "0.26.170.59819",
+      "templateHash": "4306536926065797375"
     },
     "name": "Storage Account File Share Services",
     "description": "This module deploys a Storage Account File Share Service.",
@@ -286,8 +286,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "18405917853511220559"
+              "version": "0.26.170.59819",
+              "templateHash": "13618261904162439978"
             },
             "name": "Storage Account File Shares",
             "description": "This module deploys a Storage Account File Share.",
@@ -486,8 +486,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.26.54.24096",
-                      "templateHash": "16221226236637657314"
+                      "version": "0.26.170.59819",
+                      "templateHash": "6057169747302051267"
                     }
                   },
                   "parameters": {

--- a/avm/res/storage/storage-account/file-service/share/main.json
+++ b/avm/res/storage/storage-account/file-service/share/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "18405917853511220559"
+      "version": "0.26.170.59819",
+      "templateHash": "13618261904162439978"
     },
     "name": "Storage Account File Shares",
     "description": "This module deploys a Storage Account File Share.",
@@ -205,8 +205,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "16221226236637657314"
+              "version": "0.26.170.59819",
+              "templateHash": "6057169747302051267"
             }
           },
           "parameters": {

--- a/avm/res/storage/storage-account/local-user/main.json
+++ b/avm/res/storage/storage-account/local-user/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "3388645117303533667"
+      "version": "0.26.170.59819",
+      "templateHash": "14593329616022153178"
     },
     "name": "Storage Account Local Users",
     "description": "This module deploys a Storage Account Local User, which is used for SFTP authentication.",

--- a/avm/res/storage/storage-account/main.bicep
+++ b/avm/res/storage/storage-account/main.bicep
@@ -680,7 +680,7 @@ type networkAclsType = {
 
     @description('Required. The resource ID of the target service. Can also contain a wildcard, if multiple services e.g. in a resource group should be included.')
     resourceId: string
-  }[]
+  }[]?
 
   @description('Required. Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Possible values are any combination of Logging,Metrics,AzureServices (For example, "Logging, Metrics"), or None to bypass none of those traffics.')
   bypass: (
@@ -701,7 +701,7 @@ type networkAclsType = {
 
   @description('Required. Specifies the default action of allow or deny when no other rules match.')
   defaultAction: ('Allow' | 'Deny')
-}?
+}
 
 type privateEndpointType = {
   @description('Optional. The name of the private endpoint.')

--- a/avm/res/storage/storage-account/main.bicep
+++ b/avm/res/storage/storage-account/main.bicep
@@ -680,7 +680,7 @@ type networkAclsType = {
 
     @description('Required. The resource ID of the target service. Can also contain a wildcard, if multiple services e.g. in a resource group should be included.')
     resourceId: string
-  }[]?
+  }[]
 
   @description('Required. Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Possible values are any combination of Logging,Metrics,AzureServices (For example, "Logging, Metrics"), or None to bypass none of those traffics.')
   bypass: (

--- a/avm/res/storage/storage-account/main.json
+++ b/avm/res/storage/storage-account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "13878793352750035767"
+      "version": "0.26.170.59819",
+      "templateHash": "8863225181818962940"
     },
     "name": "Storage Accounts",
     "description": "This module deploys a Storage Account.",
@@ -1691,8 +1691,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "14052382142427178929"
+              "version": "0.26.170.59819",
+              "templateHash": "4153955640795225346"
             },
             "name": "Storage Account Management Policies",
             "description": "This module deploys a Storage Account Management Policy.",
@@ -1801,8 +1801,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "3388645117303533667"
+              "version": "0.26.170.59819",
+              "templateHash": "14593329616022153178"
             },
             "name": "Storage Account Local Users",
             "description": "This module deploys a Storage Account Local User, which is used for SFTP authentication.",
@@ -2019,8 +2019,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "12175020972967228537"
+              "version": "0.26.170.59819",
+              "templateHash": "7278814029590745003"
             },
             "name": "Storage Account blob Services",
             "description": "This module deploys a Storage Account Blob Service.",
@@ -2417,8 +2417,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.26.54.24096",
-                      "templateHash": "3297137219061666309"
+                      "version": "0.26.170.59819",
+                      "templateHash": "3805384021483033369"
                     },
                     "name": "Storage Account Blob Containers",
                     "description": "This module deploys a Storage Account Blob Container.",
@@ -2686,8 +2686,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.26.54.24096",
-                              "templateHash": "2429139364933838439"
+                              "version": "0.26.170.59819",
+                              "templateHash": "12849754295459852309"
                             },
                             "name": "Storage Account Blob Container Immutability Policies",
                             "description": "This module deploys a Storage Account Blob Container Immutability Policy.",
@@ -2865,8 +2865,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "13860799899517512764"
+              "version": "0.26.170.59819",
+              "templateHash": "4306536926065797375"
             },
             "name": "Storage Account File Share Services",
             "description": "This module deploys a Storage Account File Share Service.",
@@ -3146,8 +3146,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.26.54.24096",
-                      "templateHash": "18405917853511220559"
+                      "version": "0.26.170.59819",
+                      "templateHash": "13618261904162439978"
                     },
                     "name": "Storage Account File Shares",
                     "description": "This module deploys a Storage Account File Share.",
@@ -3346,8 +3346,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.26.54.24096",
-                              "templateHash": "16221226236637657314"
+                              "version": "0.26.170.59819",
+                              "templateHash": "6057169747302051267"
                             }
                           },
                           "parameters": {
@@ -3615,8 +3615,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "13677013226831946461"
+              "version": "0.26.170.59819",
+              "templateHash": "4494965320132257914"
             },
             "name": "Storage Account Queue Services",
             "description": "This module deploys a Storage Account Queue Service.",
@@ -3860,8 +3860,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.26.54.24096",
-                      "templateHash": "17219066722763101567"
+                      "version": "0.26.170.59819",
+                      "templateHash": "2870814699283520878"
                     },
                     "name": "Storage Account Queues",
                     "description": "This module deploys a Storage Account Queue.",
@@ -4117,8 +4117,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "17373442840517371502"
+              "version": "0.26.170.59819",
+              "templateHash": "6806949296172999226"
             },
             "name": "Storage Account Table Services",
             "description": "This module deploys a Storage Account Table Service.",
@@ -4359,8 +4359,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.26.54.24096",
-                      "templateHash": "10226619499666007193"
+                      "version": "0.26.170.59819",
+                      "templateHash": "5583637725561111612"
                     },
                     "name": "Storage Account Table",
                     "description": "This module deploys a Storage Account Table.",

--- a/avm/res/storage/storage-account/management-policy/main.json
+++ b/avm/res/storage/storage-account/management-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "14052382142427178929"
+      "version": "0.26.170.59819",
+      "templateHash": "4153955640795225346"
     },
     "name": "Storage Account Management Policies",
     "description": "This module deploys a Storage Account Management Policy.",

--- a/avm/res/storage/storage-account/queue-service/main.json
+++ b/avm/res/storage/storage-account/queue-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "13677013226831946461"
+      "version": "0.26.170.59819",
+      "templateHash": "4494965320132257914"
     },
     "name": "Storage Account Queue Services",
     "description": "This module deploys a Storage Account Queue Service.",
@@ -250,8 +250,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "17219066722763101567"
+              "version": "0.26.170.59819",
+              "templateHash": "2870814699283520878"
             },
             "name": "Storage Account Queues",
             "description": "This module deploys a Storage Account Queue.",

--- a/avm/res/storage/storage-account/queue-service/queue/main.json
+++ b/avm/res/storage/storage-account/queue-service/queue/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "17219066722763101567"
+      "version": "0.26.170.59819",
+      "templateHash": "2870814699283520878"
     },
     "name": "Storage Account Queues",
     "description": "This module deploys a Storage Account Queue.",

--- a/avm/res/storage/storage-account/table-service/main.json
+++ b/avm/res/storage/storage-account/table-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "17373442840517371502"
+      "version": "0.26.170.59819",
+      "templateHash": "6806949296172999226"
     },
     "name": "Storage Account Table Services",
     "description": "This module deploys a Storage Account Table Service.",
@@ -247,8 +247,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "10226619499666007193"
+              "version": "0.26.170.59819",
+              "templateHash": "5583637725561111612"
             },
             "name": "Storage Account Table",
             "description": "This module deploys a Storage Account Table.",

--- a/avm/res/storage/storage-account/table-service/table/main.json
+++ b/avm/res/storage/storage-account/table-service/table/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "10226619499666007193"
+      "version": "0.26.170.59819",
+      "templateHash": "5583637725561111612"
     },
     "name": "Storage Account Table",
     "description": "This module deploys a Storage Account Table.",

--- a/avm/res/storage/storage-account/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/storage/storage-account/tests/e2e/defaults/main.test.bicep
@@ -45,7 +45,7 @@ module testDeployment '../../../main.bicep' = [
       allowBlobPublicAccess: false
       location: resourceLocation
       networkAcls: {
-        defaultAction: 'Allow'
+        defaultAction: 'Deny'
         bypass: 'AzureServices'
       }
     }


### PR DESCRIPTION
## Description
This PR solves the failing pipelines currently present in main.
The fix includes changing the `networkAclsType` to not be nullable anymore.

Fixes #1453


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.storage.storage-account](https://github.com/fblix/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml/badge.svg?branch=users%2Ffblix%2F1453)](https://github.com/fblix/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml)     |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
