### PR TITLE
fix: StorageAccount - Added implicit dependency to blobServices from container - `avm/res/storage/storage-account`

### DIFF
--- a/avm/res/storage/storage-account/blob-service/container/README.md
+++ b/avm/res/storage/storage-account/blob-service/container/README.md
@@ -34,6 +34,7 @@ This module deploys a Storage Account Blob Container.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`blobServiceName`](#parameter-blobservicename) | string | The name of the parent Blob Service. Required if the template is used in a standalone deployment. |
 | [`defaultEncryptionScope`](#parameter-defaultencryptionscope) | string | Default the container to use specified encryption scope for all writes. |
 | [`denyEncryptionScopeOverride`](#parameter-denyencryptionscopeoverride) | bool | Block override of encryption scope from the container default. |
 | [`enableNfsV3AllSquash`](#parameter-enablenfsv3allsquash) | bool | Enable NFSv3 all squash on blob container. |
@@ -58,6 +59,14 @@ The name of the parent Storage Account. Required if the template is used in a st
 
 - Required: Yes
 - Type: string
+
+### Parameter: `blobServiceName`
+
+The name of the parent Blob Service. Required if the template is used in a standalone deployment.
+
+- Required: No
+- Type: string
+- Default: `'default'`
 
 ### Parameter: `defaultEncryptionScope`
 

--- a/avm/res/storage/storage-account/blob-service/container/main.bicep
+++ b/avm/res/storage/storage-account/blob-service/container/main.bicep
@@ -6,6 +6,9 @@ metadata owner = 'Azure/module-maintainers'
 @description('Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment.')
 param storageAccountName string
 
+@description('Optional. The name of the parent Blob Service. Required if the template is used in a standalone deployment.')
+param blobServiceName string = 'default'
+
 @description('Required. The name of the storage container to deploy.')
 param name string
 
@@ -105,7 +108,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' existing 
   name: storageAccountName
 
   resource blobServices 'blobServices@2022-09-01' existing = {
-    name: 'default'
+    name: blobServiceName
   }
 }
 

--- a/avm/res/storage/storage-account/blob-service/container/main.json
+++ b/avm/res/storage/storage-account/blob-service/container/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "1020003258393866601"
+      "templateHash": "3558916747425087131"
     },
     "name": "Storage Account Blob Containers",
     "description": "This module deploys a Storage Account Blob Container.",
@@ -93,6 +93,13 @@
       "maxLength": 24,
       "metadata": {
         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
+      }
+    },
+    "blobServiceName": {
+      "type": "string",
+      "defaultValue": "default",
+      "metadata": {
+        "description": "Optional. The name of the parent Blob Service. Required if the template is used in a standalone deployment."
       }
     },
     "name": {
@@ -205,7 +212,7 @@
       "existing": true,
       "type": "Microsoft.Storage/storageAccounts/blobServices",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}/{1}', parameters('storageAccountName'), 'default')]",
+      "name": "[format('{0}/{1}', parameters('storageAccountName'), parameters('blobServiceName'))]",
       "dependsOn": [
         "storageAccount"
       ]
@@ -219,7 +226,7 @@
     "container": {
       "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}/{1}/{2}', parameters('storageAccountName'), 'default', parameters('name'))]",
+      "name": "[format('{0}/{1}/{2}', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name'))]",
       "properties": {
         "defaultEncryptionScope": "[if(not(empty(parameters('defaultEncryptionScope'))), parameters('defaultEncryptionScope'), null())]",
         "denyEncryptionScopeOverride": "[if(equals(parameters('denyEncryptionScopeOverride'), true()), parameters('denyEncryptionScopeOverride'), null())]",
@@ -240,8 +247,8 @@
       },
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
-      "scope": "[format('Microsoft.Storage/storageAccounts/{0}/blobServices/{1}/containers/{2}', parameters('storageAccountName'), 'default', parameters('name'))]",
-      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), 'default', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+      "scope": "[format('Microsoft.Storage/storageAccounts/{0}/blobServices/{1}/containers/{2}', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name'))]",
+      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
       "properties": {
         "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
         "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
@@ -387,7 +394,7 @@
       "metadata": {
         "description": "The resource ID of the deployed container."
       },
-      "value": "[resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), 'default', parameters('name'))]"
+      "value": "[resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name'))]"
     },
     "resourceGroupName": {
       "type": "string",

--- a/avm/res/storage/storage-account/blob-service/main.bicep
+++ b/avm/res/storage/storage-account/blob-service/main.bicep
@@ -149,6 +149,7 @@ module blobServices_container 'container/main.bicep' = [
     name: '${deployment().name}-Container-${index}'
     params: {
       storageAccountName: storageAccount.name
+      blobServiceName: blobServices.name
       name: container.name
       defaultEncryptionScope: container.?defaultEncryptionScope
       denyEncryptionScopeOverride: container.?denyEncryptionScopeOverride

--- a/avm/res/storage/storage-account/blob-service/main.json
+++ b/avm/res/storage/storage-account/blob-service/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "17077763197163073998"
+      "templateHash": "16657059190807174649"
     },
     "name": "Storage Account blob Services",
     "description": "This module deploys a Storage Account Blob Service.",
@@ -365,6 +365,9 @@
           "storageAccountName": {
             "value": "[parameters('storageAccountName')]"
           },
+          "blobServiceName": {
+            "value": "[variables('name')]"
+          },
           "name": {
             "value": "[coalesce(parameters('containers'), createArray())[copyIndex()].name]"
           },
@@ -404,7 +407,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.29.47.4906",
-              "templateHash": "1020003258393866601"
+              "templateHash": "3558916747425087131"
             },
             "name": "Storage Account Blob Containers",
             "description": "This module deploys a Storage Account Blob Container.",
@@ -491,6 +494,13 @@
               "maxLength": 24,
               "metadata": {
                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
+              }
+            },
+            "blobServiceName": {
+              "type": "string",
+              "defaultValue": "default",
+              "metadata": {
+                "description": "Optional. The name of the parent Blob Service. Required if the template is used in a standalone deployment."
               }
             },
             "name": {
@@ -603,7 +613,7 @@
               "existing": true,
               "type": "Microsoft.Storage/storageAccounts/blobServices",
               "apiVersion": "2022-09-01",
-              "name": "[format('{0}/{1}', parameters('storageAccountName'), 'default')]",
+              "name": "[format('{0}/{1}', parameters('storageAccountName'), parameters('blobServiceName'))]",
               "dependsOn": [
                 "storageAccount"
               ]
@@ -617,7 +627,7 @@
             "container": {
               "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
               "apiVersion": "2022-09-01",
-              "name": "[format('{0}/{1}/{2}', parameters('storageAccountName'), 'default', parameters('name'))]",
+              "name": "[format('{0}/{1}/{2}', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name'))]",
               "properties": {
                 "defaultEncryptionScope": "[if(not(empty(parameters('defaultEncryptionScope'))), parameters('defaultEncryptionScope'), null())]",
                 "denyEncryptionScopeOverride": "[if(equals(parameters('denyEncryptionScopeOverride'), true()), parameters('denyEncryptionScopeOverride'), null())]",
@@ -638,8 +648,8 @@
               },
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.Storage/storageAccounts/{0}/blobServices/{1}/containers/{2}', parameters('storageAccountName'), 'default', parameters('name'))]",
-              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), 'default', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+              "scope": "[format('Microsoft.Storage/storageAccounts/{0}/blobServices/{1}/containers/{2}', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name'))]",
+              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
               "properties": {
                 "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
                 "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
@@ -785,7 +795,7 @@
               "metadata": {
                 "description": "The resource ID of the deployed container."
               },
-              "value": "[resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), 'default', parameters('name'))]"
+              "value": "[resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name'))]"
             },
             "resourceGroupName": {
               "type": "string",
@@ -798,6 +808,7 @@
         }
       },
       "dependsOn": [
+        "blobServices",
         "storageAccount"
       ]
     }

