### PR TITLE
feat: DevOpsPool - Fixed parameter requirement for images

### DIFF
--- a/avm/res/dev-ops-infrastructure/pool/README.md
+++ b/avm/res/dev-ops-infrastructure/pool/README.md
@@ -604,11 +604,12 @@ The VM images of the machines in the pool.
 - Required: Yes
 - Type: array
 
-**Required parameters**
+**Conditional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`wellKnownImageName`](#parameter-imageswellknownimagename) | string | The image to use from a well-known set of images made available to customers. |
+| [`resourceId`](#parameter-imagesresourceid) | string | The specific resource id of the marketplace or compute gallery image. Required if `wellKnownImageName` is not set. |
+| [`wellKnownImageName`](#parameter-imageswellknownimagename) | string | The image to use from a well-known set of images made available to customers. Required if `resourceId` is not set. |
 
 **Optional parameters**
 
@@ -616,13 +617,19 @@ The VM images of the machines in the pool.
 | :-- | :-- | :-- |
 | [`aliases`](#parameter-imagesaliases) | array | List of aliases to reference the image by. |
 | [`buffer`](#parameter-imagesbuffer) | string | The percentage of the buffer to be allocated to this image. |
-| [`resourceId`](#parameter-imagesresourceid) | string | The resource id of the image. |
+
+### Parameter: `images.resourceId`
+
+The specific resource id of the marketplace or compute gallery image. Required if `wellKnownImageName` is not set.
+
+- Required: No
+- Type: string
 
 ### Parameter: `images.wellKnownImageName`
 
-The image to use from a well-known set of images made available to customers.
+The image to use from a well-known set of images made available to customers. Required if `resourceId` is not set.
 
-- Required: Yes
+- Required: No
 - Type: string
 
 ### Parameter: `images.aliases`
@@ -635,13 +642,6 @@ List of aliases to reference the image by.
 ### Parameter: `images.buffer`
 
 The percentage of the buffer to be allocated to this image.
-
-- Required: No
-- Type: string
-
-### Parameter: `images.resourceId`
-
-The resource id of the image.
 
 - Required: No
 - Type: string

--- a/avm/res/dev-ops-infrastructure/pool/main.bicep
+++ b/avm/res/dev-ops-infrastructure/pool/main.bicep
@@ -14,7 +14,7 @@ param fabricProfileSkuName string
 param concurrency int
 
 @description('Required. The VM images of the machines in the pool.')
-param images imageType
+param images imageType[]
 
 @description('Optional. The geo-location where the resource lives.')
 param location string = resourceGroup().location
@@ -279,12 +279,12 @@ type imageType = {
   @description('Optional. The percentage of the buffer to be allocated to this image.')
   buffer: string?
 
-  @description('Required. The image to use from a well-known set of images made available to customers.')
-  wellKnownImageName: string
+  @description('Conditional. The image to use from a well-known set of images made available to customers. Required if `resourceId` is not set.')
+  wellKnownImageName: string?
 
-  @description('Optional. The resource id of the image.')
+  @description('Conditional. The specific resource id of the marketplace or compute gallery image. Required if `wellKnownImageName` is not set.')
   resourceId: string?
-}[]
+}
 
 type organizationProfileType = {
   @description('Required. Azure DevOps organization profile.')

--- a/avm/res/dev-ops-infrastructure/pool/main.bicep
+++ b/avm/res/dev-ops-infrastructure/pool/main.bicep
@@ -235,6 +235,7 @@ output location string = managedDevOpsPool.location
 @description('The principal ID of the system assigned identity.')
 output systemAssignedMIPrincipalId string? = managedDevOpsPool.?identity.?principalId
 
+@export()
 type osProfileType = {
   @description('Required. The logon type of the machine.')
   logonType: ('Interactive' | 'Service')
@@ -252,6 +253,7 @@ type osProfileType = {
   }?
 }
 
+@export()
 type storageProfileType = {
   @description('Optional. The Azure SKU name of the machines in the pool.')
   osDiskStorageAccountType: ('Premium' | 'StandardSSD' | 'Standard')?
@@ -272,6 +274,7 @@ type storageProfileType = {
   }[]?
 }?
 
+@export()
 type imageType = {
   @description('Optional. List of aliases to reference the image by.')
   aliases: string[]?
@@ -286,6 +289,7 @@ type imageType = {
   resourceId: string?
 }
 
+@export()
 type organizationProfileType = {
   @description('Required. Azure DevOps organization profile.')
   kind: 'AzureDevOps'
@@ -317,6 +321,7 @@ type organizationProfileType = {
   }[]
 }
 
+@export()
 type dataDiskType = {
   @description('Optional. The type of caching to be enabled for the data disks. The default value for caching is readwrite. For information about the caching options see: https://blogs.msdn.microsoft.com/windowsazurestorage/2012/06/27/exploring-windows-azure-drives-disks-and-images/.')
   caching: ('None' | 'ReadOnly' | 'ReadWrite')?
@@ -331,6 +336,7 @@ type dataDiskType = {
   storageAccountType: ('Premium_LRS' | 'Premium_ZRS' | 'StandardSSD_LRS' | 'StandardSSD_ZRS' | 'Standard_LRS')?
 }[]?
 
+@export()
 type resourcePredictionsProfileAutomaticType = {
   @description('Required. The stand-by agent scheme is determined based on historical demand.')
   kind: 'Automatic'
@@ -339,11 +345,13 @@ type resourcePredictionsProfileAutomaticType = {
   predictionPreference: 'Balanced' | 'MostCostEffective' | 'MoreCostEffective' | 'MorePerformance' | 'BestPerformance'
 }
 
+@export()
 type resourcePredictionsProfileManualType = {
   @description('Required. Customer provides the stand-by agent scheme.')
   kind: 'Manual'
 }
 
+@export()
 type agentStatefulType = {
   @description('Required. Stateful profile meaning that the machines will be returned to the pool after running a job.')
   kind: 'Stateful'
@@ -362,6 +370,7 @@ type agentStatefulType = {
   resourcePredictionsProfile: (resourcePredictionsProfileAutomaticType | resourcePredictionsProfileManualType)?
 }
 
+@export()
 type agentStatelessType = {
   @description('Required. Stateless profile meaning that the machines will be cleaned up after running a job.')
   kind: 'Stateless'
@@ -400,8 +409,10 @@ type agentStatelessType = {
 }
 
 @discriminator('kind')
+@export()
 type agentProfileType = agentStatefulType | agentStatelessType
 
+@export()
 type roleAssignmentType = {
   @description('Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated.')
   name: string?
@@ -428,6 +439,7 @@ type roleAssignmentType = {
   delegatedManagedIdentityResourceId: string?
 }[]?
 
+@export()
 type lockType = {
   @description('Optional. Specify the name of lock.')
   name: string?
@@ -436,6 +448,7 @@ type lockType = {
   kind: ('CanNotDelete' | 'ReadOnly' | 'None')?
 }?
 
+@export()
 type diagnosticSettingType = {
   @description('Optional. The name of diagnostic setting.')
   name: string?
@@ -480,6 +493,7 @@ type diagnosticSettingType = {
   marketplacePartnerResourceId: string?
 }[]?
 
+@export()
 type managedIdentitiesType = {
   @description('Optional. Enables system assigned managed identity on the resource.')
   systemAssigned: bool?

--- a/avm/res/dev-ops-infrastructure/pool/main.json
+++ b/avm/res/dev-ops-infrastructure/pool/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "3502193398932835678"
+      "templateHash": "2381525425502965594"
     },
     "name": "Managed DevOps Pool",
     "description": "This module deploys the Managed DevOps Pool resource.",
@@ -130,39 +130,37 @@
       "nullable": true
     },
     "imageType": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "aliases": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. List of aliases to reference the image by."
-            }
+      "type": "object",
+      "properties": {
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "buffer": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The percentage of the buffer to be allocated to this image."
-            }
-          },
-          "wellKnownImageName": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The image to use from a well-known set of images made available to customers."
-            }
-          },
-          "resourceId": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The resource id of the image."
-            }
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. List of aliases to reference the image by."
+          }
+        },
+        "buffer": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The percentage of the buffer to be allocated to this image."
+          }
+        },
+        "wellKnownImageName": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Conditional. The image to use from a well-known set of images made available to customers. Required if `resourceId` is not set."
+          }
+        },
+        "resourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Conditional. The specific resource id of the marketplace or compute gallery image. Required if `wellKnownImageName` is not set."
           }
         }
       }
