### PR TITLE
fix: Allow empty parameters in subnet `avm/res/network/virtual-network`

### DIFF
--- a/avm/res/network/virtual-network/README.md
+++ b/avm/res/network/virtual-network/README.md
@@ -190,6 +190,13 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
       }
       {
         addressPrefix: '<addressPrefix>'
+        name: 'az-subnet-x-004'
+        natGatewayResourceId: ''
+        networkSecurityGroupResourceId: ''
+        routeTableResourceId: ''
+      }
+      {
+        addressPrefix: '<addressPrefix>'
         name: 'AzureBastionSubnet'
         networkSecurityGroupResourceId: '<networkSecurityGroupResourceId>'
       }
@@ -318,6 +325,13 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
           "networkSecurityGroupResourceId": "<networkSecurityGroupResourceId>",
           "privateEndpointNetworkPolicies": "Disabled",
           "privateLinkServiceNetworkPolicies": "Enabled"
+        },
+        {
+          "addressPrefix": "<addressPrefix>",
+          "name": "az-subnet-x-004",
+          "natGatewayResourceId": "",
+          "networkSecurityGroupResourceId": "",
+          "routeTableResourceId": ""
         },
         {
           "addressPrefix": "<addressPrefix>",

--- a/avm/res/network/virtual-network/main.bicep
+++ b/avm/res/network/virtual-network/main.bicep
@@ -130,12 +130,12 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
             : []
           delegations: contains(subnet, 'delegations') ? subnet.delegations : []
           ipAllocations: contains(subnet, 'ipAllocations') ? subnet.ipAllocations : []
-          natGateway: contains(subnet, 'natGatewayResourceId')
+          natGateway: contains(subnet, 'natGatewayResourceId') && !empty(subnet.natGatewayResourceId)
             ? {
                 id: subnet.natGatewayResourceId
               }
             : null
-          networkSecurityGroup: contains(subnet, 'networkSecurityGroupResourceId')
+          networkSecurityGroup: contains(subnet, 'networkSecurityGroupResourceId') && !empty(subnet.networkSecurityGroupResourceId)
             ? {
                 id: subnet.networkSecurityGroupResourceId
               }
@@ -146,7 +146,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
           privateLinkServiceNetworkPolicies: contains(subnet, 'privateLinkServiceNetworkPolicies')
             ? subnet.privateLinkServiceNetworkPolicies
             : null
-          routeTable: contains(subnet, 'routeTableResourceId')
+          routeTable: contains(subnet, 'routeTableResourceId') && !empty(subnet.routeTableResourceId)
             ? {
                 id: subnet.routeTableResourceId
               }

--- a/avm/res/network/virtual-network/main.json
+++ b/avm/res/network/virtual-network/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "11377673418536997302"
+      "version": "0.26.170.59819",
+      "templateHash": "15351421638054038409"
     },
     "name": "Virtual Networks",
     "description": "This module deploys a Virtual Network (vNet).",
@@ -382,11 +382,11 @@
                 "applicationGatewayIPConfigurations": "[if(contains(parameters('subnets')[copyIndex('subnets')], 'applicationGatewayIPConfigurations'), parameters('subnets')[copyIndex('subnets')].applicationGatewayIPConfigurations, createArray())]",
                 "delegations": "[if(contains(parameters('subnets')[copyIndex('subnets')], 'delegations'), parameters('subnets')[copyIndex('subnets')].delegations, createArray())]",
                 "ipAllocations": "[if(contains(parameters('subnets')[copyIndex('subnets')], 'ipAllocations'), parameters('subnets')[copyIndex('subnets')].ipAllocations, createArray())]",
