### PR TITLE
fix: Fixed `avm/res/operational-insights/workspace` diagnostic settings

### DIFF
--- a/avm/res/operational-insights/workspace/README.md
+++ b/avm/res/operational-insights/workspace/README.md
@@ -187,6 +187,15 @@ module workspace 'br/public:avm/res/operational-insights/workspace:<version>' = 
         storageAccountResourceId: '<storageAccountResourceId>'
         workspaceResourceId: '<workspaceResourceId>'
       }
+      {
+        metricCategories: [
+          {
+            category: 'AllMetrics'
+          }
+        ]
+        name: 'sendingDiagnosticSettingsToSelf'
+        useThisWorkspace: true
+      }
     ]
     gallerySolutions: [
       {
@@ -325,7 +334,6 @@ module workspace 'br/public:avm/res/operational-insights/workspace:<version>' = 
       'hidden-title': 'This is visible in the resource name'
       Role: 'DeploymentValidation'
     }
-    useDeployedWorkspaceForDiagnosticSettings: true
     useResourcePermissions: true
   }
 }
@@ -484,6 +492,15 @@ module workspace 'br/public:avm/res/operational-insights/workspace:<version>' = 
           "name": "customSetting",
           "storageAccountResourceId": "<storageAccountResourceId>",
           "workspaceResourceId": "<workspaceResourceId>"
+        },
+        {
+          "metricCategories": [
+            {
+              "category": "AllMetrics"
+            }
+          ],
+          "name": "sendingDiagnosticSettingsToSelf",
+          "useThisWorkspace": true
         }
       ]
     },
@@ -645,9 +662,6 @@ module workspace 'br/public:avm/res/operational-insights/workspace:<version>' = 
         "hidden-title": "This is visible in the resource name",
         "Role": "DeploymentValidation"
       }
