### PR TITLE
fix: Corrected deployment-name limitation 

### DIFF
--- a/avm/res/resources/deployment-script/main.bicep
+++ b/avm/res/resources/deployment-script/main.bicep
@@ -6,7 +6,7 @@ metadata owner = 'Azure/module-maintainers'
 // Parameters       //
 // ================ //
 @description('Required. Name of the Deployment Script.')
-@maxLength(24)
+@maxLength(90)
 param name string
 
 @description('Optional. Location for all resources.')
@@ -141,9 +141,51 @@ var storageAccountSettings = !empty(storageAccountResourceId)
     }
   : null
 
-// ============ //
-// Dependencies //
-// ============ //
+// ================ //
+// Resources        //
+// ================ //
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.resources-deploymentscript.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
+
+resource deploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+  name: name
+  location: location
+  tags: tags
+  identity: identity
+  kind: any(kind)
+  properties: {
+    azPowerShellVersion: kind == 'AzurePowerShell' ? azPowerShellVersion : null
+    azCliVersion: kind == 'AzureCLI' ? azCliVersion : null
+    containerSettings: !empty(containerSettings) ? containerSettings : null
+    storageAccountSettings: !empty(storageAccountResourceId) ? storageAccountSettings : null
+    arguments: arguments
+    environmentVariables: environmentVariables != null ? environmentVariables!.secureList : []
+    scriptContent: !empty(scriptContent) ? scriptContent : null
+    primaryScriptUri: !empty(primaryScriptUri) ? primaryScriptUri : null
+    supportingScriptUris: !empty(supportingScriptUris) ? supportingScriptUris : null
+    cleanupPreference: cleanupPreference
+    forceUpdateTag: runOnce ? resourceGroup().name : baseTime
+    retentionInterval: retentionInterval
+    timeout: timeout
+  }
+}
 
 resource deploymentScript_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(lock ?? {}) && lock.?kind != 'None') {
   name: lock.?name ?? 'lock-${name}'
@@ -175,52 +217,6 @@ resource deploymentScript_roleAssignments 'Microsoft.Authorization/roleAssignmen
     scope: deploymentScript
   }
 ]
-
-#disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
-  name: '46d3xbcp.res.resources-deploymentscript.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
-  properties: {
-    mode: 'Incremental'
-    template: {
-      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
-      contentVersion: '1.0.0.0'
-      resources: []
-      outputs: {
-        telemetry: {
-          type: 'String'
-          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
-        }
-      }
-    }
-  }
-}
-
-// ================ //
-// Resources        //
-// ================ //
-
-resource deploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
-  name: name
-  location: location
-  tags: tags
-  identity: identity
-  kind: any(kind)
-  properties: {
-    azPowerShellVersion: kind == 'AzurePowerShell' ? azPowerShellVersion : null
-    azCliVersion: kind == 'AzureCLI' ? azCliVersion : null
-    containerSettings: !empty(containerSettings) ? containerSettings : null
-    storageAccountSettings: !empty(storageAccountResourceId) ? storageAccountSettings : null
-    arguments: arguments
-    environmentVariables: environmentVariables != null ? environmentVariables!.secureList : []
-    scriptContent: !empty(scriptContent) ? scriptContent : null
-    primaryScriptUri: !empty(primaryScriptUri) ? primaryScriptUri : null
-    supportingScriptUris: !empty(supportingScriptUris) ? supportingScriptUris : null
-    cleanupPreference: cleanupPreference
-    forceUpdateTag: runOnce ? resourceGroup().name : baseTime
-    retentionInterval: retentionInterval
-    timeout: timeout
-  }
-}
 
 resource deploymentScriptLogs 'Microsoft.Resources/deploymentScripts/logs@2023-08-01' existing = {
   name: 'default'

--- a/avm/res/resources/deployment-script/main.json
+++ b/avm/res/resources/deployment-script/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.28.1.47646",
-      "templateHash": "2448764791611861482"
+      "templateHash": "9938722199855482315"
     },
     "name": "Deployment Scripts",
     "description": "This module deploys Deployment Scripts.",
