### PR TITLE
fix: not supported Powershell and Python versions on Automation Runbook type

### DIFF
--- a/avm/res/automation/automation-account/README.md
+++ b/avm/res/automation/automation-account/README.md
@@ -20,7 +20,7 @@ This module deploys an Azure Automation Account.
 | `Microsoft.Automation/automationAccounts` | [2022-08-08](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2022-08-08/automationAccounts) |
 | `Microsoft.Automation/automationAccounts/jobSchedules` | [2022-08-08](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2022-08-08/automationAccounts/jobSchedules) |
 | `Microsoft.Automation/automationAccounts/modules` | [2022-08-08](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2022-08-08/automationAccounts/modules) |
-| `Microsoft.Automation/automationAccounts/runbooks` | [2022-08-08](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2022-08-08/automationAccounts/runbooks) |
+| `Microsoft.Automation/automationAccounts/runbooks` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2023-11-01/automationAccounts/runbooks) |
 | `Microsoft.Automation/automationAccounts/schedules` | [2022-08-08](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2022-08-08/automationAccounts/schedules) |
 | `Microsoft.Automation/automationAccounts/softwareUpdateConfigurations` | [2019-06-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2019-06-01/automationAccounts/softwareUpdateConfigurations) |
 | `Microsoft.Automation/automationAccounts/variables` | [2022-08-08](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2022-08-08/automationAccounts/variables) |

--- a/avm/res/automation/automation-account/job-schedule/main.json
+++ b/avm/res/automation/automation-account/job-schedule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "3709450248827326388"
+      "version": "0.26.170.59819",
+      "templateHash": "1753602189799388874"
     },
     "name": "Automation Account Job Schedules",
     "description": "This module deploys an Azure Automation Account Job Schedule.",

