### PR TITLE
fix: Added `Microsoft.DevOpsInfrastructure/pools` to removal order

### DIFF
--- a/avm/utilities/pipelines/e2eValidation/resourceRemoval/Initialize-DeploymentRemoval.ps1
+++ b/avm/utilities/pipelines/e2eValidation/resourceRemoval/Initialize-DeploymentRemoval.ps1
@@ -94,6 +94,7 @@ function Initialize-DeploymentRemoval {
             'Microsoft.ContainerInstance/containerGroups' # Must be removed before their MSI
             'Microsoft.ManagedIdentity/userAssignedIdentities',
             'Microsoft.Databricks/workspaces'
+            'Microsoft.DevOpsInfrastructure/pools' # Must be removed before other resources it depends on like a virtual network
             'Microsoft.Resources/resourceGroups'
         )
 


### PR DESCRIPTION
## Description

After observing [a few times](https://github.com/Azure/bicep-registry-modules/actions/runs/11297815667/job/31425540661#step:4:887) that the removal job for the module `Microsoft.DevOpsInfrastructure/pools` failed, I figured it is time to add it to the removal order.
The error usually happens when the removal logic tries to remove the RG before the Pool - presumably because it breaks the resource's dependencies (e.g., its VNET) and in turn leaves the resource also in a broken, unremovable state.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.dev-ops-infrastructure.pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-ops-infrastructure.pool.yml/badge.svg?branch=users%2Falsehr%2FmanagedDevOpsRemovalORder&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-ops-infrastructure.pool.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation