### PR TITLE
fix: CI - Fixed moduleIndex implementation for scheduled runs

### DIFF
--- a/.github/workflows/platform.publish-module-index-json.yml
+++ b/.github/workflows/platform.publish-module-index-json.yml
@@ -15,6 +15,9 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  workflowPath: ".github/workflows/avm.res.app.job.yml"
+
 jobs:
   upload-index-data:
     runs-on: ubuntu-latest
@@ -23,7 +26,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 // Needed to fetch all history and tags
-
+      - name: "Set input parameter``s to output variables"
+        id: get-workflow-param
+        uses: ./.github/actions/templates/avm-getWorkflowInput
+        with:
+          workflowPath: "${{ env.workflowPath}}"
       - name: Log in to Azure
         uses: azure/login@v2
         with:
@@ -55,52 +62,52 @@ jobs:
             ErrorAction                                  = 'Continue'
           }
 
-          if ('${{ (fromJson(inputs.regenIndexFromBRM)) }}' -eq $true ) {
+          if ('${{ (fromJson(steps.get-workflow-param.outputs.workflowInput)).regenIndexFromBRM }}' -eq $true ) {
             $functionInput['doNotMergeWithLastModuleIndexJsonFileVersion'] = $true
           }
 
           Write-Verbose 'Invoke task with' -Verbose
           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-          if (-not (Invoke-AvmJsonModuleIndexGeneration @functionInput)) {
-            Write-Output ('{0}={1}' -f 'anyErrorsOccurred', $true) >> $env:GITHUB_ENV
-          }
+      #     if (-not (Invoke-AvmJsonModuleIndexGeneration @functionInput)) {
+      #       Write-Output ('{0}={1}' -f 'anyErrorsOccurred', $true) >> $env:GITHUB_ENV
+      #     }
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: publish-module-index-json-artifacts
-          path: |
-            moduleIndex.json
-            last-moduleIndex.json
-            generated-moduleIndex.json
+      # - name: Upload artifacts
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: publish-module-index-json-artifacts
+      #     path: |
+      #       moduleIndex.json
+      #       last-moduleIndex.json
+      #       generated-moduleIndex.json
 
-      - name: Upload to blob storage
-        shell: pwsh
-        run: |
-          $storageAccountInfo = @{
-              storageAccountName      = 'biceplivedatasaprod'
-              storageAccountContainer = 'bicep-cdn-live-data-container'
-              storageBlobName         = 'module-index'
-              storageBlobContentType  = @{'ContentType' = 'application/json'}
-          }
-          Write-Verbose ('Uploading [moduleIndex.json] to blob storage account [{0}] in container [{1}] as blob [{2}]' -f $storageAccountInfo.storageAccountName, $storageAccountInfo.storageAccountContainer, $storageAccountInfo.storageBlobName) -Verbose
+      # - name: Upload to blob storage
+      #   shell: pwsh
+      #   run: |
+      #     $storageAccountInfo = @{
+      #         storageAccountName      = 'biceplivedatasaprod'
+      #         storageAccountContainer = 'bicep-cdn-live-data-container'
+      #         storageBlobName         = 'module-index'
+      #         storageBlobContentType  = @{'ContentType' = 'application/json'}
+      #     }
+      #     Write-Verbose ('Uploading [moduleIndex.json] to blob storage account [{0}] in container [{1}] as blob [{2}]' -f $storageAccountInfo.storageAccountName, $storageAccountInfo.storageAccountContainer, $storageAccountInfo.storageBlobName) -Verbose
 
-          $storageContext = New-AzStorageContext -StorageAccountName $storageAccountInfo.storageAccountName -UseConnectedAccount
+      #     $storageContext = New-AzStorageContext -StorageAccountName $storageAccountInfo.storageAccountName -UseConnectedAccount
 
-          $functionInput = @{
-              Context    = $storageContext
-              Container  = $storageAccountInfo.storageAccountContainer
-              Blob       = $storageAccountInfo.storageBlobName
-              File       = 'moduleIndex.json'
-              Properties = $storageAccountInfo.storageBlobContentType
-          }
-          Set-AzStorageBlobContent @functionInput -Force
+      #     $functionInput = @{
+      #         Context    = $storageContext
+      #         Container  = $storageAccountInfo.storageAccountContainer
+      #         Blob       = $storageAccountInfo.storageBlobName
+      #         File       = 'moduleIndex.json'
+      #         Properties = $storageAccountInfo.storageBlobContentType
+      #     }
+      #     Set-AzStorageBlobContent @functionInput -Force
 
-          Write-Verbose ('Upload of [{0}] complete.' -f $storageAccountInfo.storageBlobName) -Verbose
+      #     Write-Verbose ('Upload of [{0}] complete.' -f $storageAccountInfo.storageBlobName) -Verbose
 
-      - name: Check if any errors occurred during 'Generate moduleIndex.json'
-        if: ${{ env.anyErrorsOccurred == 'true' }}
-        shell: pwsh
-        run: |
-          throw "Errors occurred during 'Generate moduleIndex.json' step. Please check the logs of that step in the workflow."
+      # - name: Check if any errors occurred during 'Generate moduleIndex.json'
+      #   if: ${{ env.anyErrorsOccurred == 'true' }}
+      #   shell: pwsh
+      #   run: |
+      #     throw "Errors occurred during 'Generate moduleIndex.json' step. Please check the logs of that step in the workflow."

--- a/.github/workflows/platform.publish-module-index-json.yml
+++ b/.github/workflows/platform.publish-module-index-json.yml
@@ -31,13 +31,13 @@ jobs:
         uses: ./.github/actions/templates/avm-getWorkflowInput
         with:
           workflowPath: "${{ env.workflowPath}}"
-      - name: Log in to Azure
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.PUBLISH_CLIENT_ID }}
-          tenant-id: ${{ secrets.PUBLISH_TENANT_ID }}
-          subscription-id: ${{ secrets.PUBLISH_SUBSCRIPTION_ID }}
-          enable-AzPSSession: true
+      # - name: Log in to Azure
+      #   uses: azure/login@v2
+      #   with:
+      #     client-id: ${{ secrets.PUBLISH_CLIENT_ID }}
+      #     tenant-id: ${{ secrets.PUBLISH_TENANT_ID }}
+      #     subscription-id: ${{ secrets.PUBLISH_SUBSCRIPTION_ID }}
+      #     enable-AzPSSession: true
 
       - name: Install Azure Powershell Modules
         shell: pwsh

