### PR TITLE
fix: use the safe access operator warning in `avm/res/operational-insights/workspace`

### DIFF
--- a/avm/res/operational-insights/workspace/data-export/main.json
+++ b/avm/res/operational-insights/workspace/data-export/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "7136569845646186437"
+      "version": "0.29.47.4906",
+      "templateHash": "5765609820817623497"
     },
     "name": "Log Analytics Workspace Data Exports",
     "description": "This module deploys a Log Analytics Workspace Data Export.",

--- a/avm/res/operational-insights/workspace/data-source/main.json
+++ b/avm/res/operational-insights/workspace/data-source/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "13864187993066263466"
+      "version": "0.29.47.4906",
+      "templateHash": "13460038983765020046"
     },
     "name": "Log Analytics Workspace Datasources",
     "description": "This module deploys a Log Analytics Workspace Data Source.",

--- a/avm/res/operational-insights/workspace/linked-service/main.json
+++ b/avm/res/operational-insights/workspace/linked-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "11327223922004680974"
+      "version": "0.29.47.4906",
+      "templateHash": "12032441371027552374"
     },
     "name": "Log Analytics Workspace Linked Services",
     "description": "This module deploys a Log Analytics Workspace Linked Service.",

--- a/avm/res/operational-insights/workspace/linked-storage-account/main.json
+++ b/avm/res/operational-insights/workspace/linked-storage-account/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "16393542404456450187"
+      "version": "0.29.47.4906",
+      "templateHash": "12623216644328477682"
     },
     "name": "Log Analytics Workspace Linked Storage Accounts",
     "description": "This module deploys a Log Analytics Workspace Linked Storage Account.",

--- a/avm/res/operational-insights/workspace/main.bicep
+++ b/avm/res/operational-insights/workspace/main.bicep
@@ -232,8 +232,8 @@ module logAnalyticsWorkspace_storageInsightConfigs 'storage-insight-config/main.
     name: '${uniqueString(deployment().name, location)}-LAW-StorageInsightsConfig-${index}'
     params: {
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
-      containers: storageInsightsConfig.?containers ? storageInsightsConfig.containers : []
-      tables: storageInsightsConfig.?tables ? storageInsightsConfig.tables : []
+      containers: storageInsightsConfig.?containers
+      tables: storageInsightsConfig.?tables
       storageAccountResourceId: storageInsightsConfig.storageAccountResourceId
     }
   }
@@ -245,8 +245,8 @@ module logAnalyticsWorkspace_linkedServices 'linked-service/main.bicep' = [
     params: {
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
       name: linkedService.name
-      resourceId: linkedService.?resourceId ? linkedService.resourceId : ''
-      writeAccessResourceId: linkedService.?writeAccessResourceId ? linkedService.writeAccessResourceId : ''
+      resourceId: linkedService.?resourceId
+      writeAccessResourceId: linkedService.?writeAccessResourceId
     }
   }
 ]
@@ -288,9 +288,9 @@ module logAnalyticsWorkspace_dataExports 'data-export/main.bicep' = [
     params: {
       workspaceName: logAnalyticsWorkspace.name
       name: dataExport.name
-      destination: dataExport.?destination ? dataExport.destination : {}
-      enable: dataExport.?enable ? dataExport.enable : false
-      tableNames: dataExport.?tableNames ? dataExport.tableNames : []
+      destination: dataExport.?destination
+      enable: dataExport.?enable
+      tableNames: dataExport.?tableNames
     }
   }
 ]
