### PR TITLE
fix: Small fix for both the post-removal logic & secret-passthru with PSRule

### DIFF
--- a/avm/res/compute/virtual-machine/tests/e2e/linux.max/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/linux.max/main.test.bicep
@@ -22,7 +22,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the Backup Management Service Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-BackupManagementServiceEnterpriseApplicationObjectId\'.')
 @secure()
-param backupManagementServiceEnterpriseApplicationObjectId string
+param backupManagementServiceEnterpriseApplicationObjectId string = ''
 
 // ============ //
 // Dependencies //

--- a/avm/res/compute/virtual-machine/tests/e2e/linux.max/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/linux.max/main.test.bicep
@@ -22,7 +22,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the Backup Management Service Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-BackupManagementServiceEnterpriseApplicationObjectId\'.')
 @secure()
-param backupManagementServiceEnterpriseApplicationObjectId string = ''
+param backupManagementServiceEnterpriseApplicationObjectId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/compute/virtual-machine/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/waf-aligned/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the Backup Management Service Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-BackupManagementServiceEnterpriseApplicationObjectId\'.')
 @secure()
-param backupManagementServiceEnterpriseApplicationObjectId string
+param backupManagementServiceEnterpriseApplicationObjectId string = ''
 
 // ============ //
 // Dependencies //

--- a/avm/res/compute/virtual-machine/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/waf-aligned/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the Backup Management Service Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-BackupManagementServiceEnterpriseApplicationObjectId\'.')
 @secure()
-param backupManagementServiceEnterpriseApplicationObjectId string = ''
+param backupManagementServiceEnterpriseApplicationObjectId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/compute/virtual-machine/tests/e2e/windows.max/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/windows.max/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the Backup Management Service Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-BackupManagementServiceEnterpriseApplicationObjectId\'.')
 @secure()
-param backupManagementServiceEnterpriseApplicationObjectId string
+param backupManagementServiceEnterpriseApplicationObjectId string = ''
 
 // ============ //
 // Dependencies //

--- a/avm/res/compute/virtual-machine/tests/e2e/windows.max/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/windows.max/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the Backup Management Service Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-BackupManagementServiceEnterpriseApplicationObjectId\'.')
 @secure()
-param backupManagementServiceEnterpriseApplicationObjectId string = ''
+param backupManagementServiceEnterpriseApplicationObjectId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/databricks/workspace/tests/e2e/max/main.test.bicep
+++ b/avm/res/databricks/workspace/tests/e2e/max/main.test.bicep
@@ -25,7 +25,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the AzureDatabricks Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-AzureDatabricksEnterpriseApplicationObjectId\'.')
 @secure()
-param azureDatabricksEnterpriseApplicationObjectId string = ''
+param azureDatabricksEnterpriseApplicationObjectId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/databricks/workspace/tests/e2e/max/main.test.bicep
+++ b/avm/res/databricks/workspace/tests/e2e/max/main.test.bicep
@@ -25,7 +25,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the AzureDatabricks Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-AzureDatabricksEnterpriseApplicationObjectId\'.')
 @secure()
-param azureDatabricksEnterpriseApplicationObjectId string
+param azureDatabricksEnterpriseApplicationObjectId string = ''
 
 // ============ //
 // Dependencies //

--- a/avm/res/databricks/workspace/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/databricks/workspace/tests/e2e/waf-aligned/main.test.bicep
@@ -25,7 +25,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the AzureDatabricks Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-AzureDatabricksEnterpriseApplicationObjectId\'.')
 @secure()
-param azureDatabricksEnterpriseApplicationObjectId string = ''
+param azureDatabricksEnterpriseApplicationObjectId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/databricks/workspace/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/databricks/workspace/tests/e2e/waf-aligned/main.test.bicep
@@ -25,7 +25,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the AzureDatabricks Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-AzureDatabricksEnterpriseApplicationObjectId\'.')
 @secure()
-param azureDatabricksEnterpriseApplicationObjectId string
+param azureDatabricksEnterpriseApplicationObjectId string = ''
 
 // ============ //
 // Dependencies //

--- a/avm/res/managed-services/registration-definition/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/managed-services/registration-definition/tests/e2e/defaults/main.test.bicep
@@ -18,7 +18,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The tenant Id of the lighthouse tenant. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-LighthouseManagedByTenantId\'.')
 @secure()
