### PR TITLE
fix: `avm/res/insights/metric-alert`

### DIFF
--- a/avm/res/insights/metric-alert/README.md
+++ b/avm/res/insights/metric-alert/README.md
@@ -277,10 +277,10 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
   params: {
     // Required parameters
     criteria: {
-      componentId: '<componentId>'
+      componentResourceId: '<componentResourceId>'
       failedLocationCount: 3
       'odata.type': 'Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria'
-      webTestId: '<webTestId>'
+      webTestResourceId: '<webTestResourceId>'
     }
     name: 'imawaf001'
     // Non-required parameters
@@ -318,10 +318,10 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
     // Required parameters
     "criteria": {
       "value": {
-        "componentId": "<componentId>",
+        "componentResourceId": "<componentResourceId>",
         "failedLocationCount": 3,
         "odata.type": "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria",
-        "webTestId": "<webTestId>"
+        "webTestResourceId": "<webTestResourceId>"
       }
     },
     "name": {
@@ -369,6 +369,7 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`criteria`](#parameter-criteria) | object | Maps to the 'odata.type' field. Specifies the type of the alert criteria. |
 | [`name`](#parameter-name) | string | The name of the alert. |
 
 **Conditional parameters**
@@ -385,7 +386,6 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
 | [`actions`](#parameter-actions) | array | The list of actions to take when alert triggers. |
 | [`alertDescription`](#parameter-alertdescription) | string | Description of the alert. |
 | [`autoMitigate`](#parameter-automitigate) | bool | The flag that indicates whether the alert should be auto resolved or not. |
-| [`criteria`](#parameter-criteria) | object | Maps to the 'odata.type' field. Specifies the type of the alert criteria. |
 | [`enabled`](#parameter-enabled) | bool | Indicates whether this alert is enabled. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`evaluationFrequency`](#parameter-evaluationfrequency) | string | how often the metric alert is evaluated represented in ISO 8601 duration format. |
@@ -395,6 +395,13 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
 | [`severity`](#parameter-severity) | int | The severity of the alert. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`windowSize`](#parameter-windowsize) | string | the period of time (in ISO 8601 duration format) that is used to monitor alert activity based on the threshold. |
+
+### Parameter: `criteria`
+
+Maps to the 'odata.type' field. Specifies the type of the alert criteria.
+
+- Required: Yes
+- Type: object
 
 ### Parameter: `name`
 
@@ -440,13 +447,6 @@ The flag that indicates whether the alert should be auto resolved or not.
 - Required: No
 - Type: bool
 - Default: `True`
-
-### Parameter: `criteria`
-
-Maps to the 'odata.type' field. Specifies the type of the alert criteria.
-
-- Required: Yes
-- Type: object
 
 ### Parameter: `enabled`
 

--- a/avm/res/insights/metric-alert/README.md
+++ b/avm/res/insights/metric-alert/README.md
@@ -44,17 +44,20 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
   name: 'metricAlertDeployment'
   params: {
     // Required parameters
-    criterias: [
-      {
-        criterionType: 'StaticThresholdCriterion'
-        metricName: 'Percentage CPU'
-        metricNamespace: 'microsoft.compute/virtualmachines'
-        name: 'HighCPU'
-        operator: 'GreaterThan'
-        threshold: '90'
-        timeAggregation: 'Average'
-      }
-    ]
+    criteria: {
+      allof: [
+        {
+          criterionType: 'StaticThresholdCriterion'
+          metricName: 'Percentage CPU'
+          metricNamespace: 'microsoft.compute/virtualmachines'
+          name: 'HighCPU'
+          operator: 'GreaterThan'
+          threshold: '90'
+          timeAggregation: 'Average'
+        }
+      ]
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+    }
     name: 'imamin001'
     // Non-required parameters
     location: 'Global'
@@ -77,18 +80,21 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "criterias": {
-      "value": [
-        {
-          "criterionType": "StaticThresholdCriterion",
-          "metricName": "Percentage CPU",
-          "metricNamespace": "microsoft.compute/virtualmachines",
-          "name": "HighCPU",
-          "operator": "GreaterThan",
-          "threshold": "90",
-          "timeAggregation": "Average"
-        }
-      ]
+    "criteria": {
+      "value": {
+        "allof": [
+          {
+            "criterionType": "StaticThresholdCriterion",
+            "metricName": "Percentage CPU",
+            "metricNamespace": "microsoft.compute/virtualmachines",
+            "name": "HighCPU",
+            "operator": "GreaterThan",
+            "threshold": "90",
+            "timeAggregation": "Average"
+          }
+        ],
+        "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
+      }
     },
     "name": {
       "value": "imamin001"
@@ -124,23 +130,25 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
   name: 'metricAlertDeployment'
   params: {
     // Required parameters
-    criterias: [
-      {
-        criterionType: 'StaticThresholdCriterion'
-        metricName: 'Percentage CPU'
-        metricNamespace: 'microsoft.compute/virtualmachines'
-        name: 'HighCPU'
-        operator: 'GreaterThan'
-        threshold: '90'
-        timeAggregation: 'Average'
-      }
-    ]
+    criteria: {
+      allof: [
+        {
+          criterionType: 'StaticThresholdCriterion'
+          metricName: 'Percentage CPU'
+          metricNamespace: 'microsoft.compute/virtualmachines'
+          name: 'HighCPU'
+          operator: 'GreaterThan'
+          threshold: '90'
+          timeAggregation: 'Average'
+        }
+      ]
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+    }
     name: 'imamax001'
     // Non-required parameters
     actions: [
       '<actionGroupResourceId>'
     ]
-    alertCriteriaType: 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
     location: 'Global'
     roleAssignments: [
       {
@@ -184,18 +192,21 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "criterias": {
-      "value": [
-        {
-          "criterionType": "StaticThresholdCriterion",
-          "metricName": "Percentage CPU",
-          "metricNamespace": "microsoft.compute/virtualmachines",
-          "name": "HighCPU",
-          "operator": "GreaterThan",
-          "threshold": "90",
-          "timeAggregation": "Average"
-        }
-      ]
+    "criteria": {
+      "value": {
+        "allof": [
+          {
+            "criterionType": "StaticThresholdCriterion",
+            "metricName": "Percentage CPU",
+            "metricNamespace": "microsoft.compute/virtualmachines",
+            "name": "HighCPU",
+            "operator": "GreaterThan",
+            "threshold": "90",
+            "timeAggregation": "Average"
+          }
+        ],
+        "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria"
+      }
     },
     "name": {
       "value": "imamax001"
@@ -205,9 +216,6 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
       "value": [
         "<actionGroupResourceId>"
       ]
-    },
-    "alertCriteriaType": {
-      "value": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria"
     },
     "location": {
       "value": "Global"
@@ -268,32 +276,29 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
   name: 'metricAlertDeployment'
   params: {
     // Required parameters
-    criterias: [
-      {
-        criterionType: 'StaticThresholdCriterion'
-        metricName: 'Percentage CPU'
-        metricNamespace: 'microsoft.compute/virtualmachines'
-        name: 'HighCPU'
-        operator: 'GreaterThan'
-        threshold: '90'
-        timeAggregation: 'Average'
-      }
-    ]
+    criteria: {
+      componentId: '<componentId>'
+      failedLocationCount: 3
+      'odata.type': 'Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria'
+      webTestId: '<webTestId>'
+    }
     name: 'imawaf001'
     // Non-required parameters
     actions: [
       '<actionGroupResourceId>'
     ]
-    alertCriteriaType: 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
-    location: 'Global'
+    evaluationFrequency: 'PT5M'
+    location: 'global'
+    scopes: [
+      '<appInsightsResourceId>'
+      '<pingTestResourceId>'
+    ]
     tags: {
       Environment: 'Non-Prod'
       'hidden-title': 'This is visible in the resource name'
       Role: 'DeploymentValidation'
     }
-    targetResourceRegion: 'westeurope'
-    targetResourceType: 'microsoft.compute/virtualmachines'
-    windowSize: 'PT15M'
+    windowSize: 'PT5M'
   }
 }
 ```
@@ -311,18 +316,13 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "criterias": {
-      "value": [
-        {
-          "criterionType": "StaticThresholdCriterion",
-          "metricName": "Percentage CPU",
-          "metricNamespace": "microsoft.compute/virtualmachines",
-          "name": "HighCPU",
-          "operator": "GreaterThan",
-          "threshold": "90",
-          "timeAggregation": "Average"
-        }
-      ]
+    "criteria": {
+      "value": {
+        "componentId": "<componentId>",
+        "failedLocationCount": 3,
+        "odata.type": "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria",
+        "webTestId": "<webTestId>"
+      }
     },
     "name": {
       "value": "imawaf001"
@@ -333,11 +333,17 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
         "<actionGroupResourceId>"
       ]
     },
-    "alertCriteriaType": {
-      "value": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria"
+    "evaluationFrequency": {
+      "value": "PT5M"
     },
     "location": {
-      "value": "Global"
+      "value": "global"
+    },
+    "scopes": {
+      "value": [
+        "<appInsightsResourceId>",
+        "<pingTestResourceId>"
+      ]
     },
     "tags": {
       "value": {
@@ -346,14 +352,8 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
         "Role": "DeploymentValidation"
       }
     },
-    "targetResourceRegion": {
-      "value": "westeurope"
-    },
-    "targetResourceType": {
-      "value": "microsoft.compute/virtualmachines"
-    },
     "windowSize": {
-      "value": "PT15M"
+      "value": "PT5M"
     }
   }
 }
@@ -369,7 +369,6 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`criterias`](#parameter-criterias) | array | Criterias to trigger the alert. Array of 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria' or 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria' objects. When using MultipleResourceMultipleMetricCriteria criteria type, some parameters becomes mandatory. It is not possible to convert from SingleResourceMultipleMetricCriteria to MultipleResourceMultipleMetricCriteria. The alert must be deleted and recreated. |
 | [`name`](#parameter-name) | string | The name of the alert. |
 
 **Conditional parameters**
@@ -384,9 +383,9 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`actions`](#parameter-actions) | array | The list of actions to take when alert triggers. |
-| [`alertCriteriaType`](#parameter-alertcriteriatype) | string | Maps to the 'odata.type' field. Specifies the type of the alert criteria. |
 | [`alertDescription`](#parameter-alertdescription) | string | Description of the alert. |
 | [`autoMitigate`](#parameter-automitigate) | bool | The flag that indicates whether the alert should be auto resolved or not. |
+| [`criteria`](#parameter-criteria) | object | Maps to the 'odata.type' field. Specifies the type of the alert criteria. |
 | [`enabled`](#parameter-enabled) | bool | Indicates whether this alert is enabled. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`evaluationFrequency`](#parameter-evaluationfrequency) | string | how often the metric alert is evaluated represented in ISO 8601 duration format. |
@@ -396,13 +395,6 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
 | [`severity`](#parameter-severity) | int | The severity of the alert. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`windowSize`](#parameter-windowsize) | string | the period of time (in ISO 8601 duration format) that is used to monitor alert activity based on the threshold. |
-
-### Parameter: `criterias`
-
-Criterias to trigger the alert. Array of 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria' or 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria' objects. When using MultipleResourceMultipleMetricCriteria criteria type, some parameters becomes mandatory. It is not possible to convert from SingleResourceMultipleMetricCriteria to MultipleResourceMultipleMetricCriteria. The alert must be deleted and recreated.
-
-- Required: Yes
-- Type: array
 
 ### Parameter: `name`
 
@@ -435,22 +427,6 @@ The list of actions to take when alert triggers.
 - Type: array
 - Default: `[]`
 
-### Parameter: `alertCriteriaType`
-
-Maps to the 'odata.type' field. Specifies the type of the alert criteria.
-
-- Required: No
-- Type: string
-- Default: `'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'`
-- Allowed:
-  ```Bicep
-  [
-    'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
-    'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
-    'Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria'
-  ]
-  ```
-
 ### Parameter: `alertDescription`
 
 Description of the alert.
@@ -466,6 +442,13 @@ The flag that indicates whether the alert should be auto resolved or not.
 - Required: No
 - Type: bool
 - Default: `True`
+
+### Parameter: `criteria`
+
+Maps to the 'odata.type' field. Specifies the type of the alert criteria.
+
+- Required: Yes
+- Type: object
 
 ### Parameter: `enabled`
 

--- a/avm/res/insights/metric-alert/README.md
+++ b/avm/res/insights/metric-alert/README.md
@@ -48,11 +48,11 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
       allof: [
         {
           criterionType: 'StaticThresholdCriterion'
+          dimensions: []
           metricName: 'Percentage CPU'
-          metricNamespace: 'microsoft.compute/virtualmachines'
-          name: 'HighCPU'
+          name: '1st criterion'
           operator: 'GreaterThan'
-          threshold: '90'
+          threshold: 80
           timeAggregation: 'Average'
         }
       ]
@@ -61,8 +61,9 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
     name: 'imamin001'
     // Non-required parameters
     location: 'Global'
-    targetResourceRegion: 'westeurope'
-    targetResourceType: 'microsoft.compute/virtualmachines'
+    scopes: [
+      '<virtualMachineResourceId>'
+    ]
   }
 }
 ```
@@ -85,11 +86,11 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
         "allof": [
           {
             "criterionType": "StaticThresholdCriterion",
+            "dimensions": [],
             "metricName": "Percentage CPU",
-            "metricNamespace": "microsoft.compute/virtualmachines",
-            "name": "HighCPU",
+            "name": "1st criterion",
             "operator": "GreaterThan",
-            "threshold": "90",
+            "threshold": 80,
             "timeAggregation": "Average"
           }
         ],
@@ -103,11 +104,10 @@ module metricAlert 'br/public:avm/res/insights/metric-alert:<version>' = {
     "location": {
       "value": "Global"
     },
-    "targetResourceRegion": {
-      "value": "westeurope"
-    },
-    "targetResourceType": {
-      "value": "microsoft.compute/virtualmachines"
+    "scopes": {
+      "value": [
+        "<virtualMachineResourceId>"
+      ]
     }
   }
 }
@@ -409,7 +409,6 @@ The region of the target resource(s) on which the alert is created/updated. Requ
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ### Parameter: `targetResourceType`
 
@@ -417,7 +416,6 @@ The resource type of the target resource(s) on which the alert is created/update
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ### Parameter: `actions`
 

--- a/avm/res/insights/metric-alert/main.bicep
+++ b/avm/res/insights/metric-alert/main.bicep
@@ -139,11 +139,12 @@ resource metricAlert_roleAssignments 'Microsoft.Authorization/roleAssignments@20
   for (roleAssignment, index) in (roleAssignments ?? []): {
     name: guid(metricAlert.id, roleAssignment.principalId, roleAssignment.roleDefinitionIdOrName)
     properties: {
-      roleDefinitionId: contains(builtInRoleNames, roleAssignment.roleDefinitionIdOrName)
-        ? builtInRoleNames[roleAssignment.roleDefinitionIdOrName]
-        : contains(roleAssignment.roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/')
-            ? roleAssignment.roleDefinitionIdOrName
-            : subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleAssignment.roleDefinitionIdOrName)
+      roleDefinitionId: builtInRoleNames[?roleAssignment.roleDefinitionIdOrName] ?? contains(
+          roleAssignment.roleDefinitionIdOrName,
+          '/providers/Microsoft.Authorization/roleDefinitions/'
+        )
+        ? roleAssignment.roleDefinitionIdOrName
+        : subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleAssignment.roleDefinitionIdOrName)
       principalId: roleAssignment.principalId
       description: roleAssignment.?description
       principalType: roleAssignment.?principalType

--- a/avm/res/insights/metric-alert/main.bicep
+++ b/avm/res/insights/metric-alert/main.bicep
@@ -139,12 +139,11 @@ resource metricAlert_roleAssignments 'Microsoft.Authorization/roleAssignments@20
   for (roleAssignment, index) in (roleAssignments ?? []): {
     name: guid(metricAlert.id, roleAssignment.principalId, roleAssignment.roleDefinitionIdOrName)
     properties: {
-      roleDefinitionId: builtInRoleNames[?roleAssignment.roleDefinitionIdOrName] ?? contains(
-          roleAssignment.roleDefinitionIdOrName,
-          '/providers/Microsoft.Authorization/roleDefinitions/'
-        )
-        ? roleAssignment.roleDefinitionIdOrName
-        : subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleAssignment.roleDefinitionIdOrName)
+      roleDefinitionId: contains(builtInRoleNames, roleAssignment.roleDefinitionIdOrName)
+        ? builtInRoleNames[roleAssignment.roleDefinitionIdOrName]
+        : contains(roleAssignment.roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/')
+            ? roleAssignment.roleDefinitionIdOrName
+            : subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleAssignment.roleDefinitionIdOrName)
       principalId: roleAssignment.principalId
       description: roleAssignment.?description
       principalType: roleAssignment.?principalType

--- a/avm/res/insights/metric-alert/main.bicep
+++ b/avm/res/insights/metric-alert/main.bicep
@@ -53,10 +53,10 @@ param scopes array = [
 ]
 
 @description('Conditional. The resource type of the target resource(s) on which the alert is created/updated. Required if alertCriteriaType is MultipleResourceMultipleMetricCriteria.')
-param targetResourceType string = ''
+param targetResourceType string?
 
 @description('Conditional. The region of the target resource(s) on which the alert is created/updated. Required if alertCriteriaType is MultipleResourceMultipleMetricCriteria.')
-param targetResourceRegion string = ''
+param targetResourceRegion string?
 
 @description('Optional. The flag that indicates whether the alert should be auto resolved or not.')
 param autoMitigate bool = true

--- a/avm/res/insights/metric-alert/main.json
+++ b/avm/res/insights/metric-alert/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "12888844635682396371"
+      "version": "0.29.45.22436",
+      "templateHash": "14278852936426806763"
     },
     "name": "Metric Alerts",
     "description": "This module deploys a Metric Alert.",
@@ -78,6 +78,71 @@
         }
       },
       "nullable": true
+    },
+    "alertType": {
+      "type": "object",
+      "discriminator": {
+        "propertyName": "odata.type",
+        "mapping": {
+          "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria": {
+            "$ref": "#/definitions/alertWebtestType"
+          },
+          "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria": {
+            "$ref": "#/definitions/alertResourceType"
+          },
+          "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria": {
+            "$ref": "#/definitions/alertMultiResourceType"
+          }
+        }
+      }
+    },
+    "alertResourceType": {
+      "type": "object",
+      "properties": {
+        "odata.type": {
+          "type": "string",
+          "allowedValues": [
+            "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
+          ]
+        },
+        "allof": {
+          "type": "array"
+        }
+      }
+    },
+    "alertMultiResourceType": {
+      "type": "object",
+      "properties": {
+        "odata.type": {
+          "type": "string",
+          "allowedValues": [
+            "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria"
+          ]
+        },
+        "allof": {
+          "type": "array"
+        }
+      }
+    },
+    "alertWebtestType": {
+      "type": "object",
+      "properties": {
+        "odata.type": {
+          "type": "string",
+          "allowedValues": [
+            "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria"
+          ]
+        },
+        "componentId": {
+          "type": "string"
+        },
+        "failedLocationCount": {
+          "type": "int"
+        },
+        "webTestId": {
+          "type": "string"
+        }
+      }
     }
   },
   "parameters": {
@@ -190,22 +255,10 @@
         "description": "Optional. The list of actions to take when alert triggers."
       }
     },
-    "alertCriteriaType": {
-      "type": "string",
-      "defaultValue": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
-      "allowedValues": [
-        "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
-        "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
-        "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria"
-      ],
+    "criteria": {
+      "$ref": "#/definitions/alertType",
       "metadata": {
         "description": "Optional. Maps to the 'odata.type' field. Specifies the type of the alert criteria."
-      }
-    },
-    "criterias": {
-      "type": "array",
-      "metadata": {
-        "description": "Required. Criterias to trigger the alert. Array of 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria' or 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria' objects. When using MultipleResourceMultipleMetricCriteria criteria type, some parameters becomes mandatory. It is not possible to convert from SingleResourceMultipleMetricCriteria to MultipleResourceMultipleMetricCriteria. The alert must be deleted and recreated."
       }
     },
     "roleAssignments": {
@@ -235,8 +288,8 @@
         "name": "actionGroups",
         "count": "[length(parameters('actions'))]",
         "input": {
-          "actionGroupId": "[if(contains(parameters('actions')[copyIndex('actionGroups')], 'actionGroupId'), parameters('actions')[copyIndex('actionGroups')].actionGroupId, parameters('actions')[copyIndex('actionGroups')])]",
-          "webHookProperties": "[if(contains(parameters('actions')[copyIndex('actionGroups')], 'webHookProperties'), parameters('actions')[copyIndex('actionGroups')].webHookProperties, null())]"
+          "actionGroupId": "[coalesce(tryGet(parameters('actions')[copyIndex('actionGroups')], 'actionGroupId'), parameters('actions')[copyIndex('actionGroups')])]",
+          "webHookProperties": "[coalesce(tryGet(parameters('actions')[copyIndex('actionGroups')], 'webHookProperties'), null())]"
         }
       }
     ],
@@ -284,10 +337,7 @@
         "windowSize": "[parameters('windowSize')]",
         "targetResourceType": "[parameters('targetResourceType')]",
         "targetResourceRegion": "[parameters('targetResourceRegion')]",
-        "criteria": {
-          "odata.type": "[parameters('alertCriteriaType')]",
-          "allOf": "[parameters('criterias')]"
-        },
+        "criteria": "[parameters('criteria')]",
         "autoMitigate": "[parameters('autoMitigate')]",
         "actions": "[variables('actionGroups')]"
       }

--- a/avm/res/insights/metric-alert/main.json
+++ b/avm/res/insights/metric-alert/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.45.22436",
-      "templateHash": "15686053080754660550"
+      "version": "0.29.47.4906",
+      "templateHash": "351364201704313821"
     },
     "name": "Metric Alerts",
     "description": "This module deploys a Metric Alert.",
@@ -352,7 +352,7 @@
       "scope": "[format('Microsoft.Insights/metricAlerts/{0}', parameters('name'))]",
       "name": "[guid(resourceId('Microsoft.Insights/metricAlerts', parameters('name')), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].principalId, coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName)]",
       "properties": {
-        "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName), variables('builtInRoleNames')[coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName], if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName)))]",
+        "roleDefinitionId": "[if(coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName), contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/')), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName))]",
         "principalId": "[coalesce(parameters('roleAssignments'), createArray())[copyIndex()].principalId]",
         "description": "[tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'description')]",
         "principalType": "[tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'principalType')]",

--- a/avm/res/insights/metric-alert/main.json
+++ b/avm/res/insights/metric-alert/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "351364201704313821"
+      "templateHash": "3270167901837280444"
     },
     "name": "Metric Alerts",
     "description": "This module deploys a Metric Alert.",
@@ -352,7 +352,7 @@
       "scope": "[format('Microsoft.Insights/metricAlerts/{0}', parameters('name'))]",
       "name": "[guid(resourceId('Microsoft.Insights/metricAlerts', parameters('name')), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].principalId, coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName)]",
       "properties": {
-        "roleDefinitionId": "[if(coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName), contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/')), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName))]",
+        "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName), variables('builtInRoleNames')[coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName], if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex()].roleDefinitionIdOrName)))]",
         "principalId": "[coalesce(parameters('roleAssignments'), createArray())[copyIndex()].principalId]",
         "description": "[tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'description')]",
         "principalType": "[tryGet(coalesce(parameters('roleAssignments'), createArray())[copyIndex()], 'principalType')]",

--- a/avm/res/insights/metric-alert/main.json
+++ b/avm/res/insights/metric-alert/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "3270167901837280444"
+      "templateHash": "4628455390866355711"
     },
     "name": "Metric Alerts",
     "description": "This module deploys a Metric Alert.",
@@ -133,13 +133,13 @@
             "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria"
           ]
         },
-        "componentId": {
+        "componentResourceId": {
           "type": "string"
         },
         "failedLocationCount": {
           "type": "int"
         },
-        "webTestId": {
+        "webTestResourceId": {
           "type": "string"
         }
       }
@@ -258,7 +258,7 @@
     "criteria": {
       "$ref": "#/definitions/alertType",
       "metadata": {
-        "description": "Optional. Maps to the 'odata.type' field. Specifies the type of the alert criteria."
+        "description": "Required. Maps to the 'odata.type' field. Specifies the type of the alert criteria."
       }
     },
     "roleAssignments": {
@@ -289,7 +289,7 @@
         "count": "[length(parameters('actions'))]",
         "input": {
           "actionGroupId": "[coalesce(tryGet(parameters('actions')[copyIndex('actionGroups')], 'actionGroupId'), parameters('actions')[copyIndex('actionGroups')])]",
-          "webHookProperties": "[coalesce(tryGet(parameters('actions')[copyIndex('actionGroups')], 'webHookProperties'), null())]"
+          "webHookProperties": "[tryGet(parameters('actions')[copyIndex('actionGroups')], 'webHookProperties')]"
         }
       }
     ],
@@ -337,7 +337,7 @@
         "windowSize": "[parameters('windowSize')]",
         "targetResourceType": "[parameters('targetResourceType')]",
         "targetResourceRegion": "[parameters('targetResourceRegion')]",
-        "criteria": "[parameters('criteria')]",
+        "criteria": "[union(createObject('odata.type', parameters('criteria')['odata.type']), if(contains(parameters('criteria'), 'allof'), createObject('allof', parameters('criteria').allof), createObject()), if(contains(parameters('criteria'), 'componentResourceId'), createObject('componentId', parameters('criteria').componentResourceId), createObject()), if(contains(parameters('criteria'), 'failedLocationCount'), createObject('failedLocationCount', parameters('criteria').failedLocationCount), createObject()), if(contains(parameters('criteria'), 'webTestResourceId'), createObject('webTestId', parameters('criteria').webTestResourceId), createObject()))]",
         "autoMitigate": "[parameters('autoMitigate')]",
         "actions": "[variables('actionGroups')]"
       }

--- a/avm/res/insights/metric-alert/main.json
+++ b/avm/res/insights/metric-alert/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.45.22436",
-      "templateHash": "14278852936426806763"
+      "templateHash": "15686053080754660550"
     },
     "name": "Metric Alerts",
     "description": "This module deploys a Metric Alert.",
@@ -229,14 +229,14 @@
     },
     "targetResourceType": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
       "metadata": {
         "description": "Conditional. The resource type of the target resource(s) on which the alert is created/updated. Required if alertCriteriaType is MultipleResourceMultipleMetricCriteria."
       }
     },
     "targetResourceRegion": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
       "metadata": {
         "description": "Conditional. The region of the target resource(s) on which the alert is created/updated. Required if alertCriteriaType is MultipleResourceMultipleMetricCriteria."
       }

--- a/avm/res/insights/metric-alert/tests/e2e/defaults/dependencies.bicep
+++ b/avm/res/insights/metric-alert/tests/e2e/defaults/dependencies.bicep
@@ -1,0 +1,78 @@
+@description('Required. Location to deploy resources to.')
+param resourceLocation string
+
+@description('Required. The name of the Virtual Machine to create.')
+param virtualMachineName string
+
+@description('Optional. The password to leverage for the login.')
+@secure()
+param password string = newGuid()
+
+@description('Required. The name of the Virtual Network to create.')
+param virtualNetworkName string
+
+@description('Optional. The location to deploy to.')
+param location string = resourceGroup().location
+
+var addressPrefix = '10.0.0.0/16'
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+  name: virtualNetworkName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        addressPrefix
+      ]
+    }
+    subnets: [
+      {
+        name: 'defaultSubnet'
+        properties: {
+          addressPrefix: cidrSubnet(addressPrefix, 16, 0)
+        }
+      }
+    ]
+  }
+}
+
+module vm 'br/public:avm/res/compute/virtual-machine:0.5.3' = {
+  name: '${uniqueString(deployment().name, resourceLocation)}-test-${virtualMachineName}'
+  params: {
+    location: resourceLocation
+    name: virtualMachineName
+    adminUsername: 'localAdminUser'
+    encryptionAtHost: false
+    imageReference: {
+      publisher: 'MicrosoftWindowsServer'
+      offer: 'WindowsServer'
+      sku: '2022-datacenter-azure-edition'
+      version: 'latest'
+    }
+    zone: 0
+    nicConfigurations: [
+      {
+        ipConfigurations: [
+          {
+            name: 'ipconfig01'
+            subnetResourceId: virtualNetwork.properties.subnets[0].id
+          }
+        ]
+        nicSuffix: '-nic-01'
+      }
+    ]
+    osDisk: {
+      diskSizeGB: 128
+      caching: 'ReadWrite'
+      managedDisk: {
+        storageAccountType: 'Premium_LRS'
+      }
+    }
+    osType: 'Windows'
+    vmSize: 'Standard_DS2_v2'
+    adminPassword: password
+  }
+}
+
+@description('The resource ID of the created Virtual Machine.')
+output virtualMachineResourceId string = vm.outputs.resourceId

