### PR TITLE
fix: `avm/res/machine-learning-services/workspace` Enforce location for AI Services

### DIFF
--- a/avm/res/machine-learning-services/workspace/tests/e2e/ai/main.test.bicep
+++ b/avm/res/machine-learning-services/workspace/tests/e2e/ai/main.test.bicep
@@ -11,9 +11,6 @@ metadata description = 'This instance deploys an Azure AI hub workspace.'
 @maxLength(90)
 param resourceGroupName string = 'dep-${namePrefix}-machinelearningservices.workspaces-${serviceShort}-rg'
 
-@description('Optional. The location to deploy resources to.')
-param resourceLocation string = deployment().location
-
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'mlswai'
 
@@ -23,6 +20,10 @@ param baseTime string = utcNow('u')
 @description('Optional. A token to inject into the name of each resource.')
 param namePrefix string = '#_namePrefix_#'
 
+// AI Services not available in all regions
+#disable-next-line no-hardcoded-location
+var enforcedLocation = 'uksouth'
+
 // ============ //
 // Dependencies //
 // ============ //
@@ -31,19 +32,19 @@ param namePrefix string = '#_namePrefix_#'
 // =================
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: resourceGroupName
-  location: resourceLocation
+  location: enforcedLocation
 }
 
 module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
+  name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
     keyVaultName: 'dep-${namePrefix}-kv-${serviceShort}-${substring(uniqueString(baseTime), 0, 3)}'
     applicationInsightsName: 'dep-${namePrefix}-appI-${serviceShort}'
     storageAccountName: 'dep${namePrefix}st${serviceShort}'
     secondaryStorageAccountName: 'dep${namePrefix}st${serviceShort}2'
     aiServicesName: 'dep-${namePrefix}-ai-${serviceShort}'
-    location: resourceLocation
+    location: enforcedLocation
   }
 }
 
@@ -55,10 +56,10 @@ module nestedDependencies 'dependencies.bicep' = {
 module testDeployment '../../../main.bicep' = [
   for iteration in ['init', 'idem']: {
     scope: resourceGroup
-    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
+    name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
+      location: enforcedLocation
       associatedApplicationInsightsResourceId: nestedDependencies.outputs.applicationInsightsResourceId
       associatedKeyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
       associatedStorageAccountResourceId: nestedDependencies.outputs.storageAccountResourceId
@@ -78,7 +79,7 @@ module testDeployment '../../../main.bicep' = [
           metadata: {
             ApiType: 'Azure'
             ResourceId: nestedDependencies.outputs.aiServicesResourceId
-            Location: resourceLocation
+            Location: enforcedLocation
             ApiVersion: '2023-07-01-preview'
             DeploymentApiVersion: '2023-10-01-preview'
           }
@@ -99,10 +100,10 @@ module testDeployment '../../../main.bicep' = [
 module testProjectDeployment '../../../main.bicep' = [
   for (iteration, i) in ['init', 'idem']: {
     scope: resourceGroup
-    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-proj-${iteration}'
+    name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-proj-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}002'
-      location: resourceLocation
+      location: enforcedLocation
       sku: 'Basic'
       kind: 'Project'
       hubResourceId: testDeployment[i].outputs.resourceId


### PR DESCRIPTION
## Description

Hardcodes region when deploying AI Services, as not available in East Asia.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.machine-learning-services.workspace](https://github.com/cecheta/bicep-registry-modules/actions/workflows/avm.res.machine-learning-services.workspace.yml/badge.svg?branch=ai-region)](https://github.com/cecheta/bicep-registry-modules/actions/workflows/avm.res.machine-learning-services.workspace.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