-    },
-    "useDeployedWorkspaceForDiagnosticSettings": {
-      "value": true
     },
     "useResourcePermissions": {
       "value": true
@@ -1725,7 +1739,6 @@ module workspace 'br/public:avm/res/operational-insights/workspace:<version>' = 
 | [`storageInsightsConfigs`](#parameter-storageinsightsconfigs) | array | List of storage accounts to be read by the workspace. |
 | [`tables`](#parameter-tables) | array | LAW custom tables to be deployed. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
-| [`useDeployedWorkspaceForDiagnosticSettings`](#parameter-usedeployedworkspacefordiagnosticsettings) | bool | Instead of using an external reference, use the deployed instance as the target for its diagnostic settings. |
 | [`useResourcePermissions`](#parameter-useresourcepermissions) | bool | Set to 'true' to use resource or workspace permissions and 'false' (or leave empty) to require workspace permissions. |
 
 ### Parameter: `name`
@@ -1794,6 +1807,7 @@ The diagnostic settings of the service.
 | [`metricCategories`](#parameter-diagnosticsettingsmetriccategories) | array | The name of metrics that will be streamed. "allMetrics" includes all possible metrics for the resource. Set to `[]` to disable metric collection. |
 | [`name`](#parameter-diagnosticsettingsname) | string | The name of diagnostic setting. |
 | [`storageAccountResourceId`](#parameter-diagnosticsettingsstorageaccountresourceid) | string | Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub. |
+| [`useThisWorkspace`](#parameter-diagnosticsettingsusethisworkspace) | bool | Instead of using an external reference, use the deployed instance as the target for its diagnostic settings. If set to `true`, the `workspaceResourceId` property is ignored. |
 | [`workspaceResourceId`](#parameter-diagnosticsettingsworkspaceresourceid) | string | Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub. |
 
 ### Parameter: `diagnosticSettings.eventHubAuthorizationRuleResourceId`
@@ -1913,6 +1927,13 @@ Resource ID of the diagnostic storage account. For security reasons, it is recom
 
 - Required: No
 - Type: string
+
+### Parameter: `diagnosticSettings.useThisWorkspace`
+
+Instead of using an external reference, use the deployed instance as the target for its diagnostic settings. If set to `true`, the `workspaceResourceId` property is ignored.
+
+- Required: No
+- Type: bool
 
 ### Parameter: `diagnosticSettings.workspaceResourceId`
 
@@ -2211,14 +2232,6 @@ Tags of the resource.
 
 - Required: No
 - Type: object
-
-### Parameter: `useDeployedWorkspaceForDiagnosticSettings`
-
-Instead of using an external reference, use the deployed instance as the target for its diagnostic settings.
-
-- Required: No
-- Type: bool
-- Default: `False`
 
 ### Parameter: `useResourcePermissions`
 

--- a/avm/res/operational-insights/workspace/main.bicep
+++ b/avm/res/operational-insights/workspace/main.bicep
@@ -209,7 +209,7 @@ resource logAnalyticsWorkspace_diagnosticSettings 'Microsoft.Insights/diagnostic
     name: diagnosticSetting.?name ?? '${name}-diagnosticSettings'
     properties: {
       storageAccountId: diagnosticSetting.?storageAccountResourceId
-      workspaceId: diagnosticSetting.?useThisWorkspace
+      workspaceId: (diagnosticSetting.?useThisWorkspace ?? false)
         ? logAnalyticsWorkspace.id
         : diagnosticSetting.?workspaceResourceId
       eventHubAuthorizationRuleId: diagnosticSetting.?eventHubAuthorizationRuleResourceId

--- a/avm/res/operational-insights/workspace/main.bicep
+++ b/avm/res/operational-insights/workspace/main.bicep
@@ -82,9 +82,6 @@ param useResourcePermissions bool = false
 @description('Optional. The diagnostic settings of the service.')
 param diagnosticSettings diagnosticSettingType
 
-@description('Optional. Instead of using an external reference, use the deployed instance as the target for its diagnostic settings.')
-param useDeployedWorkspaceForDiagnosticSettings bool = false
-
 @description('Optional. Indicates whether customer managed storage is mandatory for query management.')
 param forceCmkForQuery bool = true
 
@@ -212,7 +209,7 @@ resource logAnalyticsWorkspace_diagnosticSettings 'Microsoft.Insights/diagnostic
     name: diagnosticSetting.?name ?? '${name}-diagnosticSettings'
     properties: {
       storageAccountId: diagnosticSetting.?storageAccountResourceId
-      workspaceId: useDeployedWorkspaceForDiagnosticSettings
+      workspaceId: diagnosticSetting.?useThisWorkspace
         ? logAnalyticsWorkspace.id
         : diagnosticSetting.?workspaceResourceId
       eventHubAuthorizationRuleId: diagnosticSetting.?eventHubAuthorizationRuleResourceId
@@ -481,6 +478,9 @@ type diagnosticSettingType = {
 
   @description('Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type.')
   logAnalyticsDestinationType: ('Dedicated' | 'AzureDiagnostics' | null)?
+
+  @description('Optional. Instead of using an external reference, use the deployed instance as the target for its diagnostic settings. If set to `true`, the `workspaceResourceId` property is ignored.')
+  useThisWorkspace: bool?
 
   @description('Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub.')
   workspaceResourceId: string?

--- a/avm/res/operational-insights/workspace/main.json
+++ b/avm/res/operational-insights/workspace/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "16451532248560295281"
+      "templateHash": "11994891550110156380"
     },
     "name": "Log Analytics Workspaces",
     "description": "This module deploys a Log Analytics Workspace.",
@@ -551,7 +551,7 @@
           }
         ],
         "storageAccountId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'storageAccountResourceId')]",
-        "workspaceId": "[if(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'useThisWorkspace'), resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')), tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId'))]",
+        "workspaceId": "[if(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'useThisWorkspace'), false()), resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')), tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId'))]",
         "eventHubAuthorizationRuleId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubAuthorizationRuleResourceId')]",
         "eventHubName": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubName')]",
         "marketplacePartnerId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'marketplacePartnerResourceId')]",

--- a/avm/res/operational-insights/workspace/main.json
+++ b/avm/res/operational-insights/workspace/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "11421725796221742541"
+      "templateHash": "16451532248560295281"
     },
     "name": "Log Analytics Workspaces",
     "description": "This module deploys a Log Analytics Workspace.",
@@ -215,6 +215,13 @@
               "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
             }
           },
+          "useThisWorkspace": {
+            "type": "bool",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Instead of using an external reference, use the deployed instance as the target for its diagnostic settings. If set to `true`, the `workspaceResourceId` property is ignored."
+            }
+          },
           "workspaceResourceId": {
             "type": "string",
             "nullable": true,
@@ -409,13 +416,6 @@
         "description": "Optional. The diagnostic settings of the service."
       }
     },
-    "useDeployedWorkspaceForDiagnosticSettings": {
-      "type": "bool",
-      "defaultValue": false,
-      "metadata": {
-        "description": "Optional. Instead of using an external reference, use the deployed instance as the target for its diagnostic settings."
-      }
-    },
     "forceCmkForQuery": {
       "type": "bool",
       "defaultValue": true,
@@ -551,7 +551,7 @@
           }
         ],
         "storageAccountId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'storageAccountResourceId')]",
-        "workspaceId": "[if(parameters('useDeployedWorkspaceForDiagnosticSettings'), resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')), tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId'))]",
+        "workspaceId": "[if(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'useThisWorkspace'), resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')), tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId'))]",
         "eventHubAuthorizationRuleId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubAuthorizationRuleResourceId')]",
         "eventHubName": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubName')]",
         "marketplacePartnerId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'marketplacePartnerResourceId')]",

--- a/avm/res/operational-insights/workspace/tests/e2e/adv/main.test.bicep
+++ b/avm/res/operational-insights/workspace/tests/e2e/adv/main.test.bicep
@@ -174,8 +174,16 @@ module testDeployment '../../../main.bicep' = [
           storageAccountResourceId: diagnosticDependencies.outputs.storageAccountResourceId
           workspaceResourceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
         }
+        {
+          name: 'sendingDiagnosticSettingsToSelf'
+          metricCategories: [
+            {
+              category: 'AllMetrics'
+            }
+          ]
+          useThisWorkspace: true
+        }
       ]
-      useDeployedWorkspaceForDiagnosticSettings: true
       gallerySolutions: [
         {
           name: 'AzureAutomation'

--- a/avm/res/operational-insights/workspace/version.json
+++ b/avm/res/operational-insights/workspace/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.5",
+    "version": "0.6",
     "pathFilters": [
         "./main.json"
     ]


### PR DESCRIPTION
## Description

PR is fixing the issue that the parameter `useDeployedWorkspaceForDiagnosticSettings` was manipulating the workspace destination for the whole array of diagnostic settings.
It has been replaced by a parameter `useThisWorkspace` per diagnostic setting entry, which allows to set the destination workspace more granular.

Fixes #3051 


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|  [![avm.res.operational-insights.workspace](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml/badge.svg)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml)  |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
