### PR TITLE
feat: `avm/res/automation/automation-account` added support for python 3, phyton 2 packages, powershell 7.2 modules

### DIFF
--- a/avm/res/automation/automation-account/README.md
+++ b/avm/res/automation/automation-account/README.md
@@ -1573,7 +1573,62 @@ List of powershell72 modules to be created in the automation account.
 
 - Required: No
 - Type: array
-- Default: `[]`
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-powershell72modulesname) | string | Name of the Powershell72 Automation Account module. |
+| [`uri`](#parameter-powershell72modulesuri) | string | Module package URI, e.g. https://www.powershellgallery.com/api/v2/package. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`location`](#parameter-powershell72moduleslocation) | string | The location to deploy the module to. |
+| [`tags`](#parameter-powershell72modulestags) | object | Tags of the Powershell 72 module resource. |
+| [`version`](#parameter-powershell72modulesversion) | string | Module version or specify latest to get the latest version. |
+
+### Parameter: `powershell72Modules.name`
+
+Name of the Powershell72 Automation Account module.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `powershell72Modules.uri`
+
+Module package URI, e.g. https://www.powershellgallery.com/api/v2/package.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `powershell72Modules.location`
+
+The location to deploy the module to.
+
+- Required: No
+- Type: string
+
+### Parameter: `powershell72Modules.tags`
+
+Tags of the Powershell 72 module resource.
+
+- Required: No
+- Type: object
+
+### Parameter: `powershell72Modules.version`
+
+Module version or specify latest to get the latest version.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'latest'
+  ]
+  ```
 
 ### Parameter: `privateEndpoints`
 
@@ -1940,7 +1995,54 @@ List of python 2 packages to be created in the automation account.
 
 - Required: No
 - Type: array
-- Default: `[]`
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-python2packagesname) | string | Name of the Python2 Automation Account package. |
+| [`uri`](#parameter-python2packagesuri) | string | Module package URI, e.g. https://www.powershellgallery.com/api/v2/package. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`tags`](#parameter-python2packagestags) | object | Tags of the Python2 package resource. |
+| [`version`](#parameter-python2packagesversion) | string | Module version or specify latest to get the latest version. |
+
+### Parameter: `python2Packages.name`
+
+Name of the Python2 Automation Account package.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `python2Packages.uri`
+
+Module package URI, e.g. https://www.powershellgallery.com/api/v2/package.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `python2Packages.tags`
+
+Tags of the Python2 package resource.
+
+- Required: No
+- Type: object
+
+### Parameter: `python2Packages.version`
+
+Module version or specify latest to get the latest version.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'latest'
+  ]
+  ```
 
 ### Parameter: `python3Packages`
 
@@ -1948,7 +2050,54 @@ List of python 3 packages to be created in the automation account.
 
 - Required: No
 - Type: array
-- Default: `[]`
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-python3packagesname) | string | Name of the Python3 Automation Account package. |
+| [`uri`](#parameter-python3packagesuri) | string | Module package URI, e.g. https://www.powershellgallery.com/api/v2/package. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`tags`](#parameter-python3packagestags) | object | Tags of the Python3 package resource. |
+| [`version`](#parameter-python3packagesversion) | string | Module version or specify latest to get the latest version. |
+
+### Parameter: `python3Packages.name`
+
+Name of the Python3 Automation Account package.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `python3Packages.uri`
+
+Module package URI, e.g. https://www.powershellgallery.com/api/v2/package.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `python3Packages.tags`
+
+Tags of the Python3 package resource.
+
+- Required: No
+- Type: object
+
+### Parameter: `python3Packages.version`
+
+Module version or specify latest to get the latest version.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'latest'
+  ]
+  ```
 
 ### Parameter: `roleAssignments`
 

--- a/avm/res/automation/automation-account/README.md
+++ b/avm/res/automation/automation-account/README.md
@@ -2000,19 +2000,19 @@ List of python 2 packages to be created in the automation account.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`name`](#parameter-python2packagesname) | string | Name of the Python2 Automation Account package. |
+| [`name`](#parameter-python2packagesname) | string | Name of the Python3 Automation Account package. |
 | [`uri`](#parameter-python2packagesuri) | string | Module package URI, e.g. https://www.powershellgallery.com/api/v2/package. |
 
 **Optional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`tags`](#parameter-python2packagestags) | object | Tags of the Python2 package resource. |
+| [`tags`](#parameter-python2packagestags) | object | Tags of the Python3 package resource. |
 | [`version`](#parameter-python2packagesversion) | string | Module version or specify latest to get the latest version. |
 
 ### Parameter: `python2Packages.name`
 
-Name of the Python2 Automation Account package.
+Name of the Python3 Automation Account package.
 
 - Required: Yes
 - Type: string
@@ -2026,7 +2026,7 @@ Module package URI, e.g. https://www.powershellgallery.com/api/v2/package.
 
 ### Parameter: `python2Packages.tags`
 
-Tags of the Python2 package resource.
+Tags of the Python3 package resource.
 
 - Required: No
 - Type: object

--- a/avm/res/automation/automation-account/README.md
+++ b/avm/res/automation/automation-account/README.md
@@ -21,6 +21,9 @@ This module deploys an Azure Automation Account.
 | `Microsoft.Automation/automationAccounts/credentials` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2023-11-01/automationAccounts/credentials) |
 | `Microsoft.Automation/automationAccounts/jobSchedules` | [2022-08-08](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2022-08-08/automationAccounts/jobSchedules) |
 | `Microsoft.Automation/automationAccounts/modules` | [2022-08-08](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2022-08-08/automationAccounts/modules) |
+| `Microsoft.Automation/automationAccounts/powerShell72Modules` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2023-11-01/automationAccounts/powerShell72Modules) |
+| `Microsoft.Automation/automationAccounts/python2Packages` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2023-11-01/automationAccounts/python2Packages) |
+| `Microsoft.Automation/automationAccounts/python3Packages` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2023-11-01/automationAccounts/python3Packages) |
 | `Microsoft.Automation/automationAccounts/runbooks` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2023-11-01/automationAccounts/runbooks) |
 | `Microsoft.Automation/automationAccounts/schedules` | [2022-08-08](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2022-08-08/automationAccounts/schedules) |
 | `Microsoft.Automation/automationAccounts/softwareUpdateConfigurations` | [2019-06-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2019-06-01/automationAccounts/softwareUpdateConfigurations) |
@@ -234,6 +237,13 @@ module automationAccount 'br/public:avm/res/automation/automation-account:<versi
         version: 'latest'
       }
     ]
+    powershell72Modules: [
+      {
+        name: 'powershell-yaml'
+        uri: 'https://www.powershellgallery.com/api/v2/package'
+        version: 'latest'
+      }
+    ]
     privateEndpoints: [
       {
         privateDnsZoneResourceIds: [
@@ -270,6 +280,20 @@ module automationAccount 'br/public:avm/res/automation/automation-account:<versi
           'hidden-title': 'This is visible in the resource name'
           Role: 'DeploymentValidation'
         }
+      }
+    ]
+    python2Packages: [
+      {
+        name: 'pycx2-1.0.3-py2-none-any.whl'
+        uri: 'https://files.pythonhosted.org/packages/59/8c/40f66c4ac7564a68edd629a7836536af53d10b2d89f78c63e77cfcd9d460'
+        version: 'latest'
+      }
+    ]
+    python3Packages: [
+      {
+        name: 'geniz-0.0.1-py3-none-any.whl'
+        uri: 'https://files.pythonhosted.org/packages/8f/4b/c61bb7b176b34dd0c9ab0f3d821234c1e9f81f3ba5a609a1cf9032c852e7'
+        version: 'latest'
       }
     ]
     roleAssignments: [
@@ -494,6 +518,15 @@ module automationAccount 'br/public:avm/res/automation/automation-account:<versi
         }
       ]
     },
+    "powershell72Modules": {
+      "value": [
+        {
+          "name": "powershell-yaml",
+          "uri": "https://www.powershellgallery.com/api/v2/package",
+          "version": "latest"
+        }
+      ]
+    },
     "privateEndpoints": {
       "value": [
         {
@@ -531,6 +564,24 @@ module automationAccount 'br/public:avm/res/automation/automation-account:<versi
             "hidden-title": "This is visible in the resource name",
             "Role": "DeploymentValidation"
           }
+        }
+      ]
+    },
+    "python2Packages": {
+      "value": [
+        {
+          "name": "pycx2-1.0.3-py2-none-any.whl",
+          "uri": "https://files.pythonhosted.org/packages/59/8c/40f66c4ac7564a68edd629a7836536af53d10b2d89f78c63e77cfcd9d460",
+          "version": "latest"
+        }
+      ]
+    },
+    "python3Packages": {
+      "value": [
+        {
+          "name": "geniz-0.0.1-py3-none-any.whl",
+          "uri": "https://files.pythonhosted.org/packages/8f/4b/c61bb7b176b34dd0c9ab0f3d821234c1e9f81f3ba5a609a1cf9032c852e7",
+          "version": "latest"
         }
       ]
     },
@@ -1131,8 +1182,11 @@ module automationAccount 'br/public:avm/res/automation/automation-account:<versi
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. |
 | [`modules`](#parameter-modules) | array | List of modules to be created in the automation account. |
+| [`powershell72Modules`](#parameter-powershell72modules) | array | List of powershell72 modules to be created in the automation account. |
 | [`privateEndpoints`](#parameter-privateendpoints) | array | Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. |
 | [`publicNetworkAccess`](#parameter-publicnetworkaccess) | string | Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set. |
+| [`python2Packages`](#parameter-python2packages) | array | List of python 2 packages to be created in the automation account. |
+| [`python3Packages`](#parameter-python3packages) | array | List of python 3 packages to be created in the automation account. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`runbooks`](#parameter-runbooks) | array | List of runbooks to be created in the automation account. |
 | [`schedules`](#parameter-schedules) | array | List of schedules to be created in the automation account. |
@@ -1513,6 +1567,14 @@ List of modules to be created in the automation account.
 - Type: array
 - Default: `[]`
 
+### Parameter: `powershell72Modules`
+
+List of powershell72 modules to be created in the automation account.
+
+- Required: No
+- Type: array
+- Default: `[]`
+
 ### Parameter: `privateEndpoints`
 
 Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible.
@@ -1871,6 +1933,22 @@ Whether or not public network access is allowed for this resource. For security 
     'Enabled'
   ]
   ```
+
+### Parameter: `python2Packages`
+
+List of python 2 packages to be created in the automation account.
+
+- Required: No
+- Type: array
+- Default: `[]`
+
+### Parameter: `python3Packages`
+
+List of python 3 packages to be created in the automation account.
+
+- Required: No
+- Type: array
+- Default: `[]`
 
 ### Parameter: `roleAssignments`
 

--- a/avm/res/automation/automation-account/main.bicep
+++ b/avm/res/automation/automation-account/main.bicep
@@ -25,6 +25,15 @@ param credentials credentialType = []
 @description('Optional. List of modules to be created in the automation account.')
 param modules array = []
 
+@description('Optional. List of powershell72 modules to be created in the automation account.')
+param powershell72Modules array = []
+
+@description('Optional. List of python 3 packages to be created in the automation account.')
+param python3Packages array = []
+
+@description('Optional. List of python 2 packages to be created in the automation account.')
+param python2Packages array = []
+
 @description('Optional. List of runbooks to be created in the automation account.')
 param runbooks array = []
 
@@ -212,6 +221,46 @@ module automationAccount_modules 'module/main.bicep' = [
       uri: module.uri
       location: location
       tags: module.?tags ?? tags
+    }
+  }
+]
+
+module automationAccount_powershell72modules 'powershell72-modules/main.bicep' = [
+  for (pwsh72module, index) in powershell72Modules: {
+    name: '${uniqueString(deployment().name, location)}-AutoAccount-Pwsh72Module-${index}'
+    params: {
+      name: pwsh72module.name
+      automationAccountName: automationAccount.name
+      version: pwsh72module.version
+      uri: pwsh72module.uri
+      location: location
+      tags: pwsh72module.?tags ?? tags
+    }
+  }
+]
+
+module automationAccount_python3packages 'python3-packages/main.bicep' = [
+  for (python3package, index) in python3Packages: {
+    name: '${uniqueString(deployment().name, location)}-AutoAccount-Python3Package-${index}'
+    params: {
+      name: python3package.name
+      automationAccountName: automationAccount.name
+      version: python3package.version
+      uri: python3package.uri
+      tags: python3package.?tags ?? tags
+    }
+  }
+]
+
+module automationAccount_python2packages 'python2-packages/main.bicep' = [
+  for (python2package, index) in python2Packages: {
+    name: '${uniqueString(deployment().name, location)}-AutoAccount-Python2Package-${index}'
+    params: {
+      name: python2package.name
+      automationAccountName: automationAccount.name
+      version: python2package.version
+      uri: python2package.uri
+      tags: python2package.?tags ?? tags
     }
   }
 ]

