### PR TITLE
feat: add support for oidc azure/login params

### DIFF
--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -62,6 +62,9 @@ runs:
     - name: Azure Login
       uses: azure/login@v2
       with:
+        client-id: ${{ env.AZURE_CLIENT_ID }}
+        tenant-id: ${{ env.AZURE_TENANT_ID }}
+        subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
         creds: ${{ env.AZURE_CREDENTIALS }}
         enable-AzPSSession: true
 

--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -62,9 +62,11 @@ runs:
     - name: Azure Login
       uses: azure/login@v2
       with:
+        # client-id, tenant-id, and subscription-id used in OIDC authentication
         client-id: ${{ env.AZURE_CLIENT_ID }}
         tenant-id: ${{ env.AZURE_TENANT_ID }}
         subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+        # creds used in legacy client secret authentication
         creds: ${{ env.AZURE_CREDENTIALS }}
         enable-AzPSSession: true
 

--- a/.github/workflows/avm.template.module.yml
+++ b/.github/workflows/avm.template.module.yml
@@ -132,6 +132,9 @@ jobs:
           customLocation: "${{ fromJson(inputs.workflowInput).customLocation }}"
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
 
   ##################
   #   Publishing   #

--- a/.github/workflows/avm.template.module.yml
+++ b/.github/workflows/avm.template.module.yml
@@ -131,7 +131,9 @@ jobs:
           removeDeployment: "${{ fromJson(inputs.workflowInput).removeDeployment }}"
           customLocation: "${{ fromJson(inputs.workflowInput).customLocation }}"
         env:
+          ## used in legacy client secret authentication
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+          # used in OIDC federated authentication
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Description

Add support for OIDC authentication to the azure/login@v2 workflow and avoid client secrets. Compatible with actions configurations using either OIDC or AZURE_CREDNTIALS approach. 

`creds` parameter is ignored if client-id, subscription-id, or tenant-id are also specified. See https://github.com/marketplace/actions/azure-login#creds

## Testing evidence

Old approach:
![image](https://github.com/Azure/bicep-registry-modules/assets/25390936/0b9fbc50-d095-45d0-9d45-64d67f61f7f2)

After setting up a federated credential on the App Registration and adding AZURE_CLIENT_ID, AZURE_SUBSCRIPTION_ID, and AZURE_TENANT_ID workflow secrets:
(when AZURE_CREDNTIALS exists)
![image](https://github.com/Azure/bicep-registry-modules/assets/25390936/32629b28-8406-4244-baa9-c4a94ff8456f)
(when AZURE_CREDENTIALS does not exist)
![image](https://github.com/Azure/bicep-registry-modules/assets/25390936/a7db740c-5f3f-4c17-b6c1-da225c57eb9f)


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation **AVM docs should be updated to prefer OIDC setup**

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