--- a/.github/workflows/platform.publish-module-index-json.yml
+++ b/.github/workflows/platform.publish-module-index-json.yml
@@ -31,13 +31,13 @@ jobs:
         uses: ./.github/actions/templates/avm-getWorkflowInput
         with:
           workflowPath: "${{ env.workflowPath}}"
-      # - name: Log in to Azure
-      #   uses: azure/login@v2
-      #   with:
-      #     client-id: ${{ secrets.PUBLISH_CLIENT_ID }}
-      #     tenant-id: ${{ secrets.PUBLISH_TENANT_ID }}
-      #     subscription-id: ${{ secrets.PUBLISH_SUBSCRIPTION_ID }}
-      #     enable-AzPSSession: true
+      - name: Log in to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.PUBLISH_CLIENT_ID }}
+          tenant-id: ${{ secrets.PUBLISH_TENANT_ID }}
+          subscription-id: ${{ secrets.PUBLISH_SUBSCRIPTION_ID }}
+          enable-AzPSSession: true
 
       - name: Install Azure Powershell Modules
         shell: pwsh
@@ -69,45 +69,45 @@ jobs:
           Write-Verbose 'Invoke task with' -Verbose
           Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
 
-      #     if (-not (Invoke-AvmJsonModuleIndexGeneration @functionInput)) {
-      #       Write-Output ('{0}={1}' -f 'anyErrorsOccurred', $true) >> $env:GITHUB_ENV
-      #     }
+          if (-not (Invoke-AvmJsonModuleIndexGeneration @functionInput)) {
+            Write-Output ('{0}={1}' -f 'anyErrorsOccurred', $true) >> $env:GITHUB_ENV
+          }
 
