### PR TITLE
fix: Site module app insight and customDomainVerificationId

### DIFF
--- a/avm/res/web/site/README.md
+++ b/avm/res/web/site/README.md
@@ -2047,6 +2047,7 @@ module site 'br/public:avm/res/web/site:<version>' = {
 | [`clientCertMode`](#parameter-clientcertmode) | string | This composes with ClientCertEnabled setting.<li>ClientCertEnabled=false means ClientCert is ignored.<li>ClientCertEnabled=true and ClientCertMode=Required means ClientCert is required.<li>ClientCertEnabled=true and ClientCertMode=Optional means ClientCert is optional or accepted.<p> |
 | [`cloningInfo`](#parameter-cloninginfo) | object | If specified during app creation, the app is cloned from a source app. |
 | [`containerSize`](#parameter-containersize) | int | Size of the function container. |
+| [`customDomainVerificationId`](#parameter-customdomainverificationid) | string | Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification. |
 | [`dailyMemoryTimeQuota`](#parameter-dailymemorytimequota) | int | Maximum allowed daily memory-time quota (applicable on dynamic apps only). |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
 | [`enabled`](#parameter-enabled) | bool | Setting this value to false disables the app (takes the app offline). |
@@ -2207,6 +2208,13 @@ Size of the function container.
 
 - Required: No
 - Type: int
+
+### Parameter: `customDomainVerificationId`
+
+Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification.
+
+- Required: No
+- Type: string
 
 ### Parameter: `dailyMemoryTimeQuota`
 
@@ -3051,7 +3059,6 @@ Virtual Network Route All enabled. This causes all outbound traffic to have Virt
 
 | Output | Type | Description |
 | :-- | :-- | :-- |
-| `customDomainVerificationId` | string | Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification. |
 | `defaultHostname` | string | Default hostname of the app. |
 | `location` | string | The location the resource was deployed into. |
 | `name` | string | The name of the site. |

--- a/avm/res/web/site/README.md
+++ b/avm/res/web/site/README.md
@@ -2047,7 +2047,6 @@ module site 'br/public:avm/res/web/site:<version>' = {
 | [`clientCertMode`](#parameter-clientcertmode) | string | This composes with ClientCertEnabled setting.<li>ClientCertEnabled=false means ClientCert is ignored.<li>ClientCertEnabled=true and ClientCertMode=Required means ClientCert is required.<li>ClientCertEnabled=true and ClientCertMode=Optional means ClientCert is optional or accepted.<p> |
 | [`cloningInfo`](#parameter-cloninginfo) | object | If specified during app creation, the app is cloned from a source app. |
 | [`containerSize`](#parameter-containersize) | int | Size of the function container. |
-| [`customDomainVerificationId`](#parameter-customdomainverificationid) | string | Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification. |
 | [`dailyMemoryTimeQuota`](#parameter-dailymemorytimequota) | int | Maximum allowed daily memory-time quota (applicable on dynamic apps only). |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
 | [`enabled`](#parameter-enabled) | bool | Setting this value to false disables the app (takes the app offline). |
@@ -2208,13 +2207,6 @@ Size of the function container.
 
 - Required: No
 - Type: int
-
-### Parameter: `customDomainVerificationId`
-
-Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification.
-
-- Required: No
-- Type: string
 
 ### Parameter: `dailyMemoryTimeQuota`
 
@@ -3059,6 +3051,7 @@ Virtual Network Route All enabled. This causes all outbound traffic to have Virt
 
 | Output | Type | Description |
 | :-- | :-- | :-- |
+| `customDomainVerificationId` | string | Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification. |
 | `defaultHostname` | string | Default hostname of the app. |
 | `location` | string | The location the resource was deployed into. |
 | `name` | string | The name of the site. |

--- a/avm/res/web/site/main.bicep
+++ b/avm/res/web/site/main.bicep
@@ -270,7 +270,7 @@ resource app 'Microsoft.Web/sites@2022-09-01' = {
   }
 }
 
-module app_appsettings 'config--appsettings/main.bicep' = if (!empty(appSettingsKeyValuePairs)) {
+module app_appsettings 'config--appsettings/main.bicep' = if (!empty(appSettingsKeyValuePairs) || !empty(appInsightResourceId) || !empty(storageAccountResourceId)) {
   name: '${uniqueString(deployment().name, location)}-Site-Config-AppSettings'
   params: {
     appName: app.name

--- a/avm/res/web/site/main.bicep
+++ b/avm/res/web/site/main.bicep
@@ -132,9 +132,6 @@ param cloningInfo object?
 @description('Optional. Size of the function container.')
 param containerSize int?
 
-@description('Optional. Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification.')
-param customDomainVerificationId string?
-
 @description('Optional. Maximum allowed daily memory-time quota (applicable on dynamic apps only).')
 param dailyMemoryTimeQuota int?
 
@@ -254,7 +251,6 @@ resource app 'Microsoft.Web/sites@2022-09-01' = {
     clientCertMode: clientCertMode
     cloningInfo: cloningInfo
     containerSize: containerSize
-    customDomainVerificationId: customDomainVerificationId
     dailyMemoryTimeQuota: dailyMemoryTimeQuota
     enabled: enabled
     hostNameSslStates: hostNameSslStates
@@ -526,6 +522,9 @@ output location string = app.location
 
 @description('Default hostname of the app.')
 output defaultHostname string = app.properties.defaultHostName
+
+@description('Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification.')
+output customDomainVerificationId string = app.properties.customDomainVerificationId
 
 // =============== //
 //   Definitions   //

--- a/avm/res/web/site/main.json
+++ b/avm/res/web/site/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.28.1.47646",
-      "templateHash": "6862642055194235361"
+      "templateHash": "12782824420940859695"
     },
     "name": "Web/Function Apps",
     "description": "This module deploys a Web or Function App.",
@@ -703,13 +703,6 @@
         "description": "Optional. Size of the function container."
       }
     },
-    "customDomainVerificationId": {
-      "type": "string",
-      "nullable": true,
-      "metadata": {
-        "description": "Optional. Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification."
-      }
-    },
     "dailyMemoryTimeQuota": {
       "type": "int",
       "nullable": true,
@@ -835,7 +828,6 @@
         "clientCertMode": "[parameters('clientCertMode')]",
         "cloningInfo": "[parameters('cloningInfo')]",
         "containerSize": "[parameters('containerSize')]",
-        "customDomainVerificationId": "[parameters('customDomainVerificationId')]",
         "dailyMemoryTimeQuota": "[parameters('dailyMemoryTimeQuota')]",
         "enabled": "[parameters('enabled')]",
         "hostNameSslStates": "[parameters('hostNameSslStates')]",
@@ -926,7 +918,7 @@
       ]
     },
     "app_appsettings": {
-      "condition": "[not(empty(parameters('appSettingsKeyValuePairs')))]",
+      "condition": "[or(or(not(empty(parameters('appSettingsKeyValuePairs'))), not(empty(parameters('appInsightResourceId')))), not(empty(parameters('storageAccountResourceId'))))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
       "name": "[format('{0}-Site-Config-AppSettings', uniqueString(deployment().name, parameters('location')))]",
@@ -4627,6 +4619,13 @@
         "description": "Default hostname of the app."
       },
       "value": "[reference('app').defaultHostName]"
+    },
+    "customDomainVerificationId": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification."
+      },
+      "value": "[reference('app').customDomainVerificationId]"
     }
   }
 }


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

This PR fixes two issues in site module:

- Currently, if user of the module does not specify any appSettingsKeyValuePairs but only appInsightResourceId, the relevant app settings for configuring app insights is not created by the module since the bicep code only checks for appSettingsKeyValuePairs emptiness.
- Remove misleading customDomainVerificationId as param. This is a read only property and set after app service instance is created. Exposed the same as output instead.
- https://stackoverflow.com/questions/69382365/setting-the-customdomainverificationid-property-on-an-appservice-in-a-bicep-de

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.res.web.site](https://github.com/pankajagrawal16/bicep-registry-modules/actions/workflows/avm.res.web.site.yml/badge.svg?branch=site-module-app-insight-verificationid)](https://github.com/pankajagrawal16/bicep-registry-modules/actions/workflows/avm.res.web.site.yml)    |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