--- a/avm/res/automation/automation-account/main.bicep
+++ b/avm/res/automation/automation-account/main.bicep
@@ -172,7 +172,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2022-08-08' 
     }
     encryption: !empty(customerManagedKey)
       ? {
-          keySource: !empty(customerManagedKey) ? 'Microsoft.Keyvault' : 'Microsoft.Automation'
+          keySource: 'Microsoft.Keyvault'
           identity: !empty(customerManagedKey.?userAssignedIdentityResourceId)
             ? {
                 userAssignedIdentity: cMKUserAssignedIdentity.id

--- a/avm/res/automation/automation-account/main.bicep
+++ b/avm/res/automation/automation-account/main.bicep
@@ -83,8 +83,8 @@ var formattedUserAssignedIdentities = reduce(
 var identity = !empty(managedIdentities)
   ? {
       type: (managedIdentities.?systemAssigned ?? false)
-        ? (!empty(managedIdentities.?userAssignedResourceIds ?? {}) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned')
-        : (!empty(managedIdentities.?userAssignedResourceIds ?? {}) ? 'UserAssigned' : null)
+        ? (!empty(managedIdentities.?userAssignedResourceIds ?? {}) ? 'SystemAssigned, UserAssigned' : 'SystemAssigned')
+        : (!empty(managedIdentities.?userAssignedResourceIds ?? {}) ? 'UserAssigned' : 'None')
       userAssignedIdentities: !empty(formattedUserAssignedIdentities) ? formattedUserAssignedIdentities : null
     }
   : null
@@ -172,7 +172,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2022-08-08' 
     }
     encryption: !empty(customerManagedKey)
       ? {
-          keySource: 'Microsoft.KeyVault'
+          keySource: !empty(customerManagedKey) ? 'Microsoft.Keyvault' : 'Microsoft.Automation'
           identity: !empty(customerManagedKey.?userAssignedIdentityResourceId)
             ? {
                 userAssignedIdentity: cMKUserAssignedIdentity.id
@@ -180,7 +180,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2022-08-08' 
             : null
           keyVaultProperties: {
             keyName: customerManagedKey!.keyName
-            keyVaultUri: cMKKeyVault.properties.vaultUri
+            keyvaultUri: cMKKeyVault.properties.vaultUri
             keyVersion: !empty(customerManagedKey.?keyVersion ?? '')
               ? customerManagedKey!.keyVersion
               : last(split(cMKKeyVault::cMKKey.properties.keyUriWithVersion, '/'))

--- a/avm/res/automation/automation-account/main.json
+++ b/avm/res/automation/automation-account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "16001446000186457588"
+      "version": "0.26.170.59819",
+      "templateHash": "2054924198003180783"
     },
     "name": "Automation Accounts",
     "description": "This module deploys an Azure Automation Account.",
@@ -629,7 +629,7 @@
   },
   "variables": {
     "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
-    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned,UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', null())), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
+    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned, UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
     "builtInRoleNames": {
       "Automation Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f353d9bd-d4a6-484e-a77a-8050b599b867')]",
       "Automation Job Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4fe576fe-1146-4730-92eb-48519fa6bf9f')]",
@@ -704,7 +704,7 @@
         "sku": {
           "name": "[parameters('skuName')]"
         },
-        "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('keySource', 'Microsoft.KeyVault', 'identity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), createObject('userAssignedIdentity', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2], split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/')))), null()), 'keyVaultProperties', createObject('keyName', parameters('customerManagedKey').keyName, 'keyVaultUri', reference('cMKKeyVault').vaultUri, 'keyVersion', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'keyVersion'), ''))), parameters('customerManagedKey').keyVersion, last(split(reference('cMKKeyVault::cMKKey').keyUriWithVersion, '/'))))), null())]",
+        "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('keySource', if(not(empty(parameters('customerManagedKey'))), 'Microsoft.Keyvault', 'Microsoft.Automation'), 'identity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), createObject('userAssignedIdentity', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2], split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/')))), null()), 'keyVaultProperties', createObject('keyName', parameters('customerManagedKey').keyName, 'keyvaultUri', reference('cMKKeyVault').vaultUri, 'keyVersion', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'keyVersion'), ''))), parameters('customerManagedKey').keyVersion, last(split(reference('cMKKeyVault::cMKKey').keyUriWithVersion, '/'))))), null())]",
         "publicNetworkAccess": "[if(not(empty(parameters('publicNetworkAccess'))), if(equals(parameters('publicNetworkAccess'), 'Disabled'), false(), true()), if(not(empty(parameters('privateEndpoints'))), false(), null()))]",
         "disableLocalAuth": "[parameters('disableLocalAuth')]"
       },
@@ -830,8 +830,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "8037849223912660600"
+              "version": "0.26.170.59819",
+              "templateHash": "17695610509863036784"
             },
             "name": "Automation Account Modules",
             "description": "This module deploys an Azure Automation Account Module.",
@@ -972,8 +972,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "10057879847143996563"
+              "version": "0.26.170.59819",
+              "templateHash": "138940659217362139"
             },
             "name": "Automation Account Schedules",
             "description": "This module deploys an Azure Automation Account Schedule.",
@@ -1151,8 +1151,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "14714097202201612277"
+              "version": "0.26.170.59819",
+              "templateHash": "6946565957724859459"
             },
             "name": "Automation Account Runbooks",
             "description": "This module deploys an Azure Automation Account Runbook.",
@@ -1178,7 +1178,11 @@
                 "GraphPowerShell",
                 "GraphPowerShellWorkflow",
                 "PowerShell",
-                "PowerShellWorkflow"
+                "PowerShell72",
+                "PowerShellWorkflow",
+                "Python2",
+                "Python3",
+                "Script"
               ],
               "metadata": {
                 "description": "Required. The type of the runbook."
@@ -1268,7 +1272,7 @@
             },
             "runbook": {
               "type": "Microsoft.Automation/automationAccounts/runbooks",
-              "apiVersion": "2022-08-08",
+              "apiVersion": "2023-11-01",
               "name": "[format('{0}/{1}', parameters('automationAccountName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
@@ -1310,7 +1314,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('runbook', '2022-08-08', 'full').location]"
+              "value": "[reference('runbook', '2023-11-01', 'full').location]"
             }
           }
         }
@@ -1351,8 +1355,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "3709450248827326388"
+              "version": "0.26.170.59819",
+              "templateHash": "1753602189799388874"
             },
             "name": "Automation Account Job Schedules",
             "description": "This module deploys an Azure Automation Account Job Schedule.",
@@ -1479,8 +1483,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "1065450815403209329"
+              "version": "0.26.170.59819",
+              "templateHash": "12833257216729067514"
             },
             "name": "Automation Account Variables",
             "description": "This module deploys an Azure Automation Account Variable.",
