### PR TITLE
fix: workaround for Azure Stack HCI underscores

### DIFF
--- a/avm/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/avm/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -532,6 +532,12 @@ Describe 'Module tests' -Tag 'Module' {
           return
         }
 
+        # workaround for Azure Stack HCI cluster deployment settings resource, where property names have underscores - https://github.com/Azure/Azure-Verified-Modules/issues/1029
+        if ($moduleFolderPath -match 'azure-stack-hci.cluster.deployment-settings') {
+          Set-ItResult -Skipped -Because 'the module path matches "azure-stack-hci.cluster.deployment-settings" which is a special case--underscores in property names.'
+          return
+        }
+
         $incorrectParameters = @()
         foreach ($parameter in ($templateFileParameters.PSBase.Keys | Sort-Object -Culture 'en-US')) {
           # Parameters in the object are formatted like

--- a/avm/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/avm/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -532,18 +532,19 @@ Describe 'Module tests' -Tag 'Module' {
           return
         }
 
-        # workaround for Azure Stack HCI cluster deployment settings resource, where property names have underscores - https://github.com/Azure/Azure-Verified-Modules/issues/1029
-        if ($moduleFolderPath -match 'azure-stack-hci.cluster.deployment-settings') {
-          Set-ItResult -Skipped -Because 'the module path matches "azure-stack-hci.cluster.deployment-settings" which is a special case--underscores in property names.'
-          return
-        }
-
         $incorrectParameters = @()
         foreach ($parameter in ($templateFileParameters.PSBase.Keys | Sort-Object -Culture 'en-US')) {
           # Parameters in the object are formatted like
           # - tags
           # - customerManagedKey.keyVaultResourceId
           $paramName = ($parameter -split '\.')[-1]
+
+          # workaround for Azure Stack HCI cluster deployment settings resource, where property names have underscores - https://github.com/Azure/Azure-Verified-Modules/issues/1029
+          if ($moduleFolderPath -match 'azure-stack-hci[/\\]cluster[/\\]deployment-settings' -and $paramName -in ('bandwidthPercentage_SMB', 'priorityValue8021Action_Cluster', 'priorityValue8021Action_SMB')) {
+            Set-ItResult -Skipped -Because 'the module path matches "azure-stack-hci/cluster/deployment-settings" and the parameter name is in list [bandwidthPercentage_SMB, priorityValue8021Action_Cluster, priorityValue8021Action_SMB], which have underscores in the API spec.'
+            return
+          }
+
           if ($paramName.substring(0, 1) -cnotmatch '[a-z]' -or $paramName -match '-' -or $paramName -match '_') {
             $incorrectParameters += @() + $parameter
           }


### PR DESCRIPTION
## Description

Fixes https://github.com/Azure/Azure-Verified-Modules/issues/1029

## Pipeline Reference

![image](https://github.com/Azure/bicep-registry-modules/assets/25390936/c3bf13f1-d70d-4bb2-9228-d12bad7ec99a)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
