### PR TITLE
feat: Removed explicit 'latest' pwsh installation for `Set-EnvironmentOnAgent` script

### DIFF
--- a/avm/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
+++ b/avm/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
@@ -18,6 +18,9 @@ Required. Modules to be installed, must be Object
 .PARAMETER InstalledModule
 Optional. Modules that are already installed on the machine. Can be fetched via 'Get-Module -ListAvailable'
 
+.PARAMETER InstallLatestPwshVersion
+Optional. Enable to install the latest PowerShell version
+
 .EXAMPLE
 Install-CustomModule @{ Name = 'Pester' } C:\Modules
 
@@ -31,7 +34,10 @@ function Install-CustomModule {
         [Hashtable] $Module,
 
         [Parameter(Mandatory = $false)]
-        [object[]] $InstalledModule = @()
+        [object[]] $InstalledModule = @(),
+
+        [Parameter(Mandatory = $false)]
+        [switch] $InstallLatestPwshVersion
     )
 
     # Remove exsisting module in session
@@ -258,4 +264,23 @@ function Set-EnvironmentOnAgent {
     }
 
     Write-Verbose ('Install-CustomModule end') -Verbose
+}
+
+if ($InstallLatestPwshVersion) {
+    Write-Verbose '=======================' -Verbose
+    Write-Verbose 'PowerShell installation' -Verbose
+    Write-Verbose '=======================' -Verbose
+
+    # Update the list of packages
+    sudo apt-get update
+    # Install pre-requisite packages.
+    sudo apt-get install -y wget apt-transport-https software-properties-common
+    # Download the Microsoft repository GPG keys
+    wget -q "https://packages.microsoft.com/config/ubuntu/`$(lsb_release -rs)/packages-microsoft-prod.deb"
+    # Register the Microsoft repository GPG keys
+    sudo dpkg -i packages-microsoft-prod.deb
+    # Update the list of packages after we added packages.microsoft.com
+    sudo apt-get update
+    # Install PowerShell
+    sudo apt-get install -y powershell
 }

--- a/avm/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
+++ b/avm/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
@@ -258,21 +258,4 @@ function Set-EnvironmentOnAgent {
     }
 
     Write-Verbose ('Install-CustomModule end') -Verbose
-
-    #####################################
-    ##  TEMP PowerShell installation   ##
-    #####################################
-
-    # Update the list of packages
-    sudo apt-get update
-    # Install pre-requisite packages.
-    sudo apt-get install -y wget apt-transport-https software-properties-common
-    # Download the Microsoft repository GPG keys
-    wget -q "https://packages.microsoft.com/config/ubuntu/`$(lsb_release -rs)/packages-microsoft-prod.deb"
-    # Register the Microsoft repository GPG keys
-    sudo dpkg -i packages-microsoft-prod.deb
-    # Update the list of packages after we added packages.microsoft.com
-    sudo apt-get update
-    # Install PowerShell
-    sudo apt-get install -y powershell
 }

--- a/avm/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
+++ b/avm/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
@@ -18,9 +18,6 @@ Required. Modules to be installed, must be Object
 .PARAMETER InstalledModule
 Optional. Modules that are already installed on the machine. Can be fetched via 'Get-Module -ListAvailable'
 
-.PARAMETER InstallLatestPwshVersion
-Optional. Enable to install the latest PowerShell version
-
 .EXAMPLE
 Install-CustomModule @{ Name = 'Pester' } C:\Modules
 
@@ -34,10 +31,7 @@ function Install-CustomModule {
         [Hashtable] $Module,
 
         [Parameter(Mandatory = $false)]
-        [object[]] $InstalledModule = @(),
-
-        [Parameter(Mandatory = $false)]
-        [switch] $InstallLatestPwshVersion
+        [object[]] $InstalledModule = @()
     )
 
     # Remove exsisting module in session
@@ -120,6 +114,9 @@ Optional. The PowerShell modules that should be installed on the agent.
     }
 )
 
