### PR TITLE
fix: PR logic was not working with draft PRs

### DIFF
--- a/.github/workflows/platform.set-avm-github-pr-labels.yml
+++ b/.github/workflows/platform.set-avm-github-pr-labels.yml
@@ -3,7 +3,7 @@ name: .Platform - Set AVM GitHub PR labels
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, ready_for_review]
 
 jobs:
   SetAvmGitHubPrLabels:

--- a/avm/res/compute/virtual-machine/main.bicep
+++ b/avm/res/compute/virtual-machine/main.bicep
@@ -52,7 +52,7 @@ param customData string = ''
 @description('Optional. Specifies set of certificates that should be installed onto the virtual machine.')
 param certificatesToBeInstalled array = []
 
-@description('Optional. Specifies the priority for the virtual machine. ')
+@description('Optional. Specifies the priority for the virtual machine.')
 @allowed([
   'Regular'
   'Low'

--- a/avm/res/compute/virtual-machine/main.bicep
+++ b/avm/res/compute/virtual-machine/main.bicep
@@ -52,7 +52,7 @@ param customData string = ''
 @description('Optional. Specifies set of certificates that should be installed onto the virtual machine.')
 param certificatesToBeInstalled array = []
 
-@description('Optional. Specifies the priority for the virtual machine.')
+@description('Optional. Specifies the priority for the virtual machine. ')
 @allowed([
   'Regular'
   'Low'

--- a/avm/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
+++ b/avm/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
@@ -41,7 +41,7 @@ function Set-AvmGitHubPrLabels {
     $pr = gh pr view $sanitizedPrUrl --json 'author,title,url,body,comments' --repo $Repo | ConvertFrom-Json -Depth 100
     $allTeamNames = [array](Get-GithubPrRequestedReviewerTeamNames -PrUrl $sanitizedPrUrl)
     $teamNames = [array]($allTeamNames | Where-Object { $_ -ne 'bicep-admins' -and $_ -ne 'avm-core-team-technical-bicep' -and $_ -ne 'avm-module-reviewers-bicep' })
-
+    Write-Host 'TEST'
     # core team is already assigned, no or more than one module reviewer team is assigned
     if ($allTeamNames.Contains('avm-core-team-technical-bicep') -or $teamNames.Count -eq 0 -or $teamNames.Count -gt 1) {
         gh pr edit $pr.url --add-label 'Needs: Core Team :genie:' --repo $Repo

--- a/avm/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
+++ b/avm/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
@@ -41,31 +41,33 @@ function Set-AvmGitHubPrLabels {
     $pr = gh pr view $sanitizedPrUrl --json 'author,title,url,body,comments' --repo $Repo | ConvertFrom-Json -Depth 100
     $allTeamNames = [array](Get-GithubPrRequestedReviewerTeamNames -PrUrl $pr.url)
     $teamNames = [array]($allTeamNames | Where-Object { $_ -ne 'bicep-admins' -and $_ -ne 'avm-core-team-technical-bicep' -and $_ -ne 'avm-module-reviewers-bicep' })
-    Write-Host 'TEST'
-    # core team is already assigned, no or more than one module reviewer team is assigned
-    if ($allTeamNames.Contains('avm-core-team-technical-bicep') -or $teamNames.Count -eq 0 -or $teamNames.Count -gt 1) {
-        gh pr edit $pr.url --add-label 'Needs: Core Team :genie:' --repo $Repo
-    } else {
-        $teamMembers = [array](Get-GithubTeamMembersLogin -OrgName $Repo.Split('/')[0] -TeamName $teamNames[0])
 
-        # no members in module team or only one and that user submitted the PR
-        if (($teamMembers.Count -eq 0) -or ($teamMembers.Count -eq 1 -and $teamMembers[0] -eq $pr.author.login)) {
+    if ($allTeamNames.Count -gt 0) {
+        # core team is already assigned, no or more than one module reviewer team is assigned
+        if ($allTeamNames.Contains('avm-core-team-technical-bicep') -or $teamNames.Count -eq 0 -or $teamNames.Count -gt 1) {
             gh pr edit $pr.url --add-label 'Needs: Core Team :genie:' --repo $Repo
         } else {
-            gh pr edit $pr.url --add-label 'Needs: Module Owner :mega:' --repo $Repo
-        }
+            $teamMembers = [array](Get-GithubTeamMembersLogin -OrgName $Repo.Split('/')[0] -TeamName $teamNames[0])
 
-        # check for orphanded module
-        $moduleName = $teamNames[0]
-        $moduleIndex = $moduleName.StartsWith('avm-res') ? 'Bicep-Resource' : ($moduleName.StartsWith('avm-ptn') ? 'Bicep-Pattern' : 'Bicep-Utility')
-        # get CSV data
-        $modules = Get-AvmCsvData -ModuleIndex $moduleIndex
+            # no members in module team or only one and that user submitted the PR
+            if (($teamMembers.Count -eq 0) -or ($teamMembers.Count -eq 1 -and $teamMembers[0] -eq $pr.author.login)) {
+                gh pr edit $pr.url --add-label 'Needs: Core Team :genie:' --repo $Repo
+            } else {
+                gh pr edit $pr.url --add-label 'Needs: Module Owner :mega:' --repo $Repo
+            }
 
-        foreach ($module in $modules) {
-            if ($module.ModuleName.Replace('-', '').Replace('/', '-') -eq $moduleName) {
-                if ($module.ModuleStatus -eq 'Orphaned :eyes:') {
-                    gh pr edit $pr.url --add-label 'Status: Module Orphaned :eyes:' --repo $Repo
-                    break;
+            # check for orphanded module
+            $moduleName = $teamNames[0]
+            $moduleIndex = $moduleName.StartsWith('avm-res') ? 'Bicep-Resource' : ($moduleName.StartsWith('avm-ptn') ? 'Bicep-Pattern' : 'Bicep-Utility')
+            # get CSV data
+            $modules = Get-AvmCsvData -ModuleIndex $moduleIndex
+
+            foreach ($module in $modules) {
+                if ($module.ModuleName.Replace('-', '').Replace('/', '-') -eq $moduleName) {
+                    if ($module.ModuleStatus -eq 'Orphaned :eyes:') {
+                        gh pr edit $pr.url --add-label 'Status: Module Orphaned :eyes:' --repo $Repo
+                        break;
+                    }
                 }
             }
         }

--- a/avm/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
+++ b/avm/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
@@ -39,7 +39,7 @@ function Set-AvmGitHubPrLabels {
 
     $sanitizedPrUrl = $PrUrl.Replace('api.', '').Replace('repos/', '').Replace('pulls/', 'pull/')
     $pr = gh pr view $sanitizedPrUrl --json 'author,title,url,body,comments' --repo $Repo | ConvertFrom-Json -Depth 100
-    $allTeamNames = [array](Get-GithubPrRequestedReviewerTeamNames -PrUrl $sanitizedPrUrl)
+    $allTeamNames = [array](Get-GithubPrRequestedReviewerTeamNames -PrUrl $pr.url)
     $teamNames = [array]($allTeamNames | Where-Object { $_ -ne 'bicep-admins' -and $_ -ne 'avm-core-team-technical-bicep' -and $_ -ne 'avm-module-reviewers-bicep' })
     Write-Host 'TEST'
     # core team is already assigned, no or more than one module reviewer team is assigned


### PR DESCRIPTION
PR label logic only kicked in, when PR was openend. If it was a draft PR, then the workflow failed (not taking into account, that no team was assigned) and also if the PR was later ready for review, the logic never was triggered again.

Two changes:
1. logic will not only be triggered when PR is openend, but also if a PR is moved into ready for review state
2. if PR is in draft state, the code will not fail, but simply no action will be taken