### PR TITLE
fix: message for orphaned modules in workflow issues was showing the wrong module name

### DIFF
--- a/avm/utilities/pipelines/platform/Set-AvmGithubIssueForWorkflow.ps1
+++ b/avm/utilities/pipelines/platform/Set-AvmGithubIssueForWorkflow.ps1
@@ -96,7 +96,7 @@ function Set-AvmGithubIssueForWorkflow {
                     $comment = @"
 > [!IMPORTANT]
 > This module is currently orphaned (has no owner), therefore expect a higher response time.
-> @Azure/avm-core-team-technical-bicep, the workflow for the ``$moduleName`` module has failed. Please investigate the failed workflow run.
+> @Azure/avm-core-team-technical-bicep, the workflow for the ``$workflowRun.workflowName.Replace('.', '/')`` module has failed. Please investigate the failed workflow run.
 "@
 
                     if ($workflowRun.workflowName -match 'avm.(?:res|ptn)') {

--- a/avm/utilities/pipelines/platform/Set-AvmGithubIssueForWorkflow.ps1
+++ b/avm/utilities/pipelines/platform/Set-AvmGithubIssueForWorkflow.ps1
@@ -88,6 +88,7 @@ function Set-AvmGithubIssueForWorkflow {
         if ($workflowRun.conclusion -eq 'failure') {
             $issueName = "[Failed pipeline] $($workflowRun.workflowName)"
             $failedrun = "Failed run: $($workflowRun.url)"
+            $moduleName = $workflowRun.workflowName.Replace('.', '/')
 
             if ($issues.title -notcontains $issueName) {
                 if ($PSCmdlet.ShouldProcess("Issue [$issueName]", 'Create')) {
@@ -96,11 +97,10 @@ function Set-AvmGithubIssueForWorkflow {
                     $comment = @"
 > [!IMPORTANT]
 > This module is currently orphaned (has no owner), therefore expect a higher response time.
-> @Azure/avm-core-team-technical-bicep, the workflow for the ``$workflowRun.workflowName.Replace('.', '/')`` module has failed. Please investigate the failed workflow run.
+> @Azure/avm-core-team-technical-bicep, the workflow for the ``$moduleName`` module has failed. Please investigate the failed workflow run.
 "@
 
                     if ($workflowRun.workflowName -match 'avm.(?:res|ptn)') {
-                        $moduleName = $workflowRun.workflowName.Replace('.', '/')
                         $moduleIndex = $moduleName.StartsWith('avm/res') ? 'Bicep-Resource' : 'Bicep-Pattern'
                         # get CSV data
                         $module = Get-AvmCsvData -ModuleIndex $moduleIndex | Where-Object ModuleName -EQ $moduleName


### PR DESCRIPTION
message for orphaned modules in workflow issues was showing the wrong module name