### PR TITLE
fixing failing workflow runs for encrypted eventhub

### DIFF
--- a/avm/res/event-hub/namespace/README.md
+++ b/avm/res/event-hub/namespace/README.md
@@ -117,7 +117,6 @@ module namespace 'br/public:avm/res/event-hub/namespace:<version>' = {
         '<managedIdentityResourceId>'
       ]
     }
-    publicNetworkAccess: 'SecuredByPerimeter'
     requireInfrastructureEncryption: true
     skuName: 'Premium'
   }
@@ -158,9 +157,6 @@ module namespace 'br/public:avm/res/event-hub/namespace:<version>' = {
           "<managedIdentityResourceId>"
         ]
       }
-    },
-    "publicNetworkAccess": {
-      "value": "SecuredByPerimeter"
     },
     "requireInfrastructureEncryption": {
       "value": true

--- a/avm/res/event-hub/namespace/authorization-rule/main.json
+++ b/avm/res/event-hub/namespace/authorization-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "15327912662565121564"
+      "version": "0.28.1.47646",
+      "templateHash": "16196850257533249972"
     },
     "name": "Event Hub Namespace Authorization Rule",
     "description": "This module deploys an Event Hub Namespace Authorization Rule.",

--- a/avm/res/event-hub/namespace/disaster-recovery-config/main.json
+++ b/avm/res/event-hub/namespace/disaster-recovery-config/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "11732013494690054024"
+      "version": "0.28.1.47646",
+      "templateHash": "11958192120414683611"
     },
     "name": "Event Hub Namespace Disaster Recovery Configs",
     "description": "This module deploys an Event Hub Namespace Disaster Recovery Config.",

--- a/avm/res/event-hub/namespace/eventhub/authorization-rule/main.json
+++ b/avm/res/event-hub/namespace/eventhub/authorization-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "15301134976738274567"
+      "version": "0.28.1.47646",
+      "templateHash": "13970780399709322534"
     },
     "name": "Event Hub Namespace Event Hub Authorization Rules",
     "description": "This module deploys an Event Hub Namespace Event Hub Authorization Rule.",

--- a/avm/res/event-hub/namespace/eventhub/consumergroup/main.json
+++ b/avm/res/event-hub/namespace/eventhub/consumergroup/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "7757490711276971084"
+      "version": "0.28.1.47646",
+      "templateHash": "10439838475562052342"
     },
     "name": "Event Hub Namespace Event Hub Consumer Groups",
     "description": "This module deploys an Event Hub Namespace Event Hub Consumer Group.",

--- a/avm/res/event-hub/namespace/eventhub/main.json
+++ b/avm/res/event-hub/namespace/eventhub/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "14538170733088329405"
+      "version": "0.28.1.47646",
+      "templateHash": "5745450341554942810"
     },
     "name": "Event Hub Namespace Event Hubs",
     "description": "This module deploys an Event Hub Namespace Event Hub.",
@@ -416,8 +416,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "7757490711276971084"
+              "version": "0.28.1.47646",
+              "templateHash": "10439838475562052342"
             },
             "name": "Event Hub Namespace Event Hub Consumer Groups",
             "description": "This module deploys an Event Hub Namespace Event Hub Consumer Group.",
@@ -520,8 +520,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "15301134976738274567"
+              "version": "0.28.1.47646",
+              "templateHash": "13970780399709322534"
             },
             "name": "Event Hub Namespace Event Hub Authorization Rules",
             "description": "This module deploys an Event Hub Namespace Event Hub Authorization Rule.",

--- a/avm/res/event-hub/namespace/main.json
+++ b/avm/res/event-hub/namespace/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "5884251970985873966"
+      "version": "0.28.1.47646",
+      "templateHash": "5395452802067789648"
     },
     "name": "Event Hub Namespaces",
     "description": "This module deploys an Event Hub Namespace.",
@@ -854,8 +854,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "15327912662565121564"
+              "version": "0.28.1.47646",
+              "templateHash": "16196850257533249972"
             },
             "name": "Event Hub Namespace Authorization Rule",
             "description": "This module deploys an Event Hub Namespace Authorization Rule.",