@@ -302,17 +302,17 @@ module logAnalyticsWorkspace_dataSources 'data-source/main.bicep' = [
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
       name: dataSource.name
       kind: dataSource.kind
-      linkedResourceId: dataSource.?linkedResourceId ? dataSource.linkedResourceId : ''
-      eventLogName: dataSource.?eventLogName ? dataSource.eventLogName : ''
-      eventTypes: dataSource.?eventTypes ? dataSource.eventTypes : []
-      objectName: dataSource.?objectName ? dataSource.objectName : ''
-      instanceName: dataSource.?instanceName ? dataSource.instanceName : ''
-      intervalSeconds: dataSource.?intervalSeconds ? dataSource.intervalSeconds : 60
-      counterName: dataSource.?counterName ? dataSource.counterName : ''
-      state: dataSource.?state ? dataSource.state : ''
-      syslogName: dataSource.?syslogName ? dataSource.syslogName : ''
-      syslogSeverities: dataSource.?syslogSeverities ? dataSource.syslogSeverities : []
-      performanceCounters: dataSource.?performanceCounters ? dataSource.performanceCounters : []
+      linkedResourceId: dataSource.?linkedResourceId
+      eventLogName: dataSource.?eventLogName
+      eventTypes: dataSource.?eventTypes
+      objectName: dataSource.?objectName
+      instanceName: dataSource.?instanceName
+      intervalSeconds: dataSource.?intervalSeconds
+      counterName: dataSource.?counterName
+      state: dataSource.?state
+      syslogName: dataSource.?syslogName
+      syslogSeverities: dataSource.?syslogSeverities
+      performanceCounters: dataSource.?performanceCounters
     }
   }
 ]
@@ -341,8 +341,8 @@ module logAnalyticsWorkspace_solutions 'br/public:avm/res/operations-management/
       name: gallerySolution.name
       location: location
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
-      product: gallerySolution.?product ? gallerySolution.product : 'OMSGallery'
-      publisher: gallerySolution.?publisher ? gallerySolution.publisher : 'Microsoft'
+      product: gallerySolution.?product
+      publisher: gallerySolution.?publisher
       enableTelemetry: gallerySolution.?enableTelemetry ?? enableTelemetry
     }
   }

--- a/avm/res/operational-insights/workspace/main.bicep
+++ b/avm/res/operational-insights/workspace/main.bicep
@@ -232,8 +232,8 @@ module logAnalyticsWorkspace_storageInsightConfigs 'storage-insight-config/main.
     name: '${uniqueString(deployment().name, location)}-LAW-StorageInsightsConfig-${index}'
     params: {
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
-      containers: contains(storageInsightsConfig, 'containers') ? storageInsightsConfig.containers : []
-      tables: contains(storageInsightsConfig, 'tables') ? storageInsightsConfig.tables : []
+      containers: storageInsightsConfig.?containers ? storageInsightsConfig.containers : []
+      tables: storageInsightsConfig.?tables ? storageInsightsConfig.tables : []
       storageAccountResourceId: storageInsightsConfig.storageAccountResourceId
     }
   }
@@ -245,8 +245,8 @@ module logAnalyticsWorkspace_linkedServices 'linked-service/main.bicep' = [
     params: {
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
       name: linkedService.name
-      resourceId: contains(linkedService, 'resourceId') ? linkedService.resourceId : ''
-      writeAccessResourceId: contains(linkedService, 'writeAccessResourceId') ? linkedService.writeAccessResourceId : ''
+      resourceId: linkedService.?resourceId ? linkedService.resourceId : ''
+      writeAccessResourceId: linkedService.?writeAccessResourceId ? linkedService.writeAccessResourceId : ''
     }
   }
 ]
@@ -288,9 +288,9 @@ module logAnalyticsWorkspace_dataExports 'data-export/main.bicep' = [
     params: {
       workspaceName: logAnalyticsWorkspace.name
       name: dataExport.name
-      destination: contains(dataExport, 'destination') ? dataExport.destination : {}
-      enable: contains(dataExport, 'enable') ? dataExport.enable : false
-      tableNames: contains(dataExport, 'tableNames') ? dataExport.tableNames : []
+      destination: dataExport.?destination ? dataExport.destination : {}
+      enable: dataExport.?enable ? dataExport.enable : false
+      tableNames: dataExport.?tableNames ? dataExport.tableNames : []
     }
   }
 ]
