### PR TITLE
fix: Sets line ending to LF

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "editor.formatOnSave": true,
   "files.trimTrailingWhitespace": true,
   "files.autoSave": "onFocusChange",
+  "files.eol": "\n",
   "git.autofetch": true,
   "githubPullRequests.pullBranch": "always",
   "powershell.codeFormatting.autoCorrectAliases": true,


### PR DESCRIPTION
## Description

Static validation will fail with multi-line comments in bicep files, if the bicep file is saved with CRLF.

Closes #2181 

## Type of Change

- [x] Update to CI Environment or utlities (Non-module effecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
