### PR TITLE
fix: Added missing ignore path to LZ workflow trigger

### DIFF
--- a/.github/workflows/avm.ptn.lz.sub-vending.yml
+++ b/.github/workflows/avm.ptn.lz.sub-vending.yml
@@ -27,6 +27,7 @@ on:
       - ".github/workflows/avm.ptn.lz.sub-vending"
       - "avm/ptn/lz/sub-vending/**"
       - "avm/utilities/pipelines/**"
+      - "!avm/utilities/pipelines/platform/**"
       - "!*/**/README.md"
 
 env:


### PR DESCRIPTION
…ipts

## Description

Added missing ignore-path that excludes `platform` script changes from triggering this workflow. 
This aligns with all other workflows

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