-param lighthouseManagedByTenantId string = ''
+param lighthouseManagedByTenantId string
 
 // ============== //
 // Test Execution //

--- a/avm/res/managed-services/registration-definition/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/managed-services/registration-definition/tests/e2e/defaults/main.test.bicep
@@ -18,7 +18,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The tenant Id of the lighthouse tenant. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-LighthouseManagedByTenantId\'.')
 @secure()
-param lighthouseManagedByTenantId string
+param lighthouseManagedByTenantId string = ''
 
 // ============== //
 // Test Execution //

--- a/avm/res/managed-services/registration-definition/tests/e2e/max/main.test.bicep
+++ b/avm/res/managed-services/registration-definition/tests/e2e/max/main.test.bicep
@@ -18,7 +18,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The tenant Id of the lighthouse tenant. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-LighthouseManagedByTenantId\'.')
 @secure()
-param lighthouseManagedByTenantId string = ''
+param lighthouseManagedByTenantId string
 
 // ============== //
 // Test Execution //

--- a/avm/res/managed-services/registration-definition/tests/e2e/max/main.test.bicep
+++ b/avm/res/managed-services/registration-definition/tests/e2e/max/main.test.bicep
@@ -18,7 +18,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The tenant Id of the lighthouse tenant. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-LighthouseManagedByTenantId\'.')
 @secure()
-param lighthouseManagedByTenantId string
+param lighthouseManagedByTenantId string = ''
 
 // ============== //
 // Test Execution //

--- a/avm/res/managed-services/registration-definition/tests/e2e/rg/main.test.bicep
+++ b/avm/res/managed-services/registration-definition/tests/e2e/rg/main.test.bicep
@@ -22,7 +22,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The tenant Id of the lighthouse tenant. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-LighthouseManagedByTenantId\'.')
 @secure()
-param lighthouseManagedByTenantId string = ''
+param lighthouseManagedByTenantId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/managed-services/registration-definition/tests/e2e/rg/main.test.bicep
+++ b/avm/res/managed-services/registration-definition/tests/e2e/rg/main.test.bicep
@@ -22,7 +22,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The tenant Id of the lighthouse tenant. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-LighthouseManagedByTenantId\'.')
 @secure()
-param lighthouseManagedByTenantId string
+param lighthouseManagedByTenantId string = ''
 
 // ============ //
 // Dependencies //

--- a/avm/res/managed-services/registration-definition/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/managed-services/registration-definition/tests/e2e/waf-aligned/main.test.bicep
@@ -22,7 +22,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The tenant Id of the lighthouse tenant. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-LighthouseManagedByTenantId\'.')
 @secure()
-param lighthouseManagedByTenantId string = ''
+param lighthouseManagedByTenantId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/managed-services/registration-definition/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/managed-services/registration-definition/tests/e2e/waf-aligned/main.test.bicep
@@ -22,7 +22,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The tenant Id of the lighthouse tenant. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-LighthouseManagedByTenantId\'.')
 @secure()
-param lighthouseManagedByTenantId string
+param lighthouseManagedByTenantId string = ''
 
 // ============ //
 // Dependencies //

--- a/avm/utilities/pipelines/e2eValidation/resourceRemoval/helper/Invoke-ResourcePostRemoval.ps1
+++ b/avm/utilities/pipelines/e2eValidation/resourceRemoval/helper/Invoke-ResourcePostRemoval.ps1
@@ -33,7 +33,7 @@ function Invoke-ResourcePostRemoval {
         [int] $PostRemovalRetryLimit = 3
     )
 
-    $postRemovalRetryCount = 1
+    $removalRetryCount = 1
     do {
         try {
             switch ($Type) {
@@ -191,5 +191,5 @@ function Invoke-ResourcePostRemoval {
             Write-Warning ('[!] Post-removal operation failed. Reason: [{0}]. Retry [{1}/{2}]' -f $_.Exception.Message, $removalRetryCount, $PostRemovalRetryLimit)
             $removalRetryCount++
         }
-    } while ($postRemovalRetryCount -le $PostRemovalRetryLimit)
+    } while ($removalRetryCount -le $PostRemovalRetryLimit)
 }