--- a/avm/res/automation/automation-account/main.bicep
+++ b/avm/res/automation/automation-account/main.bicep
@@ -26,13 +26,13 @@ param credentials credentialType = []
 param modules array = []
 
 @description('Optional. List of powershell72 modules to be created in the automation account.')
-param powershell72Modules array = []
+param powershell72Modules pwsh72ModulesType
 
 @description('Optional. List of python 3 packages to be created in the automation account.')
-param python3Packages array = []
+param python3Packages python3PackagesType
 
 @description('Optional. List of python 2 packages to be created in the automation account.')
-param python2Packages array = []
+param python2Packages python2PackagesType
 
 @description('Optional. List of runbooks to be created in the automation account.')
 param runbooks array = []
@@ -226,21 +226,21 @@ module automationAccount_modules 'module/main.bicep' = [
 ]
 
 module automationAccount_powershell72modules 'powershell72-modules/main.bicep' = [
-  for (pwsh72module, index) in powershell72Modules: {
+  for (pwsh72module, index) in (powershell72Modules ?? []): {
     name: '${uniqueString(deployment().name, location)}-AutoAccount-Pwsh72Module-${index}'
     params: {
       name: pwsh72module.name
       automationAccountName: automationAccount.name
       version: pwsh72module.version
       uri: pwsh72module.uri
-      location: location
+      location: pwsh72module.?location
       tags: pwsh72module.?tags ?? tags
     }
   }
 ]
 
 module automationAccount_python3packages 'python3-packages/main.bicep' = [
-  for (python3package, index) in python3Packages: {
+  for (python3package, index) in (python3Packages ?? []): {
     name: '${uniqueString(deployment().name, location)}-AutoAccount-Python3Package-${index}'
     params: {
       name: python3package.name
@@ -253,7 +253,7 @@ module automationAccount_python3packages 'python3-packages/main.bicep' = [
 ]
 
 module automationAccount_python2packages 'python2-packages/main.bicep' = [
-  for (python2package, index) in python2Packages: {
+  for (python2package, index) in (python2Packages ?? []): {
     name: '${uniqueString(deployment().name, location)}-AutoAccount-Python2Package-${index}'
     params: {
       name: python2package.name
@@ -630,6 +630,51 @@ type roleAssignmentType = {
 
   @description('Optional. The Resource Id of the delegated managed identity resource.')
   delegatedManagedIdentityResourceId: string?
+}[]?
+
+type pwsh72ModulesType = {
+  @description('Required. Name of the Powershell72 Automation Account module.')
+  name: string
+
+  @description('Optional. The location to deploy the module to.')
+  location: string?
+
+  @description('Optional. Tags of the Powershell 72 module resource.')
+  tags: object?
+
+  @description('Required. Module package URI, e.g. https://www.powershellgallery.com/api/v2/package.')
+  uri: string
+
+  @description('Optional. Module version or specify latest to get the latest version.')
+  version: 'latest'?
+}[]?
+
+type python3PackagesType = {
+  @description('Required. Name of the Python3 Automation Account package.')
+  name: string
+
+  @description('Optional. Tags of the Python3 package resource.')
+  tags: object?
+
+  @description('Required. Module package URI, e.g. https://www.powershellgallery.com/api/v2/package.')
+  uri: string
+
+  @description('Optional. Module version or specify latest to get the latest version.')
+  version: 'latest'?
+}[]?
+
+type python2PackagesType = {
+  @description('Required. Name of the Python2 Automation Account package.')
+  name: string
+
+  @description('Optional. Tags of the Python2 package resource.')
+  tags: object?
+
+  @description('Required. Module package URI, e.g. https://www.powershellgallery.com/api/v2/package.')
+  uri: string
+
+  @description('Optional. Module version or specify latest to get the latest version.')
+  version: 'latest'?
 }[]?
 
 type privateEndpointType = {

--- a/avm/res/automation/automation-account/main.bicep
+++ b/avm/res/automation/automation-account/main.bicep
@@ -29,10 +29,10 @@ param modules array = []
 param powershell72Modules pwsh72ModulesType
 
 @description('Optional. List of python 3 packages to be created in the automation account.')
-param python3Packages python3PackagesType
+param python3Packages python23PackagesType
 
 @description('Optional. List of python 2 packages to be created in the automation account.')
-param python2Packages python2PackagesType
+param python2Packages python23PackagesType
 
 @description('Optional. List of runbooks to be created in the automation account.')
 param runbooks array = []
@@ -649,25 +649,11 @@ type pwsh72ModulesType = {
   version: 'latest'?
 }[]?
 
-type python3PackagesType = {
+type python23PackagesType = {
   @description('Required. Name of the Python3 Automation Account package.')
   name: string
 
   @description('Optional. Tags of the Python3 package resource.')
-  tags: object?
-
-  @description('Required. Module package URI, e.g. https://www.powershellgallery.com/api/v2/package.')
-  uri: string
-
-  @description('Optional. Module version or specify latest to get the latest version.')
-  version: 'latest'?
-}[]?
-
-type python2PackagesType = {
-  @description('Required. Name of the Python2 Automation Account package.')
-  name: string
-
-  @description('Optional. Tags of the Python2 package resource.')
   tags: object?
 
   @description('Required. Module package URI, e.g. https://www.powershellgallery.com/api/v2/package.')

--- a/avm/res/automation/automation-account/main.json
+++ b/avm/res/automation/automation-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.28.1.47646",
-      "templateHash": "4027525789249067724"
+      "templateHash": "9668583394347320858"
     },
     "name": "Automation Accounts",
     "description": "This module deploys an Azure Automation Account.",
@@ -172,7 +172,7 @@
       },
       "nullable": true
     },
-    "python3PackagesType": {
+    "python23PackagesType": {
       "type": "array",
       "items": {
         "type": "object",
@@ -188,44 +188,6 @@
             "nullable": true,
             "metadata": {
               "description": "Optional. Tags of the Python3 package resource."
-            }
-          },
-          "uri": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. Module package URI, e.g. https://www.powershellgallery.com/api/v2/package."
-            }
-          },
-          "version": {
-            "type": "string",
-            "allowedValues": [
-              "latest"
-            ],
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Module version or specify latest to get the latest version."
-            }
-          }
-        }
-      },
-      "nullable": true
-    },
-    "python2PackagesType": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. Name of the Python2 Automation Account package."
-            }
-          },
-          "tags": {
-            "type": "object",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Tags of the Python2 package resource."
             }
           },
           "uri": {
@@ -687,13 +649,13 @@
       }
     },
     "python3Packages": {
-      "$ref": "#/definitions/python3PackagesType",
+      "$ref": "#/definitions/python23PackagesType",
       "metadata": {
         "description": "Optional. List of python 3 packages to be created in the automation account."
       }
     },
     "python2Packages": {
-      "$ref": "#/definitions/python2PackagesType",
+      "$ref": "#/definitions/python23PackagesType",
       "metadata": {
         "description": "Optional. List of python 2 packages to be created in the automation account."
       }

--- a/avm/res/automation/automation-account/main.json
+++ b/avm/res/automation/automation-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.28.1.47646",
-      "templateHash": "10700112479809767700"
+      "templateHash": "4027525789249067724"
     },
     "name": "Automation Accounts",
     "description": "This module deploys an Azure Automation Account.",
@@ -121,6 +121,127 @@
             "nullable": true,
             "metadata": {
               "description": "Optional. The Resource Id of the delegated managed identity resource."
+            }
+          }
+        }
+      },
+      "nullable": true
+    },
+    "pwsh72ModulesType": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "metadata": {
+              "description": "Required. Name of the Powershell72 Automation Account module."
+            }
+          },
+          "location": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The location to deploy the module to."
+            }
+          },
+          "tags": {
+            "type": "object",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Tags of the Powershell 72 module resource."
+            }
+          },
+          "uri": {
+            "type": "string",
+            "metadata": {
+              "description": "Required. Module package URI, e.g. https://www.powershellgallery.com/api/v2/package."
+            }
+          },
+          "version": {
+            "type": "string",
+            "allowedValues": [
+              "latest"
+            ],
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Module version or specify latest to get the latest version."
+            }
+          }
+        }
+      },
+      "nullable": true
+    },
+    "python3PackagesType": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "metadata": {
+              "description": "Required. Name of the Python3 Automation Account package."
+            }
+          },
+          "tags": {
+            "type": "object",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Tags of the Python3 package resource."
+            }
+          },
+          "uri": {
+            "type": "string",
+            "metadata": {
+              "description": "Required. Module package URI, e.g. https://www.powershellgallery.com/api/v2/package."
+            }
+          },
+          "version": {
+            "type": "string",
+            "allowedValues": [
+              "latest"
+            ],
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Module version or specify latest to get the latest version."
+            }
+          }
+        }
+      },
+      "nullable": true
+    },
+    "python2PackagesType": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "metadata": {
+              "description": "Required. Name of the Python2 Automation Account package."
+            }
+          },
+          "tags": {
+            "type": "object",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Tags of the Python2 package resource."
+            }
+          },
+          "uri": {
+            "type": "string",
+            "metadata": {
+              "description": "Required. Module package URI, e.g. https://www.powershellgallery.com/api/v2/package."
+            }
+          },
+          "version": {
+            "type": "string",
+            "allowedValues": [
+              "latest"
+            ],
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Module version or specify latest to get the latest version."
             }
           }
         }