@@ -302,17 +302,17 @@ module logAnalyticsWorkspace_dataSources 'data-source/main.bicep' = [
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
       name: dataSource.name
       kind: dataSource.kind
-      linkedResourceId: contains(dataSource, 'linkedResourceId') ? dataSource.linkedResourceId : ''
-      eventLogName: contains(dataSource, 'eventLogName') ? dataSource.eventLogName : ''
-      eventTypes: contains(dataSource, 'eventTypes') ? dataSource.eventTypes : []
-      objectName: contains(dataSource, 'objectName') ? dataSource.objectName : ''
-      instanceName: contains(dataSource, 'instanceName') ? dataSource.instanceName : ''
-      intervalSeconds: contains(dataSource, 'intervalSeconds') ? dataSource.intervalSeconds : 60
-      counterName: contains(dataSource, 'counterName') ? dataSource.counterName : ''
-      state: contains(dataSource, 'state') ? dataSource.state : ''
-      syslogName: contains(dataSource, 'syslogName') ? dataSource.syslogName : ''
-      syslogSeverities: contains(dataSource, 'syslogSeverities') ? dataSource.syslogSeverities : []
-      performanceCounters: contains(dataSource, 'performanceCounters') ? dataSource.performanceCounters : []
+      linkedResourceId: dataSource.?linkedResourceId ? dataSource.linkedResourceId : ''
+      eventLogName: dataSource.?eventLogName ? dataSource.eventLogName : ''
+      eventTypes: dataSource.?eventTypes ? dataSource.eventTypes : []
+      objectName: dataSource.?objectName ? dataSource.objectName : ''
+      instanceName: dataSource.?instanceName ? dataSource.instanceName : ''
+      intervalSeconds: dataSource.?intervalSeconds ? dataSource.intervalSeconds : 60
+      counterName: dataSource.?counterName ? dataSource.counterName : ''
+      state: dataSource.?state ? dataSource.state : ''
+      syslogName: dataSource.?syslogName ? dataSource.syslogName : ''
+      syslogSeverities: dataSource.?syslogSeverities ? dataSource.syslogSeverities : []
+      performanceCounters: dataSource.?performanceCounters ? dataSource.performanceCounters : []
     }
   }
 ]
@@ -341,8 +341,8 @@ module logAnalyticsWorkspace_solutions 'br/public:avm/res/operations-management/
       name: gallerySolution.name
       location: location
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
-      product: contains(gallerySolution, 'product') ? gallerySolution.product : 'OMSGallery'
-      publisher: contains(gallerySolution, 'publisher') ? gallerySolution.publisher : 'Microsoft'
+      product: gallerySolution.?product ? gallerySolution.product : 'OMSGallery'
+      publisher: gallerySolution.?publisher ? gallerySolution.publisher : 'Microsoft'
       enableTelemetry: gallerySolution.?enableTelemetry ?? enableTelemetry
     }
   }

--- a/avm/res/operational-insights/workspace/main.json
+++ b/avm/res/operational-insights/workspace/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "12925967037035427868"
+      "templateHash": "16932080828331107291"
     },
     "name": "Log Analytics Workspaces",
     "description": "This module deploys a Log Analytics Workspace.",
@@ -600,8 +600,12 @@
           "logAnalyticsWorkspaceName": {
             "value": "[parameters('name')]"
           },
-          "containers": "[if(tryGet(parameters('storageInsightsConfigs')[copyIndex()], 'containers'), createObject('value', parameters('storageInsightsConfigs')[copyIndex()].containers), createObject('value', createArray()))]",
-          "tables": "[if(tryGet(parameters('storageInsightsConfigs')[copyIndex()], 'tables'), createObject('value', parameters('storageInsightsConfigs')[copyIndex()].tables), createObject('value', createArray()))]",
+          "containers": {
+            "value": "[tryGet(parameters('storageInsightsConfigs')[copyIndex()], 'containers')]"
+          },
+          "tables": {
+            "value": "[tryGet(parameters('storageInsightsConfigs')[copyIndex()], 'tables')]"
+          },
           "storageAccountResourceId": {
             "value": "[parameters('storageInsightsConfigs')[copyIndex()].storageAccountResourceId]"
           }