--- a/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
@@ -16,7 +16,7 @@ binding:
 # Require minimum versions of modules.
 requires:
   PSRule: "@pre >=2.9.0"
-  PSRule.Rules.Azure: "1.13.0"
+  PSRule.Rules.Azure: "@pre >=1.38.0"
 
 # Use PSRule for Azure.
 include:

--- a/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
@@ -16,7 +16,7 @@ binding:
 # Require minimum versions of modules.
 requires:
   PSRule: "@pre >=2.9.0"
-  PSRule.Rules.Azure: "@pre >=1.29.0"
+  PSRule.Rules.Azure: "1.13.0"
 
 # Use PSRule for Azure.
 include:

--- a/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
@@ -72,6 +72,13 @@ configuration:
       "tokenValidityLength",
     ]
 
+  # Required parameters for test files validated by PSRule
+  # Ref: https://azure.github.io/PSRule.Rules.Azure/setup/configuring-expansion/#required-parameter-defaults
+  AZURE_PARAMETER_DEFAULTS:
+    backupManagementServiceEnterpriseApplicationObjectId: $GUID_PLACEHOLDER$
+    azureDatabricksEnterpriseApplicationObjectId: $GUID_PLACEHOLDER$
+    lighthouseManagedByTenantId: $GUID_PLACEHOLDER$
+
 rule:
   # Enable custom rules that don't exist in the baseline
   includeLocal: false

--- a/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
@@ -75,9 +75,9 @@ configuration:
   # Required parameters for test files validated by PSRule
   # Ref: https://azure.github.io/PSRule.Rules.Azure/setup/configuring-expansion/#required-parameter-defaults
   AZURE_PARAMETER_DEFAULTS:
-    backupManagementServiceEnterpriseApplicationObjectId: $GUID_PLACEHOLDER$
-    azureDatabricksEnterpriseApplicationObjectId: $GUID_PLACEHOLDER$
-    lighthouseManagedByTenantId: $GUID_PLACEHOLDER$
+    backupManagementServiceEnterpriseApplicationObjectId: "$GUID_PLACEHOLDER$"
+    azureDatabricksEnterpriseApplicationObjectId: "$GUID_PLACEHOLDER$"
+    lighthouseManagedByTenantId: "$GUID_PLACEHOLDER$"
 
 rule:
   # Enable custom rules that don't exist in the baseline

--- a/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
@@ -75,9 +75,9 @@ configuration:
   # Required parameters for test files validated by PSRule
   # Ref: https://azure.github.io/PSRule.Rules.Azure/setup/configuring-expansion/#required-parameter-defaults
   AZURE_PARAMETER_DEFAULTS:
-    backupManagementServiceEnterpriseApplicationObjectId: "$GUID_PLACEHOLDER$"
-    azureDatabricksEnterpriseApplicationObjectId: "$GUID_PLACEHOLDER$"
-    lighthouseManagedByTenantId: "$GUID_PLACEHOLDER$"
+    backupManagementServiceEnterpriseApplicationObjectId: $GUID_PLACEHOLDER$
+    azureDatabricksEnterpriseApplicationObjectId: $GUID_PLACEHOLDER$
+    lighthouseManagedByTenantId: $GUID_PLACEHOLDER$
 
 rule:
   # Enable custom rules that don't exist in the baseline

--- a/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
@@ -72,13 +72,6 @@ configuration:
       "tokenValidityLength",
     ]
 
-  # Required parameters for test files validated by PSRule
-  # Ref: https://azure.github.io/PSRule.Rules.Azure/setup/configuring-expansion/#required-parameter-defaults
-  AZURE_PARAMETER_DEFAULTS:
-    backupManagementServiceEnterpriseApplicationObjectId: $GUID_PLACEHOLDER$
-    azureDatabricksEnterpriseApplicationObjectId: $GUID_PLACEHOLDER$
-    lighthouseManagedByTenantId: $GUID_PLACEHOLDER$
-
 rule:
   # Enable custom rules that don't exist in the baseline
   includeLocal: false


### PR DESCRIPTION
## Description

- Fixed the post-deployment loop referencing incorrect variables
- Enabled PSRule to work with secrets pass-thru parameters it must be able to expand

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.compute.virtual-machine](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine.yml/badge.svg?branch=users%2Falsehr%2FciRemovalAndPSRuleFix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
