### PR TITLE
fix: test update for ZR default

### DIFF
--- a/avm/res/db-for-my-sql/flexible-server/README.md
+++ b/avm/res/db-for-my-sql/flexible-server/README.md
@@ -178,7 +178,7 @@ module flexibleServer 'br/public:avm/res/db-for-my-sql/flexible-server:<version>
       }
     ]
     geoRedundantBackup: 'Enabled'
-    highAvailability: 'SameZone'
+    highAvailability: 'ZoneRedundant'
     location: '<location>'
     lock: {
       kind: 'CanNotDelete'
@@ -323,7 +323,7 @@ module flexibleServer 'br/public:avm/res/db-for-my-sql/flexible-server:<version>
       "value": "Enabled"
     },
     "highAvailability": {
-      "value": "SameZone"
+      "value": "ZoneRedundant"
     },
     "location": {
       "value": "<location>"

--- a/avm/res/db-for-my-sql/flexible-server/main.json
+++ b/avm/res/db-for-my-sql/flexible-server/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.1.47646",
-      "templateHash": "13929385437976763418"
+      "version": "0.29.47.4906",
+      "templateHash": "12125422157581852477"
     },
     "name": "DBforMySQL Flexible Servers",
     "description": "This module deploys a DBforMySQL Flexible Server.",

--- a/avm/res/db-for-my-sql/flexible-server/tests/e2e/max/main.test.bicep
+++ b/avm/res/db-for-my-sql/flexible-server/tests/e2e/max/main.test.bicep
@@ -157,7 +157,7 @@ module testDeployment '../../../main.bicep' = [
           startIpAddress: '100.100.100.1'
         }
       ]
-      highAvailability: 'SameZone'
+      highAvailability: 'ZoneRedundant'
       storageAutoGrow: 'Enabled'
       version: '8.0.21'
       customerManagedKey: {


### PR DESCRIPTION
## Description

The module defaults 'ZoneRedundant' for the HA property by default. This PR just aligns the max test to that same baseline.

## Pipeline Reference

| Pipeline |
| -------- |
|[![avm.res.db-for-my-sql.flexible-server](https://github.com/tsc-buddy/bicep-registry-modules/actions/workflows/avm.res.db-for-my-sql.flexible-server.yml/badge.svg?branch=fix%2Fmysql-az-test-update)](https://github.com/tsc-buddy/bicep-registry-modules/actions/workflows/avm.res.db-for-my-sql.flexible-server.yml)|

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
