### PR TITLE
fix: Addressing avm environment quota for serverfarms

### DIFF
--- a/avm/res/web/serverfarm/README.md
+++ b/avm/res/web/serverfarm/README.md
@@ -259,7 +259,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
   params: {
     // Required parameters
     name: 'wsfwaf001'
-    skuCapacity: 3
+    skuCapacity: 1
     skuName: 'P1v3'
     // Non-required parameters
     diagnosticSettings: [
@@ -287,7 +287,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
       'hidden-title': 'This is visible in the resource name'
       Role: 'DeploymentValidation'
     }
-    zoneRedundant: true
+    zoneRedundant: false
   }
 }
 ```
@@ -309,7 +309,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
       "value": "wsfwaf001"
     },
     "skuCapacity": {
-      "value": 3
+      "value": 1
     },
     "skuName": {
       "value": "P1v3"
@@ -351,7 +351,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
       }
     },
     "zoneRedundant": {
-      "value": true
+      "value": false
     }
   }
 }

--- a/avm/res/web/serverfarm/README.md
+++ b/avm/res/web/serverfarm/README.md
@@ -246,7 +246,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
 
 ### Example 3: _WAF-aligned_
 
-This instance deploys the module in alignment with the best-practices of the Azure Well-Architected Framework.
+This instance deploys the module in alignment with the best-practices of the Azure Well-Architected Framework. Note - whilst this test is WAF aligned, zoneRedundant is set to false to avoid temporary AVM environment challenges. It is highly recommended that users of this module set the property value to true.
 
 
 <details>

--- a/avm/res/web/serverfarm/README.md
+++ b/avm/res/web/serverfarm/README.md
@@ -259,7 +259,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
   params: {
     // Required parameters
     name: 'wsfwaf001'
-    skuCapacity: 1
+    skuCapacity: 2
     skuName: 'P1v3'
     // Non-required parameters
     diagnosticSettings: [
@@ -309,7 +309,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
       "value": "wsfwaf001"
     },
     "skuCapacity": {
-      "value": 1
+      "value": 2
     },
     "skuName": {
       "value": "P1v3"

--- a/avm/res/web/serverfarm/README.md
+++ b/avm/res/web/serverfarm/README.md
@@ -394,7 +394,7 @@ module serverfarm 'br/public:avm/res/web/serverfarm:<version>' = {
 | [`targetWorkerCount`](#parameter-targetworkercount) | int | Scaling worker count. |
 | [`targetWorkerSize`](#parameter-targetworkersize) | int | The instance size of the hosting plan (small, medium, or large). |
 | [`workerTierName`](#parameter-workertiername) | string | Target worker tier assigned to the App Service plan. |
-| [`zoneRedundant`](#parameter-zoneredundant) | bool | Zone Redundancy can only be used on Premium or ElasticPremium SKU Tiers within ZRS Supported regions (https://learn.microsoft.com/en-us/azure/storage/common/redundancy-regions-zrs). |
+| [`zoneRedundant`](#parameter-zoneredundant) | bool | Zone Redundant server farms can only be used on Premium or ElasticPremium SKU tiers within ZRS Supported regions (https://learn.microsoft.com/en-us/azure/storage/common/redundancy-regions-zrs). |
 
 ### Parameter: `name`
 
@@ -758,7 +758,7 @@ Target worker tier assigned to the App Service plan.
 
 ### Parameter: `zoneRedundant`
 
-Zone Redundancy can only be used on Premium or ElasticPremium SKU Tiers within ZRS Supported regions (https://learn.microsoft.com/en-us/azure/storage/common/redundancy-regions-zrs).
+Zone Redundant server farms can only be used on Premium or ElasticPremium SKU tiers within ZRS Supported regions (https://learn.microsoft.com/en-us/azure/storage/common/redundancy-regions-zrs).
 
 - Required: No
 - Type: bool

--- a/avm/res/web/serverfarm/main.bicep
+++ b/avm/res/web/serverfarm/main.bicep
@@ -60,7 +60,7 @@ param targetWorkerCount int = 0
 ])
 param targetWorkerSize int = 0
 
-@description('Optional. Zone Redundancy can only be used on Premium or ElasticPremium SKU Tiers within ZRS Supported regions (https://learn.microsoft.com/en-us/azure/storage/common/redundancy-regions-zrs).')
+@description('Optional. Zone Redundant server farms can only be used on Premium or ElasticPremium SKU tiers within ZRS Supported regions (https://learn.microsoft.com/en-us/azure/storage/common/redundancy-regions-zrs).')
 param zoneRedundant bool = startsWith(skuName, 'P') || startsWith(skuName, 'EP') ? true : false
 
 @description('Optional. The lock settings of the service.')
@@ -100,24 +100,23 @@ var builtInRoleNames = {
   )
 }
 
-resource avmTelemetry 'Microsoft.Resources/deployments@2023-07-01' =
-  if (enableTelemetry) {
-    name: '46d3xbcp.res.web-serverfarm.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
-    properties: {
-      mode: 'Incremental'
-      template: {
-        '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
-        contentVersion: '1.0.0.0'
-        resources: []
-        outputs: {
-          telemetry: {
-            type: 'String'
-            value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
-          }
+resource avmTelemetry 'Microsoft.Resources/deployments@2023-07-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.web-serverfarm.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
         }
       }
     }
   }
+}
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: name
@@ -166,17 +165,16 @@ resource appServicePlan_diagnosticSettings 'Microsoft.Insights/diagnosticSetting
   }
 ]
 
-resource appServicePlan_lock 'Microsoft.Authorization/locks@2020-05-01' =
-  if (!empty(lock ?? {}) && lock.?kind != 'None') {
-    name: lock.?name ?? 'lock-${name}'
-    properties: {
-      level: lock.?kind ?? ''
-      notes: lock.?kind == 'CanNotDelete'
-        ? 'Cannot delete resource or child resources.'
-        : 'Cannot delete or modify the resource or child resources.'
-    }
-    scope: appServicePlan
+resource appServicePlan_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(lock ?? {}) && lock.?kind != 'None') {
+  name: lock.?name ?? 'lock-${name}'
+  properties: {
+    level: lock.?kind ?? ''
+    notes: lock.?kind == 'CanNotDelete'
+      ? 'Cannot delete resource or child resources.'
+      : 'Cannot delete or modify the resource or child resources.'
   }
+  scope: appServicePlan
+}
 
 resource appServicePlan_roleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for (roleAssignment, index) in (roleAssignments ?? []): {

--- a/avm/res/web/serverfarm/main.json
+++ b/avm/res/web/serverfarm/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.27.1.19265",
-      "templateHash": "18350528700097099026"
+      "templateHash": "3135450909992165111"
     },
     "name": "App Service Plan",
     "description": "This module deploys an App Service Plan.",
@@ -293,7 +293,7 @@
       "type": "bool",
       "defaultValue": "[if(or(startsWith(parameters('skuName'), 'P'), startsWith(parameters('skuName'), 'EP')), true(), false())]",
       "metadata": {
-        "description": "Optional. Zone Redundancy can only be used on Premium or ElasticPremium SKU Tiers within ZRS Supported regions (https://learn.microsoft.com/en-us/azure/storage/common/redundancy-regions-zrs)."
+        "description": "Optional. Zone Redundant server farms can only be used on Premium or ElasticPremium SKU tiers within ZRS Supported regions (https://learn.microsoft.com/en-us/azure/storage/common/redundancy-regions-zrs)."
       }
     },
     "lock": {

--- a/avm/res/web/serverfarm/main.json
+++ b/avm/res/web/serverfarm/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.170.59819",
-      "templateHash": "5846778493081554072"
+      "version": "0.27.1.19265",
+      "templateHash": "18350528700097099026"
     },
     "name": "App Service Plan",
     "description": "This module deploys an App Service Plan.",

--- a/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
@@ -15,7 +15,7 @@ param resourceGroupName string = 'dep-${namePrefix}-web.serverfarms-${serviceSho
 param serviceShort string = 'wsfwaf'
 
 @description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
-param namePrefix string = 'fs'
+param namePrefix string = '#_namePrefix_#'
 
 #disable-next-line no-hardcoded-location // Just a value to avoid ongoing capacity challenges
 var enforcedLocation = 'eastus'

--- a/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
@@ -57,7 +57,7 @@ module testDeployment '../../../main.bicep' = [
       location: enforcedLocation
       skuName: 'P1v3'
       skuCapacity: 1
-      zoneRedundant: false // This should be set to true for production deployments
+      zoneRedundant: false
       kind: 'App'
       lock: {
         name: 'lock'

--- a/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
@@ -1,7 +1,7 @@
 targetScope = 'subscription'
 
 metadata name = 'WAF-aligned'
-metadata description = 'This instance deploys the module in alignment with the best-practices of the Azure Well-Architected Framework.'
+metadata description = 'This instance deploys the module in alignment with the best-practices of the Azure Well-Architected Framework. Note - whilst this test is WAF aligned, zoneRedundant is set to false to avoid temporary AVM environment challenges. It is highly recommended that users of this module set the property value to true.'
 
 // ========== //
 // Parameters //

--- a/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
@@ -15,7 +15,7 @@ param resourceGroupName string = 'dep-${namePrefix}-web.serverfarms-${serviceSho
 param serviceShort string = 'wsfwaf'
 
 @description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
-param namePrefix string = '#_namePrefix_#'
+param namePrefix string = 'fs'
 
 #disable-next-line no-hardcoded-location // Just a value to avoid ongoing capacity challenges
 var enforcedLocation = 'eastus'
@@ -56,8 +56,8 @@ module testDeployment '../../../main.bicep' = [
       name: '${namePrefix}${serviceShort}001'
       location: enforcedLocation
       skuName: 'P1v3'
-      skuCapacity: 3
-      zoneRedundant: true
+      skuCapacity: 1
+      zoneRedundant: false // This should be set to true for production deployments
       kind: 'App'
       lock: {
         name: 'lock'

--- a/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/web/serverfarm/tests/e2e/waf-aligned/main.test.bicep
@@ -56,7 +56,7 @@ module testDeployment '../../../main.bicep' = [
       name: '${namePrefix}${serviceShort}001'
       location: enforcedLocation
       skuName: 'P1v3'
-      skuCapacity: 1
+      skuCapacity: 2
       zoneRedundant: false
       kind: 'App'
       lock: {


### PR DESCRIPTION
## Description

This PR addresses the issue with the AVM bicep-registry-modules deployment environment not having quota to support zone redundant app services plans. This was being investigated seperately by @AlexanderSehr and some of the other core team. Alex advised that the plan was to:

- Disable the zonal deployment in the (waf?) test in a new PR to unblock the module.

The changes in the PR now have the **_zoneredunant_** param set to 'false' in the WAF test but with two instances to pass the PSRule test.
This should also close the below as the deployment should now run successfully in the AVM environment and then move onto the publish. Bringing the version in sync with the docs.

Closes #1928
Closes #2188 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.web.serverfarm](https://github.com/tsc-buddy/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml/badge.svg?branch=fix%2Fwaf-test-env-bug)](https://github.com/tsc-buddy/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml)      |

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utlities (Non-module effecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to day with the contribution guide at https://aka.ms/avm/contribute/bicep -->