@@ -1594,8 +1598,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "7204307644126778192"
+              "version": "0.26.170.59819",
+              "templateHash": "11747347606522833060"
             },
             "name": "Log Analytics Workspace Linked Services",
             "description": "This module deploys a Log Analytics Workspace Linked Service.",
@@ -1913,8 +1917,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "7586828544795723203"
+              "version": "0.26.170.59819",
+              "templateHash": "14866221548688198425"
             },
             "name": "Automation Account Software Update Configurations",
             "description": "This module deploys an Azure Automation Account Software Update Configuration.",

--- a/avm/res/automation/automation-account/main.json
+++ b/avm/res/automation/automation-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.170.59819",
-      "templateHash": "2054924198003180783"
+      "templateHash": "9883583040461189210"
     },
     "name": "Automation Accounts",
     "description": "This module deploys an Azure Automation Account.",
@@ -704,7 +704,7 @@
         "sku": {
           "name": "[parameters('skuName')]"
         },
-        "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('keySource', if(not(empty(parameters('customerManagedKey'))), 'Microsoft.Keyvault', 'Microsoft.Automation'), 'identity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), createObject('userAssignedIdentity', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2], split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/')))), null()), 'keyVaultProperties', createObject('keyName', parameters('customerManagedKey').keyName, 'keyvaultUri', reference('cMKKeyVault').vaultUri, 'keyVersion', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'keyVersion'), ''))), parameters('customerManagedKey').keyVersion, last(split(reference('cMKKeyVault::cMKKey').keyUriWithVersion, '/'))))), null())]",
+        "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('keySource', 'Microsoft.Keyvault', 'identity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), createObject('userAssignedIdentity', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2], split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/')))), null()), 'keyVaultProperties', createObject('keyName', parameters('customerManagedKey').keyName, 'keyvaultUri', reference('cMKKeyVault').vaultUri, 'keyVersion', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'keyVersion'), ''))), parameters('customerManagedKey').keyVersion, last(split(reference('cMKKeyVault::cMKKey').keyUriWithVersion, '/'))))), null())]",
         "publicNetworkAccess": "[if(not(empty(parameters('publicNetworkAccess'))), if(equals(parameters('publicNetworkAccess'), 'Disabled'), false(), true()), if(not(empty(parameters('privateEndpoints'))), false(), null()))]",
         "disableLocalAuth": "[parameters('disableLocalAuth')]"
       },

--- a/avm/res/automation/automation-account/module/main.json
+++ b/avm/res/automation/automation-account/module/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "8037849223912660600"
+      "version": "0.26.170.59819",
+      "templateHash": "17695610509863036784"
     },
     "name": "Automation Account Modules",
     "description": "This module deploys an Azure Automation Account Module.",

--- a/avm/res/automation/automation-account/runbook/README.md
+++ b/avm/res/automation/automation-account/runbook/README.md
@@ -14,7 +14,7 @@ This module deploys an Azure Automation Account Runbook.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Automation/automationAccounts/runbooks` | [2022-08-08](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2022-08-08/automationAccounts/runbooks) |
+| `Microsoft.Automation/automationAccounts/runbooks` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2023-11-01/automationAccounts/runbooks) |
 
 ## Parameters
 
@@ -69,7 +69,11 @@ The type of the runbook.
     'GraphPowerShell'
     'GraphPowerShellWorkflow'
     'PowerShell'
+    'PowerShell72'
     'PowerShellWorkflow'
+    'Python2'
+    'Python3'
+    'Script'
   ]
   ```
 

--- a/avm/res/automation/automation-account/runbook/main.bicep
+++ b/avm/res/automation/automation-account/runbook/main.bicep
@@ -13,7 +13,11 @@ param automationAccountName string
   'GraphPowerShell'
   'GraphPowerShellWorkflow'
   'PowerShell'
+  'PowerShell72'
   'PowerShellWorkflow'
+  'Python2'
+  'Python3'
+  'Script'
 ])
 @sys.description('Required. The type of the runbook.')
 param type string
@@ -74,7 +78,7 @@ var publishContentLink = empty(uri)
       version: !empty(version) ? version : null
     }
 
