### PR TITLE
fix: Fixed `Set-AVMModule` dependency on Windows OS

### DIFF
--- a/avm/res/document-db/database-account/tests/e2e/analytical/main.test.bicep
+++ b/avm/res/document-db/database-account/tests/e2e/analytical/main.test.bicep
@@ -29,8 +29,6 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
   location: enforcedLocation
 }
 
-module t 'br/public:avm/res/virtual-machine-images/image-template:0.2.1'
-
 // ============== //
 // Test Execution //
 // ============== //

--- a/avm/res/document-db/database-account/tests/e2e/analytical/main.test.bicep
+++ b/avm/res/document-db/database-account/tests/e2e/analytical/main.test.bicep
@@ -29,6 +29,8 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
   location: enforcedLocation
 }
 
+module t 'br/public:avm/res/virtual-machine-images/image-template:0.2.1'
+
 // ============== //
 // Test Execution //
 // ============== //

--- a/avm/utilities/tools/helper/Set-ModuleFileAndFolderSetup.ps1
+++ b/avm/utilities/tools/helper/Set-ModuleFileAndFolderSetup.ps1
@@ -46,17 +46,14 @@ function Set-ModuleFileAndFolderSetup {
     )
 
     if ([String]::IsNullOrEmpty($CurrentLevelFolderPath)) {
-        # Extract resource type identifier
-        $resourceTypeIdentifier = ($FullModuleFolderPath -split '[\/|\\]{1}avm[\/|\\]{1}(res|ptn)[\/|\\]{1}')[2] # <provider>\<resourceType>
+        # Extract path elements
+        $repoRoot, $moduleType, $resourceTypeIdentifier = $FullModuleFolderPath -split '[\/|\\]{1}avm[\/|\\]{1}(res|ptn)[\/|\\]{1}' # .*/bicep-registry-modules, res|ptn, <provider>/<resourceType>
 
         # Split resource type identifier into components
-        $providerNamespace, $resourceType, $childResourceType = $resourceTypeIdentifier -split '[\/|\\]', 3
-
-        # Construct the root module path up to the providerNamespace (excluding resourceType and childResourceType)
-        $avmModuleRoot = ($FullModuleFolderPath -split [regex]::Escape("\$providerNamespace\$resourceType"))[0] + "\$providerNamespace"
+        $providerNamespace, $resourceType, $childResourceType = $resourceTypeIdentifier -split '[\/|\\]', 3 # <provider>, <resourceType>, <childResourceType>
 
         # Join the required path to get up to the resource type folder
-        $CurrentLevelFolderPath = Join-Path -Path $avmModuleRoot -ChildPath $resourceType
+        $CurrentLevelFolderPath = Join-Path $repoRoot 'avm' $moduleType $providerNamespace $resourceType
     }
 
     # Collect data


### PR DESCRIPTION
## Description

In one part of the code, the paths where hardcoded to `\` which is fine for Windows, but if you use the script on Linux/Mac/Codespaces, the scripts starts to behave in unintended ways
I also aligned the code with other parts of our utilitites (especially regarding the use of `[\/|\\]`)

Tested both locally in Windows, as well as in Codespace with AAD module. As expected, no new files were created. Fixes #2637 

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
