### PR TITLE
feat: add doNotMergeWithLastModuleIndexJsonFileVersion flexibility to workflow

### DIFF
--- a/.github/workflows/platform.publish-module-index-json.yml
+++ b/.github/workflows/platform.publish-module-index-json.yml
@@ -5,9 +5,9 @@ on:
     - cron: 45 11 * * * # Run daily at 3:45 AM PST
   workflow_dispatch:
     inputs:
-      doNotMergeWithLastModuleIndexJsonFileVersion:
+      regenIndexFromBRM:
         type: boolean
-        description: "doNotMergeWithLastModuleIndexJsonFileVersion | If toggled, the last version of the moduleIndex.json file that is downloaded from the storage account will not be merged with the current generated moduleIndex.json file. Effectively creating the moduleIndex.json from scrath based on what is in BRM at the time of the run."
+        description: "regenIndexFromBRM | Regenerate the moduleIndex.json file from scratch based on what is in BRM at the time of the run, instead of integrating it with its previous version."
         required: false
         default: false
 
@@ -55,26 +55,15 @@ jobs:
             ErrorAction                                  = 'Continue'
           }
 
-          if ('${{ (fromJson(inputs.doNotMergeWithLastModuleIndexJsonFileVersion)) }}' -eq '$true' ) {
-            Write-Verbose "Invoke task with" -Verbose
-            Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
-            Write-Verbose "doNotMergeWithLastModuleIndexJsonFileVersion value is..." -Verbose
-            Write-Verbose ('${{ (fromJson(inputs.doNotMergeWithLastModuleIndexJsonFileVersion)) }}' | ConvertTo-Json | Out-String) -Verbose
-
-            if(-not (Invoke-AvmJsonModuleIndexGeneration -doNotMergeWithLastModuleIndexJsonFileVersion @functionInput)) {
-              Write-Output ('{0}={1}' -f 'anyErrorsOccurred', $true) >> $env:GITHUB_ENV
-            }
+          if ('${{ (fromJson(inputs.regenIndexFromBRM)) }}' -eq $true ) {
+            $functionInput['doNotMergeWithLastModuleIndexJsonFileVersion'] = $true
           }
 
-          if ('${{ (fromJson(inputs.doNotMergeWithLastModuleIndexJsonFileVersion)) }}' -eq '$false' ) {
-            Write-Verbose "Invoke task with" -Verbose
-            Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
-            Write-Verbose "doNotMergeWithLastModuleIndexJsonFileVersion value is..." -Verbose
-            Write-Verbose ('${{ (fromJson(inputs.doNotMergeWithLastModuleIndexJsonFileVersion)) }}' | ConvertTo-Json | Out-String) -Verbose
+          Write-Verbose 'Invoke task with' -Verbose
+          Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-            if(-not (Invoke-AvmJsonModuleIndexGeneration @functionInput)) {
-              Write-Output ('{0}={1}' -f 'anyErrorsOccurred', $true) >> $env:GITHUB_ENV
-            }
+          if (-not (Invoke-AvmJsonModuleIndexGeneration @functionInput)) {
+            Write-Output ('{0}={1}' -f 'anyErrorsOccurred', $true) >> $env:GITHUB_ENV
           }
 
       - name: Upload artifacts

--- a/.github/workflows/platform.publish-module-index-json.yml
+++ b/.github/workflows/platform.publish-module-index-json.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: 45 11 * * * # Run daily at 3:45 AM PST
   workflow_dispatch:
+    inputs:
+      doNotMergeWithLastModuleIndexJsonFileVersion:
+        type: boolean
+        description: "doNotMergeWithLastModuleIndexJsonFileVersion | If toggled, the last version of the moduleIndex.json file that is downloaded from the storage account will not be merged with the current generated moduleIndex.json file. Effectively creating the moduleIndex.json from scrath based on what is in BRM at the time of the run."
+        required: false
+        default: false
 
 permissions:
   id-token: write
@@ -49,11 +55,26 @@ jobs:
             ErrorAction                                  = 'Continue'
           }
 
-          Write-Verbose "Invoke task with" -Verbose
-          Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+          if ('${{ (fromJson(inputs.doNotMergeWithLastModuleIndexJsonFileVersion)) }}' -eq '$true' ) {
+            Write-Verbose "Invoke task with" -Verbose
+            Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+            Write-Verbose "doNotMergeWithLastModuleIndexJsonFileVersion value is..." -Verbose
+            Write-Verbose ('${{ (fromJson(inputs.doNotMergeWithLastModuleIndexJsonFileVersion)) }}' | ConvertTo-Json | Out-String) -Verbose
 
-          if(-not (Invoke-AvmJsonModuleIndexGeneration @functionInput)) {
-            Write-Output ('{0}={1}' -f 'anyErrorsOccurred', $true) >> $env:GITHUB_ENV
+            if(-not (Invoke-AvmJsonModuleIndexGeneration -doNotMergeWithLastModuleIndexJsonFileVersion @functionInput)) {
+              Write-Output ('{0}={1}' -f 'anyErrorsOccurred', $true) >> $env:GITHUB_ENV
+            }
+          }
+
+          if ('${{ (fromJson(inputs.doNotMergeWithLastModuleIndexJsonFileVersion)) }}' -eq '$false' ) {
+            Write-Verbose "Invoke task with" -Verbose
+            Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+            Write-Verbose "doNotMergeWithLastModuleIndexJsonFileVersion value is..." -Verbose
+            Write-Verbose ('${{ (fromJson(inputs.doNotMergeWithLastModuleIndexJsonFileVersion)) }}' | ConvertTo-Json | Out-String) -Verbose
+
+            if(-not (Invoke-AvmJsonModuleIndexGeneration @functionInput)) {
+              Write-Output ('{0}={1}' -f 'anyErrorsOccurred', $true) >> $env:GITHUB_ENV
+            }
           }
 
       - name: Upload artifacts

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,25 @@
     "files.encoding": "utf8bom",
     "files.insertFinalNewline": true,
     "editor.detectIndentation": false // VS Code will not detect indentation/tab/space from the file and use settings editor.insertSpaces and editor.tabSize instead
-  }
+  },
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#fbbb31",
+    "activityBar.background": "#fbbb31",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#039c6c",
+    "activityBarBadge.foreground": "#e7e7e7",
+    "commandCenter.border": "#15202b99",
+    "sash.hoverBorder": "#fbbb31",
+    "statusBar.background": "#f4a805",
+    "statusBar.foreground": "#15202b",
+    "statusBarItem.hoverBackground": "#c28604",
+    "statusBarItem.remoteBackground": "#f4a805",
+    "statusBarItem.remoteForeground": "#15202b",
+    "titleBar.activeBackground": "#f4a805",
+    "titleBar.activeForeground": "#15202b",
+    "titleBar.inactiveBackground": "#f4a80599",
+    "titleBar.inactiveForeground": "#15202b99"
+  },
+  "peacock.color": "#f4a805"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,25 +28,5 @@
     "files.encoding": "utf8bom",
     "files.insertFinalNewline": true,
     "editor.detectIndentation": false // VS Code will not detect indentation/tab/space from the file and use settings editor.insertSpaces and editor.tabSize instead
