### PR TITLE
Update `avm/res/dev-test-lab/lab` to enforce system identity

### DIFF
--- a/avm/res/dev-test-lab/lab/README.md
+++ b/avm/res/dev-test-lab/lab/README.md
@@ -767,7 +767,7 @@ module lab 'br/public:avm/res/dev-test-lab/lab:<version>' = {
 | [`labStorageType`](#parameter-labstoragetype) | string | Type of storage used by the lab. It can be either Premium or Standard. |
 | [`location`](#parameter-location) | string | Location for all Resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
-| [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. DevTest Labs creates a system-assigned identity by default the first time it creates the lab environment. |
+| [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. For new labs created after 8/10/2020, the lab's system assigned identity is set to On by default and lab owner will not be able to turn this off for the lifecycle of the lab. |
 | [`managementIdentitiesResourceIds`](#parameter-managementidentitiesresourceids) | array | The resource ID(s) to assign to the virtual machines associated with this lab. |
 | [`mandatoryArtifactsResourceIdsLinux`](#parameter-mandatoryartifactsresourceidslinux) | array | The ordered list of artifact resource IDs that should be applied on all Linux VM creations by default, prior to the artifacts specified by the user. |
 | [`mandatoryArtifactsResourceIdsWindows`](#parameter-mandatoryartifactsresourceidswindows) | array | The ordered list of artifact resource IDs that should be applied on all Windows VM creations by default, prior to the artifacts specified by the user. |
@@ -915,7 +915,7 @@ Artifact sources to create for the lab.
 | :-- | :-- | :-- |
 | [`branchRef`](#parameter-artifactsourcesbranchref) | string | The artifact source's branch reference (e.g. main or master). |
 | [`displayName`](#parameter-artifactsourcesdisplayname) | string | The display name of the artifact source. Default is the name of the artifact source. |
-| [`securityToken`](#parameter-artifactsourcessecuritytoken) | securestring | The security token to authenticate to the artifact source. |
+| [`securityToken`](#parameter-artifactsourcessecuritytoken) | securestring | The security token to authenticate to the artifact source. Private artifacts use the system-identity of the lab to store the security token for the artifact source in the lab's managed Azure Key Vault. Access to the Azure Key Vault is granted automatically only when the lab is created with a system-assigned identity. |
 | [`sourceType`](#parameter-artifactsourcessourcetype) | string | The artifact source's type. |
 | [`status`](#parameter-artifactsourcesstatus) | string | Indicates if the artifact source is enabled (values: Enabled, Disabled). Default is "Enabled". |
 | [`tags`](#parameter-artifactsourcestags) | object | The tags of the artifact source. |
@@ -964,7 +964,7 @@ The display name of the artifact source. Default is the name of the artifact sou
 
 ### Parameter: `artifactsources.securityToken`
 
-The security token to authenticate to the artifact source.
+The security token to authenticate to the artifact source. Private artifacts use the system-identity of the lab to store the security token for the artifact source in the lab's managed Azure Key Vault. Access to the Azure Key Vault is granted automatically only when the lab is created with a system-assigned identity.
 
 - Required: No
 - Type: securestring
@@ -1401,7 +1401,7 @@ Specify the name of lock.
 
 ### Parameter: `managedIdentities`
 
-The managed identity definition for this resource. DevTest Labs creates a system-assigned identity by default the first time it creates the lab environment.
+The managed identity definition for this resource. For new labs created after 8/10/2020, the lab's system assigned identity is set to On by default and lab owner will not be able to turn this off for the lifecycle of the lab.
 
 - Required: No
 - Type: object

--- a/avm/res/dev-test-lab/lab/main.bicep
+++ b/avm/res/dev-test-lab/lab/main.bicep
@@ -125,7 +125,9 @@ var identity = !empty(managedIdentities)
       type: !empty(managedIdentities.?userAssignedResourceIds ?? {}) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned'
       userAssignedIdentities: !empty(formattedUserAssignedIdentities) ? formattedUserAssignedIdentities : null
     }
-  : any(null)
+  : {
+      type: 'SystemAssigned'
+    }
 
 var formattedManagementIdentities = !empty(managementIdentitiesResourceIds)
   ? reduce(map((managementIdentitiesResourceIds ?? []), (id) => { '${id}': {} }), {}, (cur, next) => union(cur, next))

--- a/avm/res/dev-test-lab/lab/main.bicep
+++ b/avm/res/dev-test-lab/lab/main.bicep
@@ -57,7 +57,7 @@ param premiumDataDisks string = 'Disabled'
 @description('Optional. The properties of any lab support message associated with this lab.')
 param support object = {}
 
-@description('Optional. The managed identity definition for this resource. DevTest Labs creates a system-assigned identity by default the first time it creates the lab environment.')
+@description('Optional. The managed identity definition for this resource. For new labs created after 8/10/2020, the lab\'s system assigned identity is set to On by default and lab owner will not be able to turn this off for the lifecycle of the lab.')
 param managedIdentities managedIdentitiesType
 
 @description('Optional. The resource ID(s) to assign to the virtual machines associated with this lab.')
@@ -441,7 +441,7 @@ type artifactsourcesType = {
   @description('Required. The artifact source\'s URI.')
   uri: string
 
-  @description('Optional. The security token to authenticate to the artifact source.')
+  @description('Optional. The security token to authenticate to the artifact source. Private artifacts use the system-identity of the lab to store the security token for the artifact source in the lab\'s managed Azure Key Vault. Access to the Azure Key Vault is granted automatically only when the lab is created with a system-assigned identity.')
   @secure()
   securityToken: string?
 }[]?

--- a/avm/res/dev-test-lab/lab/main.json
+++ b/avm/res/dev-test-lab/lab/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "7318769296207121382"
+      "templateHash": "9164793528274272981"
     },
     "name": "DevTest Labs",
     "description": "This module deploys a DevTest Lab.",
@@ -205,7 +205,7 @@
             "type": "securestring",
             "nullable": true,
             "metadata": {
-              "description": "Optional. The security token to authenticate to the artifact source."
+              "description": "Optional. The security token to authenticate to the artifact source. Private artifacts use the system-identity of the lab to store the security token for the artifact source in the lab's managed Azure Key Vault. Access to the Azure Key Vault is granted automatically only when the lab is created with a system-assigned identity."
             }
           }
         }
@@ -1010,7 +1010,7 @@
     "managedIdentities": {
       "$ref": "#/definitions/managedIdentitiesType",
       "metadata": {
-        "description": "Optional. The managed identity definition for this resource. DevTest Labs creates a system-assigned identity by default the first time it creates the lab environment."
+        "description": "Optional. The managed identity definition for this resource. For new labs created after 8/10/2020, the lab's system assigned identity is set to On by default and lab owner will not be able to turn this off for the lifecycle of the lab."
       }
     },
     "managementIdentitiesResourceIds": {

--- a/avm/res/dev-test-lab/lab/main.json
+++ b/avm/res/dev-test-lab/lab/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "17290806626721732157"
+      "templateHash": "7318769296207121382"
     },
     "name": "DevTest Labs",
     "description": "This module deploys a DevTest Lab.",
@@ -1130,7 +1130,7 @@
       }
     ],
     "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
-    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned,UserAssigned', 'SystemAssigned'), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
+    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned,UserAssigned', 'SystemAssigned'), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), createObject('type', 'SystemAssigned'))]",
     "formattedManagementIdentities": "[if(not(empty(parameters('managementIdentitiesResourceIds'))), reduce(map(coalesce(parameters('managementIdentitiesResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next')))), createObject())]",
     "builtInRoleNames": {
       "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",


### PR DESCRIPTION
Closes #3108 

## Description

- Set the identity component to enforce System assigned identity. This was the case in CARML, but it was missed during the migration and uplift in AVM.

History in CARML
```bicep
  identity: {
    type: !empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned'
    userAssignedIdentities: !empty(userAssignedIdentities) ? userAssignedIdentities : any(null)
  }
```

This must be set to enforce System identity as per MSFT [DevTest Lab - Configure Identity](https://learn.microsoft.com/en-us/azure/devtest-labs/configure-lab-identity#configure-identity) guidance:

![image](https://github.com/user-attachments/assets/e62fdfaa-3b4e-47a7-bef3-22a2a95de160)

See the comment https://github.com/Azure/bicep-registry-modules/issues/3108#issuecomment-2316868063 for more details

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.dev-test-lab.lab](https://github.com/ahmadabdalla/bicep-registry-modules/actions/workflows/avm.res.dev-test-lab.lab.yml/badge.svg?branch=users%2Fahmad%2F3108_DTL_IDEN)](https://github.com/ahmadabdalla/bicep-registry-modules/actions/workflows/avm.res.dev-test-lab.lab.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