@@ -734,7 +732,10 @@
       }
     },
     "images": {
-      "$ref": "#/definitions/imageType",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/imageType"
+      },
       "metadata": {
         "description": "Required. The VM images of the machines in the pool."
       }

--- a/avm/res/dev-ops-infrastructure/pool/main.json
+++ b/avm/res/dev-ops-infrastructure/pool/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "2381525425502965594"
+      "templateHash": "14560645908978883645"
     },
     "name": "Managed DevOps Pool",
     "description": "This module deploys the Managed DevOps Pool resource.",
@@ -57,6 +57,9 @@
             "description": "Optional. The secret management settings of the machines in the pool."
           }
         }
+      },
+      "metadata": {
+        "__bicep_export!": true
       }
     },
     "storageProfileType": {
@@ -127,7 +130,10 @@
           }
         }
       },
-      "nullable": true
+      "nullable": true,
+      "metadata": {
+        "__bicep_export!": true
+      }
     },
     "imageType": {
       "type": "object",
@@ -163,6 +169,9 @@
             "description": "Conditional. The specific resource id of the marketplace or compute gallery image. Required if `wellKnownImageName` is not set."
           }
         }
+      },
+      "metadata": {
+        "__bicep_export!": true
       }
     },
     "organizationProfileType": {
@@ -253,6 +262,9 @@
             "description": "Required. The list of Azure DevOps organizations the pool should be present in.."
           }
         }