@@ -743,8 +747,12 @@
           "name": {
             "value": "[parameters('linkedServices')[copyIndex()].name]"
           },
-          "resourceId": "[if(tryGet(parameters('linkedServices')[copyIndex()], 'resourceId'), createObject('value', parameters('linkedServices')[copyIndex()].resourceId), createObject('value', ''))]",
-          "writeAccessResourceId": "[if(tryGet(parameters('linkedServices')[copyIndex()], 'writeAccessResourceId'), createObject('value', parameters('linkedServices')[copyIndex()].writeAccessResourceId), createObject('value', ''))]"
+          "resourceId": {
+            "value": "[tryGet(parameters('linkedServices')[copyIndex()], 'resourceId')]"
+          },
+          "writeAccessResourceId": {
+            "value": "[tryGet(parameters('linkedServices')[copyIndex()], 'writeAccessResourceId')]"
+          }
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -1148,9 +1156,15 @@
           "name": {
             "value": "[parameters('dataExports')[copyIndex()].name]"
           },
-          "destination": "[if(tryGet(parameters('dataExports')[copyIndex()], 'destination'), createObject('value', parameters('dataExports')[copyIndex()].destination), createObject('value', createObject()))]",
-          "enable": "[if(tryGet(parameters('dataExports')[copyIndex()], 'enable'), createObject('value', parameters('dataExports')[copyIndex()].enable), createObject('value', false()))]",
-          "tableNames": "[if(tryGet(parameters('dataExports')[copyIndex()], 'tableNames'), createObject('value', parameters('dataExports')[copyIndex()].tableNames), createObject('value', createArray()))]"
+          "destination": {
+            "value": "[tryGet(parameters('dataExports')[copyIndex()], 'destination')]"
+          },
+          "enable": {
+            "value": "[tryGet(parameters('dataExports')[copyIndex()], 'enable')]"
+          },
+          "tableNames": {
+            "value": "[tryGet(parameters('dataExports')[copyIndex()], 'tableNames')]"
+          }
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -1266,17 +1280,39 @@
           "kind": {
             "value": "[parameters('dataSources')[copyIndex()].kind]"
           },