@@ -560,22 +681,19 @@
       }
     },
     "powershell72Modules": {
-      "type": "array",
-      "defaultValue": [],
+      "$ref": "#/definitions/pwsh72ModulesType",
       "metadata": {
         "description": "Optional. List of powershell72 modules to be created in the automation account."
       }
     },
     "python3Packages": {
-      "type": "array",
-      "defaultValue": [],
+      "$ref": "#/definitions/python3PackagesType",
       "metadata": {
         "description": "Optional. List of python 3 packages to be created in the automation account."
       }
     },
     "python2Packages": {
-      "type": "array",
-      "defaultValue": [],
+      "$ref": "#/definitions/python2PackagesType",
       "metadata": {
         "description": "Optional. List of python 2 packages to be created in the automation account."
       }
@@ -1151,7 +1269,7 @@
     "automationAccount_powershell72modules": {
       "copy": {
         "name": "automationAccount_powershell72modules",
-        "count": "[length(parameters('powershell72Modules'))]"
+        "count": "[length(coalesce(parameters('powershell72Modules'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
@@ -1163,22 +1281,22 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[parameters('powershell72Modules')[copyIndex()].name]"
+            "value": "[coalesce(parameters('powershell72Modules'), createArray())[copyIndex()].name]"
           },
           "automationAccountName": {
             "value": "[parameters('name')]"
           },
           "version": {
-            "value": "[parameters('powershell72Modules')[copyIndex()].version]"
+            "value": "[coalesce(parameters('powershell72Modules'), createArray())[copyIndex()].version]"
           },
           "uri": {
-            "value": "[parameters('powershell72Modules')[copyIndex()].uri]"
+            "value": "[coalesce(parameters('powershell72Modules'), createArray())[copyIndex()].uri]"
           },
           "location": {
-            "value": "[parameters('location')]"
+            "value": "[tryGet(coalesce(parameters('powershell72Modules'), createArray())[copyIndex()], 'location')]"
           },
           "tags": {
-            "value": "[coalesce(tryGet(parameters('powershell72Modules')[copyIndex()], 'tags'), parameters('tags'))]"
+            "value": "[coalesce(tryGet(coalesce(parameters('powershell72Modules'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
           }
         },
         "template": {
@@ -1189,7 +1307,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.28.1.47646",
-              "templateHash": "179728908258115803"
+              "templateHash": "849556923664889988"
             },
             "name": "Automation Account Powershell72 Modules",
             "description": "This module deploys a Powershell72 Module in the Automation Account.",
@@ -1232,7 +1350,7 @@
               "type": "object",
               "nullable": true,
               "metadata": {
-                "description": "Optional. Tags of the Automation Account resource."
+                "description": "Optional. Tags of the Powershell 72 module resource."
               }
             }
           },
@@ -1299,7 +1417,7 @@
     "automationAccount_python3packages": {
       "copy": {
         "name": "automationAccount_python3packages",
-        "count": "[length(parameters('python3Packages'))]"
+        "count": "[length(coalesce(parameters('python3Packages'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
@@ -1311,19 +1429,19 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[parameters('python3Packages')[copyIndex()].name]"
+            "value": "[coalesce(parameters('python3Packages'), createArray())[copyIndex()].name]"
           },
           "automationAccountName": {
             "value": "[parameters('name')]"
           },
           "version": {
-            "value": "[parameters('python3Packages')[copyIndex()].version]"
+            "value": "[coalesce(parameters('python3Packages'), createArray())[copyIndex()].version]"
           },
           "uri": {
-            "value": "[parameters('python3Packages')[copyIndex()].uri]"
+            "value": "[coalesce(parameters('python3Packages'), createArray())[copyIndex()].uri]"
           },
           "tags": {
-            "value": "[coalesce(tryGet(parameters('python3Packages')[copyIndex()], 'tags'), parameters('tags'))]"
+            "value": "[coalesce(tryGet(coalesce(parameters('python3Packages'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
           }
         },
         "template": {
@@ -1436,7 +1554,7 @@
     "automationAccount_python2packages": {
       "copy": {
         "name": "automationAccount_python2packages",
-        "count": "[length(parameters('python2Packages'))]"
+        "count": "[length(coalesce(parameters('python2Packages'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
@@ -1448,19 +1566,19 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[parameters('python2Packages')[copyIndex()].name]"
+            "value": "[coalesce(parameters('python2Packages'), createArray())[copyIndex()].name]"
           },
           "automationAccountName": {
             "value": "[parameters('name')]"
           },
           "version": {
-            "value": "[parameters('python2Packages')[copyIndex()].version]"
+            "value": "[coalesce(parameters('python2Packages'), createArray())[copyIndex()].version]"
           },
           "uri": {
-            "value": "[parameters('python2Packages')[copyIndex()].uri]"
+            "value": "[coalesce(parameters('python2Packages'), createArray())[copyIndex()].uri]"
           },
           "tags": {
-            "value": "[coalesce(tryGet(parameters('python2Packages')[copyIndex()], 'tags'), parameters('tags'))]"
+            "value": "[coalesce(tryGet(coalesce(parameters('python2Packages'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
           }
         },
         "template": {

--- a/avm/res/automation/automation-account/main.json
+++ b/avm/res/automation/automation-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.28.1.47646",
-      "templateHash": "9253206103047535758"
+      "templateHash": "10700112479809767700"
     },
     "name": "Automation Accounts",
     "description": "This module deploys an Azure Automation Account.",
@@ -557,6 +557,27 @@
       "defaultValue": [],
       "metadata": {
         "description": "Optional. List of modules to be created in the automation account."
+      }
+    },
+    "powershell72Modules": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional. List of powershell72 modules to be created in the automation account."
+      }
+    },
+    "python3Packages": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional. List of python 3 packages to be created in the automation account."
+      }
+    },
+    "python2Packages": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional. List of python 2 packages to be created in the automation account."
       }
     },
     "runbooks": {
@@ -1119,6 +1140,428 @@
                 "description": "The location the resource was deployed into."
               },
               "value": "[reference('module', '2022-08-08', 'full').location]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "automationAccount"
