### PR TITLE
chore: `res/app/job` - not orphaned anymore

### DIFF
--- a/avm/res/app/job/ORPHANED.md
+++ b/avm/res/app/job/ORPHANED.md
@@ -1,4 +1,0 @@
-⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️
-
-- Only security and bug fixes are being handled by the AVM core team at present.
-- If interested in becoming the module owner of this orphaned module (must be Microsoft FTE), please look for the related "orphaned module" GitHub issue [here](https://aka.ms/AVM/OrphanedModules)!

--- a/avm/res/app/job/README.md
+++ b/avm/res/app/job/README.md
@@ -1,10 +1,5 @@
 # Container App Jobs `[Microsoft.App/jobs]`
 
-> ⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️
-> 
-> - Only security and bug fixes are being handled by the AVM core team at present.
-> - If interested in becoming the module owner of this orphaned module (must be Microsoft FTE), please look for the related "orphaned module" GitHub issue [here](https://aka.ms/AVM/OrphanedModules)!
-
 This module deploys a Container App Job.
 
 ## Navigation

--- a/avm/res/app/job/main.json
+++ b/avm/res/app/job/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.27.1.19265",
-      "templateHash": "11649443218681434280"
+      "version": "0.26.170.59819",
+      "templateHash": "3096359783958038878"
     },
     "name": "Container App Jobs",
     "description": "This module deploys a Container App Job.",


### PR DESCRIPTION
## Description

I removed the orphaned hint.

## Pipeline Reference

| Pipeline |
| -------- |
|   [![avm.res.app.job](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.app.job.yml/badge.svg?branch=app-job-owner-change)](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.app.job.yml)       |

The pipeline fails, because the module is marked as orphaned and is expecting the orphaned.md, which I removed ¯\\_(ツ)_/¯

## Type of Change

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
