### PR TITLE
fix: fix URL to PR, for PR labeling automation

### DIFF
--- a/avm/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
+++ b/avm/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
@@ -37,9 +37,8 @@ function Set-AvmGitHubPrLabels {
     . (Join-Path $RepoRoot 'avm' 'utilities' 'pipelines' 'platform' 'helper' 'Get-GithubTeamMembersLogin.ps1')
     . (Join-Path $RepoRoot 'avm' 'utilities' 'pipelines' 'platform' 'helper' 'Get-AvmCsvData.ps1')
 
-    Write-Host 'This is a test'
     $pr = gh pr view $PrUrl.Replace('api.', '').Replace('repos/', '') --json 'author,title,url,body,comments' --repo $Repo | ConvertFrom-Json -Depth 100
-    $allTeamNames = [array](Get-GithubPrRequestedReviewerTeamNames -PrUrl $PrUrl.Replace('api.', '').Replace('repos/', ''))
+    $allTeamNames = [array](Get-GithubPrRequestedReviewerTeamNames -PrUrl $PrUrl.Replace('api.', '').Replace('repos/', '').Replace('pulls/', 'pull'))
     $teamNames = [array]($allTeamNames | Where-Object { $_ -ne 'bicep-admins' -and $_ -ne 'avm-core-team-technical-bicep' -and $_ -ne 'avm-module-reviewers-bicep' })
 
     # core team is already assigned, no or more than one module reviewer team is assigned

--- a/avm/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
+++ b/avm/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
@@ -37,6 +37,7 @@ function Set-AvmGitHubPrLabels {
     . (Join-Path $RepoRoot 'avm' 'utilities' 'pipelines' 'platform' 'helper' 'Get-GithubTeamMembersLogin.ps1')
     . (Join-Path $RepoRoot 'avm' 'utilities' 'pipelines' 'platform' 'helper' 'Get-AvmCsvData.ps1')
 
+    Write-Host 'This is a test'
     $pr = gh pr view $PrUrl.Replace('api.', '').Replace('repos/', '') --json 'author,title,url,body,comments' --repo $Repo | ConvertFrom-Json -Depth 100
     $allTeamNames = [array](Get-GithubPrRequestedReviewerTeamNames -PrUrl $PrUrl.Replace('api.', '').Replace('repos/', ''))
     $teamNames = [array]($allTeamNames | Where-Object { $_ -ne 'bicep-admins' -and $_ -ne 'avm-core-team-technical-bicep' -and $_ -ne 'avm-module-reviewers-bicep' })

--- a/avm/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
+++ b/avm/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
@@ -37,8 +37,9 @@ function Set-AvmGitHubPrLabels {
     . (Join-Path $RepoRoot 'avm' 'utilities' 'pipelines' 'platform' 'helper' 'Get-GithubTeamMembersLogin.ps1')
     . (Join-Path $RepoRoot 'avm' 'utilities' 'pipelines' 'platform' 'helper' 'Get-AvmCsvData.ps1')
 
-    $pr = gh pr view $PrUrl.Replace('api.', '').Replace('repos/', '') --json 'author,title,url,body,comments' --repo $Repo | ConvertFrom-Json -Depth 100
-    $allTeamNames = [array](Get-GithubPrRequestedReviewerTeamNames -PrUrl $PrUrl.Replace('api.', '').Replace('repos/', '').Replace('pulls/', 'pull'))
+    $sanitizedPrUrl = $PrUrl.Replace('api.', '').Replace('repos/', '').Replace('pulls/', 'pull')
+    $pr = gh pr view $sanitizedPrUrl --json 'author,title,url,body,comments' --repo $Repo | ConvertFrom-Json -Depth 100
+    $allTeamNames = [array](Get-GithubPrRequestedReviewerTeamNames -PrUrl $sanitizedPrUrl)
     $teamNames = [array]($allTeamNames | Where-Object { $_ -ne 'bicep-admins' -and $_ -ne 'avm-core-team-technical-bicep' -and $_ -ne 'avm-module-reviewers-bicep' })
 
     # core team is already assigned, no or more than one module reviewer team is assigned


### PR DESCRIPTION
On PR created trigger, GH provides the URL to the PR through the 'github.event.pull_request.url' variable. Unfortunately, there is a spelling issue in it: it has an "s" too much in it (pulls instead of pull), see 'https://github.com/Azure/bicep-registry-modules/pull**s**/3016'. Because of that, the PR labeling logic fail, a it can't find the PR