+      ]
+    },
+    "automationAccount_powershell72modules": {
+      "copy": {
+        "name": "automationAccount_powershell72modules",
+        "count": "[length(parameters('powershell72Modules'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('{0}-AutoAccount-Pwsh72Module-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[parameters('powershell72Modules')[copyIndex()].name]"
+          },
+          "automationAccountName": {
+            "value": "[parameters('name')]"
+          },
+          "version": {
+            "value": "[parameters('powershell72Modules')[copyIndex()].version]"
+          },
+          "uri": {
+            "value": "[parameters('powershell72Modules')[copyIndex()].uri]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[coalesce(tryGet(parameters('powershell72Modules')[copyIndex()], 'tags'), parameters('tags'))]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.28.1.47646",
+              "templateHash": "179728908258115803"
+            },
+            "name": "Automation Account Powershell72 Modules",
+            "description": "This module deploys a Powershell72 Module in the Automation Account.",
+            "owner": "Azure/module-maintainers"
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the Powershell72 Automation Account module."
+              }
+            },
+            "automationAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the parent Automation Account. Required if the template is used in a standalone deployment."
+              }
+            },
+            "uri": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Module package URI, e.g. https://www.powershellgallery.com/api/v2/package."
+              }
+            },
+            "version": {
+              "type": "string",
+              "defaultValue": "latest",
+              "metadata": {
+                "description": "Optional. Module version or specify latest to get the latest version."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all resources."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the Automation Account resource."
+              }
+            }
+          },
+          "resources": {
+            "automationAccount": {
+              "existing": true,
+              "type": "Microsoft.Automation/automationAccounts",
+              "apiVersion": "2022-08-08",
+              "name": "[parameters('automationAccountName')]"
+            },
+            "powershell72module": {
+              "type": "Microsoft.Automation/automationAccounts/powerShell72Modules",
+              "apiVersion": "2023-11-01",
+              "name": "[format('{0}/{1}', parameters('automationAccountName'), parameters('name'))]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "contentLink": {
+                  "uri": "[if(not(equals(parameters('version'), 'latest')), format('{0}/{1}/{2}', parameters('uri'), parameters('name'), parameters('version')), format('{0}/{1}', parameters('uri'), parameters('name')))]",
+                  "version": "[if(not(equals(parameters('version'), 'latest')), parameters('version'), null())]"
+                }
+              },
+              "dependsOn": [
+                "automationAccount"
+              ]
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the deployed module."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the deployed module."
+              },
+              "value": "[resourceId('Microsoft.Automation/automationAccounts/powerShell72Modules', parameters('automationAccountName'), parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the deployed module."
+              },
+              "value": "[resourceGroup().name]"
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "The location the resource was deployed into."
+              },
+              "value": "[reference('powershell72module', '2023-11-01', 'full').location]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "automationAccount"
+      ]
+    },
+    "automationAccount_python3packages": {
+      "copy": {
+        "name": "automationAccount_python3packages",
+        "count": "[length(parameters('python3Packages'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('{0}-AutoAccount-Python3Package-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[parameters('python3Packages')[copyIndex()].name]"
+          },
+          "automationAccountName": {
+            "value": "[parameters('name')]"
+          },
+          "version": {
+            "value": "[parameters('python3Packages')[copyIndex()].version]"
+          },
+          "uri": {
+            "value": "[parameters('python3Packages')[copyIndex()].uri]"
+          },
+          "tags": {
+            "value": "[coalesce(tryGet(parameters('python3Packages')[copyIndex()], 'tags'), parameters('tags'))]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.28.1.47646",
+              "templateHash": "6307484872853391839"
+            },
+            "name": "Automation Account Python 3 Packages",
+            "description": "This module deploys a Python3 Package in the Automation Account.",
+            "owner": "Azure/module-maintainers"
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the Python3 Automation Account package."
+              }
+            },
+            "automationAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the parent Automation Account. Required if the template is used in a standalone deployment."
+              }
+            },
+            "uri": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Package URI, e.g. https://www.powershellgallery.com/api/v2/package."
+              }
+            },
+            "version": {
+              "type": "string",
+              "defaultValue": "latest",
+              "metadata": {
+                "description": "Optional. Package version or specify latest to get the latest version."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the Automation Account resource."
+              }
+            }
+          },
+          "resources": {
+            "automationAccount": {
+              "existing": true,
+              "type": "Microsoft.Automation/automationAccounts",
+              "apiVersion": "2022-08-08",
+              "name": "[parameters('automationAccountName')]"
+            },
+            "python3package": {
+              "type": "Microsoft.Automation/automationAccounts/python3Packages",
+              "apiVersion": "2023-11-01",
+              "name": "[format('{0}/{1}', parameters('automationAccountName'), parameters('name'))]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "contentLink": {
+                  "uri": "[if(not(equals(parameters('version'), 'latest')), format('{0}/{1}/{2}', parameters('uri'), parameters('name'), parameters('version')), format('{0}/{1}', parameters('uri'), parameters('name')))]",
+                  "version": "[if(not(equals(parameters('version'), 'latest')), parameters('version'), null())]"
+                }
+              },
+              "dependsOn": [
+                "automationAccount"
+              ]
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the deployed package."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the deployed package."
+              },
+              "value": "[resourceId('Microsoft.Automation/automationAccounts/python3Packages', parameters('automationAccountName'), parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the deployed package."
+              },
+              "value": "[resourceGroup().name]"
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "The location the resource was deployed into."
+              },
+              "value": "[reference('python3package', '2023-11-01', 'full').location]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "automationAccount"
+      ]
+    },
+    "automationAccount_python2packages": {
+      "copy": {
+        "name": "automationAccount_python2packages",
+        "count": "[length(parameters('python2Packages'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('{0}-AutoAccount-Python2Package-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[parameters('python2Packages')[copyIndex()].name]"
+          },
+          "automationAccountName": {
+            "value": "[parameters('name')]"
+          },
+          "version": {
+            "value": "[parameters('python2Packages')[copyIndex()].version]"
+          },
+          "uri": {
+            "value": "[parameters('python2Packages')[copyIndex()].uri]"
+          },
+          "tags": {
+            "value": "[coalesce(tryGet(parameters('python2Packages')[copyIndex()], 'tags'), parameters('tags'))]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.28.1.47646",
+              "templateHash": "6415380564614412076"
+            },
+            "name": "Automation Account Python 2 Packages",
+            "description": "This module deploys a Python2 Package in the Automation Account.",
+            "owner": "Azure/module-maintainers"
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the Python2 Automation Account package."
+              }
+            },
+            "automationAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the parent Automation Account. Required if the template is used in a standalone deployment."
+              }
+            },
+            "uri": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Package URI, e.g. https://www.powershellgallery.com/api/v2/package."
+              }
+            },
+            "version": {
+              "type": "string",
+              "defaultValue": "latest",
+              "metadata": {
+                "description": "Optional. Package version or specify latest to get the latest version."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the Automation Account resource."
+              }
+            }
+          },
+          "resources": {
+            "automationAccount": {
+              "existing": true,
+              "type": "Microsoft.Automation/automationAccounts",
+              "apiVersion": "2022-08-08",
+              "name": "[parameters('automationAccountName')]"
+            },
+            "python2package": {
+              "type": "Microsoft.Automation/automationAccounts/python2Packages",
+              "apiVersion": "2023-11-01",
+              "name": "[format('{0}/{1}', parameters('automationAccountName'), parameters('name'))]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "contentLink": {
+                  "uri": "[if(not(equals(parameters('version'), 'latest')), format('{0}/{1}/{2}', parameters('uri'), parameters('name'), parameters('version')), format('{0}/{1}', parameters('uri'), parameters('name')))]",
+                  "version": "[if(not(equals(parameters('version'), 'latest')), parameters('version'), null())]"
+                }
+              },
+              "dependsOn": [
+                "automationAccount"
+              ]
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the deployed package."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the deployed package."
+              },
+              "value": "[resourceId('Microsoft.Automation/automationAccounts/python2Packages', parameters('automationAccountName'), parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the deployed package."
+              },
+              "value": "[resourceGroup().name]"
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "The location the resource was deployed into."
+              },
+              "value": "[reference('python2package', '2023-11-01', 'full').location]"
             }
           }
         }