-                "natGateway": "[if(contains(parameters('subnets')[copyIndex('subnets')], 'natGatewayResourceId'), createObject('id', parameters('subnets')[copyIndex('subnets')].natGatewayResourceId), null())]",
-                "networkSecurityGroup": "[if(contains(parameters('subnets')[copyIndex('subnets')], 'networkSecurityGroupResourceId'), createObject('id', parameters('subnets')[copyIndex('subnets')].networkSecurityGroupResourceId), null())]",
+                "natGateway": "[if(and(contains(parameters('subnets')[copyIndex('subnets')], 'natGatewayResourceId'), not(empty(parameters('subnets')[copyIndex('subnets')].natGatewayResourceId))), createObject('id', parameters('subnets')[copyIndex('subnets')].natGatewayResourceId), null())]",
+                "networkSecurityGroup": "[if(and(contains(parameters('subnets')[copyIndex('subnets')], 'networkSecurityGroupResourceId'), not(empty(parameters('subnets')[copyIndex('subnets')].networkSecurityGroupResourceId))), createObject('id', parameters('subnets')[copyIndex('subnets')].networkSecurityGroupResourceId), null())]",
                 "privateEndpointNetworkPolicies": "[if(contains(parameters('subnets')[copyIndex('subnets')], 'privateEndpointNetworkPolicies'), parameters('subnets')[copyIndex('subnets')].privateEndpointNetworkPolicies, null())]",
                 "privateLinkServiceNetworkPolicies": "[if(contains(parameters('subnets')[copyIndex('subnets')], 'privateLinkServiceNetworkPolicies'), parameters('subnets')[copyIndex('subnets')].privateLinkServiceNetworkPolicies, null())]",
-                "routeTable": "[if(contains(parameters('subnets')[copyIndex('subnets')], 'routeTableResourceId'), createObject('id', parameters('subnets')[copyIndex('subnets')].routeTableResourceId), null())]",
+                "routeTable": "[if(and(contains(parameters('subnets')[copyIndex('subnets')], 'routeTableResourceId'), not(empty(parameters('subnets')[copyIndex('subnets')].routeTableResourceId))), createObject('id', parameters('subnets')[copyIndex('subnets')].routeTableResourceId), null())]",
                 "serviceEndpoints": "[if(contains(parameters('subnets')[copyIndex('subnets')], 'serviceEndpoints'), parameters('subnets')[copyIndex('subnets')].serviceEndpoints, createArray())]",
                 "serviceEndpointPolicies": "[if(contains(parameters('subnets')[copyIndex('subnets')], 'serviceEndpointPolicies'), parameters('subnets')[copyIndex('subnets')].serviceEndpointPolicies, createArray())]"
               }
@@ -523,8 +523,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "11309828149329550402"
+              "version": "0.26.170.59819",
+              "templateHash": "17306638026226376877"
             },
             "name": "Virtual Network Subnets",
             "description": "This module deploys a Virtual Network Subnet.",
@@ -849,8 +849,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "2926837656927862519"
+              "version": "0.26.170.59819",
+              "templateHash": "17624189975510507274"
             },
             "name": "Virtual Network Peerings",
             "description": "This module deploys a Virtual Network Peering.",
@@ -994,8 +994,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "2926837656927862519"
+              "version": "0.26.170.59819",
+              "templateHash": "17624189975510507274"
             },
             "name": "Virtual Network Peerings",
             "description": "This module deploys a Virtual Network Peering.",

--- a/avm/res/network/virtual-network/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/max/main.test.bicep
@@ -151,11 +151,18 @@ module testDeployment '../../../main.bicep' = [
         }
         {
           addressPrefix: cidrSubnet(addressPrefix, 24, 4)
+          name: '${namePrefix}-az-subnet-x-004'
+          networkSecurityGroupResourceId: ''
+          natGatewayResourceId: ''
+          routeTableResourceId: ''
+        }
+        {
+          addressPrefix: cidrSubnet(addressPrefix, 24, 5)
           name: 'AzureBastionSubnet'
           networkSecurityGroupResourceId: nestedDependencies.outputs.networkSecurityGroupBastionResourceId
         }
         {
-          addressPrefix: cidrSubnet(addressPrefix, 24, 5)
+          addressPrefix: cidrSubnet(addressPrefix, 24, 6)
           name: 'AzureFirewallSubnet'
         }
       ]


### PR DESCRIPTION
## Description

You cannot provide the following parameters in your subnet parameter, if they are empty:

- networkSecurityGroup
- natGateway
- routeTable

As soon as they are set, they have to have a correct resource id. 

This PR implements additional checks for given, but empty, parameters.
I also added a new subnet definition in the `max` test to check for the correct behaviour.

Fixes #1681
Closes #1681

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.network.virtual-network](https://github.com/cloudchristoph/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network.yml/badge.svg?branch=1681_vnet_subnet_conditional_params)](https://github.com/cloudchristoph/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network.yml) |

## Type of Change

- [ ] Update to CI Environment or utilities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