-resource runbook 'Microsoft.Automation/automationAccounts/runbooks@2022-08-08' = {
+resource runbook 'Microsoft.Automation/automationAccounts/runbooks@2023-11-01' = {
   name: name
   parent: automationAccount
   location: location

--- a/avm/res/automation/automation-account/runbook/main.json
+++ b/avm/res/automation/automation-account/runbook/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "14714097202201612277"
+      "version": "0.26.170.59819",
+      "templateHash": "6946565957724859459"
     },
     "name": "Automation Account Runbooks",
     "description": "This module deploys an Azure Automation Account Runbook.",
@@ -32,7 +32,11 @@
         "GraphPowerShell",
         "GraphPowerShellWorkflow",
         "PowerShell",
-        "PowerShellWorkflow"
+        "PowerShell72",
+        "PowerShellWorkflow",
+        "Python2",
+        "Python3",
+        "Script"
       ],
       "metadata": {
         "description": "Required. The type of the runbook."
@@ -122,7 +126,7 @@
     },
     "runbook": {
       "type": "Microsoft.Automation/automationAccounts/runbooks",
-      "apiVersion": "2022-08-08",
+      "apiVersion": "2023-11-01",
       "name": "[format('{0}/{1}', parameters('automationAccountName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -164,7 +168,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('runbook', '2022-08-08', 'full').location]"
+      "value": "[reference('runbook', '2023-11-01', 'full').location]"
     }
   }
 }

--- a/avm/res/automation/automation-account/schedule/main.json
+++ b/avm/res/automation/automation-account/schedule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "10057879847143996563"
+      "version": "0.26.170.59819",
+      "templateHash": "138940659217362139"
     },
     "name": "Automation Account Schedules",
     "description": "This module deploys an Azure Automation Account Schedule.",

--- a/avm/res/automation/automation-account/software-update-configuration/main.json
+++ b/avm/res/automation/automation-account/software-update-configuration/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "7586828544795723203"
+      "version": "0.26.170.59819",
+      "templateHash": "14866221548688198425"
     },
     "name": "Automation Account Software Update Configurations",
     "description": "This module deploys an Azure Automation Account Software Update Configuration.",

--- a/avm/res/automation/automation-account/variable/main.json
+++ b/avm/res/automation/automation-account/variable/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "1065450815403209329"
+      "version": "0.26.170.59819",
+      "templateHash": "12833257216729067514"
     },
     "name": "Automation Account Variables",
     "description": "This module deploys an Azure Automation Account Variable.",

--- a/avm/utilities/pipelines/staticValidation/psrule/.ps-rule/min-suppress.Rule.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/.ps-rule/min-suppress.Rule.yaml
@@ -15,8 +15,8 @@ spec:
     - Azure.Cognitive.ManagedIdentity
       # Automation specific
     - Azure.Automation.ManagedIdentity
-    - Azure.Automation.AuditLogs
-    - Azure.Automation.PlatformLogs
+    - Azure.Automation.AuditLogs # Diagnostic Settings cannot be set by default, but require user input
+    - Azure.Automation.PlatformLogs # Diagnostic Settings cannot be set by default, but require user input
       # Key Vault specific
     - Azure.KeyVault.Logs
     - Azure.KeyVault.Firewall

--- a/avm/utilities/pipelines/staticValidation/psrule/.ps-rule/min-suppress.Rule.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/.ps-rule/min-suppress.Rule.yaml
@@ -15,6 +15,8 @@ spec:
     - Azure.Cognitive.ManagedIdentity
       # Automation specific
     - Azure.Automation.ManagedIdentity
+    - Azure.Automation.AuditLogs
+    - Azure.Automation.PlatformLogs
       # Key Vault specific
     - Azure.KeyVault.Logs
     - Azure.KeyVault.Firewall


### PR DESCRIPTION
## Description
- updated runbook API version t 2023-11-01 to support all the following runbook types:
'Graph'
'GraphPowerShell'
'GraphPowerShellWorkflow'
'PowerShell'
'PowerShell72'
'PowerShellWorkflow'
'Python2'
'Python3'
'Script' (required)
- updated useridentity and keyservices to be compliant with new bicep requirements
- updated PSRule excemption file for default checks

Closes #1757 
Closes #1743 
Closes #1445 

## Pipeline Reference

| Pipeline |
| -------- |
[![avm.res.automation.automation-account](https://github.com/elanzel/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml/badge.svg?branch=automationaccount)](https://github.com/elanzel/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml)
|          |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
