### PR TITLE
fix: Fixed use of Gallery-Image SecurityType parameter value 'Standard' and added additional types 

### DIFF
--- a/avm/res/compute/gallery/README.md
+++ b/avm/res/compute/gallery/README.md
@@ -206,7 +206,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
           product: 'testProduct'
           publisher: 'testPublisher'
         }
-        securityType: 'TrustedLaunch'
+        securityType: 'Standard'
         vCPUs: {
           max: 8
           min: 2
@@ -436,7 +436,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
             "product": "testProduct",
             "publisher": "testPublisher"
           },
-          "securityType": "TrustedLaunch",
+          "securityType": "Standard",
           "vCPUs": {
             "max": 8,
             "min": 2
@@ -668,7 +668,7 @@ param images = [
       product: 'testProduct'
       publisher: 'testPublisher'
     }
-    securityType: 'TrustedLaunch'
+    securityType: 'Standard'
     vCPUs: {
       max: 8
       min: 2
@@ -1243,6 +1243,8 @@ The security type of the image. Requires a hyperVGeneration V2. Defaults to `Sta
     'ConfidentialVMSupported'
     'Standard'
     'TrustedLaunch'
+    'TrustedLaunchAndConfidentialVmSupported'
+    'TrustedLaunchSupported'
   ]
   ```
 

--- a/avm/res/compute/gallery/application/main.json
+++ b/avm/res/compute/gallery/application/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "7960057132021914503"
+      "version": "0.30.23.60470",
+      "templateHash": "13081960860160182257"
     },
     "name": "Compute Galleries Applications",
     "description": "This module deploys an Azure Compute Gallery Application.",

--- a/avm/res/compute/gallery/image/README.md
+++ b/avm/res/compute/gallery/image/README.md
@@ -432,6 +432,8 @@ The security type of the image. Requires a hyperVGeneration V2.
     'ConfidentialVMSupported'
     'Standard'
     'TrustedLaunch'
+    'TrustedLaunchAndConfidentialVmSupported'
+    'TrustedLaunchSupported'
   ]
   ```
 

--- a/avm/res/compute/gallery/image/main.bicep
+++ b/avm/res/compute/gallery/image/main.bicep
@@ -39,7 +39,13 @@ param memory resourceRangeType = { min: 4, max: 16 }
 param releaseNoteUri string?
 
 @sys.description('Optional. The security type of the image. Requires a hyperVGeneration V2.')
-param securityType ('Standard' | 'TrustedLaunch' | 'ConfidentialVM' | 'ConfidentialVMSupported')?
+param securityType (
+  | 'Standard'
+  | 'ConfidentialVM'
+  | 'TrustedLaunchSupported'
+  | 'TrustedLaunch'
+  | 'TrustedLaunchAndConfidentialVmSupported'
+  | 'ConfidentialVMSupported')?
 
 @sys.description('Optional. Specify if the image supports accelerated networking.')
 param isAcceleratedNetworkSupported bool = true
@@ -132,7 +138,7 @@ resource image 'Microsoft.Compute/galleries/images@2023-07-03' = {
           value: '${isAcceleratedNetworkSupported}'
         }
       ],
-      (securityType != null
+      (securityType != null && securityType != 'Standard' // Standard is the default and is not set
         ? [
             {
               name: 'SecurityType'

--- a/avm/res/compute/gallery/image/main.json
+++ b/avm/res/compute/gallery/image/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "17284709546040050431"
+      "version": "0.30.23.60470",
+      "templateHash": "5984025187928110337"
     },
     "name": "Compute Galleries Image Definitions",
     "description": "This module deploys an Azure Compute Gallery Image Definition.",
@@ -275,7 +275,9 @@
         "ConfidentialVM",
         "ConfidentialVMSupported",
         "Standard",
-        "TrustedLaunch"
+        "TrustedLaunch",
+        "TrustedLaunchAndConfidentialVmSupported",
+        "TrustedLaunchSupported"
       ],
       "nullable": true,
       "metadata": {
@@ -399,7 +401,7 @@
         },
         "endOfLifeDate": "[parameters('endOfLifeDate')]",
         "eula": "[parameters('eula')]",
-        "features": "[union(createArray(createObject('name', 'IsAcceleratedNetworkSupported', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), if(not(equals(parameters('securityType'), null())), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
+        "features": "[union(createArray(createObject('name', 'IsAcceleratedNetworkSupported', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
         "hyperVGeneration": "[coalesce(parameters('hyperVGeneration'), if(not(empty(coalesce(parameters('securityType'), ''))), 'V2', 'V1'))]",
         "identifier": {
           "publisher": "[parameters('identifier').publisher]",

--- a/avm/res/compute/gallery/main.bicep
+++ b/avm/res/compute/gallery/main.bicep
@@ -214,6 +214,7 @@ output imageResourceIds array = [
 //   Definitions   //
 // =============== //
 
+@export()
 type lockType = {
   @sys.description('Optional. Specify the name of lock.')
   name: string?
@@ -222,6 +223,7 @@ type lockType = {
   kind: ('CanNotDelete' | 'ReadOnly' | 'None')?
 }
 
+@export()
 type roleAssignmentType = {
   @sys.description('Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated.')
   name: string?
@@ -249,6 +251,8 @@ type roleAssignmentType = {
 }[]
 
 import { identifierType, purchasePlanType, resourceRangeType } from './image/main.bicep'
+
+@export()
 type imageType = {
   @sys.description('Required. Name of the image definition.')
   @minLength(1)
@@ -277,7 +281,13 @@ type imageType = {
   hyperVGeneration: ('V1' | 'V2')?
 
   @sys.description('Optional. The security type of the image. Requires a hyperVGeneration V2. Defaults to `Standard`.')
-  securityType: ('Standard' | 'TrustedLaunch' | 'ConfidentialVM' | 'ConfidentialVMSupported')?
+  securityType: (
+    | 'Standard'
+    | 'ConfidentialVM'
+    | 'TrustedLaunchSupported'
+    | 'TrustedLaunch'
+    | 'TrustedLaunchAndConfidentialVmSupported'
+    | 'ConfidentialVMSupported')?
 
   @sys.description('Optional. Specify if the image supports accelerated networking. Defaults to true.')
   isAcceleratedNetworkSupported: bool?

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "16056066182123599311"
+      "version": "0.30.23.60470",
+      "templateHash": "17783194818453553981"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery).",
@@ -35,6 +35,9 @@
             "description": "Optional. Specify the type of lock."
           }
         }
+      },
+      "metadata": {
+        "__bicep_export!": true
       }
     },
     "roleAssignmentType": {
@@ -107,6 +110,9 @@
             }
           }
         }
+      },
+      "metadata": {
+        "__bicep_export!": true
       }
     },
     "imageType": {
@@ -184,7 +190,9 @@
             "ConfidentialVM",
             "ConfidentialVMSupported",
             "Standard",
-            "TrustedLaunch"
+            "TrustedLaunch",
+            "TrustedLaunchAndConfidentialVmSupported",
+            "TrustedLaunchSupported"
           ],
           "nullable": true,
           "metadata": {
@@ -261,6 +269,9 @@
             "description": "Optional. Describes the disallowed disk types."
           }
         }
+      },
+      "metadata": {
+        "__bicep_export!": true
       }
     },
     "identifierType": {
@@ -573,8 +584,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "7960057132021914503"
+              "version": "0.30.23.60470",
+              "templateHash": "13081960860160182257"
             },
             "name": "Compute Galleries Applications",
             "description": "This module deploys an Azure Compute Gallery Application.",
@@ -934,8 +945,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "17284709546040050431"
+              "version": "0.30.23.60470",
+              "templateHash": "5984025187928110337"
             },
             "name": "Compute Galleries Image Definitions",
             "description": "This module deploys an Azure Compute Gallery Image Definition.",
@@ -1204,7 +1215,9 @@
                 "ConfidentialVM",
                 "ConfidentialVMSupported",
                 "Standard",
-                "TrustedLaunch"
+                "TrustedLaunch",
+                "TrustedLaunchAndConfidentialVmSupported",
+                "TrustedLaunchSupported"
               ],
               "nullable": true,
               "metadata": {
@@ -1328,7 +1341,7 @@
                 },
                 "endOfLifeDate": "[parameters('endOfLifeDate')]",
                 "eula": "[parameters('eula')]",
-                "features": "[union(createArray(createObject('name', 'IsAcceleratedNetworkSupported', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), if(not(equals(parameters('securityType'), null())), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
+                "features": "[union(createArray(createObject('name', 'IsAcceleratedNetworkSupported', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
                 "hyperVGeneration": "[coalesce(parameters('hyperVGeneration'), if(not(empty(coalesce(parameters('securityType'), ''))), 'V2', 'V1'))]",
                 "identifier": {
                   "publisher": "[parameters('identifier').publisher]",

--- a/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
@@ -135,7 +135,7 @@ module testDeployment '../../../main.bicep' = [
         }
         {
           name: '${namePrefix}-az-imgd-wdtl-003'
-          securityType: 'TrustedLaunch'
+          securityType: 'Standard'
           osType: 'Windows'
           osState: 'Generalized'
           hyperVGeneration: 'V2'


### PR DESCRIPTION
## Description

- Fixed use of Gallery-Image SecurityType parameter value 'Standard' ('Standard' should not be set)
- Added additional types 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|       [![avm.res.compute.gallery](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml/badge.svg?branch=users%2Falsehr%2FgallerySecurityType&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml)   |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
