### PR TITLE
feat: DeploymentRemoval: Added LZ-Vending MgmtGroup to deployment cleanup

### DIFF
--- a/.github/workflows/platform.deployment.history.cleanup.yml
+++ b/.github/workflows/platform.deployment.history.cleanup.yml
@@ -116,7 +116,7 @@ jobs:
 
             $mgmtGroupIdInput = '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).customManagementGroupId }}'
 
-            foreach($mgmtGroupId in @('${{ secrets.ARM_MGMTGROUP_ID }}', 'bicep-lz-vending-automation-child-nonExistend')) {
+            foreach($mgmtGroupId in @('${{ secrets.ARM_MGMTGROUP_ID }}', 'bicep-lz-vending-automation-child')) {
               Write-Verbose "Processing mgmtGroupId [$mgmtGroupId]" -Verbose
               $functionInput = @{
                 ManagementGroupId            = $mgmtGroupId

--- a/.github/workflows/platform.deployment.history.cleanup.yml
+++ b/.github/workflows/platform.deployment.history.cleanup.yml
@@ -18,11 +18,6 @@ on:
         description: "The number of days to keep deployments with status [failed]" # 'Running' are always excluded
         required: false
         default: "14"
-      customManagementGroupId:
-        type: string
-        description: "The ID of the management group. Defaults to the default AVM group" # 'Running' are always excluded
-        required: false
-        default: ""
   schedule:
     - cron: "0 0 * * *"
 
@@ -121,13 +116,15 @@ jobs:
 
             $mgmtGroupIdInput = '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).customManagementGroupId }}'
 
-            $functionInput = @{
-              ManagementGroupId            = [String]::IsNullOrEmpty($mgmtGroupIdInput) ? '${{ secrets.ARM_MGMTGROUP_ID }}' : $mgmtGroupIdInput
-              maxDeploymentRetentionInDays = '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).maxDeploymentRetentionInDays }}'
+            foreach($mgmtGroupId in @('${{ secrets.ARM_MGMTGROUP_ID }}', 'bicep-lz-vending-automation-child-nonExistend')) {
+              $functionInput = @{
+                ManagementGroupId            = $mgmtGroupId
+                maxDeploymentRetentionInDays = '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).maxDeploymentRetentionInDays }}'
+              }
+
+              Write-Verbose "Invoke task with" -Verbose
+              Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+
+              Clear-ManagementGroupDeploymentHistory @functionInput
             }
-
-            Write-Verbose "Invoke task with" -Verbose
-            Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
-
-            Clear-ManagementGroupDeploymentHistory @functionInput
           azPSVersion: "latest"

--- a/.github/workflows/platform.deployment.history.cleanup.yml
+++ b/.github/workflows/platform.deployment.history.cleanup.yml
@@ -18,6 +18,11 @@ on:
         description: "The number of days to keep deployments with status [failed]" # 'Running' are always excluded
         required: false
         default: "14"
+      customManagementGroupId:
+        type: string
+        description: "The ID of the management group. Defaults to the default AVM group" # 'Running' are always excluded
+        required: false
+        default: ""
   schedule:
     - cron: "0 0 * * *"
 
@@ -114,8 +119,10 @@ jobs:
             # Load used functions
             . (Join-Path $env:GITHUB_WORKSPACE 'avm' 'utilities' 'pipelines' 'platform' 'deploymentRemoval' 'Clear-ManagementGroupDeploymentHistory.ps1')
 
+            $mgmtGroupIdInput = '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).customManagementGroupId }}'
+
             $functionInput = @{
-              ManagementGroupId            = '${{ secrets.ARM_MGMTGROUP_ID }}'
+              ManagementGroupId            = [String]::IsNullOrEmpty($mgmtGroupIdInput) ? '${{ secrets.ARM_MGMTGROUP_ID }}' : $mgmtGroupIdInput
               maxDeploymentRetentionInDays = '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).maxDeploymentRetentionInDays }}'
             }
 

--- a/.github/workflows/platform.deployment.history.cleanup.yml
+++ b/.github/workflows/platform.deployment.history.cleanup.yml
@@ -117,6 +117,7 @@ jobs:
             $mgmtGroupIdInput = '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).customManagementGroupId }}'
 
             foreach($mgmtGroupId in @('${{ secrets.ARM_MGMTGROUP_ID }}', 'bicep-lz-vending-automation-child-nonExistend')) {
+              Write-Verbose "Processing mgmtGroupId [$mgmtGroupId]" -Verbose
               $functionInput = @{
                 ManagementGroupId            = $mgmtGroupId
                 maxDeploymentRetentionInDays = '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).maxDeploymentRetentionInDays }}'

--- a/avm/utilities/pipelines/platform/deploymentRemoval/Clear-ManagementGroupDeploymentHistory.ps1
+++ b/avm/utilities/pipelines/platform/deploymentRemoval/Clear-ManagementGroupDeploymentHistory.ps1
@@ -53,7 +53,12 @@ function Clear-ManagementGroupDeploymentHistory {
             Authorization = 'Bearer {0}' -f ((Get-AzAccessToken -AsSecureString).Token | ConvertFrom-SecureString -AsPlainText)
         }
     }
-    $response = Invoke-RestMethod @getInputObject
+    try {
+        $response = Invoke-RestMethod @getInputObject
+    } catch {
+        Write-Warning "Management Group [$ManagementGroupId] not found or not authorized. Skipping removal."
+        return
+    }
 
     if (($response | Get-Member -MemberType 'NoteProperty').Name -notcontains 'value') {
         throw ('Fetching deployments failed with error [{0}]' -f ($reponse | Out-String))


### PR DESCRIPTION
## Description

Added LZ-Vending MgmtGroup to deployment cleanup
Added resilient case handling for forks where the mgmt-group may not exist (is skipped)
> WARNING: Management Group [xyz] not found or not authorized. Skipping removal.

Fixes #2302


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![.Platform - Clean up deployment history](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.deployment.history.cleanup.yml/badge.svg?branch=users%2Falsehr%2FdeploymentRemovalMgmtId&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.deployment.history.cleanup.yml)       |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
