### PR TITLE
fix: `prefixLength` minimum value in `avm/res/network/public-ip-prefix`

### DIFF
--- a/avm/res/network/public-ip-prefix/main.bicep
+++ b/avm/res/network/public-ip-prefix/main.bicep
@@ -10,7 +10,7 @@ param name string
 param location string = resourceGroup().location
 
 @description('Required. Length of the Public IP Prefix.')
-@minValue(28)
+@minValue(21)
 @maxValue(31)
 param prefixLength int
 

--- a/avm/res/network/public-ip-prefix/main.json
+++ b/avm/res/network/public-ip-prefix/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "2074867794511783977"
+      "version": "0.30.23.60470",
+      "templateHash": "13346619343009869073"
     },
     "name": "Public IP Prefixes",
     "description": "This module deploys a Public IP Prefix.",
@@ -129,7 +129,7 @@
     },
     "prefixLength": {
       "type": "int",
-      "minValue": 28,
+      "minValue": 21,
       "maxValue": 31,
       "metadata": {
         "description": "Required. Length of the Public IP Prefix."


### PR DESCRIPTION
## Description

Updates the minimum value of the `prefixLength` parameter to `/21` as per:
- https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-address-prefix

> If you are [deriving a Public IP Prefix from a Custom IP Prefix (BYOIP range)](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/manage-custom-ip-address-prefix#create-a-public-ip-prefix-from-a-custom-ip-prefix), the prefix size can be as large as the Custom IP Prefix.

- https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/custom-ip-address-prefix :
> A custom IPv4 Prefix must be between /21 and /24

Fixes #3367 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.network.public-ip-prefix](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-prefix.yml/badge.svg?branch=users%2Fkrbar%2FpfxFix)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-prefix.yml)     |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
