### PR TITLE
fix: Fixed GH Pester output for warnings

### DIFF
--- a/avm/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
+++ b/avm/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
@@ -304,15 +304,14 @@ function Set-PesterGitHubOutput {
 
                 if ($test.ScriptBlock.File -match $moduleSplitRegex) {
                     # Module test
-                    $testLine = $test.ScriptBlock.StartPosition.StartLine
                     $testFileIdentifier = $test.ScriptBlock.File -split $moduleSplitRegex
+                    $testFile = ('avm/{0}/{1}' -f $testFileIdentifier[1], $testFileIdentifier[2]) -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
                 } else {
                     # None-module test
                     $testFile = $test.ScriptBlock.File -replace ('{0}[\\|\/]*' -f [regex]::Escape($RepoRootPath))
                 }
 
-                $testFile = ('avm/{0}/{1}' -f $testFileIdentifier[1], $testFileIdentifier[2]) -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
-
+                $testLine = $test.ScriptBlock.StartPosition.StartLine
                 $testReference = '{0}:{1}' -f (Split-Path $testFile -Leaf), $testLine
                 if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
                     # Creating URL to test file to enable users to 'click' on it


### PR DESCRIPTION
## Description

Fixed GH Pester output for warnings that led to a null-pointer exception

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.insights.scheduled-query-rule](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.scheduled-query-rule.yml/badge.svg?branch=users%2Falsehr%2FgithubOutputBug&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.scheduled-query-rule.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