-          "linkedResourceId": "[if(tryGet(parameters('dataSources')[copyIndex()], 'linkedResourceId'), createObject('value', parameters('dataSources')[copyIndex()].linkedResourceId), createObject('value', ''))]",
-          "eventLogName": "[if(tryGet(parameters('dataSources')[copyIndex()], 'eventLogName'), createObject('value', parameters('dataSources')[copyIndex()].eventLogName), createObject('value', ''))]",
-          "eventTypes": "[if(tryGet(parameters('dataSources')[copyIndex()], 'eventTypes'), createObject('value', parameters('dataSources')[copyIndex()].eventTypes), createObject('value', createArray()))]",
-          "objectName": "[if(tryGet(parameters('dataSources')[copyIndex()], 'objectName'), createObject('value', parameters('dataSources')[copyIndex()].objectName), createObject('value', ''))]",
-          "instanceName": "[if(tryGet(parameters('dataSources')[copyIndex()], 'instanceName'), createObject('value', parameters('dataSources')[copyIndex()].instanceName), createObject('value', ''))]",
-          "intervalSeconds": "[if(tryGet(parameters('dataSources')[copyIndex()], 'intervalSeconds'), createObject('value', parameters('dataSources')[copyIndex()].intervalSeconds), createObject('value', 60))]",
-          "counterName": "[if(tryGet(parameters('dataSources')[copyIndex()], 'counterName'), createObject('value', parameters('dataSources')[copyIndex()].counterName), createObject('value', ''))]",
-          "state": "[if(tryGet(parameters('dataSources')[copyIndex()], 'state'), createObject('value', parameters('dataSources')[copyIndex()].state), createObject('value', ''))]",
-          "syslogName": "[if(tryGet(parameters('dataSources')[copyIndex()], 'syslogName'), createObject('value', parameters('dataSources')[copyIndex()].syslogName), createObject('value', ''))]",
-          "syslogSeverities": "[if(tryGet(parameters('dataSources')[copyIndex()], 'syslogSeverities'), createObject('value', parameters('dataSources')[copyIndex()].syslogSeverities), createObject('value', createArray()))]",
-          "performanceCounters": "[if(tryGet(parameters('dataSources')[copyIndex()], 'performanceCounters'), createObject('value', parameters('dataSources')[copyIndex()].performanceCounters), createObject('value', createArray()))]"
+          "linkedResourceId": {
+            "value": "[tryGet(parameters('dataSources')[copyIndex()], 'linkedResourceId')]"
+          },
+          "eventLogName": {
+            "value": "[tryGet(parameters('dataSources')[copyIndex()], 'eventLogName')]"
+          },
+          "eventTypes": {
+            "value": "[tryGet(parameters('dataSources')[copyIndex()], 'eventTypes')]"
+          },
+          "objectName": {
+            "value": "[tryGet(parameters('dataSources')[copyIndex()], 'objectName')]"
+          },
+          "instanceName": {
+            "value": "[tryGet(parameters('dataSources')[copyIndex()], 'instanceName')]"
+          },
+          "intervalSeconds": {
+            "value": "[tryGet(parameters('dataSources')[copyIndex()], 'intervalSeconds')]"
+          },
+          "counterName": {
+            "value": "[tryGet(parameters('dataSources')[copyIndex()], 'counterName')]"
+          },
+          "state": {
+            "value": "[tryGet(parameters('dataSources')[copyIndex()], 'state')]"
+          },
+          "syslogName": {
+            "value": "[tryGet(parameters('dataSources')[copyIndex()], 'syslogName')]"
+          },
+          "syslogSeverities": {
+            "value": "[tryGet(parameters('dataSources')[copyIndex()], 'syslogSeverities')]"
+          },
+          "performanceCounters": {
+            "value": "[tryGet(parameters('dataSources')[copyIndex()], 'performanceCounters')]"
+          }
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -1773,8 +1809,12 @@
           "logAnalyticsWorkspaceName": {
             "value": "[parameters('name')]"
           },
-          "product": "[if(tryGet(parameters('gallerySolutions')[copyIndex()], 'product'), createObject('value', parameters('gallerySolutions')[copyIndex()].product), createObject('value', 'OMSGallery'))]",
-          "publisher": "[if(tryGet(parameters('gallerySolutions')[copyIndex()], 'publisher'), createObject('value', parameters('gallerySolutions')[copyIndex()].publisher), createObject('value', 'Microsoft'))]",
+          "product": {
+            "value": "[tryGet(parameters('gallerySolutions')[copyIndex()], 'product')]"
+          },
+          "publisher": {
+            "value": "[tryGet(parameters('gallerySolutions')[copyIndex()], 'publisher')]"
+          },
           "enableTelemetry": {
             "value": "[coalesce(tryGet(parameters('gallerySolutions')[copyIndex()], 'enableTelemetry'), parameters('enableTelemetry'))]"
           }

--- a/avm/res/operational-insights/workspace/main.json
+++ b/avm/res/operational-insights/workspace/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "4858897614510907922"
+      "version": "0.29.47.4906",
+      "templateHash": "12925967037035427868"
     },
     "name": "Log Analytics Workspaces",
     "description": "This module deploys a Log Analytics Workspace.",
@@ -600,8 +600,8 @@
           "logAnalyticsWorkspaceName": {
             "value": "[parameters('name')]"
           },
-          "containers": "[if(contains(parameters('storageInsightsConfigs')[copyIndex()], 'containers'), createObject('value', parameters('storageInsightsConfigs')[copyIndex()].containers), createObject('value', createArray()))]",
-          "tables": "[if(contains(parameters('storageInsightsConfigs')[copyIndex()], 'tables'), createObject('value', parameters('storageInsightsConfigs')[copyIndex()].tables), createObject('value', createArray()))]",
+          "containers": "[if(tryGet(parameters('storageInsightsConfigs')[copyIndex()], 'containers'), createObject('value', parameters('storageInsightsConfigs')[copyIndex()].containers), createObject('value', createArray()))]",
+          "tables": "[if(tryGet(parameters('storageInsightsConfigs')[copyIndex()], 'tables'), createObject('value', parameters('storageInsightsConfigs')[copyIndex()].tables), createObject('value', createArray()))]",
           "storageAccountResourceId": {
             "value": "[parameters('storageInsightsConfigs')[copyIndex()].storageAccountResourceId]"
           }