-  },
-  "workbench.colorCustomizations": {
-    "activityBar.activeBackground": "#fbbb31",
-    "activityBar.background": "#fbbb31",
-    "activityBar.foreground": "#15202b",
-    "activityBar.inactiveForeground": "#15202b99",
-    "activityBarBadge.background": "#039c6c",
-    "activityBarBadge.foreground": "#e7e7e7",
-    "commandCenter.border": "#15202b99",
-    "sash.hoverBorder": "#fbbb31",
-    "statusBar.background": "#f4a805",
-    "statusBar.foreground": "#15202b",
-    "statusBarItem.hoverBackground": "#c28604",
-    "statusBarItem.remoteBackground": "#f4a805",
-    "statusBarItem.remoteForeground": "#15202b",
-    "titleBar.activeBackground": "#f4a805",
-    "titleBar.activeForeground": "#15202b",
-    "titleBar.inactiveBackground": "#f4a80599",
-    "titleBar.inactiveForeground": "#15202b99"
-  },
-  "peacock.color": "#f4a805"
+  }
 }


### PR DESCRIPTION
## Description

Following on from #2711 it was overlooked that the merge capability would mean that even though the changes made in #2711 worked the merged `moudleIndex.json` does not contain the correctly ordered list.

Therefore adding this to introduce the capability to invoke the `doNotMergeWithLastModuleIndexJsonFileVersion` parameter input for the workflow so we can use in scenarios like this to overwrite whatever is in the `moduleIndex.json` and create it from scratch if needed, like now.

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
