### PR TITLE
fix: Serverfarm: Disable AZ PSRule rule as not available in AVM subscription 

### DIFF
--- a/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
+++ b/avm/utilities/pipelines/staticValidation/psrule/ps-rule.yaml
@@ -81,3 +81,4 @@ rule:
     - Azure.VM.UseHybridUseBenefit
     - Azure.AppConfig.PurgeProtect
     - Azure.MySQL.MaintenanceWindow # Must be excluded until https://msdata.visualstudio.com/Database%20Systems/_workitems/edit/2788114 is fixed
+    - Azure.AppService.AvailabilityZone # Must disable as the serverfarm premium skus are not available in the AVM subscription. The module is WAF-aligned, just the tests don't validate it


### PR DESCRIPTION
## Description

The module implements a logic that automatically enables zones in a premium SKU is used. Those SKUs are unfortunately not available in the AVM subscription which is why we have to deploy the service in a standard SKU. Because that's not aligned with PSRule we have to disable the test in the PSRule settings.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|      [![avm.res.web.serverfarm](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml/badge.svg?branch=users%2Falsehr%2FserverFarmReliability&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml)    |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