@@ -613,8 +613,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "16775981135504794519"
+              "version": "0.29.47.4906",
+              "templateHash": "1745671120474305926"
             },
             "name": "Log Analytics Workspace Storage Insight Configs",
             "description": "This module deploys a Log Analytics Workspace Storage Insight Config.",
@@ -743,8 +743,8 @@
           "name": {
             "value": "[parameters('linkedServices')[copyIndex()].name]"
           },
-          "resourceId": "[if(contains(parameters('linkedServices')[copyIndex()], 'resourceId'), createObject('value', parameters('linkedServices')[copyIndex()].resourceId), createObject('value', ''))]",
-          "writeAccessResourceId": "[if(contains(parameters('linkedServices')[copyIndex()], 'writeAccessResourceId'), createObject('value', parameters('linkedServices')[copyIndex()].writeAccessResourceId), createObject('value', ''))]"
+          "resourceId": "[if(tryGet(parameters('linkedServices')[copyIndex()], 'resourceId'), createObject('value', parameters('linkedServices')[copyIndex()].resourceId), createObject('value', ''))]",
+          "writeAccessResourceId": "[if(tryGet(parameters('linkedServices')[copyIndex()], 'writeAccessResourceId'), createObject('value', parameters('linkedServices')[copyIndex()].writeAccessResourceId), createObject('value', ''))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -753,8 +753,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "11327223922004680974"
+              "version": "0.29.47.4906",
+              "templateHash": "12032441371027552374"
             },
             "name": "Log Analytics Workspace Linked Services",
             "description": "This module deploys a Log Analytics Workspace Linked Service.",
@@ -875,8 +875,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "16393542404456450187"
+              "version": "0.29.47.4906",
+              "templateHash": "12623216644328477682"
             },
             "name": "Log Analytics Workspace Linked Storage Accounts",
             "description": "This module deploys a Log Analytics Workspace Linked Storage Account.",
@@ -998,8 +998,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "18166536793397048488"
+              "version": "0.29.47.4906",
+              "templateHash": "7683333179440464721"
             },
             "name": "Log Analytics Workspace Saved Searches",
             "description": "This module deploys a Log Analytics Workspace Saved Search.",
@@ -1148,9 +1148,9 @@
           "name": {
             "value": "[parameters('dataExports')[copyIndex()].name]"
           },
-          "destination": "[if(contains(parameters('dataExports')[copyIndex()], 'destination'), createObject('value', parameters('dataExports')[copyIndex()].destination), createObject('value', createObject()))]",
-          "enable": "[if(contains(parameters('dataExports')[copyIndex()], 'enable'), createObject('value', parameters('dataExports')[copyIndex()].enable), createObject('value', false()))]",
-          "tableNames": "[if(contains(parameters('dataExports')[copyIndex()], 'tableNames'), createObject('value', parameters('dataExports')[copyIndex()].tableNames), createObject('value', createArray()))]"
+          "destination": "[if(tryGet(parameters('dataExports')[copyIndex()], 'destination'), createObject('value', parameters('dataExports')[copyIndex()].destination), createObject('value', createObject()))]",
+          "enable": "[if(tryGet(parameters('dataExports')[copyIndex()], 'enable'), createObject('value', parameters('dataExports')[copyIndex()].enable), createObject('value', false()))]",
+          "tableNames": "[if(tryGet(parameters('dataExports')[copyIndex()], 'tableNames'), createObject('value', parameters('dataExports')[copyIndex()].tableNames), createObject('value', createArray()))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -1158,8 +1158,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "7136569845646186437"
+              "version": "0.29.47.4906",
+              "templateHash": "5765609820817623497"
             },
             "name": "Log Analytics Workspace Data Exports",
             "description": "This module deploys a Log Analytics Workspace Data Export.",