+      },
+      "metadata": {
+        "__bicep_export!": true
       }
     },
     "dataDiskType": {
@@ -302,7 +314,10 @@
           }
         }
       },
-      "nullable": true
+      "nullable": true,
+      "metadata": {
+        "__bicep_export!": true
+      }
     },
     "resourcePredictionsProfileAutomaticType": {
       "type": "object",
@@ -329,6 +344,9 @@
             "description": "Required. Determines the balance between cost and performance."
           }
         }
+      },
+      "metadata": {
+        "__bicep_export!": true
       }
     },
     "resourcePredictionsProfileManualType": {
@@ -343,6 +361,9 @@
             "description": "Required. Customer provides the stand-by agent scheme."
           }
         }
+      },
+      "metadata": {
+        "__bicep_export!": true
       }
     },
     "agentStatefulType": {
@@ -394,6 +415,9 @@
             "description": "Optional. Determines how the stand-by scheme should be provided."
           }
         }
+      },
+      "metadata": {
+        "__bicep_export!": true
       }
     },
     "agentStatelessType": {
@@ -452,6 +476,9 @@
             "description": "Optional. Determines how the stand-by scheme should be provided."
           }
         }
+      },
+      "metadata": {
+        "__bicep_export!": true
       }
     },
     "agentProfileType": {
@@ -466,6 +493,9 @@
             "$ref": "#/definitions/agentStatelessType"
           }
         }
+      },
+      "metadata": {
+        "__bicep_export!": true
       }
     },
     "roleAssignmentType": {
@@ -539,7 +569,10 @@
           }
         }
       },
-      "nullable": true
+      "nullable": true,
+      "metadata": {
+        "__bicep_export!": true
+      }
     },
     "lockType": {
       "type": "object",
@@ -564,7 +597,10 @@
           }
         }
       },
-      "nullable": true
+      "nullable": true,
+      "metadata": {
+        "__bicep_export!": true
+      }
     },
     "diagnosticSettingType": {
       "type": "array",
@@ -684,7 +720,10 @@
           }
         }
       },
-      "nullable": true
+      "nullable": true,
+      "metadata": {
+        "__bicep_export!": true
+      }
     },
     "managedIdentitiesType": {
       "type": "object",
@@ -707,7 +746,10 @@
           }
         }
       },
-      "nullable": true
+      "nullable": true,
+      "metadata": {
+        "__bicep_export!": true
+      }
     }
   },
   "parameters": {


### PR DESCRIPTION
## Description

Fixed the requirement for the image parameter to allow the usage of a compute gallery image

@elizatar

Example from portal deployment

![image](https://github.com/user-attachments/assets/d6a304eb-bc27-4d71-8411-cd62eeb42e2b)

Exported JSON
```json
"images": [
    {
        "resourceId": "/Subscriptions/b765c5e5-ae60-4724-9b59-36fbcf56795b/Providers/Microsoft.Compute/Locations/westeurope/publishers/microsoftwindowsdesktop/artifacttypes/vmimage/offers/windows-11/skus/win11-22h2-pro/versions/latest",
        "buffer": "*"
    },
    {
        "wellKnownImageName": "ubuntu-22.04/latest",
        "buffer": "*",
        "aliases": [
            "ubuntu-22.04"
        ]
    },
    {
        "resourceId": "/subscriptions/b765c5e5-ae60-4724-9b59-36fbcf56795b/resourceGroups/rg-ado-agents/providers/Microsoft.Compute/galleries/galaib/images/sid-linux/versions/latest",
        "buffer": "*"
    }
]
```

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.dev-ops-infrastructure.pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-ops-infrastructure.pool.yml/badge.svg?branch=users%2Falsehr%2FdevopsPoolImageFix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-ops-infrastructure.pool.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
