### PR TITLE
fix: Kusto Cluster - Fixed identity output 

### DIFF
--- a/avm/res/databricks/workspace/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/databricks/workspace/tests/e2e/defaults/main.test.bicep
@@ -43,6 +43,14 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: resourceLocation
+      test: {
+        primary: {
+          addressPrefixes: ['oi']
+        }
+        secondary: {
+          addressPrefixes: ['there']
+        }
+      }
     }
   }
 ]

--- a/avm/res/databricks/workspace/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/databricks/workspace/tests/e2e/defaults/main.test.bicep
@@ -43,14 +43,6 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: resourceLocation
-      test: {
-        primary: {
-          addressPrefixes: ['oi']
-        }
-        secondary: {
-          addressPrefixes: ['there']
-        }
-      }
     }
   }
 ]

--- a/avm/res/kusto/cluster/README.md
+++ b/avm/res/kusto/cluster/README.md
@@ -1699,7 +1699,6 @@ The resource ID of the subnet to which to deploy the Kusto Cluster.
 
 | Output | Type | Description |
 | :-- | :-- | :-- |
-| `identity` | object | The identity of the cluster. |
 | `location` | string | The location the resource was deployed into. |
 | `name` | string | The name of the kusto cluster. |
 | `privateEndpoints` | array | The private endpoints of the kusto cluster. |

--- a/avm/res/kusto/cluster/main.bicep
+++ b/avm/res/kusto/cluster/main.bicep
@@ -375,9 +375,6 @@ output name string = kustoCluster.name
 @description('The location the resource was deployed into.')
 output location string = kustoCluster.location
 
-@description('The identity of the cluster.')
-output identity object = kustoCluster.identity
-
 @description('The private endpoints of the kusto cluster.')
 output privateEndpoints array = [
   for (pe, i) in (!empty(privateEndpoints) ? array(privateEndpoints) : []): {

--- a/avm/res/kusto/cluster/main.json
+++ b/avm/res/kusto/cluster/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "9987903523872780142"
+      "templateHash": "17272299626990757362"
     },
     "name": "Kusto Cluster",
     "description": "This module deploys a Kusto Cluster.",
@@ -1976,13 +1976,6 @@
         "description": "The location the resource was deployed into."
       },
       "value": "[reference('kustoCluster', '2023-08-15', 'full').location]"
-    },
-    "identity": {
-      "type": "object",
-      "metadata": {
-        "description": "The identity of the cluster."
-      },
-      "value": "[reference('kustoCluster', '2023-08-15', 'full').identity]"
     },
     "privateEndpoints": {
       "type": "array",


### PR DESCRIPTION
## Description

The identity property does not always exist which is why the deployment fails for e.g. the defaults test.
I assume the primary reason to add it was to return the System-Assigned-Identity information which has its own separate output and the identity ouptut can hence be removed.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.res.kusto.cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kusto.cluster.yml/badge.svg?branch=users%2Falsehr%2FkustoMsiFix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kusto.cluster.yml)       |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
