### PR TITLE
feat: Added custom Azure storage replication rule and updated ps-rule

### DIFF
--- a/avm/utilities/pipelines/staticValidation/psrule/.ps-rule/custom-rules.Rule.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/.ps-rule/custom-rules.Rule.yaml
@@ -1,0 +1,14 @@
+# Synopsis: Use a zone or geo redundant storage account
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: 'Custom.Azure.Storage.UseReplication'
+spec:
+  type:
+  - Microsoft.Storage/storageAccounts
+  condition:
+    anyOf:
+      - field: 'Sku.name'
+        contains: 'ZRS'
+      - field: 'Sku.name'
+        contains: 'GRS'

--- a/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
@@ -74,8 +74,9 @@ configuration:
 
 rule:
   # Enable custom rules that don't exist in the baseline
-  includeLocal: false
+  includeLocal: true
   exclude:
     # Ignore the following rules for all resources
     - Azure.KeyVault.PurgeProtect
     - Azure.VM.UseHybridUseBenefit
+    - Azure.Storage.UseReplication


### PR DESCRIPTION
## Description
Added PSrule customization of the builtin rule `Azure.Storage.UseReplication` to check for any type of ZRS or GRS to pass the reliability test

Fixes #1724 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [X] Update to CI Environment or utlities (Non-module effecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ X] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ X] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