@@ -951,8 +951,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "11732013494690054024"
+              "version": "0.28.1.47646",
+              "templateHash": "11958192120414683611"
             },
             "name": "Event Hub Namespace Disaster Recovery Configs",
             "description": "This module deploys an Event Hub Namespace Disaster Recovery Config.",
@@ -1067,8 +1067,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "14538170733088329405"
+              "version": "0.28.1.47646",
+              "templateHash": "5745450341554942810"
             },
             "name": "Event Hub Namespace Event Hubs",
             "description": "This module deploys an Event Hub Namespace Event Hub.",
@@ -1478,8 +1478,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.26.54.24096",
-                      "templateHash": "7757490711276971084"
+                      "version": "0.28.1.47646",
+                      "templateHash": "10439838475562052342"
                     },
                     "name": "Event Hub Namespace Event Hub Consumer Groups",
                     "description": "This module deploys an Event Hub Namespace Event Hub Consumer Group.",
@@ -1582,8 +1582,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.26.54.24096",
-                      "templateHash": "15301134976738274567"
+                      "version": "0.28.1.47646",
+                      "templateHash": "13970780399709322534"
                     },
                     "name": "Event Hub Namespace Event Hub Authorization Rules",
                     "description": "This module deploys an Event Hub Namespace Event Hub Authorization Rule.",
@@ -1718,8 +1718,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "3984181780336367181"
+              "version": "0.28.1.47646",
+              "templateHash": "4849410286147918309"
             },
             "name": "Event Hub Namespace Network Rule Sets",
             "description": "This module deploys an Event Hub Namespace Network Rule Set.",

--- a/avm/res/event-hub/namespace/network-rule-set/main.json
+++ b/avm/res/event-hub/namespace/network-rule-set/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "3984181780336367181"
+      "version": "0.28.1.47646",
+      "templateHash": "4849410286147918309"
     },
     "name": "Event Hub Namespace Network Rule Sets",
     "description": "This module deploys an Event Hub Namespace Network Rule Set.",

--- a/avm/res/event-hub/namespace/tests/e2e/encr/main.test.bicep
+++ b/avm/res/event-hub/namespace/tests/e2e/encr/main.test.bicep
@@ -55,7 +55,7 @@ module testDeployment '../../../main.bicep' = {
   params: {
     name: '${namePrefix}${serviceShort}001'
     location: resourceLocation
-    publicNetworkAccess: 'SecuredByPerimeter'
+    //publicNetworkAccess: 'SecuredByPerimeter'
     skuName: 'Premium'
     managedIdentities: {
       systemAssigned: false

--- a/avm/res/event-hub/namespace/tests/e2e/encr/main.test.bicep
+++ b/avm/res/event-hub/namespace/tests/e2e/encr/main.test.bicep
@@ -55,7 +55,6 @@ module testDeployment '../../../main.bicep' = {
   params: {
     name: '${namePrefix}${serviceShort}001'
     location: resourceLocation
-    //publicNetworkAccess: 'SecuredByPerimeter'
     skuName: 'Premium'
     managedIdentities: {
       systemAssigned: false

--- a/avm/utilities/pipelines/staticValidation/psrule/.ps-rule/min-suppress.Rule.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/.ps-rule/min-suppress.Rule.yaml
@@ -17,6 +17,8 @@ spec:
     - Azure.Automation.ManagedIdentity
     - Azure.Automation.AuditLogs # Diagnostic Settings cannot be set by default, but require user input
     - Azure.Automation.PlatformLogs # Diagnostic Settings cannot be set by default, but require user input
+      # Event Hub specific
+    - Azure.EventHub.Firewall
       # Key Vault specific
     - Azure.KeyVault.Logs
     - Azure.KeyVault.Firewall


### PR DESCRIPTION
## Description

Fixes the issues on encrypted eventhub deployment that was due to publicNetworkAccess set to "SecuredbyPerimeter"
fixes #1729

## Pipeline Reference

| Pipeline |
| -------- |
|     [![avm.res.event-hub.namespace](https://github.com/elanzel/bicep-registry-modules/actions/workflows/avm.res.event-hub.namespace.yml/badge.svg?branch=eventhub_prfix)](https://github.com/elanzel/bicep-registry-modules/actions/workflows/avm.res.event-hub.namespace.yml)     |

## Type of Change

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
