### PR TITLE
fix: Remove local cross-reference in `avm/res/automation/automation-account`

### DIFF
--- a/avm/res/automation/automation-account/README.md
+++ b/avm/res/automation/automation-account/README.md
@@ -2032,7 +2032,6 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `res/operational-insights/workspace/linked-service` | Local reference |
 | `br/public:avm/res/network/private-endpoint:0.4.1` | Remote reference |
 | `br/public:avm/res/operations-management/solution:0.1.0` | Remote reference |
 

--- a/avm/res/automation/automation-account/credential/main.json
+++ b/avm/res/automation/automation-account/credential/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "17311442241252857733"
+      "version": "0.29.47.4906",
+      "templateHash": "10580987489047715400"
     },
     "name": "Automation Account Credential",
     "description": "This module deploys Azure Automation Account Credential.",

--- a/avm/res/automation/automation-account/job-schedule/main.json
+++ b/avm/res/automation/automation-account/job-schedule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "7852489714477748054"
+      "version": "0.29.47.4906",
+      "templateHash": "10826746631810286901"
     },
     "name": "Automation Account Job Schedules",
     "description": "This module deploys an Azure Automation Account Job Schedule.",

--- a/avm/res/automation/automation-account/main.bicep
+++ b/avm/res/automation/automation-account/main.bicep
@@ -282,7 +282,7 @@ module automationAccount_variables 'variable/main.bicep' = [
   }
 ]
 
-module automationAccount_linkedService '../../operational-insights/workspace/linked-service/main.bicep' = if (!empty(linkedWorkspaceResourceId)) {
+module automationAccount_linkedService 'modules/linked-service.bicep' = if (!empty(linkedWorkspaceResourceId)) {
   name: '${uniqueString(deployment().name, location)}-AutoAccount-LinkedService'
   params: {
     name: 'automation'

--- a/avm/res/automation/automation-account/main.json
+++ b/avm/res/automation/automation-account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "15361181633952207113"
+      "version": "0.29.47.4906",
+      "templateHash": "16338073338722282064"
     },
     "name": "Automation Accounts",
     "description": "This module deploys an Azure Automation Account.",
@@ -860,8 +860,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "17311442241252857733"
+              "version": "0.29.47.4906",
+              "templateHash": "10580987489047715400"
             },
             "name": "Automation Account Credential",
             "description": "This module deploys Azure Automation Account Credential.",
@@ -1019,8 +1019,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "1661319858724328950"
+              "version": "0.29.47.4906",
+              "templateHash": "14556422655915492083"
             },
             "name": "Automation Account Modules",
             "description": "This module deploys an Azure Automation Account Module.",
@@ -1161,8 +1161,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "11730927882334055011"
+              "version": "0.29.47.4906",
+              "templateHash": "6299933839999486418"
             },
             "name": "Automation Account Schedules",
             "description": "This module deploys an Azure Automation Account Schedule.",
@@ -1340,8 +1340,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "16990805873972671446"
+              "version": "0.29.47.4906",
+              "templateHash": "11653746330709835761"
             },
             "name": "Automation Account Runbooks",
             "description": "This module deploys an Azure Automation Account Runbook.",
@@ -1544,8 +1544,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "7852489714477748054"
+              "version": "0.29.47.4906",
+              "templateHash": "10826746631810286901"
             },
             "name": "Automation Account Job Schedules",
             "description": "This module deploys an Azure Automation Account Job Schedule.",
@@ -1672,8 +1672,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "17408217027458282021"
+              "version": "0.29.47.4906",
+              "templateHash": "13284693609482301780"
             },
             "name": "Automation Account Variables",
             "description": "This module deploys an Azure Automation Account Variable.",
@@ -1787,8 +1787,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "11327223922004680974"
+              "version": "0.29.47.4906",
+              "templateHash": "12032441371027552374"
             },
             "name": "Log Analytics Workspace Linked Services",
             "description": "This module deploys a Log Analytics Workspace Linked Service.",
