### PR TITLE
fix: Accounting for upcoming breaking change of `Get-AzAccessToken`

### DIFF
--- a/avm/utilities/pipelines/platform/deploymentRemoval/Clear-ManagementGroupDeploymentHistory.ps1
+++ b/avm/utilities/pipelines/platform/deploymentRemoval/Clear-ManagementGroupDeploymentHistory.ps1
@@ -50,7 +50,7 @@ function Clear-ManagementGroupDeploymentHistory {
         Method  = 'GET'
         Uri     = "https://management.azure.com/providers/Microsoft.Management/managementGroups/$ManagementGroupId/providers/Microsoft.Resources/deployments/?api-version=2021-04-01"
         Headers = @{
-            Authorization = 'Bearer {0}' -f (Get-AzAccessToken).Token
+            Authorization = 'Bearer {0}' -f ((Get-AzAccessToken -AsSecureString).Token | ConvertFrom-SecureString -AsPlainText)
         }
     }
     $response = Invoke-RestMethod @getInputObject
@@ -103,7 +103,7 @@ function Clear-ManagementGroupDeploymentHistory {
             Method  = 'POST'
             Uri     = 'https://management.azure.com/batch?api-version=2020-06-01'
             Headers = @{
-                Authorization  = 'Bearer {0}' -f (Get-AzAccessToken).Token
+                Authorization  = 'Bearer {0}' -f ((Get-AzAccessToken -AsSecureString).Token | ConvertFrom-SecureString -AsPlainText)
                 'Content-Type' = 'application/json'
             }
             Body    = @{

--- a/avm/utilities/pipelines/platform/deploymentRemoval/Clear-SubscriptionDeploymentHistory.ps1
+++ b/avm/utilities/pipelines/platform/deploymentRemoval/Clear-SubscriptionDeploymentHistory.ps1
@@ -54,7 +54,7 @@ function Clear-SubscriptionDeploymentHistory {
         Method  = 'GET'
         Uri     = "https://management.azure.com/subscriptions/$subscriptionId/providers/Microsoft.Resources/deployments?api-version=2020-06-01"
         Headers = @{
-            Authorization = 'Bearer {0}' -f (Get-AzAccessToken).Token
+            Authorization = 'Bearer {0}' -f ((Get-AzAccessToken -AsSecureString).Token | ConvertFrom-SecureString -AsPlainText)
         }
     }
     $response = Invoke-RestMethod @getInputObject
@@ -107,7 +107,7 @@ function Clear-SubscriptionDeploymentHistory {
             Method  = 'POST'
             Uri     = 'https://management.azure.com/batch?api-version=2020-06-01'
             Headers = @{
-                Authorization  = 'Bearer {0}' -f (Get-AzAccessToken).Token
+                Authorization  = 'Bearer {0}' -f ((Get-AzAccessToken -AsSecureString).Token | ConvertFrom-SecureString -AsPlainText)
                 'Content-Type' = 'application/json'
             }
             Body    = @{


### PR DESCRIPTION
## Description

This PR is accounting for an upcoming breaking change that changes the return value of `Get-AzAccessToken`:
```
WARNING: Upcoming breaking changes in the cmdlet 'Get-AzAccessToken' :
The Token property of the output type will be changed from String to SecureString. Add the [-AsSecureString] switch to avoid the impact of this upcoming breaking change.
- The change is expected to take effect in Az version : '13.0.0'
- The change is expected to take effect in Az.Accounts version : '4.0.0'
Note : Go to https://aka.ms/azps-changewarnings for steps to suppress this breaking change warning, and other information on breaking changes in Azure PowerShell.
```
We effectively, proactively already switch to a secureString which will eventually be the default.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![.Platform - Clean up deployment history](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.deployment.history.cleanup.yml/badge.svg?branch=users%2Falsehr%2FGetAzTokenPrepareBreaking&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.deployment.history.cleanup.yml)       |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
