### PR TITLE
fix: Update publishing job to only trigger if git repo is assocaited to the upstream repo

### DIFF
--- a/.github/workflows/avm.template.module.yml
+++ b/.github/workflows/avm.template.module.yml
@@ -140,6 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     # Note: Below always() required in condition due to psrule jobs being skipped for ptn modules not having defaults or waf-aligned folders
     if: github.ref == 'refs/heads/main' &&
+      github.repository	 == 'Azure/bicep-registry-modules' &&
       always() &&
       needs.job_module_static_validation.result == 'success' &&
       needs.job_module_deploy_validation.result == 'success'


### PR DESCRIPTION
## Description

Experiencing the publishing job getting triggered when using the main branch in forks. Adding an additional condition to the job to only trigger if the workflow is being run within the upstream repository.  

https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

Pipeline run with context set to my fork
https://github.com/oZakari/bicep-registry-modules/actions/runs/8930012279

Pipeline with context set to Azure org
https://github.com/oZakari/bicep-registry-modules/actions/runs/8930022963

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utlities (Non-module effecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
