### PR TITLE
fix: AppServicePlan - SKU selection improvements

### DIFF
--- a/avm/res/web/serverfarm/README.md
+++ b/avm/res/web/serverfarm/README.md
@@ -47,7 +47,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
   params: {
     // Required parameters
     name: 'wsfmin001'
-    skuCapacity: 1
+    skuCapacity: 2
     skuName: 'B1'
     // Non-required parameters
     location: '<location>'
@@ -72,7 +72,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
       "value": "wsfmin001"
     },
     "skuCapacity": {
-      "value": 1
+      "value": 2
     },
     "skuName": {
       "value": "B1"

--- a/avm/res/web/serverfarm/README.md
+++ b/avm/res/web/serverfarm/README.md
@@ -48,7 +48,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
     // Required parameters
     name: 'wsfmin001'
     skuCapacity: 2
-    skuName: 'B1'
+    skuName: 'S1'
     // Non-required parameters
     location: '<location>'
   }
@@ -75,7 +75,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
       "value": 2
     },
     "skuName": {
-      "value": "B1"
+      "value": "S1"
     },
     // Non-required parameters
     "location": {

--- a/avm/res/web/serverfarm/README.md
+++ b/avm/res/web/serverfarm/README.md
@@ -47,13 +47,8 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
   params: {
     // Required parameters
     name: 'wsfmin001'
-    sku: {
-      capacity: 3
-      family: 'P'
-      name: 'P1v3'
-      size: 'P1v3'
-      tier: 'Premium'
-    }
+    skuCapacity: 1
+    skuName: 'B1'
     // Non-required parameters
     location: '<location>'
   }
@@ -76,14 +71,11 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
     "name": {
       "value": "wsfmin001"
     },
-    "sku": {
-      "value": {
-        "capacity": 3,
-        "family": "P",
-        "name": "P1v3",
-        "size": "P1v3",
-        "tier": "Premium"
-      }
+    "skuCapacity": {
+      "value": 1
+    },
+    "skuName": {
+      "value": "B1"
     },
     // Non-required parameters
     "location": {
@@ -111,13 +103,8 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
   params: {
     // Required parameters
     name: 'wsfmax001'
-    sku: {
-      capacity: 1
-      family: 'S'
-      name: 'S1'
-      size: 'S1'
-      tier: 'Standard'
-    }
+    skuCapacity: 1
+    skuName: 'S1'
     // Non-required parameters
     diagnosticSettings: [
       {
@@ -183,14 +170,11 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
     "name": {
       "value": "wsfmax001"
     },
-    "sku": {
-      "value": {
-        "capacity": 1,
-        "family": "S",
-        "name": "S1",
-        "size": "S1",
-        "tier": "Standard"
-      }
+    "skuCapacity": {
+      "value": 1
+    },
+    "skuName": {
+      "value": "S1"
     },
     // Non-required parameters
     "diagnosticSettings": {
@@ -275,13 +259,8 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
   params: {
     // Required parameters
     name: 'wsfwaf001'
-    sku: {
-      capacity: 3
-      family: 'P'
-      name: 'P1v3'
-      size: 'P1v3'
-      tier: 'Premium'
-    }
+    skuCapacity: 3
+    skuName: 'P1v3'
     // Non-required parameters
     diagnosticSettings: [
       {
@@ -329,14 +308,11 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
     "name": {
       "value": "wsfwaf001"
     },
-    "sku": {
-      "value": {
-        "capacity": 3,
-        "family": "P",
-        "name": "P1v3",
-        "size": "P1v3",
-        "tier": "Premium"
-      }
+    "skuCapacity": {
+      "value": 3
+    },
+    "skuName": {
+      "value": "P1v3"
     },
     // Non-required parameters
     "diagnosticSettings": {
@@ -392,7 +368,8 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-name) | string | Name of the app service plan. |
-| [`sku`](#parameter-sku) | object | Defines the name, tier, size, family and capacity of the App Service Plan. |
+| [`skuCapacity`](#parameter-skucapacity) | int | Number of workers associated with the App Service Plan. |
+| [`skuName`](#parameter-skuname) | string | The name of the SKU will Determine the tier, size, family of the App Service Plan. |
 
 **Conditional parameters**
 
@@ -426,12 +403,19 @@ Name of the app service plan.
 - Required: Yes
 - Type: string
 
-### Parameter: `sku`
+### Parameter: `skuCapacity`
 
-Defines the name, tier, size, family and capacity of the App Service Plan.
+Number of workers associated with the App Service Plan.
 
 - Required: Yes
-- Type: object
+- Type: int
+
+### Parameter: `skuName`
+
+The name of the SKU will Determine the tier, size, family of the App Service Plan.
+
+- Required: Yes
+- Type: string
 
 ### Parameter: `reserved`
 
@@ -778,7 +762,7 @@ Zone Redundancy can only be used on Premium or ElasticPremium SKU Tiers within Z
 
 - Required: No
 - Type: bool
-- Default: `[if(or(equals(parameters('sku').tier, 'Premium'), equals(parameters('sku').tier, 'ElasticPremium')), true(), false())]`
+- Default: `[if(or(startsWith(parameters('skuName'), 'P'), startsWith(parameters('skuName'), 'EP')), true(), false())]`
 
 
 ## Outputs

--- a/avm/res/web/serverfarm/main.bicep
+++ b/avm/res/web/serverfarm/main.bicep
@@ -7,21 +7,19 @@ metadata owner = 'Azure/module-maintainers'
 @maxLength(60)
 param name string
 
-@description('Required. Defines the name, tier, size, family and capacity of the App Service Plan.')
+@description('Required. The name of the SKU will Determine the tier, size, family of the App Service Plan.')
 @metadata({
   example: '''
-  {
-    name: 'P1v3'
-    tier: 'Premium'
-    size: 'P1v3'
-    family: 'P'
-    capacity: 3
-  }
+  'F1'
+  'B1'
+  'P1v3'
+  'I1v2'
   '''
 })
-param sku object
-
 param skuName string
+
+@description('Required. Number of workers associated with the App Service Plan.')
+param skuCapacity int
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
@@ -63,7 +61,7 @@ param targetWorkerCount int = 0
 param targetWorkerSize int = 0
 
 @description('Optional. Zone Redundancy can only be used on Premium or ElasticPremium SKU Tiers within ZRS Supported regions (https://learn.microsoft.com/en-us/azure/storage/common/redundancy-regions-zrs).')
-param zoneRedundant bool = (sku.tier == 'Premium' || sku.tier == 'ElasticPremium') ? true : false
+param zoneRedundant bool = startsWith(skuName, 'P') || startsWith(skuName, 'EP') ? true : false
 
 @description('Optional. The lock settings of the service.')
 param lock lockType
@@ -128,12 +126,7 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   tags: tags
   sku: {
     name: skuName
-    tier: contains(skuName, 'P')
-      ? 'Premium'
-      : contains(skuName, 'I') ? 'Isolated' : contains(skuName, 'E') ? 'ElasticPremium' : null
-    size: sku.size
-    family: sku.family
-    capacity: sku.capacity
+    capacity: skuCapacity
   }
   properties: {
     workerTierName: workerTierName

--- a/avm/res/web/serverfarm/main.bicep
+++ b/avm/res/web/serverfarm/main.bicep
@@ -21,6 +21,8 @@ param name string
 })
 param sku object
 
+param skuName string
+
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
@@ -124,7 +126,15 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   kind: kind
   location: location
   tags: tags
-  sku: sku
+  sku: {
+    name: skuName
+    tier: contains(skuName, 'P')
+      ? 'Premium'
+      : contains(skuName, 'I') ? 'Isolated' : contains(skuName, 'E') ? 'ElasticPremium' : null
+    size: sku.size
+    family: sku.family
+    capacity: sku.capacity
+  }
   properties: {
     workerTierName: workerTierName
     hostingEnvironmentProfile: !empty(appServiceEnvironmentId)

--- a/avm/res/web/serverfarm/main.json
+++ b/avm/res/web/serverfarm/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.170.59819",
-      "templateHash": "16669238654401736455"
+      "templateHash": "5846778493081554072"
     },
     "name": "App Service Plan",
     "description": "This module deploys an App Service Plan.",
@@ -201,11 +201,17 @@
         "description": "Required. Name of the app service plan."
       }
     },
-    "sku": {
-      "type": "object",
+    "skuName": {
+      "type": "string",
       "metadata": {
-        "example": "  {\n    name: 'P1v3'\n    tier: 'Premium'\n    size: 'P1v3'\n    family: 'P'\n    capacity: 3\n  }\n  ",
-        "description": "Required. Defines the name, tier, size, family and capacity of the App Service Plan."
+        "example": "  'F1'\n  'B1'\n  'P1v3'\n  'I1v2'\n  ",
+        "description": "Required. The name of the SKU will Determine the tier, size, family of the App Service Plan."
+      }
+    },
+    "skuCapacity": {
+      "type": "int",
+      "metadata": {
+        "description": "Required. Number of workers associated with the App Service Plan."
       }
     },
     "location": {
@@ -285,7 +291,7 @@
     },
     "zoneRedundant": {
       "type": "bool",
-      "defaultValue": "[if(or(equals(parameters('sku').tier, 'Premium'), equals(parameters('sku').tier, 'ElasticPremium')), true(), false())]",
+      "defaultValue": "[if(or(startsWith(parameters('skuName'), 'P'), startsWith(parameters('skuName'), 'EP')), true(), false())]",
       "metadata": {
         "description": "Optional. Zone Redundancy can only be used on Premium or ElasticPremium SKU Tiers within ZRS Supported regions (https://learn.microsoft.com/en-us/azure/storage/common/redundancy-regions-zrs)."
       }
@@ -362,7 +368,10 @@
       "kind": "[parameters('kind')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
-      "sku": "[parameters('sku')]",
+      "sku": {
+        "name": "[parameters('skuName')]",
+        "capacity": "[parameters('skuCapacity')]"
+      },
       "properties": {
         "workerTierName": "[parameters('workerTierName')]",
         "hostingEnvironmentProfile": "[if(not(empty(parameters('appServiceEnvironmentId'))), createObject('id', parameters('appServiceEnvironmentId')), null())]",

--- a/avm/res/web/serverfarm/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'wsfmin'
 param namePrefix string = '#_namePrefix_#'
 
 #disable-next-line no-hardcoded-location // Just a value to avoid ongoing capacity challenges
-var tempLocation = 'eastus'
+var tempLocation = 'australiaeast'
 
 // ============ //
 // Dependencies //
@@ -46,13 +46,8 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: tempLocation
-      sku: {
-        name: 'P1v3'
-        tier: 'Premium'
-        size: 'P1v3'
-        family: 'P'
-        capacity: 3
-      }
+      skuName: 'B1'
+      skuCapacity: 1
     }
   }
 ]

--- a/avm/res/web/serverfarm/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/defaults/main.test.bicep
@@ -21,7 +21,7 @@ param serviceShort string = 'wsfmin'
 param namePrefix string = '#_namePrefix_#'
 
 #disable-next-line no-hardcoded-location // Just a value to avoid ongoing capacity challenges
-var tempLocation = 'australiaeast'
+var tempLocation = 'eastus'
 
 // ============ //
 // Dependencies //

--- a/avm/res/web/serverfarm/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/defaults/main.test.bicep
@@ -46,7 +46,7 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: tempLocation
-      skuName: 'B1'
+      skuName: 'S1'
       skuCapacity: 2
     }
   }

--- a/avm/res/web/serverfarm/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/defaults/main.test.bicep
@@ -47,7 +47,7 @@ module testDeployment '../../../main.bicep' = [
       name: '${namePrefix}${serviceShort}001'
       location: tempLocation
       skuName: 'B1'
-      skuCapacity: 1
+      skuCapacity: 2
     }
   }
 ]

--- a/avm/res/web/serverfarm/tests/e2e/max/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/max/main.test.bicep
@@ -67,13 +67,8 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: tempLocation
-      sku: {
-        name: 'S1'
-        tier: 'Standard'
-        size: 'S1'
-        family: 'S'
-        capacity: 1
-      }
+      skuName: 'S1'
+      skuCapacity: 1
       perSiteScaling: true
       zoneRedundant: false
       kind: 'App'

--- a/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
@@ -58,13 +58,8 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: tempLocation
-      sku: {
-        name: 'P1v3'
-        tier: 'Premium'
-        size: 'P1v3'
-        family: 'P'
-        capacity: 3
-      }
+      skuName: 'P1v3'
+      skuCapacity: 3
       zoneRedundant: true
       kind: 'App'
       lock: {

--- a/avm/res/web/serverfarm/version.json
+++ b/avm/res/web/serverfarm/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1",
+  "version": "0.2",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
## Description
Provides improvements to simplify the selection of SKUs for App Service Plans by relying on the RP to provide the values for 'tier', 'family' and 'size' properties based on the 'name' provided. Logic adjusted on ZR param to accommodate the change also.

Closes #1506 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.web.serverfarm](https://github.com/tsc-buddy/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml/badge.svg?branch=fix%2F1506-sku-updates)](https://github.com/tsc-buddy/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml)     |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