+.PARAMETER InstallLatestPwshVersion
+Optional. Enable to install the latest PowerShell version
+
 .EXAMPLE
 Set-EnvironmentOnAgent
 
@@ -139,7 +136,10 @@ function Set-EnvironmentOnAgent {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
-        [Hashtable[]] $PSModules = @()
+        [Hashtable[]] $PSModules = @(),
+
+        [Parameter(Mandatory = $false)]
+        [switch] $InstallLatestPwshVersion
     )
 
     ############################


### PR DESCRIPTION
## Description

- Removed explicit 'latest' pwsh installation for `Set-EnvironmentOnAgent` script
- The original issue was rooted in an issue with pwsh version `7.2.9` which was fixed fast, but the version not updated on the agents for the longest time. Now, the pre-installed pwsh version is 7.4.*, rendering the installation redundant (and could actually lead to issues)

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.ptn.aca-lza.hosting-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.aca-lza.hosting-environment.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.aca-lza.hosting-environment.yml)
[![avm.ptn.ai-platform.baseline](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.ai-platform.baseline.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.ai-platform.baseline.yml)
[![avm.ptn.authorization.policy-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-assignment.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-assignment.yml)
[![avm.ptn.authorization.resource-role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.resource-role-assignment.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.resource-role-assignment.yml)
[![avm.ptn.authorization.role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-assignment.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-assignment.yml)
[![avm.ptn.azd.acr-container-app](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.acr-container-app.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.acr-container-app.yml)
[![avm.ptn.azd.aks](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks.yml)      
[![avm.ptn.azd.apim-api](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.apim-api.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.apim-api.yml)
[![avm.ptn.azd.container-app-upsert](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-app-upsert.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-app-upsert.yml)
[![avm.ptn.azd.container-apps-stack](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-apps-stack.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-apps-stack.yml)
[![avm.ptn.azd.insights-dashboard](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.insights-dashboard.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.insights-dashboard.yml)
[![avm.ptn.azd.ml-ai-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.ml-ai-environment.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.ml-ai-environment.yml)
[![avm.ptn.azd.ml-hub-dependencies](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.ml-hub-dependencies.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.ml-hub-dependencies.yml)
[![avm.ptn.azd.ml-project](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.ml-project.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.ml-project.yml)
[![avm.ptn.azd.monitoring](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.monitoring.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.monitoring.yml)
[![avm.ptn.deployment-script.import-image-to-acr](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.deployment-script.import-image-to-acr.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.deployment-script.import-image-to-acr.yml) (unrelated WAF)
[![avm.ptn.dev-ops.cicd-agents-and-runners](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.dev-ops.cicd-agents-and-runners.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.dev-ops.cicd-agents-and-runners.yml)
[![avm.ptn.finops-toolkit.finops-hub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.finops-toolkit.finops-hub.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.finops-toolkit.finops-hub.yml)
[![avm.ptn.lz.sub-vending](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml)
[![avm.ptn.network.hub-networking](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml) (unrelated WAF)
[![avm.ptn.network.private-link-private-dns-zones](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.private-link-private-dns-zones.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.private-link-private-dns-zones.yml)
[![avm.ptn.policy-insights.remediation](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.policy-insights.remediation.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.policy-insights.remediation.yml)
[![avm.ptn.security.security-center](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.security.security-center.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.security.security-center.yml)
[![avm.ptn.virtual-machine-images.azure-image-builder](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml)
[![avm.res.aad.domain-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.aad.domain-service.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.aad.domain-service.yml)
[![avm.res.alerts-management.action-rule](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.alerts-management.action-rule.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.alerts-management.action-rule.yml)
[![avm.res.analysis-services.server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml)
[![avm.res.api-management.service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.api-management.service.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.api-management.service.yml)
[![avm.res.app-configuration.configuration-store](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app-configuration.configuration-store.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app-configuration.configuration-store.yml)
[![avm.res.app.container-app](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.container-app.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.container-app.yml)
[![avm.res.app.job](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.job.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.job.yml)      
[![avm.res.app.managed-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.managed-environment.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.managed-environment.yml)
[![avm.res.automation.automation-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml)
[![avm.res.batch.batch-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.batch.batch-account.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.batch.batch-account.yml)
[![avm.res.cache.redis](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cache.redis.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cache.redis.yml)
[![avm.res.cdn.profile](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml)
[![avm.res.cognitive-services.account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml)
[![avm.res.communication.communication-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.communication-service.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.communication-service.yml)
[![avm.res.communication.email-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.email-service.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.email-service.yml)
[![avm.res.compute.availability-set](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.availability-set.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.availability-set.yml)
[![avm.res.compute.disk-encryption-set](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk-encryption-set.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk-encryption-set.yml)
[![avm.res.compute.disk](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk.yml)
[![avm.res.compute.gallery](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml)
[![avm.res.compute.image](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.image.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.image.yml)
[![avm.res.compute.proximity-placement-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.proximity-placement-group.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.proximity-placement-group.yml)
[![avm.res.compute.ssh-public-key](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.ssh-public-key.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.ssh-public-key.yml)
[![avm.res.compute.virtual-machine-scale-set](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine-scale-set.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine-scale-set.yml)
[![avm.res.compute.virtual-machine](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine.yml)
[![avm.res.consumption.budget](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.consumption.budget.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.consumption.budget.yml)
[![avm.res.container-instance.container-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-instance.container-group.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-instance.container-group.yml)
[![avm.res.container-registry.registry](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-registry.registry.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-registry.registry.yml)
[![avm.res.container-service.managed-cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-service.managed-cluster.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-service.managed-cluster.yml)
[![avm.res.data-factory.factory](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.data-factory.factory.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.data-factory.factory.yml)
[![avm.res.data-protection.backup-vault](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.data-protection.backup-vault.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.data-protection.backup-vault.yml)
[![avm.res.databricks.access-connector](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.access-connector.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.access-connector.yml)
[![avm.res.databricks.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.workspace.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.workspace.yml)
[![avm.res.db-for-my-sql.flexible-server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.db-for-my-sql.flexible-server.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.db-for-my-sql.flexible-server.yml)
[![avm.res.db-for-postgre-sql.flexible-server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.db-for-postgre-sql.flexible-server.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.db-for-postgre-sql.flexible-server.yml)
[![avm.res.desktop-virtualization.application-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.application-group.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.application-group.yml)
[![avm.res.desktop-virtualization.host-pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.host-pool.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.host-pool.yml)
[![avm.res.desktop-virtualization.scaling-plan](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.scaling-plan.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.scaling-plan.yml)
[![avm.res.desktop-virtualization.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.workspace.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.workspace.yml)
[![avm.res.dev-ops-infrastructure.pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-ops-infrastructure.pool.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-ops-infrastructure.pool.yml)
[![avm.res.dev-test-lab.lab](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-test-lab.lab.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-test-lab.lab.yml) (unrelated WAF + broken template)
[![avm.res.digital-twins.digital-twins-instance](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.digital-twins.digital-twins-instance.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.digital-twins.digital-twins-instance.yml)
[![avm.res.document-db.database-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.document-db.database-account.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.document-db.database-account.yml)
[![avm.res.document-db.mongo-cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.document-db.mongo-cluster.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.document-db.mongo-cluster.yml)
[![avm.res.event-grid.domain](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.domain.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.domain.yml)
[![avm.res.event-grid.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.namespace.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.namespace.yml)
[![avm.res.event-grid.system-topic](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.system-topic.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.system-topic.yml)
[![avm.res.event-grid.topic](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.topic.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.topic.yml)
[![avm.res.event-hub.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-hub.namespace.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-hub.namespace.yml)
[![avm.res.fabric.capacity](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.fabric.capacity.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.fabric.capacity.yml)
[![avm.res.health-bot.health-bot](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.health-bot.health-bot.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.health-bot.health-bot.yml)
[![avm.res.healthcare-apis.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.healthcare-apis.workspace.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.healthcare-apis.workspace.yml)
[![avm.res.hybrid-compute.machine](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.machine.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.machine.yml)
[![avm.res.insights.action-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.action-group.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.action-group.yml)
[![avm.res.insights.activity-log-alert](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.activity-log-alert.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.activity-log-alert.yml)
[![avm.res.insights.component](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.component.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.component.yml)
[![avm.res.insights.data-collection-endpoint](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-endpoint.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-endpoint.yml)
[![avm.res.insights.data-collection-rule](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-rule.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-rule.yml)
[![avm.res.insights.diagnostic-setting](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.diagnostic-setting.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.diagnostic-setting.yml)
[![avm.res.insights.metric-alert](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.metric-alert.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.metric-alert.yml)
[![avm.res.insights.private-link-scope](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.private-link-scope.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.private-link-scope.yml)
[![avm.res.insights.scheduled-query-rule](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.scheduled-query-rule.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.scheduled-query-rule.yml)
[![avm.res.insights.webtest](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.webtest.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.webtest.yml)
[![avm.res.key-vault.vault](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml)
[![avm.res.kubernetes-configuration.extension](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-configuration.extension.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-configuration.extension.yml)
[![avm.res.kubernetes-configuration.flux-configuration](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-configuration.flux-configuration.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-configuration.flux-configuration.yml)
[![avm.res.kusto.cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kusto.cluster.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kusto.cluster.yml)
[![avm.res.load-test-service.load-test](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.load-test-service.load-test.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.load-test-service.load-test.yml)
[![avm.res.logic.workflow](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.logic.workflow.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.logic.workflow.yml)
[![avm.res.machine-learning-services.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.machine-learning-services.workspace.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.machine-learning-services.workspace.yml)
[![avm.res.maintenance.maintenance-configuration](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.maintenance-configuration.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.maintenance-configuration.yml)
[![avm.res.managed-identity.user-assigned-identity](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-identity.user-assigned-identity.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-identity.user-assigned-identity.yml)
[![avm.res.managed-services.registration-definition](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-services.registration-definition.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-services.registration-definition.yml)
[![avm.res.management.management-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.management.management-group.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.management.management-group.yml)
[![avm.res.net-app.net-app-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.net-app.net-app-account.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.net-app.net-app-account.yml)
[![avm.res.network.application-gateway-web-application-firewall-policy](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-gateway-web-application-firewall-policy.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-gateway-web-application-firewall-policy.yml)
[![avm.res.network.application-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-gateway.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-gateway.yml)
[![avm.res.network.application-security-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-security-group.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-security-group.yml)
[![avm.res.network.azure-firewall](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.azure-firewall.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.azure-firewall.yml)
[![avm.res.network.bastion-host](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.bastion-host.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.bastion-host.yml)
[![avm.res.network.connection](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.connection.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.connection.yml)
[![avm.res.network.ddos-protection-plan](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ddos-protection-plan.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ddos-protection-plan.yml)
[![avm.res.network.dns-forwarding-ruleset](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-forwarding-ruleset.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-forwarding-ruleset.yml)
[![avm.res.network.dns-resolver](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-resolver.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-resolver.yml)
[![avm.res.network.dns-zone](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-zone.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-zone.yml)
[![avm.res.network.express-route-circuit](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-circuit.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-circuit.yml)
[![avm.res.network.express-route-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-gateway.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-gateway.yml)
[![avm.res.network.firewall-policy](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.firewall-policy.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.firewall-policy.yml)
[![avm.res.network.front-door-web-application-firewall-policy](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.front-door-web-application-firewall-policy.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.front-door-web-application-firewall-policy.yml)
[![avm.res.network.front-door](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.front-door.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.front-door.yml)
[![avm.res.network.ip-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ip-group.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ip-group.yml)
[![avm.res.network.load-balancer](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.load-balancer.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.load-balancer.yml)
[![avm.res.network.local-network-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.local-network-gateway.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.local-network-gateway.yml)
[![avm.res.network.nat-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml)
[![avm.res.network.network-interface](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-interface.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-interface.yml)
[![avm.res.network.network-manager](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-manager.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-manager.yml)
[![avm.res.network.network-security-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-security-group.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-security-group.yml)
[![avm.res.network.network-watcher](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-watcher.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-watcher.yml)
[![avm.res.network.private-dns-zone](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-dns-zone.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-dns-zone.yml)
[![avm.res.network.private-endpoint](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-endpoint.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-endpoint.yml)
[![avm.res.network.private-link-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-link-service.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-link-service.yml)
[![avm.res.network.public-ip-address](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml)
[![avm.res.network.public-ip-prefix](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-prefix.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-prefix.yml)
[![avm.res.network.route-table](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.route-table.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.route-table.yml)
[![avm.res.network.service-endpoint-policy](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.service-endpoint-policy.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.service-endpoint-policy.yml)
[![avm.res.network.trafficmanagerprofile](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.trafficmanagerprofile.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.trafficmanagerprofile.yml)
[![avm.res.network.virtual-hub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-hub.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-hub.yml)
[![avm.res.network.virtual-network-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network-gateway.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network-gateway.yml)
[![avm.res.network.virtual-network](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network.yml)
[![avm.res.network.virtual-wan](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-wan.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-wan.yml)
[![avm.res.network.vpn-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-gateway.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-gateway.yml)
[![avm.res.network.vpn-server-configuration](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-server-configuration.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-server-configuration.yml)
[![avm.res.network.vpn-site](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-site.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-site.yml)
[![avm.res.operational-insights.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml)
[![avm.res.operations-management.solution](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.operations-management.solution.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.operations-management.solution.yml)
[![avm.res.portal.dashboard](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.portal.dashboard.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.portal.dashboard.yml)
[![avm.res.power-bi-dedicated.capacity](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.power-bi-dedicated.capacity.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.power-bi-dedicated.capacity.yml)
[![avm.res.purview.account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.purview.account.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.purview.account.yml)
[![avm.res.recovery-services.vault](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.recovery-services.vault.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.recovery-services.vault.yml)
[![avm.res.relay.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.relay.namespace.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.relay.namespace.yml)
[![avm.res.resource-graph.query](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resource-graph.query.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resource-graph.query.yml)
[![avm.res.resources.deployment-script](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.deployment-script.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.deployment-script.yml)
[![avm.res.resources.resource-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.resource-group.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.resource-group.yml)
[![avm.res.search.search-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.search.search-service.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.search.search-service.yml)
[![avm.res.service-bus.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-bus.namespace.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-bus.namespace.yml)
[![avm.res.service-fabric.cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-fabric.cluster.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-fabric.cluster.yml)
[![avm.res.service-networking.traffic-controller](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-networking.traffic-controller.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-networking.traffic-controller.yml)
[![avm.res.signal-r-service.signal-r](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.signal-r.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.signal-r.yml)
[![avm.res.signal-r-service.web-pub-sub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.web-pub-sub.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.web-pub-sub.yml)
[![avm.res.sql.instance-pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.instance-pool.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.instance-pool.yml)
[![avm.res.sql.managed-instance](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.managed-instance.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.managed-instance.yml)
[![avm.res.sql.server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml)
[![avm.res.storage.storage-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml)
[![avm.res.synapse.private-link-hub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.synapse.private-link-hub.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.synapse.private-link-hub.yml)
[![avm.res.synapse.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.synapse.workspace.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.synapse.workspace.yml)
[![avm.res.virtual-machine-images.image-template](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.virtual-machine-images.image-template.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.virtual-machine-images.image-template.yml)
[![avm.res.web.connection](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.connection.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.connection.yml)
[![avm.res.web.hosting-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.hosting-environment.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.hosting-environment.yml) (unrelated WAF)
[![avm.res.web.serverfarm](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml)
[![avm.res.web.site](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.site.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.site.yml)   
[![avm.res.web.static-site](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.static-site.yml/badge.svg?branch=users%2Falsehr%2FtestPwshNonInstall&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.static-site.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