--- a/avm/res/storage/storage-account/main.json
+++ b/avm/res/storage/storage-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "6735651687082765200"
+      "templateHash": "8986504733456130232"
     },
     "name": "Storage Accounts",
     "description": "This module deploys a Storage Account.",
@@ -2266,7 +2266,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.29.47.4906",
-              "templateHash": "17077763197163073998"
+              "templateHash": "16657059190807174649"
             },
             "name": "Storage Account blob Services",
             "description": "This module deploys a Storage Account Blob Service.",
@@ -2625,6 +2625,9 @@
                   "storageAccountName": {
                     "value": "[parameters('storageAccountName')]"
                   },
+                  "blobServiceName": {
+                    "value": "[variables('name')]"
+                  },
                   "name": {
                     "value": "[coalesce(parameters('containers'), createArray())[copyIndex()].name]"
                   },
@@ -2664,7 +2667,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.29.47.4906",
-                      "templateHash": "1020003258393866601"
+                      "templateHash": "3558916747425087131"
                     },
                     "name": "Storage Account Blob Containers",
                     "description": "This module deploys a Storage Account Blob Container.",
@@ -2751,6 +2754,13 @@
                       "maxLength": 24,
                       "metadata": {
                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
+                      }
+                    },
+                    "blobServiceName": {
+                      "type": "string",
+                      "defaultValue": "default",
+                      "metadata": {
+                        "description": "Optional. The name of the parent Blob Service. Required if the template is used in a standalone deployment."
                       }
                     },
                     "name": {
@@ -2863,7 +2873,7 @@
                       "existing": true,
                       "type": "Microsoft.Storage/storageAccounts/blobServices",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}/{1}', parameters('storageAccountName'), 'default')]",