--- a/avm/res/insights/metric-alert/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/insights/metric-alert/tests/e2e/defaults/main.test.bicep
@@ -43,17 +43,20 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: 'Global'
-      criterias: [
-        {
-          criterionType: 'StaticThresholdCriterion'
-          metricName: 'Percentage CPU'
-          metricNamespace: 'microsoft.compute/virtualmachines'
-          name: 'HighCPU'
-          operator: 'GreaterThan'
-          threshold: '90'
-          timeAggregation: 'Average'
-        }
-      ]
+      criteria: {
+        allof: [
+          {
+            criterionType: 'StaticThresholdCriterion'
+            metricName: 'Percentage CPU'
+            metricNamespace: 'microsoft.compute/virtualmachines'
+            name: 'HighCPU'
+            operator: 'GreaterThan'
+            threshold: '90'
+            timeAggregation: 'Average'
+          }
+        ]
+        'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      }
       targetResourceRegion: 'westeurope'
       targetResourceType: 'microsoft.compute/virtualmachines'
     }

--- a/avm/res/insights/metric-alert/tests/e2e/max/main.test.bicep
+++ b/avm/res/insights/metric-alert/tests/e2e/max/main.test.bicep
@@ -53,21 +53,23 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: 'Global'
-      criterias: [
-        {
-          criterionType: 'StaticThresholdCriterion'
-          metricName: 'Percentage CPU'
-          metricNamespace: 'microsoft.compute/virtualmachines'
-          name: 'HighCPU'
-          operator: 'GreaterThan'
-          threshold: '90'
-          timeAggregation: 'Average'
-        }
-      ]
+      criteria: {
+        allof: [
+          {
+            criterionType: 'StaticThresholdCriterion'
+            metricName: 'Percentage CPU'
+            metricNamespace: 'microsoft.compute/virtualmachines'
+            name: 'HighCPU'
+            operator: 'GreaterThan'
+            threshold: '90'
+            timeAggregation: 'Average'
+          }
+        ]
+        'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      }
       actions: [
         nestedDependencies.outputs.actionGroupResourceId
       ]
-      alertCriteriaType: 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
       roleAssignments: [
         {
           roleDefinitionIdOrName: 'Owner'

--- a/avm/res/insights/metric-alert/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/insights/metric-alert/tests/e2e/waf-aligned/dependencies.bicep
@@ -1,6 +1,12 @@
 @description('Required. The name of the Action Group to create.')
 param actionGroupName string
 
+@description('Required. The name of the Application Insights to create.')
+param appInsightsName string
+
+@description('Required. Location to deploy resources to.')
+param resourceLocation string
+
 resource actionGroup 'Microsoft.Insights/actionGroups@2022-06-01' = {
   name: actionGroupName
   location: 'global'
@@ -11,5 +17,63 @@ resource actionGroup 'Microsoft.Insights/actionGroups@2022-06-01' = {
   }
 }
 
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: resourceLocation
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+  }
+}
+
+resource pingTest 'Microsoft.Insights/webtests@2022-06-15' = {
+  name: 'PingTest-${toLower(appInsightsName)}'
+  location: resourceLocation
+  properties: {
+    Name: 'PingTest-${toLower(appInsightsName)}'
+    Description: 'Basic ping test'
+    Enabled: true
+    Frequency: 300
+    Timeout: 120
+    Kind: 'standard'
+    RetryEnabled: true
+    Locations: [
+      {
+        Id: 'us-il-ch1-azr'
+      }
+      {
+        Id: 'latam-br-gru-edge'
+      }
+      {
+        Id: 'us-fl-mia-edge'
+      }
+      {
+        Id: 'apac-jp-kaw-edge'
+      }
+      {
+        Id: 'emea-fr-pra-edge'
+      }
+    ]
+    ValidationRules: {
+      ExpectedHttpStatusCode: 200
+      IgnoreHttpStatusCode: false
+      SSLCheck: false
+    }
+    Request: {
+      RequestUrl: 'https://www.microsoft.com'
+      HttpVerb: 'GET'
+      ParseDependentRequests: false
+    }
+    SyntheticMonitorId: 'PingTest-${toLower(appInsightsName)}'
+  }
+  tags: {
+    'hidden-link:${appInsights.id}': 'Resource'
+  }
+}
+
 @description('The resource ID of the created Action Group.')
 output actionGroupResourceId string = actionGroup.id
+@description('The resource ID of the created Application Insights.')
+output appInsightsResourceId string = appInsights.id
+@description('The resource ID of the webtest.')
+output pingTestResourceId string = pingTest.id

--- a/avm/res/insights/metric-alert/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/insights/metric-alert/tests/e2e/waf-aligned/main.test.bicep
@@ -36,6 +36,8 @@ module nestedDependencies 'dependencies.bicep' = {
   name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
   params: {
     actionGroupName: 'dep-${namePrefix}-ag-${serviceShort}'
+    appInsightsName: 'dep-${namePrefix}-app-${serviceShort}'
+    resourceLocation: resourceLocation
   }
 }
 
@@ -50,25 +52,22 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: 'Global'
-      criterias: [
-        {
-          criterionType: 'StaticThresholdCriterion'
-          metricName: 'Percentage CPU'
-          metricNamespace: 'microsoft.compute/virtualmachines'
-          name: 'HighCPU'
-          operator: 'GreaterThan'
-          threshold: '90'
-          timeAggregation: 'Average'
-        }
+      location: 'global'
+      scopes: [
+        nestedDependencies.outputs.pingTestResourceId
+        nestedDependencies.outputs.appInsightsResourceId
       ]
+      criteria: {
+        componentId: nestedDependencies.outputs.appInsightsResourceId
+        failedLocationCount: 3
+        'odata.type': 'Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria'
+        webTestId: nestedDependencies.outputs.pingTestResourceId
+      }
       actions: [
         nestedDependencies.outputs.actionGroupResourceId
       ]
-      alertCriteriaType: 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
-      targetResourceRegion: 'westeurope'
-      targetResourceType: 'microsoft.compute/virtualmachines'
-      windowSize: 'PT15M'
+      windowSize: 'PT5M'
+      evaluationFrequency: 'PT5M'
       tags: {
         'hidden-title': 'This is visible in the resource name'
         Environment: 'Non-Prod'

--- a/avm/res/insights/metric-alert/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/insights/metric-alert/tests/e2e/waf-aligned/main.test.bicep
@@ -58,10 +58,10 @@ module testDeployment '../../../main.bicep' = [
         nestedDependencies.outputs.appInsightsResourceId
       ]
       criteria: {
-        componentId: nestedDependencies.outputs.appInsightsResourceId
+        componentResourceId: nestedDependencies.outputs.appInsightsResourceId
         failedLocationCount: 3
         'odata.type': 'Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria'
-        webTestId: nestedDependencies.outputs.pingTestResourceId
+        webTestResourceId: nestedDependencies.outputs.pingTestResourceId
       }
       actions: [
         nestedDependencies.outputs.actionGroupResourceId

--- a/avm/res/insights/metric-alert/version.json
+++ b/avm/res/insights/metric-alert/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.1",
+    "version": "0.2",
     "pathFilters": [
         "./main.json"
     ]


### PR DESCRIPTION
## Description
closes #2693

Provides the ability to create metric alerts for 'Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria'

## Pipeline Reference

| Pipeline |
| -------- |
|        [![avm.res.insights.metric-alert](https://github.com/arnoldna/bicep-registry-modules/actions/workflows/avm.res.insights.metric-alert.yml/badge.svg?branch=avm/res/insights/metric-alert)](https://github.com/arnoldna/bicep-registry-modules/actions/workflows/avm.res.insights.metric-alert.yml)  |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [X] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [X] Update to documentation

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
