### PR TITLE
chore: updated AVM successor for `avm/ptn/authorization/resource-role-assignment`

### DIFF
--- a/modules/authorization/resource-scope-role-assignment/README.md
+++ b/modules/authorization/resource-scope-role-assignment/README.md
@@ -1,6 +1,6 @@
-<h1 style="color: steelblue;">⚠️ Retired ⚠️</h1>
+<h1 style="color: steelblue;">⚠️ Replaced ⚠️</h1>
 
-This module has been retired without a replacement module in Azure Verified Modules (AVM).
+This module has been replaced by the following equivalent module in Azure Verified Modules (AVM): [avm/ptn/authorization/resource-role-assignment](https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/authorization/resource-role-assignment).
 
 For more information, see the informational notice [here](https://github.com/Azure/bicep-registry-modules?tab=readme-ov-file#%EF%B8%8F-new-standard-for-bicep-modules---avm-%EF%B8%8F).
 

--- a/modules/authorization/resource-scope-role-assignment/REPLACED.md
+++ b/modules/authorization/resource-scope-role-assignment/REPLACED.md
@@ -1,0 +1,5 @@
+<h1 style="color: steelblue;">⚠️ Replaced ⚠️</h1>
+
+This module has been replaced by the following equivalent module in Azure Verified Modules (AVM): [avm/ptn/authorization/resource-role-assignment](https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/authorization/resource-role-assignment).
+
+For more information, see the informational notice [here](https://github.com/Azure/bicep-registry-modules?tab=readme-ov-file#%EF%B8%8F-new-standard-for-bicep-modules---avm-%EF%B8%8F).

--- a/modules/authorization/resource-scope-role-assignment/RETIRED.md
+++ b/modules/authorization/resource-scope-role-assignment/RETIRED.md
@@ -1,5 +1,0 @@
-<h1 style="color: steelblue;">⚠️ Retired ⚠️</h1>
-
-This module has been retired without a replacement module in Azure Verified Modules (AVM).
-
-For more information, see the informational notice [here](https://github.com/Azure/bicep-registry-modules?tab=readme-ov-file#%EF%B8%8F-new-standard-for-bicep-modules---avm-%EF%B8%8F).


### PR DESCRIPTION
This PR updates the pointers from the formerly retired `authorization/resource-scope-role-assignment` module, as it now has been migrated to AVM as `avm/ptn/authorization/resource-role-assignment`.