+                      "name": "[format('{0}/{1}', parameters('storageAccountName'), parameters('blobServiceName'))]",
                       "dependsOn": [
                         "storageAccount"
                       ]
@@ -2877,7 +2887,7 @@
                     "container": {
                       "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}/{1}/{2}', parameters('storageAccountName'), 'default', parameters('name'))]",
+                      "name": "[format('{0}/{1}/{2}', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name'))]",
                       "properties": {
                         "defaultEncryptionScope": "[if(not(empty(parameters('defaultEncryptionScope'))), parameters('defaultEncryptionScope'), null())]",
                         "denyEncryptionScopeOverride": "[if(equals(parameters('denyEncryptionScopeOverride'), true()), parameters('denyEncryptionScopeOverride'), null())]",
@@ -2898,8 +2908,8 @@
                       },
                       "type": "Microsoft.Authorization/roleAssignments",
                       "apiVersion": "2022-04-01",
-                      "scope": "[format('Microsoft.Storage/storageAccounts/{0}/blobServices/{1}/containers/{2}', parameters('storageAccountName'), 'default', parameters('name'))]",
-                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), 'default', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                      "scope": "[format('Microsoft.Storage/storageAccounts/{0}/blobServices/{1}/containers/{2}', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
                       "properties": {
                         "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
                         "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
@@ -3045,7 +3055,7 @@
                       "metadata": {
                         "description": "The resource ID of the deployed container."
                       },
-                      "value": "[resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), 'default', parameters('name'))]"
+                      "value": "[resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name'))]"
                     },
                     "resourceGroupName": {
                       "type": "string",
@@ -3058,6 +3068,7 @@
                 }
               },
               "dependsOn": [
+                "blobServices",
                 "storageAccount"
               ]
             }


### PR DESCRIPTION
## Description

- Added implicit dependency to blobServices from container

Closes #3210


## Pipeline Reference

| Pipeline |
| -------- |
|    [![avm.res.storage.storage-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml/badge.svg?branch=users%2Falsehr%2FsaDep&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
