### PR TITLE
fix: `res/aad/domain-service` disables tlsV1, ntlmV1 and kerberosRc4Encryption by default

### DIFF
--- a/avm/res/aad/domain-service/README.md
+++ b/avm/res/aad/domain-service/README.md
@@ -481,7 +481,7 @@ The value is to enable Kerberos requests that use RC4 encryption.
 
 - Required: No
 - Type: string
-- Default: `'Enabled'`
+- Default: `'Disabled'`
 - Allowed:
   ```Bicep
   [
@@ -593,7 +593,7 @@ The value is to enable clients making request using NTLM v1.
 
 - Required: No
 - Type: string
-- Default: `'Enabled'`
+- Default: `'Disabled'`
 - Allowed:
   ```Bicep
   [
@@ -778,7 +778,7 @@ The value is to enable clients making request using TLSv1.
 
 - Required: No
 - Type: string
-- Default: `'Enabled'`
+- Default: `'Disabled'`
 - Allowed:
   ```Bicep
   [

--- a/avm/res/aad/domain-service/main.bicep
+++ b/avm/res/aad/domain-service/main.bicep
@@ -74,14 +74,14 @@ param filteredSync string = 'Enabled'
   'Enabled'
   'Disabled'
 ])
-param tlsV1 string = 'Enabled'
+param tlsV1 string = 'Disabled'
 
 @description('Optional. The value is to enable clients making request using NTLM v1.')
 @allowed([
   'Enabled'
   'Disabled'
 ])
-param ntlmV1 string = 'Enabled'
+param ntlmV1 string = 'Disabled'
 
 @description('Optional. The value is to enable synchronized users to use NTLM authentication.')
 @allowed([
@@ -104,7 +104,7 @@ param syncOnPremPasswords string = 'Enabled'
   'Enabled'
   'Disabled'
 ])
-param kerberosRc4Encryption string = 'Enabled'
+param kerberosRc4Encryption string = 'Disabled'
 
 @description('Optional. The value is to enable to provide a protected channel between the Kerberos client and the KDC.')
 @allowed([
@@ -180,24 +180,23 @@ var builtInRoleNames = {
 // Resources      //
 // ============== //
 
-resource avmTelemetry 'Microsoft.Resources/deployments@2023-07-01' =
-  if (enableTelemetry) {
-    name: '46d3xbcp.res.aad-domainservice.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
-    properties: {
-      mode: 'Incremental'
-      template: {
-        '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
-        contentVersion: '1.0.0.0'
-        resources: []
-        outputs: {
-          telemetry: {
-            type: 'String'
-            value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
-          }
+resource avmTelemetry 'Microsoft.Resources/deployments@2023-07-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.aad-domainservice.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
         }
       }
     }
   }
+}
 
 resource domainservice 'Microsoft.AAD/domainServices@2022-12-01' = {
   name: name
@@ -260,17 +259,16 @@ resource domainservice_diagnosticSettings 'Microsoft.Insights/diagnosticSettings
   }
 ]
 
-resource domainservice_lock 'Microsoft.Authorization/locks@2020-05-01' =
-  if (!empty(lock ?? {}) && lock.?kind != 'None') {
-    name: lock.?name ?? 'lock-${name}'
-    properties: {
-      level: lock.?kind ?? ''
-      notes: lock.?kind == 'CanNotDelete'
-        ? 'Cannot delete resource or child resources.'
-        : 'Cannot delete or modify the resource or child resources.'
-    }
-    scope: domainservice
+resource domainservice_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(lock ?? {}) && lock.?kind != 'None') {
+  name: lock.?name ?? 'lock-${name}'
+  properties: {
+    level: lock.?kind ?? ''
+    notes: lock.?kind == 'CanNotDelete'
+      ? 'Cannot delete resource or child resources.'
+      : 'Cannot delete or modify the resource or child resources.'
   }
+  scope: domainservice
+}
 
 resource domainservice_roleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for (roleAssignment, index) in (roleAssignments ?? []): {

--- a/avm/res/aad/domain-service/main.json
+++ b/avm/res/aad/domain-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "7265620724598107360"
+      "version": "0.27.1.19265",
+      "templateHash": "11541389602215050557"
     },
     "name": "Azure Active Directory Domain Services",
     "description": "This module deploys an Azure Active Directory Domain Services (AADDS) instance.",
@@ -343,7 +343,7 @@
     },
     "tlsV1": {
       "type": "string",
-      "defaultValue": "Enabled",
+      "defaultValue": "Disabled",
       "allowedValues": [
         "Enabled",
         "Disabled"
@@ -354,7 +354,7 @@
     },
     "ntlmV1": {
       "type": "string",
-      "defaultValue": "Enabled",
+      "defaultValue": "Disabled",
       "allowedValues": [
         "Enabled",
         "Disabled"
@@ -387,7 +387,7 @@
     },
     "kerberosRc4Encryption": {
       "type": "string",
-      "defaultValue": "Enabled",
+      "defaultValue": "Disabled",
       "allowedValues": [
         "Enabled",
         "Disabled"

--- a/avm/res/aad/domain-service/version.json
+++ b/avm/res/aad/domain-service/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1",
+  "version": "0.2",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
## Description

Changing the default values, as the old defaults caused the deployments, triggered by the GitHub Actions, to fail.

Closes #2064

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.res.aad.domain-service](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.aad.domain-service.yml/badge.svg?branch=aad-encryption-updates)](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.aad.domain-service.yml)       |

## Type of Change

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