--- a/avm/res/automation/automation-account/powershell72-modules/README.md
+++ b/avm/res/automation/automation-account/powershell72-modules/README.md
@@ -36,7 +36,7 @@ This module deploys a Powershell72 Module in the Automation Account.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`location`](#parameter-location) | string | Location for all resources. |
-| [`tags`](#parameter-tags) | object | Tags of the Automation Account resource. |
+| [`tags`](#parameter-tags) | object | Tags of the Powershell 72 module resource. |
 | [`version`](#parameter-version) | string | Module version or specify latest to get the latest version. |
 
 ### Parameter: `name`
@@ -70,7 +70,7 @@ Location for all resources.
 
 ### Parameter: `tags`
 
-Tags of the Automation Account resource.
+Tags of the Powershell 72 module resource.
 
 - Required: No
 - Type: object

--- a/avm/res/automation/automation-account/powershell72-modules/README.md
+++ b/avm/res/automation/automation-account/powershell72-modules/README.md
@@ -1,0 +1,102 @@
+# Automation Account Powershell72 Modules `[Microsoft.Automation/automationAccounts/powerShell72Modules]`
+
+This module deploys a Powershell72 Module in the Automation Account.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+- [Data Collection](#Data-Collection)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Automation/automationAccounts/powerShell72Modules` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2023-11-01/automationAccounts/powerShell72Modules) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-name) | string | Name of the Powershell72 Automation Account module. |
+| [`uri`](#parameter-uri) | string | Module package URI, e.g. https://www.powershellgallery.com/api/v2/package. |
+
+**Conditional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`automationAccountName`](#parameter-automationaccountname) | string | The name of the parent Automation Account. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`location`](#parameter-location) | string | Location for all resources. |
+| [`tags`](#parameter-tags) | object | Tags of the Automation Account resource. |
+| [`version`](#parameter-version) | string | Module version or specify latest to get the latest version. |
+
+### Parameter: `name`
+
+Name of the Powershell72 Automation Account module.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `uri`
+
+Module package URI, e.g. https://www.powershellgallery.com/api/v2/package.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `automationAccountName`
+
+The name of the parent Automation Account. Required if the template is used in a standalone deployment.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `location`
+
+Location for all resources.
+
+- Required: No
+- Type: string
+- Default: `[resourceGroup().location]`
+
+### Parameter: `tags`
+
+Tags of the Automation Account resource.
+
+- Required: No
+- Type: object
+
+### Parameter: `version`
+
+Module version or specify latest to get the latest version.
+
+- Required: No
+- Type: string
+- Default: `'latest'`
+
+
+## Outputs
+
+| Output | Type | Description |
+| :-- | :-- | :-- |
+| `location` | string | The location the resource was deployed into. |
+| `name` | string | The name of the deployed module. |
+| `resourceGroupName` | string | The resource group of the deployed module. |
+| `resourceId` | string | The resource ID of the deployed module. |
+
+## Cross-referenced modules
+
+_None_
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/automation/automation-account/powershell72-modules/main.bicep
+++ b/avm/res/automation/automation-account/powershell72-modules/main.bicep
@@ -17,7 +17,7 @@ param version string = 'latest'
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
-@description('Optional. Tags of the Automation Account resource.')
+@description('Optional. Tags of the Powershell 72 module resource.')
 param tags object?
 
 resource automationAccount 'Microsoft.Automation/automationAccounts@2022-08-08' existing = {

--- a/avm/res/automation/automation-account/powershell72-modules/main.bicep
+++ b/avm/res/automation/automation-account/powershell72-modules/main.bicep
@@ -1,0 +1,50 @@
+metadata name = 'Automation Account Powershell72 Modules'
+metadata description = 'This module deploys a Powershell72 Module in the Automation Account.'
+metadata owner = 'Azure/module-maintainers'
+
+@description('Required. Name of the Powershell72 Automation Account module.')
+param name string
+
+@description('Conditional. The name of the parent Automation Account. Required if the template is used in a standalone deployment.')
+param automationAccountName string
+
+@description('Required. Module package URI, e.g. https://www.powershellgallery.com/api/v2/package.')
+param uri string
+
+@description('Optional. Module version or specify latest to get the latest version.')
+param version string = 'latest'
+
+@description('Optional. Location for all resources.')
+param location string = resourceGroup().location
+
+@description('Optional. Tags of the Automation Account resource.')
+param tags object?
+
+resource automationAccount 'Microsoft.Automation/automationAccounts@2022-08-08' existing = {
+  name: automationAccountName
+}
+
+resource powershell72module 'Microsoft.Automation/automationAccounts/powerShell72Modules@2023-11-01' = {
+  name: name
+  parent: automationAccount
+  location: location
+  tags: tags
+  properties: {
+    contentLink: {
+      uri: version != 'latest' ? '${uri}/${name}/${version}' : '${uri}/${name}'
+      version: version != 'latest' ? version : null
+    }
+  }
+}
+
+@description('The name of the deployed module.')
+output name string = powershell72module.name
+
+@description('The resource ID of the deployed module.')
+output resourceId string = powershell72module.id
+
+@description('The resource group of the deployed module.')
+output resourceGroupName string = resourceGroup().name
+
+@description('The location the resource was deployed into.')
+output location string = powershell72module.location

--- a/avm/res/automation/automation-account/powershell72-modules/main.json
+++ b/avm/res/automation/automation-account/powershell72-modules/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.28.1.47646",
-      "templateHash": "179728908258115803"
+      "templateHash": "849556923664889988"
     },
     "name": "Automation Account Powershell72 Modules",
     "description": "This module deploys a Powershell72 Module in the Automation Account.",
@@ -49,7 +49,7 @@
       "type": "object",
       "nullable": true,
       "metadata": {
-        "description": "Optional. Tags of the Automation Account resource."
+        "description": "Optional. Tags of the Powershell 72 module resource."
       }
     }
   },

--- a/avm/res/automation/automation-account/powershell72-modules/main.json
+++ b/avm/res/automation/automation-account/powershell72-modules/main.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.28.1.47646",
+      "templateHash": "179728908258115803"
+    },
+    "name": "Automation Account Powershell72 Modules",
+    "description": "This module deploys a Powershell72 Module in the Automation Account.",
+    "owner": "Azure/module-maintainers"
+  },
+  "parameters": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Name of the Powershell72 Automation Account module."
+      }
+    },
+    "automationAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Conditional. The name of the parent Automation Account. Required if the template is used in a standalone deployment."
+      }
+    },
+    "uri": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Module package URI, e.g. https://www.powershellgallery.com/api/v2/package."
+      }
+    },
+    "version": {
+      "type": "string",
+      "defaultValue": "latest",
+      "metadata": {
+        "description": "Optional. Module version or specify latest to get the latest version."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Optional. Location for all resources."
+      }
+    },
+    "tags": {
+      "type": "object",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Tags of the Automation Account resource."
+      }
+    }
+  },
+  "resources": {
+    "automationAccount": {
+      "existing": true,
+      "type": "Microsoft.Automation/automationAccounts",
+      "apiVersion": "2022-08-08",
+      "name": "[parameters('automationAccountName')]"
+    },
+    "powershell72module": {
+      "type": "Microsoft.Automation/automationAccounts/powerShell72Modules",
+      "apiVersion": "2023-11-01",
+      "name": "[format('{0}/{1}', parameters('automationAccountName'), parameters('name'))]",
+      "location": "[parameters('location')]",
+      "tags": "[parameters('tags')]",
+      "properties": {
+        "contentLink": {
+          "uri": "[if(not(equals(parameters('version'), 'latest')), format('{0}/{1}/{2}', parameters('uri'), parameters('name'), parameters('version')), format('{0}/{1}', parameters('uri'), parameters('name')))]",
+          "version": "[if(not(equals(parameters('version'), 'latest')), parameters('version'), null())]"
+        }
+      },
+      "dependsOn": [
+        "automationAccount"
+      ]
+    }
+  },
+  "outputs": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the deployed module."
+      },
+      "value": "[parameters('name')]"
+    },
+    "resourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource ID of the deployed module."
+      },
+      "value": "[resourceId('Microsoft.Automation/automationAccounts/powerShell72Modules', parameters('automationAccountName'), parameters('name'))]"
+    },
+    "resourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource group of the deployed module."
+      },
+      "value": "[resourceGroup().name]"
+    },
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "The location the resource was deployed into."
+      },
+      "value": "[reference('powershell72module', '2023-11-01', 'full').location]"
+    }
+  }
+}