@@ -151,7 +151,7 @@
   "parameters": {
     "name": {
       "type": "string",
-      "maxLength": 24,
+      "maxLength": 90,
       "metadata": {
         "description": "Required. Name of the Deployment Script."
       }
@@ -352,42 +352,6 @@
       "resourceGroup": "[split(if(not(empty(parameters('storageAccountResourceId'))), parameters('storageAccountResourceId'), '////'), '/')[4]]",
       "name": "[last(split(if(not(empty(parameters('storageAccountResourceId'))), parameters('storageAccountResourceId'), 'dummyAccount'), '/'))]"
     },
-    "deploymentScript_lock": {
-      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
-      "type": "Microsoft.Authorization/locks",
-      "apiVersion": "2020-05-01",
-      "scope": "[format('Microsoft.Resources/deploymentScripts/{0}', parameters('name'))]",
-      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
-      "properties": {
-        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
-        "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
-      },
-      "dependsOn": [
-        "deploymentScript"
-      ]
-    },
-    "deploymentScript_roleAssignments": {
-      "copy": {
-        "name": "deploymentScript_roleAssignments",
-        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]"
-      },
-      "type": "Microsoft.Authorization/roleAssignments",
-      "apiVersion": "2022-04-01",
-      "scope": "[format('Microsoft.Resources/deploymentScripts/{0}', parameters('name'))]",
-      "name": "[guid(resourceId('Microsoft.Resources/deploymentScripts', parameters('name')), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].principalId, coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName)]",
-      "properties": {
-        "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName), variables('builtInRoleNames')[coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName], if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName)))]",
-        "principalId": "[coalesce(parameters('roleAssignments'), createArray())[copyIndex()].principalId]",
-        "description": "[tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'description')]",
-        "principalType": "[tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'principalType')]",
-        "condition": "[tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'condition')]",
-        "conditionVersion": "[if(not(empty(tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
-        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
-      },
-      "dependsOn": [
-        "deploymentScript"
-      ]
-    },
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
@@ -433,6 +397,42 @@
       },
       "dependsOn": [
         "storageAccount"
+      ]
+    },
+    "deploymentScript_lock": {
+      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+      "type": "Microsoft.Authorization/locks",
+      "apiVersion": "2020-05-01",
+      "scope": "[format('Microsoft.Resources/deploymentScripts/{0}', parameters('name'))]",
+      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+      "properties": {
+        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+        "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+      },
+      "dependsOn": [
+        "deploymentScript"
+      ]
+    },
+    "deploymentScript_roleAssignments": {
+      "copy": {
+        "name": "deploymentScript_roleAssignments",
+        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]"
+      },
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "scope": "[format('Microsoft.Resources/deploymentScripts/{0}', parameters('name'))]",
+      "name": "[guid(resourceId('Microsoft.Resources/deploymentScripts', parameters('name')), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].principalId, coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName)]",
+      "properties": {
+        "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName), variables('builtInRoleNames')[coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName], if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName)))]",
+        "principalId": "[coalesce(parameters('roleAssignments'), createArray())[copyIndex()].principalId]",
+        "description": "[tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'description')]",
+        "principalType": "[tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'principalType')]",
+        "condition": "[tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'condition')]",
+        "conditionVersion": "[if(not(empty(tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+      },
+      "dependsOn": [
+        "deploymentScript"
       ]
     },
     "deploymentScriptLogs": {


### PR DESCRIPTION
## Description

- Moved name length limitation from 24 up to 90 as per [api-specs](https://github.com/Azure/azure-rest-api-specs/blob/3cb1b51638616435470fc10ea00de92512186ece/specification/resources/resource-manager/Microsoft.Resources/stable/2023-08-01/deploymentScripts.json#L950-L959)
- Slightly adjusted order of resources

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|       [![avm.res.resources.deployment-script](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.deployment-script.yml/badge.svg?branch=users%2Falsehr%2FdeploymentScriptName&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.deployment-script.yml)   |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
