### PR TITLE
fix: `avm/ptn/deployment/import-image-to-acr` fixes bugs handling newImageName

### DIFF
--- a/avm/ptn/deployment-script/import-image-to-acr/README.md
+++ b/avm/ptn/deployment-script/import-image-to-acr/README.md
@@ -115,7 +115,7 @@ module importImageToAcr 'br/public:avm/ptn/deployment-script/import-image-to-acr
     cleanupPreference: 'OnExpiration'
     location: '<location>'
     managedIdentities: '<managedIdentities>'
-    newImageName: 'your-image-name:tag'
+    newImageName: 'application/your-image-name:tag'
     overwriteExistingImage: true
     storageAccountResourceId: '<storageAccountResourceId>'
     subnetResourceIds: '<subnetResourceIds>'
@@ -163,7 +163,7 @@ module importImageToAcr 'br/public:avm/ptn/deployment-script/import-image-to-acr
       "value": "<managedIdentities>"
     },
     "newImageName": {
-      "value": "your-image-name:tag"
+      "value": "application/your-image-name:tag"
     },
     "overwriteExistingImage": {
       "value": true
@@ -395,7 +395,7 @@ The new image name in the ACR. You can use this to import a publically available
 
 - Required: No
 - Type: string
-- Default: `[last(split(parameters('image'), '/'))]`
+- Default: `[string(skip(parameters('image'), add(indexOf(parameters('image'), '/'), 1)))]`
 - Example: `your-image-name:tag`
 
 ### Parameter: `overwriteExistingImage`

--- a/avm/ptn/deployment-script/import-image-to-acr/main.bicep
+++ b/avm/ptn/deployment-script/import-image-to-acr/main.bicep
@@ -47,7 +47,7 @@ param sourceRegistryPassword string = ''
 @metadata({
   example: 'your-image-name:tag'
 })
-param newImageName string = last(split(image, '/'))
+param newImageName string = string(skip(image, indexOf(image, '/') + 1))
 
 @description('Optional. The image will be overwritten if it already exists in the ACR with the same tag. Default is false.')
 param overwriteExistingImage bool = false
@@ -234,7 +234,9 @@ output deploymentScriptOutput string[] = imageImport.outputs.deploymentScriptLog
 @description('An array of the imported images.')
 output importedImage importedImageType = {
   originalImage: image
-  acrHostedImage: '${acr.properties.loginServer}${string(skip(image, indexOf(image,'/')))}'
+  acrHostedImage: empty(newImageName)
+    ? '${acr.properties.loginServer}${string(skip(image, indexOf(image,'/')))}'
+    : '${acr.properties.loginServer}/${newImageName}'
 }
 
 // ================ //

--- a/avm/ptn/deployment-script/import-image-to-acr/main.json
+++ b/avm/ptn/deployment-script/import-image-to-acr/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "15179702678978782456"
+      "templateHash": "13166673091432959100"
     },
     "name": "import-image-to-acr",
     "description": "This modules deployes an image to an Azure Container Registry.",
@@ -127,7 +127,7 @@
     },
     "newImageName": {
       "type": "string",
-      "defaultValue": "[last(split(parameters('image'), '/'))]",
+      "defaultValue": "[string(skip(parameters('image'), add(indexOf(parameters('image'), '/'), 1)))]",
       "metadata": {
         "example": "your-image-name:tag",
         "description": "Optional. The new image name in the ACR. You can use this to import a publically available image with a custom name for later updating from e.g., your build pipeline."
@@ -910,7 +910,7 @@
       },
       "value": {
         "originalImage": "[parameters('image')]",
-        "acrHostedImage": "[format('{0}{1}', reference('acr').loginServer, string(skip(parameters('image'), indexOf(parameters('image'), '/'))))]"
+        "acrHostedImage": "[if(empty(parameters('newImageName')), format('{0}{1}', reference('acr').loginServer, string(skip(parameters('image'), indexOf(parameters('image'), '/')))), format('{0}/{1}', reference('acr').loginServer, parameters('newImageName')))]"
       }
     }
   }

--- a/avm/ptn/deployment-script/import-image-to-acr/tests/e2e/max/main.test.bicep
+++ b/avm/ptn/deployment-script/import-image-to-acr/tests/e2e/max/main.test.bicep
@@ -69,7 +69,7 @@ module testDeployment '../../../main.bicep' = [
       // commented out, as the user is not available in the test environment
       // sourceRegistryUsername: 'username'
       // sourceRegistryPassword: keyVault.getSecret(dependencies.outputs.keyVaultSecretName)
-      newImageName: 'your-image-name:tag'
+      newImageName: 'application/your-image-name:tag'
       cleanupPreference: 'OnExpiration'
       assignRbacRole: true
       managedIdentities: { userAssignedResourcesIds: [dependencies.outputs.managedIdentityResourceId] }


### PR DESCRIPTION
## Description

Fixes bugs handling newImageName

Closes #3326 

## Pipeline Reference

| Pipeline |
| -------- |
|   [![avm.ptn.deployment-script.import-image-to-acr](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.ptn.deployment-script.import-image-to-acr.yml/badge.svg?branch=import-image-fixes)](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.ptn.deployment-script.import-image-to-acr.yml)       |

## Type of Change


- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