--- a/avm/res/automation/automation-account/python2-packages/README.md
+++ b/avm/res/automation/automation-account/python2-packages/README.md
@@ -1,0 +1,93 @@
+# Automation Account Python 2 Packages `[Microsoft.Automation/automationAccounts/python2Packages]`
+
+This module deploys a Python2 Package in the Automation Account.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+- [Data Collection](#Data-Collection)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Automation/automationAccounts/python2Packages` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2023-11-01/automationAccounts/python2Packages) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-name) | string | Name of the Python2 Automation Account package. |
+| [`uri`](#parameter-uri) | string | Package URI, e.g. https://www.powershellgallery.com/api/v2/package. |
+
+**Conditional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`automationAccountName`](#parameter-automationaccountname) | string | The name of the parent Automation Account. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`tags`](#parameter-tags) | object | Tags of the Automation Account resource. |
+| [`version`](#parameter-version) | string | Package version or specify latest to get the latest version. |
+
+### Parameter: `name`
+
+Name of the Python2 Automation Account package.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `uri`
+
+Package URI, e.g. https://www.powershellgallery.com/api/v2/package.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `automationAccountName`
+
+The name of the parent Automation Account. Required if the template is used in a standalone deployment.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `tags`
+
+Tags of the Automation Account resource.
+
+- Required: No
+- Type: object
+
+### Parameter: `version`
+
+Package version or specify latest to get the latest version.
+
+- Required: No
+- Type: string
+- Default: `'latest'`
+
+
+## Outputs
+
+| Output | Type | Description |
+| :-- | :-- | :-- |
+| `location` | string | The location the resource was deployed into. |
+| `name` | string | The name of the deployed package. |
+| `resourceGroupName` | string | The resource group of the deployed package. |
+| `resourceId` | string | The resource ID of the deployed package. |
+
+## Cross-referenced modules
+
+_None_
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/automation/automation-account/python2-packages/main.bicep
+++ b/avm/res/automation/automation-account/python2-packages/main.bicep
@@ -1,0 +1,46 @@
+metadata name = 'Automation Account Python 2 Packages'
+metadata description = 'This module deploys a Python2 Package in the Automation Account.'
+metadata owner = 'Azure/module-maintainers'
+
+@description('Required. Name of the Python2 Automation Account package.')
+param name string
+
+@description('Conditional. The name of the parent Automation Account. Required if the template is used in a standalone deployment.')
+param automationAccountName string
+
+@description('Required. Package URI, e.g. https://www.powershellgallery.com/api/v2/package.')
+param uri string
+
+@description('Optional. Package version or specify latest to get the latest version.')
+param version string = 'latest'
+
+@description('Optional. Tags of the Automation Account resource.')
+param tags object?
+
+resource automationAccount 'Microsoft.Automation/automationAccounts@2022-08-08' existing = {
+  name: automationAccountName
+}
+
+resource python2package 'Microsoft.Automation/automationAccounts/python2Packages@2023-11-01' = {
+  name: name
+  parent: automationAccount
+  tags: tags
+  properties: {
+    contentLink: {
+      uri: version != 'latest' ? '${uri}/${name}/${version}' : '${uri}/${name}'
+      version: version != 'latest' ? version : null
+    }
+  }
+}
+
+@description('The name of the deployed package.')
+output name string = python2package.name
+
+@description('The resource ID of the deployed package.')
+output resourceId string = python2package.id
+
+@description('The resource group of the deployed package.')
+output resourceGroupName string = resourceGroup().name
+
+@description('The location the resource was deployed into.')
+output location string = python2package.location

--- a/avm/res/automation/automation-account/python2-packages/main.json
+++ b/avm/res/automation/automation-account/python2-packages/main.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.28.1.47646",
+      "templateHash": "6415380564614412076"
+    },
+    "name": "Automation Account Python 2 Packages",
+    "description": "This module deploys a Python2 Package in the Automation Account.",
+    "owner": "Azure/module-maintainers"
+  },
+  "parameters": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Name of the Python2 Automation Account package."
+      }
+    },
+    "automationAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Conditional. The name of the parent Automation Account. Required if the template is used in a standalone deployment."
+      }
+    },
+    "uri": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Package URI, e.g. https://www.powershellgallery.com/api/v2/package."
+      }
+    },
+    "version": {
+      "type": "string",
+      "defaultValue": "latest",
+      "metadata": {
+        "description": "Optional. Package version or specify latest to get the latest version."
+      }
+    },
+    "tags": {
+      "type": "object",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Tags of the Automation Account resource."
+      }
+    }
+  },
+  "resources": {
+    "automationAccount": {
+      "existing": true,
+      "type": "Microsoft.Automation/automationAccounts",
+      "apiVersion": "2022-08-08",
+      "name": "[parameters('automationAccountName')]"
+    },
+    "python2package": {
+      "type": "Microsoft.Automation/automationAccounts/python2Packages",
+      "apiVersion": "2023-11-01",
+      "name": "[format('{0}/{1}', parameters('automationAccountName'), parameters('name'))]",
+      "tags": "[parameters('tags')]",
+      "properties": {
+        "contentLink": {
+          "uri": "[if(not(equals(parameters('version'), 'latest')), format('{0}/{1}/{2}', parameters('uri'), parameters('name'), parameters('version')), format('{0}/{1}', parameters('uri'), parameters('name')))]",
+          "version": "[if(not(equals(parameters('version'), 'latest')), parameters('version'), null())]"
+        }
+      },
+      "dependsOn": [
+        "automationAccount"
+      ]
+    }
+  },
+  "outputs": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the deployed package."
+      },
+      "value": "[parameters('name')]"
+    },
+    "resourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource ID of the deployed package."
+      },
+      "value": "[resourceId('Microsoft.Automation/automationAccounts/python2Packages', parameters('automationAccountName'), parameters('name'))]"
+    },
+    "resourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource group of the deployed package."
+      },
+      "value": "[resourceGroup().name]"
+    },
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "The location the resource was deployed into."
+      },
+      "value": "[reference('python2package', '2023-11-01', 'full').location]"
+    }
+  }
+}

