### PR TITLE
fix: Updated hub-network output

### DIFF
--- a/avm/ptn/network/hub-networking/README.md
+++ b/avm/ptn/network/hub-networking/README.md
@@ -1663,6 +1663,7 @@ Location for all Resources.
 | `hubBastions` | array | Array of hub bastion resources. |
 | `hubVirtualNetworks` | array | Array of hub virtual network resources. |
 | `hubVirtualNetworkSubnets` | array | The subnets of the hub virtual network. |
+| `resourceGroupName` | string | The resource group the resources were deployed into. |
 
 ## Cross-referenced modules
 

--- a/avm/ptn/network/hub-networking/main.bicep
+++ b/avm/ptn/network/hub-networking/main.bicep
@@ -23,6 +23,7 @@ var hubVirtualNetworkPeerings = [for (hub, index) in items(hubVirtualNetworks ??
 // Resources      //
 // ============== //
 
+#disable-next-line no-deployments-resources
 resource avmTelemetry 'Microsoft.Resources/deployments@2023-07-01' = if (enableTelemetry) {
   name: '46d3xbcp.ptn.network-hubnetworking.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
@@ -266,6 +267,9 @@ output hubAzureFirewalls object[] = [
 output hubVirtualNetworkSubnets array = [
   for (hub, index) in items(hubVirtualNetworks ?? {}): hubVirtualNetwork[index].outputs.subnetNames
 ]
+
+@description('The resource group the resources were deployed into.')
+output resourceGroupName string = resourceGroup().name
 
 // ================ //
 // Definitions      //

--- a/avm/ptn/network/hub-networking/main.json
+++ b/avm/ptn/network/hub-networking/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "4469274513824919483"
+      "templateHash": "9188161100861636713"
     },
     "name": "Hub Networking",
     "description": "This module is designed to simplify the creation of multi-region hub networks in Azure. It will create a number of virtual networks and subnets, and optionally peer them together in a mesh topology with routing.",
@@ -6894,6 +6894,13 @@
         "count": "[length(items(coalesce(parameters('hubVirtualNetworks'), createObject())))]",
         "input": "[reference(format('hubVirtualNetwork[{0}]', copyIndex())).outputs.subnetNames.value]"
       }
+    },
+    "resourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource group the resources were deployed into."
+      },
+      "value": "[resourceGroup().name]"
     }
   }
 }

--- a/avm/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/avm/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -1039,7 +1039,7 @@ Describe 'Module tests' -Tag 'Module' {
             }
 
             # ? remove ? or update specs
-            It '[<moduleFolderName>] Resource Group output should exist for resources that are deployed into a resource group scope.' -TestCases $moduleFolderTestCases {
+            It '[<moduleFolderName>] Resource Group output should exist for resources that are deployed into a resource group scope.' -TestCases ($moduleFolderTestCases | Where-Object { $_.moduleType -eq 'res' }) {
 
                 param(
                     [hashtable] $templateFileContent,
@@ -1059,7 +1059,7 @@ Describe 'Module tests' -Tag 'Module' {
                 }
             }
 
-            It '[<moduleFolderName>] Resource modules should have a name output.' -TestCases $moduleFolderTestCases {
+            It '[<moduleFolderName>] Resource modules should have a name output.' -TestCases ($moduleFolderTestCases | Where-Object { $_.moduleType -eq 'res' }) {
 
                 param(
                     [hashtable] $templateFileContent,
@@ -1092,7 +1092,7 @@ Describe 'Module tests' -Tag 'Module' {
                 $outputs | Should -Contain 'name'
             }
 
-            It '[<moduleFolderName>] Resource modules should have a Resource ID output.' -TestCases $moduleFolderTestCases {
+            It '[<moduleFolderName>] Resource modules should have a Resource ID output.' -TestCases ($moduleFolderTestCases | Where-Object { $_.moduleType -eq 'res' }) {
 
                 param(
                     [hashtable] $templateFileContent,
@@ -1126,7 +1126,7 @@ Describe 'Module tests' -Tag 'Module' {
                 $outputs | Should -Contain 'resourceId'
             }
 
-            It '[<moduleFolderName>] Resource modules Principal ID output should exist, if supported.' -TestCases $moduleFolderTestCases {
+            It '[<moduleFolderName>] Resource modules Principal ID output should exist, if supported.' -TestCases ($moduleFolderTestCases | Where-Object { $_.moduleType -eq 'res' }) {
 
                 param(
                     [hashtable] $templateFileContent

--- a/avm/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/avm/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -1039,7 +1039,7 @@ Describe 'Module tests' -Tag 'Module' {
             }
 
             # ? remove ? or update specs
-            It '[<moduleFolderName>] Resource Group output should exist for resources that are deployed into a resource group scope.' -TestCases ($moduleFolderTestCases | Where-Object { $_.moduleType -eq 'res' }) {
+            It '[<moduleFolderName>] Resource Group output should exist for resources that are deployed into a resource group scope.' -TestCases $moduleFolderTestCases {
 
                 param(
                     [hashtable] $templateFileContent,
@@ -1059,7 +1059,7 @@ Describe 'Module tests' -Tag 'Module' {
                 }
             }
 
-            It '[<moduleFolderName>] Resource modules should have a name output.' -TestCases ($moduleFolderTestCases | Where-Object { $_.moduleType -eq 'res' }) {
+            It '[<moduleFolderName>] Resource modules should have a name output.' -TestCases $moduleFolderTestCases {
 
                 param(
                     [hashtable] $templateFileContent,
@@ -1092,7 +1092,7 @@ Describe 'Module tests' -Tag 'Module' {
                 $outputs | Should -Contain 'name'
             }
 
-            It '[<moduleFolderName>] Resource modules should have a Resource ID output.' -TestCases ($moduleFolderTestCases | Where-Object { $_.moduleType -eq 'res' }) {
+            It '[<moduleFolderName>] Resource modules should have a Resource ID output.' -TestCases $moduleFolderTestCases {
 
                 param(
                     [hashtable] $templateFileContent,
@@ -1126,7 +1126,7 @@ Describe 'Module tests' -Tag 'Module' {
                 $outputs | Should -Contain 'resourceId'
             }
 
-            It '[<moduleFolderName>] Resource modules Principal ID output should exist, if supported.' -TestCases ($moduleFolderTestCases | Where-Object { $_.moduleType -eq 'res' }) {
+            It '[<moduleFolderName>] Resource modules Principal ID output should exist, if supported.' -TestCases $moduleFolderTestCases {
 
                 param(
                     [hashtable] $templateFileContent


### PR DESCRIPTION
## Description

Added missing resource group output to hub-network pattern module

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.ptn.network.hub-networking](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml/badge.svg?branch=users%2Falsehr%2FoutputTest&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml)       |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

