### PR TITLE
fix: `avm/ptn/ai-platform/baseline` Enforce location when deploying VM with zones

### DIFF
--- a/avm/ptn/ai-platform/baseline/README.md
+++ b/avm/ptn/ai-platform/baseline/README.md
@@ -227,7 +227,7 @@ module baseline 'br/public:avm/ptn/ai-platform/baseline:<version>' = {
       }
       patchMode: 'AutomaticByPlatform'
       size: 'Standard_DS1_v2'
-      zone: 1
+      zone: 0
     }
     virtualNetworkConfiguration: {
       addressPrefix: '10.1.0.0/16'
@@ -366,7 +366,7 @@ module baseline 'br/public:avm/ptn/ai-platform/baseline:<version>' = {
         },
         "patchMode": "AutomaticByPlatform",
         "size": "Standard_DS1_v2",
-        "zone": 1
+        "zone": 0
       }
     },
     "virtualNetworkConfiguration": {

--- a/avm/ptn/ai-platform/baseline/tests/e2e/max/main.test.bicep
+++ b/avm/ptn/ai-platform/baseline/tests/e2e/max/main.test.bicep
@@ -113,7 +113,7 @@ module testDeployment '../../../main.bicep' = [
       virtualMachineConfiguration: {
         enabled: true
         name: take('${namePrefix}-vm-${serviceShort}', 15)
-        zone: 1
+        zone: 0
         size: 'Standard_DS1_v2'
         adminUsername: username
         adminPassword: password

--- a/avm/ptn/ai-platform/baseline/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/ptn/ai-platform/baseline/tests/e2e/waf-aligned/main.test.bicep
@@ -11,8 +11,9 @@ metadata description = 'This instance deploys the module in alignment with the b
 @maxLength(90)
 param resourceGroupName string = 'dep-${namePrefix}-aiplatform-baseline-${serviceShort}-rg'
 
-@description('Optional. The location to deploy resources to.')
-param resourceLocation string = deployment().location
+// Enforce uksouth to avoid restrictions around VM zones in certain regions
+#disable-next-line no-hardcoded-location
+var enforcedLocation = 'uksouth'
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'aipbwaf'
@@ -39,16 +40,16 @@ param password string = newGuid()
 // =================
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: resourceGroupName
-  location: resourceLocation
+  location: enforcedLocation
 }
 
 module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
+  name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
     storageAccountName: 'dep${namePrefix}st${serviceShort}'
     maintenanceConfigurationName: 'dep-${namePrefix}-mc-${serviceShort}'
-    location: resourceLocation
+    location: enforcedLocation
   }
 }
 
@@ -60,7 +61,7 @@ module nestedDependencies 'dependencies.bicep' = {
 module testDeployment '../../../main.bicep' = [
   for iteration in ['init', 'idem']: {
     scope: resourceGroup
-    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
+    name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}${substring(uniqueString(baseTime), 0, 3)}'
       virtualMachineConfiguration: {


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

This fixes the CI build, by deploying the VM with an availability zone into uksouth, as there are no zone restrictions in this location.

![image](https://github.com/user-attachments/assets/414f8ee4-26a1-49f8-88fb-f26bfa849a4a)

Error from pipeline.

```
  VERBOSE: 08:53:09 - The deployment 'a-p-ap-b-waf-aligned-t1-20240814T0808098316Z' failed with error(s). Showing 2 out of 2 error(s).
  Status Message: The template deployment 'idx4jtu3qkiqg-virtual-machine' is not valid according to the validation procedure. The tracking id is '3498bd14-2fe0-49c5-84d8-d8c5037ee9be'. See inner errors for details. (Code: InvalidTemplateDeployment)
   - The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_D2s_v3' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details. (Code:SkuNotAvailable)
  Status Message: At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details. (Code: DeploymentFailed)
   - The template deployment 'idx4jtu3qkiqg-virtual-machine' is not valid according to the validation procedure. The tracking id is '3498bd14-2fe0-49c5-84d8-d8c5037ee9be'. See inner errors for details. (Code: InvalidTemplateDeployment)
     - The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_D2s_v3' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details. (Code:SkuNotAvailable)
  CorrelationId: 1c745da8-57c2-47a6-936a-e7b5e22f698d
```

Also disabling availability zones for `max` example, so this does not fail either.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.ptn.ai-platform.baseline](https://github.com/cecheta/bicep-registry-modules/actions/workflows/avm.ptn.ai-platform.baseline.yml/badge.svg?branch=vm-zone)](https://github.com/cecheta/bicep-registry-modules/actions/workflows/avm.ptn.ai-platform.baseline.yml) |

Note: I can only run this in my subscription if I hardcode the location in the pipeline to `uksouth`, as I cannot deploy any VMs into westeurope, which I why this was not caught earlier.

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
