### PR TITLE
fix: Fixed error test formatting for static validation

### DIFF
--- a/avm/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
+++ b/avm/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
@@ -144,21 +144,21 @@ function Set-PesterGitHubOutput {
 
             if ($failedTest.ScriptBlock.File -match $moduleSplitRegex) {
                 # Module test
-                $errorFileIdentifier = $failedTest.ErrorRecord.TargetObject.File -split $moduleSplitRegex
-                $errorTestFile = ('avm/{0}/{1}' -f $errorFileIdentifier[1], $errorFileIdentifier[2]) -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
+                $testFileIdentifier = $failedTest.ErrorRecord.TargetObject.File -split $moduleSplitRegex
+                $testFile = ('avm/{0}/{1}' -f $testFileIdentifier[1], $testFileIdentifier[2]) -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
             } else {
                 # None-module test
                 $testFile = $failedTest.ScriptBlock.File -replace ('{0}[\\|\/]*' -f [regex]::Escape($RepoRootPath))
             }
 
-            $errorTestLine = $failedTest.ErrorRecord.TargetObject.Line
+            $testLine = $failedTest.ErrorRecord.TargetObject.Line
             $errorMessage = ($failedTest.ErrorRecord.TargetObject.Message.Trim() -replace '_', '\_') -replace '\n', '<br>' # Replace new lines with <br> to enable line breaks in markdown
 
-            $testReference = '{0}:{1}' -f (Split-Path $errorTestFile -Leaf), $errorTestLine
+            $testReference = '{0}:{1}' -f (Split-Path $testFile -Leaf), $testLine
 
             if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
                 # Creating URL to test file to enable users to 'click' on it
-                $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$errorTestFile#L$errorTestLine)"
+                $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$testFile#L$testLine)"
             }
 
             $fileContent += '| {0} | {1} | <code>{2}</code> |' -f $testName, $errorMessage, $testReference


### PR DESCRIPTION
## Description

- Fixed incorrect variable naming for formating failed tests for GH output
- Aligned naming of different scenarios (passed, failed, warning) to reduce this happening again in the future

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
