### PR TITLE
fix: module `avm/res/network/connection` added trafficSelectorPolicies property

### DIFF
--- a/avm/res/network/connection/README.md
+++ b/avm/res/network/connection/README.md
@@ -333,6 +333,7 @@ module connection 'br/public:avm/res/network/connection:<version>' = {
 | [`peer`](#parameter-peer) | object | The remote peer. Used for connection connectionType [ExpressRoute]. |
 | [`routingWeight`](#parameter-routingweight) | int | The weight added to routes learned from this BGP speaker. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
+| [`trafficSelectorPolicies`](#parameter-trafficselectorpolicies) | array | The traffic selector policies to be considered by this connection. |
 | [`useLocalAzureIpAddress`](#parameter-uselocalazureipaddress) | bool | Use private local Azure IP for the connection. Only available for IPSec Virtual Network Gateways that use the Azure Private IP Property. |
 | [`usePolicyBasedTrafficSelectors`](#parameter-usepolicybasedtrafficselectors) | bool | Enable policy-based traffic selectors. |
 | [`virtualNetworkGateway2`](#parameter-virtualnetworkgateway2) | object | The remote Virtual Network Gateway. Used for connection connectionType [Vnet2Vnet]. |
@@ -541,6 +542,14 @@ Tags of the resource.
 
 - Required: No
 - Type: object
+
+### Parameter: `trafficSelectorPolicies`
+
+The traffic selector policies to be considered by this connection.
+
+- Required: No
+- Type: array
+- Default: `[]`
 
 ### Parameter: `useLocalAzureIpAddress`
 

--- a/avm/res/network/connection/main.bicep
+++ b/avm/res/network/connection/main.bicep
@@ -47,6 +47,9 @@ param dpdTimeoutSeconds int = 45
 @description('Optional. Enable policy-based traffic selectors.')
 param usePolicyBasedTrafficSelectors bool = false
 
+@description('Optional. The traffic selector policies to be considered by this connection.')
+param trafficSelectorPolicies array = []
+
 @description('Optional. Bypass the ExpressRoute gateway when accessing private-links. ExpressRoute FastPath (expressRouteGatewayBypass) must be enabled. Only available when connection connectionType is Express Route.')
 param enablePrivateLinkFastPath bool = false
 
@@ -132,6 +135,7 @@ resource connection 'Microsoft.Network/connections@2023-04-01' = {
     peer: connectionType == 'ExpressRoute' ? peer : null
     authorizationKey: connectionType == 'ExpressRoute' && !empty(authorizationKey) ? authorizationKey : null
     sharedKey: connectionType != 'ExpressRoute' ? vpnSharedKey : null
+    trafficSelectorPolicies: trafficSelectorPolicies
     usePolicyBasedTrafficSelectors: usePolicyBasedTrafficSelectors
     ipsecPolicies: !empty(customIPSecPolicy.ipsecEncryption)
       ? [

--- a/avm/res/network/connection/main.json
+++ b/avm/res/network/connection/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "16458068655280591810"
+      "version": "0.29.47.4906",
+      "templateHash": "13075925260036107325"
     },
     "name": "Virtual Network Gateway Connections",
     "description": "This module deploys a Virtual Network Gateway Connection.",
@@ -117,6 +117,13 @@
       "defaultValue": false,
       "metadata": {
         "description": "Optional. Enable policy-based traffic selectors."
+      }
+    },
+    "trafficSelectorPolicies": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional. The traffic selector policies to be considered by this connection."
       }
     },
     "enablePrivateLinkFastPath": {
@@ -258,6 +265,7 @@
         "peer": "[if(equals(parameters('connectionType'), 'ExpressRoute'), parameters('peer'), null())]",
         "authorizationKey": "[if(and(equals(parameters('connectionType'), 'ExpressRoute'), not(empty(parameters('authorizationKey')))), parameters('authorizationKey'), null())]",
         "sharedKey": "[if(not(equals(parameters('connectionType'), 'ExpressRoute')), parameters('vpnSharedKey'), null())]",
+        "trafficSelectorPolicies": "[parameters('trafficSelectorPolicies')]",
         "usePolicyBasedTrafficSelectors": "[parameters('usePolicyBasedTrafficSelectors')]",
         "ipsecPolicies": "[if(not(empty(parameters('customIPSecPolicy').ipsecEncryption)), createArray(createObject('saLifeTimeSeconds', parameters('customIPSecPolicy').saLifeTimeSeconds, 'saDataSizeKilobytes', parameters('customIPSecPolicy').saDataSizeKilobytes, 'ipsecEncryption', parameters('customIPSecPolicy').ipsecEncryption, 'ipsecIntegrity', parameters('customIPSecPolicy').ipsecIntegrity, 'ikeEncryption', parameters('customIPSecPolicy').ikeEncryption, 'ikeIntegrity', parameters('customIPSecPolicy').ikeIntegrity, 'dhGroup', parameters('customIPSecPolicy').dhGroup, 'pfsGroup', parameters('customIPSecPolicy').pfsGroup)), parameters('customIPSecPolicy').ipsecEncryption)]",
         "routingWeight": "[parameters('routingWeight')]",


### PR DESCRIPTION
## Description
Added missing property: trafficSelectorPolicies

Fixes #2791 
Closes #2791 


## Pipeline Reference

[![avm.res.network.connection](https://github.com/fabmas/bicep-registry-modules/actions/workflows/avm.res.network.connection.yml/badge.svg)](https://github.com/fabmas/bicep-registry-modules/actions/workflows/avm.res.network.connection.yml)

## Type of Change

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