@@ -1266,17 +1266,17 @@
           "kind": {
             "value": "[parameters('dataSources')[copyIndex()].kind]"
           },
-          "linkedResourceId": "[if(contains(parameters('dataSources')[copyIndex()], 'linkedResourceId'), createObject('value', parameters('dataSources')[copyIndex()].linkedResourceId), createObject('value', ''))]",
-          "eventLogName": "[if(contains(parameters('dataSources')[copyIndex()], 'eventLogName'), createObject('value', parameters('dataSources')[copyIndex()].eventLogName), createObject('value', ''))]",
-          "eventTypes": "[if(contains(parameters('dataSources')[copyIndex()], 'eventTypes'), createObject('value', parameters('dataSources')[copyIndex()].eventTypes), createObject('value', createArray()))]",
-          "objectName": "[if(contains(parameters('dataSources')[copyIndex()], 'objectName'), createObject('value', parameters('dataSources')[copyIndex()].objectName), createObject('value', ''))]",
-          "instanceName": "[if(contains(parameters('dataSources')[copyIndex()], 'instanceName'), createObject('value', parameters('dataSources')[copyIndex()].instanceName), createObject('value', ''))]",
-          "intervalSeconds": "[if(contains(parameters('dataSources')[copyIndex()], 'intervalSeconds'), createObject('value', parameters('dataSources')[copyIndex()].intervalSeconds), createObject('value', 60))]",
-          "counterName": "[if(contains(parameters('dataSources')[copyIndex()], 'counterName'), createObject('value', parameters('dataSources')[copyIndex()].counterName), createObject('value', ''))]",
-          "state": "[if(contains(parameters('dataSources')[copyIndex()], 'state'), createObject('value', parameters('dataSources')[copyIndex()].state), createObject('value', ''))]",
-          "syslogName": "[if(contains(parameters('dataSources')[copyIndex()], 'syslogName'), createObject('value', parameters('dataSources')[copyIndex()].syslogName), createObject('value', ''))]",
-          "syslogSeverities": "[if(contains(parameters('dataSources')[copyIndex()], 'syslogSeverities'), createObject('value', parameters('dataSources')[copyIndex()].syslogSeverities), createObject('value', createArray()))]",
-          "performanceCounters": "[if(contains(parameters('dataSources')[copyIndex()], 'performanceCounters'), createObject('value', parameters('dataSources')[copyIndex()].performanceCounters), createObject('value', createArray()))]"
+          "linkedResourceId": "[if(tryGet(parameters('dataSources')[copyIndex()], 'linkedResourceId'), createObject('value', parameters('dataSources')[copyIndex()].linkedResourceId), createObject('value', ''))]",
+          "eventLogName": "[if(tryGet(parameters('dataSources')[copyIndex()], 'eventLogName'), createObject('value', parameters('dataSources')[copyIndex()].eventLogName), createObject('value', ''))]",
+          "eventTypes": "[if(tryGet(parameters('dataSources')[copyIndex()], 'eventTypes'), createObject('value', parameters('dataSources')[copyIndex()].eventTypes), createObject('value', createArray()))]",
+          "objectName": "[if(tryGet(parameters('dataSources')[copyIndex()], 'objectName'), createObject('value', parameters('dataSources')[copyIndex()].objectName), createObject('value', ''))]",
+          "instanceName": "[if(tryGet(parameters('dataSources')[copyIndex()], 'instanceName'), createObject('value', parameters('dataSources')[copyIndex()].instanceName), createObject('value', ''))]",
+          "intervalSeconds": "[if(tryGet(parameters('dataSources')[copyIndex()], 'intervalSeconds'), createObject('value', parameters('dataSources')[copyIndex()].intervalSeconds), createObject('value', 60))]",
+          "counterName": "[if(tryGet(parameters('dataSources')[copyIndex()], 'counterName'), createObject('value', parameters('dataSources')[copyIndex()].counterName), createObject('value', ''))]",
+          "state": "[if(tryGet(parameters('dataSources')[copyIndex()], 'state'), createObject('value', parameters('dataSources')[copyIndex()].state), createObject('value', ''))]",
+          "syslogName": "[if(tryGet(parameters('dataSources')[copyIndex()], 'syslogName'), createObject('value', parameters('dataSources')[copyIndex()].syslogName), createObject('value', ''))]",
+          "syslogSeverities": "[if(tryGet(parameters('dataSources')[copyIndex()], 'syslogSeverities'), createObject('value', parameters('dataSources')[copyIndex()].syslogSeverities), createObject('value', createArray()))]",
+          "performanceCounters": "[if(tryGet(parameters('dataSources')[copyIndex()], 'performanceCounters'), createObject('value', parameters('dataSources')[copyIndex()].performanceCounters), createObject('value', createArray()))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -1285,8 +1285,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "13864187993066263466"
+              "version": "0.29.47.4906",
+              "templateHash": "13460038983765020046"
             },
             "name": "Log Analytics Workspace Datasources",
             "description": "This module deploys a Log Analytics Workspace Data Source.",