@@ -2106,8 +2106,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.28.1.47646",
-              "templateHash": "5046214814278705138"
+              "version": "0.29.47.4906",
+              "templateHash": "752305553206238634"
             },
             "name": "Automation Account Software Update Configurations",
             "description": "This module deploys an Azure Automation Account Software Update Configuration.",

--- a/avm/res/automation/automation-account/module/main.json
+++ b/avm/res/automation/automation-account/module/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "1661319858724328950"
+      "version": "0.29.47.4906",
+      "templateHash": "14556422655915492083"
     },
     "name": "Automation Account Modules",
     "description": "This module deploys an Azure Automation Account Module.",

--- a/avm/res/automation/automation-account/modules/linked-service.bicep
+++ b/avm/res/automation/automation-account/modules/linked-service.bicep
@@ -1,0 +1,41 @@
+metadata name = 'Log Analytics Workspace Linked Services'
+metadata description = 'This module deploys a Log Analytics Workspace Linked Service.'
+metadata owner = 'Azure/module-maintainers'
+
+@description('Conditional. The name of the parent Log Analytics workspace. Required if the template is used in a standalone deployment.')
+param logAnalyticsWorkspaceName string
+
+@description('Required. Name of the link.')
+param name string
+
+@description('Required. The resource ID of the resource that will be linked to the workspace. This should be used for linking resources which require read access.')
+param resourceId string = ''
+
+@description('Optional. The resource ID of the resource that will be linked to the workspace. This should be used for linking resources which require write access.')
+param writeAccessResourceId string = ''
+
+@description('Optional. Tags to configure in the resource.')
+param tags object?
+
+resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
+  name: logAnalyticsWorkspaceName
+}
+
+resource linkedService 'Microsoft.OperationalInsights/workspaces/linkedServices@2020-08-01' = {
+  name: name
+  parent: workspace
+  tags: tags
+  properties: {
+    resourceId: resourceId
+    writeAccessResourceId: empty(writeAccessResourceId) ? null : writeAccessResourceId
+  }
+}
+
+@description('The name of the deployed linked service.')
+output name string = linkedService.name
+
+@description('The resource ID of the deployed linked service.')
+output resourceId string = linkedService.id
+
+@description('The resource group where the linked service is deployed.')
+output resourceGroupName string = resourceGroup().name

--- a/avm/res/automation/automation-account/runbook/main.json
+++ b/avm/res/automation/automation-account/runbook/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "16990805873972671446"
+      "version": "0.29.47.4906",
+      "templateHash": "11653746330709835761"
     },
     "name": "Automation Account Runbooks",
     "description": "This module deploys an Azure Automation Account Runbook.",

--- a/avm/res/automation/automation-account/schedule/main.json
+++ b/avm/res/automation/automation-account/schedule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "11730927882334055011"
+      "version": "0.29.47.4906",
+      "templateHash": "6299933839999486418"
     },
     "name": "Automation Account Schedules",
     "description": "This module deploys an Azure Automation Account Schedule.",

--- a/avm/res/automation/automation-account/software-update-configuration/main.json
+++ b/avm/res/automation/automation-account/software-update-configuration/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "5046214814278705138"
+      "version": "0.29.47.4906",
+      "templateHash": "752305553206238634"
     },
     "name": "Automation Account Software Update Configurations",
     "description": "This module deploys an Azure Automation Account Software Update Configuration.",

--- a/avm/res/automation/automation-account/variable/main.json
+++ b/avm/res/automation/automation-account/variable/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "17408217027458282021"
+      "version": "0.29.47.4906",
+      "templateHash": "13284693609482301780"
     },
     "name": "Automation Account Variables",
     "description": "This module deploys an Azure Automation Account Variable.",


### PR DESCRIPTION
## Description

The PR removes a (not allowed) local cross-reference from the Automation Account module

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|  [![avm.res.automation.automation-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml/badge.svg?branch=users%2Fkrbar%2FautomationAccountCrossRefFix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml)  |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