--- a/avm/res/automation/automation-account/python3-packages/README.md
+++ b/avm/res/automation/automation-account/python3-packages/README.md
@@ -1,0 +1,93 @@
+# Automation Account Python 3 Packages `[Microsoft.Automation/automationAccounts/python3Packages]`
+
+This module deploys a Python3 Package in the Automation Account.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
+- [Data Collection](#Data-Collection)
+
+## Resource Types
+
+| Resource Type | API Version |
+| :-- | :-- |
+| `Microsoft.Automation/automationAccounts/python3Packages` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Automation/2023-11-01/automationAccounts/python3Packages) |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-name) | string | Name of the Python3 Automation Account package. |
+| [`uri`](#parameter-uri) | string | Package URI, e.g. https://www.powershellgallery.com/api/v2/package. |
+
+**Conditional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`automationAccountName`](#parameter-automationaccountname) | string | The name of the parent Automation Account. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`tags`](#parameter-tags) | object | Tags of the Automation Account resource. |
+| [`version`](#parameter-version) | string | Package version or specify latest to get the latest version. |
+
+### Parameter: `name`
+
+Name of the Python3 Automation Account package.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `uri`
+
+Package URI, e.g. https://www.powershellgallery.com/api/v2/package.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `automationAccountName`
+
+The name of the parent Automation Account. Required if the template is used in a standalone deployment.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `tags`
+
+Tags of the Automation Account resource.
+
+- Required: No
+- Type: object
+
+### Parameter: `version`
+
+Package version or specify latest to get the latest version.
+
+- Required: No
+- Type: string
+- Default: `'latest'`
+
+
+## Outputs
+
+| Output | Type | Description |
+| :-- | :-- | :-- |
+| `location` | string | The location the resource was deployed into. |
+| `name` | string | The name of the deployed package. |
+| `resourceGroupName` | string | The resource group of the deployed package. |
+| `resourceId` | string | The resource ID of the deployed package. |
+
+## Cross-referenced modules
+
+_None_
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/automation/automation-account/python3-packages/main.bicep
+++ b/avm/res/automation/automation-account/python3-packages/main.bicep
@@ -1,0 +1,46 @@
+metadata name = 'Automation Account Python 3 Packages'
+metadata description = 'This module deploys a Python3 Package in the Automation Account.'
+metadata owner = 'Azure/module-maintainers'
+
+@description('Required. Name of the Python3 Automation Account package.')
+param name string
+
+@description('Conditional. The name of the parent Automation Account. Required if the template is used in a standalone deployment.')
+param automationAccountName string
+
+@description('Required. Package URI, e.g. https://www.powershellgallery.com/api/v2/package.')
+param uri string
+
+@description('Optional. Package version or specify latest to get the latest version.')
+param version string = 'latest'
+
+@description('Optional. Tags of the Automation Account resource.')
+param tags object?
+
+resource automationAccount 'Microsoft.Automation/automationAccounts@2022-08-08' existing = {
+  name: automationAccountName
+}
+
+resource python3package 'Microsoft.Automation/automationAccounts/python3Packages@2023-11-01' = {
+  name: name
+  parent: automationAccount
+  tags: tags
+  properties: {
+    contentLink: {
+      uri: version != 'latest' ? '${uri}/${name}/${version}' : '${uri}/${name}'
+      version: version != 'latest' ? version : null
+    }
+  }
+}
+
+@description('The name of the deployed package.')
+output name string = python3package.name
+
+@description('The resource ID of the deployed package.')
+output resourceId string = python3package.id
+
+@description('The resource group of the deployed package.')
+output resourceGroupName string = resourceGroup().name
+
+@description('The location the resource was deployed into.')
+output location string = python3package.location

--- a/avm/res/automation/automation-account/python3-packages/main.json
+++ b/avm/res/automation/automation-account/python3-packages/main.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.28.1.47646",
+      "templateHash": "6307484872853391839"
+    },
+    "name": "Automation Account Python 3 Packages",
+    "description": "This module deploys a Python3 Package in the Automation Account.",
+    "owner": "Azure/module-maintainers"
+  },
+  "parameters": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Name of the Python3 Automation Account package."
+      }
+    },
+    "automationAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Conditional. The name of the parent Automation Account. Required if the template is used in a standalone deployment."
+      }
+    },
+    "uri": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. Package URI, e.g. https://www.powershellgallery.com/api/v2/package."
+      }
+    },
+    "version": {
+      "type": "string",
+      "defaultValue": "latest",
+      "metadata": {
+        "description": "Optional. Package version or specify latest to get the latest version."
+      }
+    },
+    "tags": {
+      "type": "object",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Tags of the Automation Account resource."
+      }
+    }
+  },
+  "resources": {
+    "automationAccount": {
+      "existing": true,
+      "type": "Microsoft.Automation/automationAccounts",
+      "apiVersion": "2022-08-08",
+      "name": "[parameters('automationAccountName')]"
+    },
+    "python3package": {
+      "type": "Microsoft.Automation/automationAccounts/python3Packages",
+      "apiVersion": "2023-11-01",
+      "name": "[format('{0}/{1}', parameters('automationAccountName'), parameters('name'))]",
+      "tags": "[parameters('tags')]",
+      "properties": {
+        "contentLink": {
+          "uri": "[if(not(equals(parameters('version'), 'latest')), format('{0}/{1}/{2}', parameters('uri'), parameters('name'), parameters('version')), format('{0}/{1}', parameters('uri'), parameters('name')))]",
+          "version": "[if(not(equals(parameters('version'), 'latest')), parameters('version'), null())]"
+        }
+      },
+      "dependsOn": [
+        "automationAccount"
+      ]
+    }
+  },
+  "outputs": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the deployed package."
+      },
+      "value": "[parameters('name')]"
+    },
+    "resourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource ID of the deployed package."
+      },
+      "value": "[resourceId('Microsoft.Automation/automationAccounts/python3Packages', parameters('automationAccountName'), parameters('name'))]"
+    },
+    "resourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource group of the deployed package."
+      },
+      "value": "[resourceGroup().name]"
+    },
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "The location the resource was deployed into."
+      },
+      "value": "[reference('python3package', '2023-11-01', 'full').location]"
+    }
+  }
+}

--- a/avm/res/automation/automation-account/tests/e2e/max/main.test.bicep
+++ b/avm/res/automation/automation-account/tests/e2e/max/main.test.bicep
@@ -114,6 +114,27 @@ module testDeployment '../../../main.bicep' = [
           version: 'latest'
         }
       ]
+      powershell72Modules: [
+        {
+          name: 'powershell-yaml'
+          uri: 'https://www.powershellgallery.com/api/v2/package'
+          version: 'latest'
+        }
+      ]
+      python3Packages: [
+        {
+          name: 'geniz-0.0.1-py3-none-any.whl'
+          uri: 'https://files.pythonhosted.org/packages/8f/4b/c61bb7b176b34dd0c9ab0f3d821234c1e9f81f3ba5a609a1cf9032c852e7'
+          version: 'latest'
+        }
+      ]
+      python2Packages: [
+        {
+          name: 'pycx2-1.0.3-py2-none-any.whl'
+          uri: 'https://files.pythonhosted.org/packages/59/8c/40f66c4ac7564a68edd629a7836536af53d10b2d89f78c63e77cfcd9d460'
+          version: 'latest'
+        }
+      ]
       privateEndpoints: [
         {
           privateDnsZoneResourceIds: [


### PR DESCRIPTION
## Description
Added support for python 3, phyton 2 packages, powershell 7.2 modules

Fixes #2485


## Pipeline Reference

| Pipeline |
| -------- |
|    [![avm.res.automation.automation-account](https://github.com/elanzel/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml/badge.svg?branch=autaccount-issue2485)](https://github.com/elanzel/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml)     |

## Type of Change

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