@@ -1516,8 +1516,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "9332283068393802804"
+              "version": "0.29.47.4906",
+              "templateHash": "18192909452867259226"
             },
             "name": "Log Analytics Workspace Tables",
             "description": "This module deploys a Log Analytics Workspace Table.",
@@ -1773,8 +1773,8 @@
           "logAnalyticsWorkspaceName": {
             "value": "[parameters('name')]"
           },
-          "product": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'product'), createObject('value', parameters('gallerySolutions')[copyIndex()].product), createObject('value', 'OMSGallery'))]",
-          "publisher": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'publisher'), createObject('value', parameters('gallerySolutions')[copyIndex()].publisher), createObject('value', 'Microsoft'))]",
+          "product": "[if(tryGet(parameters('gallerySolutions')[copyIndex()], 'product'), createObject('value', parameters('gallerySolutions')[copyIndex()].product), createObject('value', 'OMSGallery'))]",
+          "publisher": "[if(tryGet(parameters('gallerySolutions')[copyIndex()], 'publisher'), createObject('value', parameters('gallerySolutions')[copyIndex()].publisher), createObject('value', 'Microsoft'))]",
           "enableTelemetry": {
             "value": "[coalesce(tryGet(parameters('gallerySolutions')[copyIndex()], 'enableTelemetry'), parameters('enableTelemetry'))]"
           }

--- a/avm/res/operational-insights/workspace/saved-search/main.json
+++ b/avm/res/operational-insights/workspace/saved-search/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "18166536793397048488"
+      "version": "0.29.47.4906",
+      "templateHash": "7683333179440464721"
     },
     "name": "Log Analytics Workspace Saved Searches",
     "description": "This module deploys a Log Analytics Workspace Saved Search.",

--- a/avm/res/operational-insights/workspace/storage-insight-config/main.json
+++ b/avm/res/operational-insights/workspace/storage-insight-config/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "16775981135504794519"
+      "version": "0.29.47.4906",
+      "templateHash": "1745671120474305926"
     },
     "name": "Log Analytics Workspace Storage Insight Configs",
     "description": "This module deploys a Log Analytics Workspace Storage Insight Config.",

--- a/avm/res/operational-insights/workspace/table/main.json
+++ b/avm/res/operational-insights/workspace/table/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "9332283068393802804"
+      "version": "0.29.47.4906",
+      "templateHash": "18192909452867259226"
     },
     "name": "Log Analytics Workspace Tables",
     "description": "This module deploys a Log Analytics Workspace Table.",


### PR DESCRIPTION
## Description

Addressed the Bicep warning
`Use the safe access (.?) operator instead of checking object contents with the 'contains' function.`
(except for RBAC, which will be handled by a separate PR)

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.operational-insights.workspace](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml/badge.svg?event=workflow_dispatch)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
