### PR TITLE
fix: Purview Account - Updated enforced location to latest supported

### DIFF
--- a/avm/res/purview/account/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/purview/account/tests/e2e/defaults/main.test.bicep
@@ -20,8 +20,8 @@ param serviceShort string = 'pvamin'
 param namePrefix string = '#_namePrefix_#'
 
 // Set to fixed location as the RP function returns unsupported locations
-// Right now (2024/03) the following locations are supported: eastus, eastus2, southcentralus, westcentralus, westus, westus2, westus3
-param enforcedLocation string = 'eastus'
+// Right now (2024/07) the following locations are supported: uksouth
+param enforcedLocation string = 'uksouth'
 
 // =========== //
 // Deployments //

--- a/avm/res/purview/account/tests/e2e/max/main.test.bicep
+++ b/avm/res/purview/account/tests/e2e/max/main.test.bicep
@@ -20,8 +20,8 @@ param serviceShort string = 'pvamax'
 param namePrefix string = '#_namePrefix_#'
 
 // Set to fixed location as the RP function returns unsupported locations
-// Right now (2024/03) the following locations are supported: eastus, eastus2, southcentralus, westcentralus, westus, westus2, westus3
-param enforcedLocation string = 'eastus'
+// Right now (2024/07) the following locations are supported: uksouth
+param enforcedLocation string = 'uksouth'
 
 // =========== //
 // Deployments //

--- a/avm/res/purview/account/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/purview/account/tests/e2e/waf-aligned/main.test.bicep
@@ -20,8 +20,8 @@ param serviceShort string = 'pvawaf'
 param namePrefix string = '#_namePrefix_#'
 
 // Set to fixed location as the RP function returns unsupported locations
-// Right now (2024/03) the following locations are supported: eastus, eastus2, southcentralus, westcentralus, westus, westus2, westus3
-param enforcedLocation string = 'eastus'
+// Right now (2024/07) the following locations are supported: uksouth
+param enforcedLocation string = 'uksouth'
 
 // =========== //
 // Deployments //


### PR DESCRIPTION
## Description

Apparently, in March, the list of allowed locations was `eastus, eastus2, southcentralus, westcentralus, westus, westus2, westus3`.
As per the [latest workflow run](https://github.com/Azure/bicep-registry-modules/actions/runs/10044151114/job/27758833078) it's now apparently only `uksouth`

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|      [![avm.res.purview.account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.purview.account.yml/badge.svg?branch=users%2Falsehr%2FpurviewLoc&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.purview.account.yml)    |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