-      # - name: Upload artifacts
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: publish-module-index-json-artifacts
-      #     path: |
-      #       moduleIndex.json
-      #       last-moduleIndex.json
-      #       generated-moduleIndex.json
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-module-index-json-artifacts
+          path: |
+            moduleIndex.json
+            last-moduleIndex.json
+            generated-moduleIndex.json
 
-      # - name: Upload to blob storage
-      #   shell: pwsh
-      #   run: |
-      #     $storageAccountInfo = @{
-      #         storageAccountName      = 'biceplivedatasaprod'
-      #         storageAccountContainer = 'bicep-cdn-live-data-container'
-      #         storageBlobName         = 'module-index'
-      #         storageBlobContentType  = @{'ContentType' = 'application/json'}
-      #     }
-      #     Write-Verbose ('Uploading [moduleIndex.json] to blob storage account [{0}] in container [{1}] as blob [{2}]' -f $storageAccountInfo.storageAccountName, $storageAccountInfo.storageAccountContainer, $storageAccountInfo.storageBlobName) -Verbose
+      - name: Upload to blob storage
+        shell: pwsh
+        run: |
+          $storageAccountInfo = @{
+              storageAccountName      = 'biceplivedatasaprod'
+              storageAccountContainer = 'bicep-cdn-live-data-container'
+              storageBlobName         = 'module-index'
+              storageBlobContentType  = @{'ContentType' = 'application/json'}
+          }
+          Write-Verbose ('Uploading [moduleIndex.json] to blob storage account [{0}] in container [{1}] as blob [{2}]' -f $storageAccountInfo.storageAccountName, $storageAccountInfo.storageAccountContainer, $storageAccountInfo.storageBlobName) -Verbose
 
-      #     $storageContext = New-AzStorageContext -StorageAccountName $storageAccountInfo.storageAccountName -UseConnectedAccount
+          $storageContext = New-AzStorageContext -StorageAccountName $storageAccountInfo.storageAccountName -UseConnectedAccount
 
-      #     $functionInput = @{
-      #         Context    = $storageContext
-      #         Container  = $storageAccountInfo.storageAccountContainer
-      #         Blob       = $storageAccountInfo.storageBlobName
-      #         File       = 'moduleIndex.json'
-      #         Properties = $storageAccountInfo.storageBlobContentType
-      #     }
-      #     Set-AzStorageBlobContent @functionInput -Force
+          $functionInput = @{
+              Context    = $storageContext
+              Container  = $storageAccountInfo.storageAccountContainer
+              Blob       = $storageAccountInfo.storageBlobName
+              File       = 'moduleIndex.json'
+              Properties = $storageAccountInfo.storageBlobContentType
+          }
+          Set-AzStorageBlobContent @functionInput -Force
 
-      #     Write-Verbose ('Upload of [{0}] complete.' -f $storageAccountInfo.storageBlobName) -Verbose
+          Write-Verbose ('Upload of [{0}] complete.' -f $storageAccountInfo.storageBlobName) -Verbose
 
-      # - name: Check if any errors occurred during 'Generate moduleIndex.json'
-      #   if: ${{ env.anyErrorsOccurred == 'true' }}
-      #   shell: pwsh
-      #   run: |
-      #     throw "Errors occurred during 'Generate moduleIndex.json' step. Please check the logs of that step in the workflow."
+      - name: Check if any errors occurred during 'Generate moduleIndex.json'
+        if: ${{ env.anyErrorsOccurred == 'true' }}
+        shell: pwsh
+        run: |
+          throw "Errors occurred during 'Generate moduleIndex.json' step. Please check the logs of that step in the workflow."


### PR DESCRIPTION
## Description

- Added code we use in the module pipelines to read workflow inputs and rely on that task as opposed to direct runtime parameter references (which are only available during workflow_dispatch)

Condition tests
_With tickbox_
![image](https://github.com/user-attachments/assets/2cd355a9-5c06-4143-9003-deeb3b2a4440)

_Without tickbox_
![image](https://github.com/user-attachments/assets/0a9ed2cc-c977-40f1-aa3e-0a593992846b)

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|      [![.Platform - Publish [moduleIndex.json]](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.publish-module-index-json.yml/badge.svg?event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.publish-module-index-json.yml)    |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
