### PR TITLE
feat: Add strong types to `avm/res/sql/server` and it's children 

### DIFF
--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -584,7 +584,7 @@ module server 'br/public:avm/res/sql/server:<version>' = {
             workspaceResourceId: '<workspaceResourceId>'
           }
         ]
-        elasticPoolId: '<elasticPoolId>'
+        elasticPoolResourceId: '<elasticPoolResourceId>'
         encryptionProtectorObj: {
           serverKeyName: '<serverKeyName>'
           serverKeyType: 'AzureKeyVault'
@@ -755,7 +755,7 @@ module server 'br/public:avm/res/sql/server:<version>' = {
               "workspaceResourceId": "<workspaceResourceId>"
             }
           ],
-          "elasticPoolId": "<elasticPoolId>",
+          "elasticPoolResourceId": "<elasticPoolResourceId>",
           "encryptionProtectorObj": {
             "serverKeyName": "<serverKeyName>",
             "serverKeyType": "AzureKeyVault"
@@ -948,7 +948,7 @@ param databases = [
         workspaceResourceId: '<workspaceResourceId>'
       }
     ]
-    elasticPoolId: '<elasticPoolId>'
+    elasticPoolResourceId: '<elasticPoolResourceId>'
     encryptionProtectorObj: {
       serverKeyName: '<serverKeyName>'
       serverKeyType: 'AzureKeyVault'
@@ -1107,7 +1107,7 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           name: 'Basic'
           tier: 'Basic'
         }
-        sourceDatabaseId: '<sourceDatabaseId>'
+        sourceDatabaseResourceId: '<sourceDatabaseResourceId>'
       }
     ]
     location: '<location>'
@@ -1153,7 +1153,7 @@ module server 'br/public:avm/res/sql/server:<version>' = {
             "name": "Basic",
             "tier": "Basic"
           },
-          "sourceDatabaseId": "<sourceDatabaseId>"
+          "sourceDatabaseResourceId": "<sourceDatabaseResourceId>"
         }
       ]
     },
@@ -1195,7 +1195,7 @@ param databases = [
       name: 'Basic'
       tier: 'Basic'
     }
-    sourceDatabaseId: '<sourceDatabaseId>'
+    sourceDatabaseResourceId: '<sourceDatabaseResourceId>'
   }
 ]
 param location = '<location>'
@@ -1427,7 +1427,7 @@ module server 'br/public:avm/res/sql/server:<version>' = {
             workspaceResourceId: '<workspaceResourceId>'
           }
         ]
-        elasticPoolId: '<elasticPoolId>'
+        elasticPoolResourceId: '<elasticPoolResourceId>'
         encryptionProtectorObj: {
           serverKeyName: '<serverKeyName>'
           serverKeyType: 'AzureKeyVault'
@@ -1562,7 +1562,7 @@ module server 'br/public:avm/res/sql/server:<version>' = {
               "workspaceResourceId": "<workspaceResourceId>"
             }
           ],
-          "elasticPoolId": "<elasticPoolId>",
+          "elasticPoolResourceId": "<elasticPoolResourceId>",
           "encryptionProtectorObj": {
             "serverKeyName": "<serverKeyName>",
             "serverKeyType": "AzureKeyVault"
@@ -1715,7 +1715,7 @@ param databases = [
         workspaceResourceId: '<workspaceResourceId>'
       }
     ]
-    elasticPoolId: '<elasticPoolId>'
+    elasticPoolResourceId: '<elasticPoolResourceId>'
     encryptionProtectorObj: {
       serverKeyName: '<serverKeyName>'
       serverKeyType: 'AzureKeyVault'
@@ -2091,7 +2091,7 @@ The databases to create in the server.
 | [`collation`](#parameter-databasescollation) | string | The collation of the database. |
 | [`createMode`](#parameter-databasescreatemode) | string | Specifies the mode of database creation. |
 | [`diagnosticSettings`](#parameter-databasesdiagnosticsettings) | array | The diagnostic settings of the service. |
-| [`elasticPoolId`](#parameter-databaseselasticpoolid) | string | The resource identifier of the elastic pool containing this database. |
+| [`elasticPoolResourceId`](#parameter-databaseselasticpoolresourceid) | string | The resource identifier of the elastic pool containing this database. |
 | [`encryptionProtector`](#parameter-databasesencryptionprotector) | string | The azure key vault URI of the database if it's configured with per Database Customer Managed Keys. |
 | [`encryptionProtectorAutoRotation`](#parameter-databasesencryptionprotectorautorotation) | bool | The flag to enable or disable auto rotation of database encryption protector AKV key. |
 | [`federatedClientId`](#parameter-databasesfederatedclientid) | string | The Client id used for cross tenant per database CMK scenario. |
@@ -2107,16 +2107,16 @@ The databases to create in the server.
 | [`performCutover`](#parameter-databasesperformcutover) | bool | To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress. |
 | [`preferredEnclaveType`](#parameter-databasespreferredenclavetype) | string | Type of enclave requested on the database. |
 | [`readScale`](#parameter-databasesreadscale) | string | The state of read-only routing. If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale database within an elastic pool. |
-| [`recoverableDatabaseId`](#parameter-databasesrecoverabledatabaseid) | string | The resource identifier of the recoverable database associated with create operation of this database. |
-| [`recoveryServicesRecoveryPointId`](#parameter-databasesrecoveryservicesrecoverypointid) | string | The resource identifier of the recovery point associated with create operation of this database. |
+| [`recoverableDatabaseResourceId`](#parameter-databasesrecoverabledatabaseresourceid) | string | The resource identifier of the recoverable database associated with create operation of this database. |
+| [`recoveryServicesRecoveryPointResourceId`](#parameter-databasesrecoveryservicesrecoverypointresourceid) | string | The resource identifier of the recovery point associated with create operation of this database. |
 | [`requestedBackupStorageRedundancy`](#parameter-databasesrequestedbackupstorageredundancy) | string | The storage account type to be used to store backups for this database. |
-| [`restorableDroppedDatabaseId`](#parameter-databasesrestorabledroppeddatabaseid) | string | The resource identifier of the restorable dropped database associated with create operation of this database. |
+| [`restorableDroppedDatabaseResourceId`](#parameter-databasesrestorabledroppeddatabaseresourceid) | string | The resource identifier of the restorable dropped database associated with create operation of this database. |
 | [`restorePointInTime`](#parameter-databasesrestorepointintime) | string | Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database. |
 | [`sampleName`](#parameter-databasessamplename) | string | The name of the sample schema to apply when creating this database. |
 | [`secondaryType`](#parameter-databasessecondarytype) | string | The secondary type of the database if it is a secondary. |
 | [`sku`](#parameter-databasessku) | object | The database SKU. |
 | [`sourceDatabaseDeletionDate`](#parameter-databasessourcedatabasedeletiondate) | string | Specifies the time that the database was deleted. |
-| [`sourceDatabaseId`](#parameter-databasessourcedatabaseid) | string | The resource identifier of the source database associated with create operation of this database. |
+| [`sourceDatabaseResourceId`](#parameter-databasessourcedatabaseresourceid) | string | The resource identifier of the source database associated with create operation of this database. |
 | [`sourceResourceId`](#parameter-databasessourceresourceid) | string | The resource identifier of the source associated with the create operation of this database. |
 | [`tags`](#parameter-databasestags) | object | Tags of the resource. |
 | [`useFreeLimit`](#parameter-databasesusefreelimit) | bool | Whether or not the database uses free monthly limits. Allowed on one database in a subscription. |
@@ -2334,7 +2334,7 @@ Resource ID of the diagnostic log analytics workspace. For security reasons, it 
 - Required: No
 - Type: string
 
-### Parameter: `databases.elasticPoolId`
+### Parameter: `databases.elasticPoolResourceId`
 
 The resource identifier of the elastic pool containing this database.
 
@@ -2474,14 +2474,14 @@ The state of read-only routing. If enabled, connections that have application in
   ]
   ```
 
-### Parameter: `databases.recoverableDatabaseId`
+### Parameter: `databases.recoverableDatabaseResourceId`
 
 The resource identifier of the recoverable database associated with create operation of this database.
 
 - Required: No
 - Type: string
 
-### Parameter: `databases.recoveryServicesRecoveryPointId`
+### Parameter: `databases.recoveryServicesRecoveryPointResourceId`
 
 The resource identifier of the recovery point associated with create operation of this database.
 
@@ -2504,7 +2504,7 @@ The storage account type to be used to store backups for this database.
   ]
   ```
 
-### Parameter: `databases.restorableDroppedDatabaseId`
+### Parameter: `databases.restorableDroppedDatabaseResourceId`
 
 The resource identifier of the restorable dropped database associated with create operation of this database.
 
@@ -2604,7 +2604,7 @@ Specifies the time that the database was deleted.
 - Required: No
 - Type: string
 
-### Parameter: `databases.sourceDatabaseId`
+### Parameter: `databases.sourceDatabaseResourceId`
 
 The resource identifier of the source database associated with create operation of this database.
 
@@ -2814,7 +2814,6 @@ The elastic pool SKU.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-elasticpoolsskuname) | string | The name of the SKU, typically, a letter + Number code, e.g. P3. |
-| [`tier`](#parameter-elasticpoolsskutier) | string | The tier or edition of the particular SKU, e.g. Basic, Premium. |
 
 **Optional parameters**
 
@@ -2823,6 +2822,7 @@ The elastic pool SKU.
 | [`capacity`](#parameter-elasticpoolsskucapacity) | int | The capacity of the particular SKU. |
 | [`family`](#parameter-elasticpoolsskufamily) | string | If the service has different generations of hardware, for the same SKU, then that can be captured here. |
 | [`size`](#parameter-elasticpoolsskusize) | string | Size of the particular SKU. |
+| [`tier`](#parameter-elasticpoolsskutier) | string | The tier or edition of the particular SKU, e.g. Basic, Premium. |
 
 ### Parameter: `elasticPools.sku.name`
 
@@ -2848,13 +2848,6 @@ The name of the SKU, typically, a letter + Number code, e.g. P3.
   ]
   ```
 
-### Parameter: `elasticPools.sku.tier`
-
-The tier or edition of the particular SKU, e.g. Basic, Premium.
-
-- Required: No
-- Type: string
-
 ### Parameter: `elasticPools.sku.capacity`
 
 The capacity of the particular SKU.
@@ -2872,6 +2865,13 @@ If the service has different generations of hardware, for the same SKU, then tha
 ### Parameter: `elasticPools.sku.size`
 
 Size of the particular SKU.
+
+- Required: No
+- Type: string
+
+### Parameter: `elasticPools.sku.tier`
+
+The tier or edition of the particular SKU, e.g. Basic, Premium.
 
 - Required: No
 - Type: string

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -25,7 +25,7 @@ This module deploys an Azure SQL Server.
 | `Microsoft.Sql/servers` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/servers) |
 | `Microsoft.Sql/servers/auditingSettings` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/servers/auditingSettings) |
 | `Microsoft.Sql/servers/databases` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/servers/databases) |
-| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies) |
+| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
 | `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies) |
 | `Microsoft.Sql/servers/elasticPools` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/servers/elasticPools) |
 | `Microsoft.Sql/servers/encryptionProtector` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/servers/encryptionProtector) |
@@ -585,10 +585,6 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           }
         ]
         elasticPoolResourceId: '<elasticPoolResourceId>'
-        encryptionProtectorObj: {
-          serverKeyName: '<serverKeyName>'
-          serverKeyType: 'AzureKeyVault'
-        }
         licenseType: 'LicenseIncluded'
         maxSizeBytes: 34359738368
         name: 'sqlsmaxdb-001'
@@ -609,6 +605,10 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         }
       }
     ]
+    encryptionProtectorObj: {
+      serverKeyName: '<serverKeyName>'
+      serverKeyType: 'AzureKeyVault'
+    }
     firewallRules: [
       {
         endIpAddress: '0.0.0.0'
@@ -756,10 +756,6 @@ module server 'br/public:avm/res/sql/server:<version>' = {
             }
           ],
           "elasticPoolResourceId": "<elasticPoolResourceId>",
-          "encryptionProtectorObj": {
-            "serverKeyName": "<serverKeyName>",
-            "serverKeyType": "AzureKeyVault"
-          },
           "licenseType": "LicenseIncluded",
           "maxSizeBytes": 34359738368,
           "name": "sqlsmaxdb-001",
@@ -782,6 +778,12 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           }
         }
       ]
+    },
+    "encryptionProtectorObj": {
+      "value": {
+        "serverKeyName": "<serverKeyName>",
+        "serverKeyType": "AzureKeyVault"
+      }
     },
     "firewallRules": {
       "value": [
@@ -949,10 +951,6 @@ param databases = [
       }
     ]
     elasticPoolResourceId: '<elasticPoolResourceId>'
-    encryptionProtectorObj: {
-      serverKeyName: '<serverKeyName>'
-      serverKeyType: 'AzureKeyVault'
-    }
     licenseType: 'LicenseIncluded'
     maxSizeBytes: 34359738368
     name: 'sqlsmaxdb-001'
@@ -973,6 +971,10 @@ param elasticPools = [
     }
   }
 ]
+param encryptionProtectorObj = {
+  serverKeyName: '<serverKeyName>'
+  serverKeyType: 'AzureKeyVault'
+}
 param firewallRules = [
   {
     endIpAddress: '0.0.0.0'
@@ -1428,10 +1430,6 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           }
         ]
         elasticPoolResourceId: '<elasticPoolResourceId>'
-        encryptionProtectorObj: {
-          serverKeyName: '<serverKeyName>'
-          serverKeyType: 'AzureKeyVault'
-        }
         licenseType: 'LicenseIncluded'
         maxSizeBytes: 34359738368
         name: 'sqlswafdb-001'
@@ -1453,6 +1451,10 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         }
       }
     ]
+    encryptionProtectorObj: {
+      serverKeyName: '<serverKeyName>'
+      serverKeyType: 'AzureKeyVault'
+    }
     keys: [
       {
         serverKeyType: 'AzureKeyVault'
@@ -1563,10 +1565,6 @@ module server 'br/public:avm/res/sql/server:<version>' = {
             }
           ],
           "elasticPoolResourceId": "<elasticPoolResourceId>",
-          "encryptionProtectorObj": {
-            "serverKeyName": "<serverKeyName>",
-            "serverKeyType": "AzureKeyVault"
-          },
           "licenseType": "LicenseIncluded",
           "maxSizeBytes": 34359738368,
           "name": "sqlswafdb-001",
@@ -1590,6 +1588,12 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           }
         }
       ]
+    },
+    "encryptionProtectorObj": {
+      "value": {
+        "serverKeyName": "<serverKeyName>",
+        "serverKeyType": "AzureKeyVault"
+      }
     },
     "keys": {
       "value": [
@@ -1716,10 +1720,6 @@ param databases = [
       }
     ]
     elasticPoolResourceId: '<elasticPoolResourceId>'
-    encryptionProtectorObj: {
-      serverKeyName: '<serverKeyName>'
-      serverKeyType: 'AzureKeyVault'
-    }
     licenseType: 'LicenseIncluded'
     maxSizeBytes: 34359738368
     name: 'sqlswafdb-001'
@@ -1741,6 +1741,10 @@ param elasticPools = [
     }
   }
 ]
+param encryptionProtectorObj = {
+  serverKeyName: '<serverKeyName>'
+  serverKeyType: 'AzureKeyVault'
+}
 param keys = [
   {
     serverKeyType: 'AzureKeyVault'
@@ -2087,6 +2091,8 @@ The databases to create in the server.
 | :-- | :-- | :-- |
 | [`autoPauseDelay`](#parameter-databasesautopausedelay) | int | Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled. |
 | [`availabilityZone`](#parameter-databasesavailabilityzone) | string | Specifies the availability zone the database is pinned to. |
+| [`backupLongTermRetentionPolicy`](#parameter-databasesbackuplongtermretentionpolicy) | object | The long term backup retention policy for the database. |
+| [`backupShortTermRetentionPolicy`](#parameter-databasesbackupshorttermretentionpolicy) | object | The short term backup retention policy for the database. |
 | [`catalogCollation`](#parameter-databasescatalogcollation) | string | Collation of the metadata catalog. |
 | [`collation`](#parameter-databasescollation) | string | The collation of the database. |
 | [`createMode`](#parameter-databasescreatemode) | string | Specifies the mode of database creation. |
@@ -2151,6 +2157,101 @@ Specifies the availability zone the database is pinned to.
     'NoPreference'
   ]
   ```
+
+### Parameter: `databases.backupLongTermRetentionPolicy`
+
+The long term backup retention policy for the database.
+
+- Required: No
+- Type: object
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`backupStorageAccessTier`](#parameter-databasesbackuplongtermretentionpolicybackupstorageaccesstier) | string | The BackupStorageAccessTier for the LTR backups. |
+| [`makeBackupsImmutable`](#parameter-databasesbackuplongtermretentionpolicymakebackupsimmutable) | bool | The setting whether to make LTR backups immutable. |
+| [`monthlyRetention`](#parameter-databasesbackuplongtermretentionpolicymonthlyretention) | string | Monthly retention in ISO 8601 duration format. |
+| [`weeklyRetention`](#parameter-databasesbackuplongtermretentionpolicyweeklyretention) | string | Weekly retention in ISO 8601 duration format. |
+| [`weekOfYear`](#parameter-databasesbackuplongtermretentionpolicyweekofyear) | int | Week of year backup to keep for yearly retention. |
+| [`yearlyRetention`](#parameter-databasesbackuplongtermretentionpolicyyearlyretention) | string | Yearly retention in ISO 8601 duration format. |
+
+### Parameter: `databases.backupLongTermRetentionPolicy.backupStorageAccessTier`
+
+The BackupStorageAccessTier for the LTR backups.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Archive'
+    'Hot'
+  ]
+  ```
+
+### Parameter: `databases.backupLongTermRetentionPolicy.makeBackupsImmutable`
+
+The setting whether to make LTR backups immutable.
+
+- Required: No
+- Type: bool
+
+### Parameter: `databases.backupLongTermRetentionPolicy.monthlyRetention`
+
+Monthly retention in ISO 8601 duration format.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.backupLongTermRetentionPolicy.weeklyRetention`
+
+Weekly retention in ISO 8601 duration format.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.backupLongTermRetentionPolicy.weekOfYear`
+
+Week of year backup to keep for yearly retention.
+
+- Required: No
+- Type: int
+
+### Parameter: `databases.backupLongTermRetentionPolicy.yearlyRetention`
+
+Yearly retention in ISO 8601 duration format.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.backupShortTermRetentionPolicy`
+
+The short term backup retention policy for the database.
+
+- Required: No
+- Type: object
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`diffBackupIntervalInHours`](#parameter-databasesbackupshorttermretentionpolicydiffbackupintervalinhours) | int | Differential backup interval in hours. |
+| [`retentionDays`](#parameter-databasesbackupshorttermretentionpolicyretentiondays) | int | Point-in-time retention in days. |
+
+### Parameter: `databases.backupShortTermRetentionPolicy.diffBackupIntervalInHours`
+
+Differential backup interval in hours.
+
+- Required: No
+- Type: int
+
+### Parameter: `databases.backupShortTermRetentionPolicy.retentionDays`
+
+Point-in-time retention in days.
+
+- Required: No
+- Type: int
 
 ### Parameter: `databases.catalogCollation`
 

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -46,11 +46,12 @@ The following section provides usage examples for the module, which were used to
 - [With an administrator](#example-1-with-an-administrator)
 - [With audit settings](#example-2-with-audit-settings)
 - [Using only defaults](#example-3-using-only-defaults)
-- [Deploying with a key vault reference to save secrets](#example-4-deploying-with-a-key-vault-reference-to-save-secrets)
-- [Using large parameter set](#example-5-using-large-parameter-set)
-- [With a secondary database](#example-6-with-a-secondary-database)
-- [With vulnerability assessment](#example-7-with-vulnerability-assessment)
-- [WAF-aligned](#example-8-waf-aligned)
+- [Using elastic pool](#example-4-using-elastic-pool)
+- [Deploying with a key vault reference to save secrets](#example-5-deploying-with-a-key-vault-reference-to-save-secrets)
+- [Using large parameter set](#example-6-using-large-parameter-set)
+- [With a secondary database](#example-7-with-a-secondary-database)
+- [With vulnerability assessment](#example-8-with-vulnerability-assessment)
+- [WAF-aligned](#example-9-waf-aligned)
 
 ### Example 1: _With an administrator_
 
@@ -312,7 +313,134 @@ param location = '<location>'
 </details>
 <p>
 
-### Example 4: _Deploying with a key vault reference to save secrets_
+### Example 4: _Using elastic pool_
+
+This instance deploys the module with an elastic pool.
+
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module server 'br/public:avm/res/sql/server:<version>' = {
+  name: 'serverDeployment'
+  params: {
+    // Required parameters
+    name: 'epool001'
+    // Non-required parameters
+    administratorLogin: 'adminUserName'
+    administratorLoginPassword: '<administratorLoginPassword>'
+    elasticPools: [
+      {
+        name: 'epool-ep-001'
+      }
+      {
+        name: 'epool-ep-002'
+        perDatabaseSettings: {
+          maxCapacity: 4
+          minCapacity: 1
+        }
+        sku: {
+          capacity: 4
+          name: 'GP_Gen5'
+          tier: 'GeneralPurpose'
+        }
+      }
+    ]
+    location: '<location>'
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON parameters file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "name": {
+      "value": "epool001"
+    },
+    // Non-required parameters
+    "administratorLogin": {
+      "value": "adminUserName"
+    },
+    "administratorLoginPassword": {
+      "value": "<administratorLoginPassword>"
+    },
+    "elasticPools": {
+      "value": [
+        {
+          "name": "epool-ep-001"
+        },
+        {
+          "name": "epool-ep-002",
+          "perDatabaseSettings": {
+            "maxCapacity": 4,
+            "minCapacity": 1
+          },
+          "sku": {
+            "capacity": 4,
+            "name": "GP_Gen5",
+            "tier": "GeneralPurpose"
+          }
+        }
+      ]
+    },
+    "location": {
+      "value": "<location>"
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via Bicep parameters file</summary>
+
+```bicep-params
+using 'br/public:avm/res/sql/server:<version>'
+
+// Required parameters
+param name = 'epool001'
+// Non-required parameters
+param administratorLogin = 'adminUserName'
+param administratorLoginPassword = '<administratorLoginPassword>'
+param elasticPools = [
+  {
+    name: 'epool-ep-001'
+  }
+  {
+    name: 'epool-ep-002'
+    perDatabaseSettings: {
+      maxCapacity: 4
+      minCapacity: 1
+    }
+    sku: {
+      capacity: 4
+      name: 'GP_Gen5'
+      tier: 'GeneralPurpose'
+    }
+  }
+]
+param location = '<location>'
+```
+
+</details>
+<p>
+
+### Example 5: _Deploying with a key vault reference to save secrets_
 
 This instance deploys the module saving all its secrets in a key vault.
 
@@ -420,7 +548,7 @@ param secretsExportConfiguration = {
 </details>
 <p>
 
-### Example 5: _Using large parameter set_
+### Example 6: _Using large parameter set_
 
 This instance deploys the module with most of its features enabled.
 
@@ -940,7 +1068,7 @@ param vulnerabilityAssessmentsObj = {
 </details>
 <p>
 
-### Example 6: _With a secondary database_
+### Example 7: _With a secondary database_
 
 This instance deploys the module with a secondary database.
 
@@ -1063,7 +1191,7 @@ param tags = {
 </details>
 <p>
 
-### Example 7: _With vulnerability assessment_
+### Example 8: _With vulnerability assessment_
 
 This instance deploys the module with a vulnerability assessment.
 
@@ -1240,7 +1368,7 @@ param vulnerabilityAssessmentsObj = {
 </details>
 <p>
 
-### Example 8: _WAF-aligned_
+### Example 9: _WAF-aligned_
 
 This instance deploys the module in alignment with the best-practices of the Azure Well-Architected Framework.
 
@@ -1676,8 +1804,10 @@ param vulnerabilityAssessmentsObj = {
 | [`elasticPools`](#parameter-elasticpools) | array | The Elastic Pools to create in the server. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`encryptionProtectorObj`](#parameter-encryptionprotectorobj) | object | The encryption protection configuration. |
+| [`federatedClientId`](#parameter-federatedclientid) | string | The Client id used for cross tenant CMK scenario |
 | [`firewallRules`](#parameter-firewallrules) | array | The firewall rules to create in the server. |
 | [`isIPv6Enabled`](#parameter-isipv6enabled) | string | Whether or not to enable IPv6 support for this server. |
+| [`keyId`](#parameter-keyid) | string | A CMK URI of the key to use for encryption. |
 | [`keys`](#parameter-keys) | array | The keys to configure. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
@@ -1722,7 +1852,80 @@ The Azure Active Directory (AAD) administrator authentication. Required if no `a
 
 - Required: No
 - Type: object
-- Default: `{}`
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`azureADOnlyAuthentication`](#parameter-administratorsazureadonlyauthentication) | bool | Azure Active Directory only Authentication enabled. |
+| [`login`](#parameter-administratorslogin) | string | Login name of the server administrator. |
+| [`principalType`](#parameter-administratorsprincipaltype) | string | Principal Type of the sever administrator. |
+| [`sid`](#parameter-administratorssid) | string | SID (object ID) of the server administrator. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`administratorType`](#parameter-administratorsadministratortype) | string | Type of the sever administrator. |
+| [`tenantId`](#parameter-administratorstenantid) | string | Tenant ID of the administrator. |
+
+### Parameter: `administrators.azureADOnlyAuthentication`
+
+Azure Active Directory only Authentication enabled.
+
+- Required: Yes
+- Type: bool
+
+### Parameter: `administrators.login`
+
+Login name of the server administrator.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `administrators.principalType`
+
+Principal Type of the sever administrator.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Application'
+    'Group'
+    'User'
+  ]
+  ```
+
+### Parameter: `administrators.sid`
+
+SID (object ID) of the server administrator.
+
+- Required: Yes
+- Type: string
+- Example: `#_managementGroupId_#`
+
+### Parameter: `administrators.administratorType`
+
+Type of the sever administrator.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'ActiveDirectory'
+  ]
+  ```
+
+### Parameter: `administrators.tenantId`
+
+Tenant ID of the administrator.
+
+- Required: No
+- Type: string
+- Example: `#_managementGroupId_#`
 
 ### Parameter: `primaryUserAssignedIdentityId`
 
@@ -1852,6 +2055,249 @@ The Elastic Pools to create in the server.
 - Type: array
 - Default: `[]`
 
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-elasticpoolsname) | string | The name of the Elastic Pool. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`autoPauseDelay`](#parameter-elasticpoolsautopausedelay) | int | Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled. |
+| [`availabilityZone`](#parameter-elasticpoolsavailabilityzone) | string | Specifies the availability zone the pool's primary replica is pinned to. |
+| [`highAvailabilityReplicaCount`](#parameter-elasticpoolshighavailabilityreplicacount) | int | The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools. |
+| [`licenseType`](#parameter-elasticpoolslicensetype) | string | The license type to apply for this elastic pool. |
+| [`maintenanceConfigurationId`](#parameter-elasticpoolsmaintenanceconfigurationid) | string | Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur. |
+| [`maxSizeBytes`](#parameter-elasticpoolsmaxsizebytes) | int | The storage limit for the database elastic pool in bytes. |
+| [`minCapacity`](#parameter-elasticpoolsmincapacity) | int | Minimal capacity that serverless pool will not shrink below, if not paused |
+| [`perDatabaseSettings`](#parameter-elasticpoolsperdatabasesettings) | object | The per database settings for the elastic pool. |
+| [`preferredEnclaveType`](#parameter-elasticpoolspreferredenclavetype) | string | Type of enclave requested on the elastic pool. |
+| [`sku`](#parameter-elasticpoolssku) | object | The elastic pool SKU. |
+| [`tags`](#parameter-elasticpoolstags) | object | Tags of the resource. |
+| [`zoneRedundant`](#parameter-elasticpoolszoneredundant) | bool | Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones. |
+
+### Parameter: `elasticPools.name`
+
+The name of the Elastic Pool.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `elasticPools.autoPauseDelay`
+
+Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled.
+
+- Required: No
+- Type: int
+
+### Parameter: `elasticPools.availabilityZone`
+
+Specifies the availability zone the pool's primary replica is pinned to.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    '1'
+    '2'
+    '3'
+    'NoPreference'
+  ]
+  ```
+
+### Parameter: `elasticPools.highAvailabilityReplicaCount`
+
+The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools.
+
+- Required: No
+- Type: int
+
+### Parameter: `elasticPools.licenseType`
+
+The license type to apply for this elastic pool.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'BasePrice'
+    'LicenseIncluded'
+  ]
+  ```
+
+### Parameter: `elasticPools.maintenanceConfigurationId`
+
+Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur.
+
+- Required: No
+- Type: string
+
+### Parameter: `elasticPools.maxSizeBytes`
+
+The storage limit for the database elastic pool in bytes.
+
+- Required: No
+- Type: int
+
+### Parameter: `elasticPools.minCapacity`
+
+Minimal capacity that serverless pool will not shrink below, if not paused
+
+- Required: No
+- Type: int
+
+### Parameter: `elasticPools.perDatabaseSettings`
+
+The per database settings for the elastic pool.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`minCapacity`](#parameter-elasticpoolsperdatabasesettingsmincapacity) | int | The minimum capacity all databases are guaranteed. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`autoPauseDelay`](#parameter-elasticpoolsperdatabasesettingsautopausedelay) | int | Auto Pause Delay for per database within pool |
+
+**Reqired parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`maxCapacity`](#parameter-elasticpoolsperdatabasesettingsmaxcapacity) | int | The maximum capacity any one database can consume. |
+
+### Parameter: `elasticPools.perDatabaseSettings.minCapacity`
+
+The minimum capacity all databases are guaranteed.
+
+- Required: Yes
+- Type: int
+
+### Parameter: `elasticPools.perDatabaseSettings.autoPauseDelay`
+
+Auto Pause Delay for per database within pool
+
+- Required: No
+- Type: int
+
+### Parameter: `elasticPools.perDatabaseSettings.maxCapacity`
+
+The maximum capacity any one database can consume.
+
+- Required: Yes
+- Type: int
+
+### Parameter: `elasticPools.preferredEnclaveType`
+
+Type of enclave requested on the elastic pool.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Default'
+    'VBS'
+  ]
+  ```
+
+### Parameter: `elasticPools.sku`
+
+The elastic pool SKU.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-elasticpoolsskuname) | string | The name of the SKU, typically, a letter + Number code, e.g. P3. |
+| [`tier`](#parameter-elasticpoolsskutier) | string | The tier or edition of the particular SKU, e.g. Basic, Premium. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`capacity`](#parameter-elasticpoolsskucapacity) | int | The capacity of the particular SKU. |
+| [`family`](#parameter-elasticpoolsskufamily) | string | If the service has different generations of hardware, for the same SKU, then that can be captured here. |
+| [`size`](#parameter-elasticpoolsskusize) | string | Size of the particular SKU |
+
+### Parameter: `elasticPools.sku.name`
+
+The name of the SKU, typically, a letter + Number code, e.g. P3.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'BasicPool'
+    'BC_DC'
+    'BC_Gen5'
+    'GP_DC'
+    'GP_FSv2'
+    'GP_Gen5'
+    'HS_Gen5'
+    'HS_MOPRMS'
+    'HS_PRMS'
+    'PremiumPool'
+    'ServerlessPool'
+    'StandardPool'
+  ]
+  ```
+
+### Parameter: `elasticPools.sku.tier`
+
+The tier or edition of the particular SKU, e.g. Basic, Premium.
+
+- Required: No
+- Type: string
+
+### Parameter: `elasticPools.sku.capacity`
+
+The capacity of the particular SKU.
+
+- Required: No
+- Type: int
+
+### Parameter: `elasticPools.sku.family`
+
+If the service has different generations of hardware, for the same SKU, then that can be captured here.
+
+- Required: No
+- Type: string
+
+### Parameter: `elasticPools.sku.size`
+
+Size of the particular SKU
+
+- Required: No
+- Type: string
+
+### Parameter: `elasticPools.tags`
+
+Tags of the resource.
+
+- Required: No
+- Type: object
+
+### Parameter: `elasticPools.zoneRedundant`
+
+Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones.
+
+- Required: No
+- Type: bool
+
 ### Parameter: `enableTelemetry`
 
 Enable/Disable usage telemetry for module.
@@ -1867,6 +2313,13 @@ The encryption protection configuration.
 - Required: No
 - Type: object
 - Default: `{}`
+
+### Parameter: `federatedClientId`
+
+The Client id used for cross tenant CMK scenario
+
+- Required: No
+- Type: string
 
 ### Parameter: `firewallRules`
 
@@ -1890,6 +2343,13 @@ Whether or not to enable IPv6 support for this server.
     'Enabled'
   ]
   ```
+
+### Parameter: `keyId`
+
+A CMK URI of the key to use for encryption.
+
+- Required: No
+- Type: string
 
 ### Parameter: `keys`
 

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -327,16 +327,16 @@ module server 'br/public:avm/res/sql/server:<version>' = {
   name: 'serverDeployment'
   params: {
     // Required parameters
-    name: 'epool001'
+    name: 'ssep001'
     // Non-required parameters
     administratorLogin: 'adminUserName'
     administratorLoginPassword: '<administratorLoginPassword>'
     elasticPools: [
       {
-        name: 'epool-ep-001'
+        name: 'ssep-ep-001'
       }
       {
-        name: 'epool-ep-002'
+        name: 'ssep-ep-002'
         perDatabaseSettings: {
           maxCapacity: '4'
           minCapacity: '0.5'
@@ -367,7 +367,7 @@ module server 'br/public:avm/res/sql/server:<version>' = {
   "parameters": {
     // Required parameters
     "name": {
-      "value": "epool001"
+      "value": "ssep001"
     },
     // Non-required parameters
     "administratorLogin": {
@@ -379,10 +379,10 @@ module server 'br/public:avm/res/sql/server:<version>' = {
     "elasticPools": {
       "value": [
         {
-          "name": "epool-ep-001"
+          "name": "ssep-ep-001"
         },
         {
-          "name": "epool-ep-002",
+          "name": "ssep-ep-002",
           "perDatabaseSettings": {
             "maxCapacity": "4",
             "minCapacity": "0.5"
@@ -413,16 +413,16 @@ module server 'br/public:avm/res/sql/server:<version>' = {
 using 'br/public:avm/res/sql/server:<version>'
 
 // Required parameters
-param name = 'epool001'
+param name = 'ssep001'
 // Non-required parameters
 param administratorLogin = 'adminUserName'
 param administratorLoginPassword = '<administratorLoginPassword>'
 param elasticPools = [
   {
-    name: 'epool-ep-001'
+    name: 'ssep-ep-001'
   }
   {
-    name: 'epool-ep-002'
+    name: 'ssep-ep-002'
     perDatabaseSettings: {
       maxCapacity: '4'
       minCapacity: '0.5'

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -1824,7 +1824,7 @@ param vulnerabilityAssessmentsObj = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`administratorLogin`](#parameter-administratorlogin) | securestring | The administrator username for the server. Required if no `administrators` object for AAD authentication is provided. |
+| [`administratorLogin`](#parameter-administratorlogin) | string | The administrator username for the server. Required if no `administrators` object for AAD authentication is provided. |
 | [`administratorLoginPassword`](#parameter-administratorloginpassword) | securestring | The administrator login password. Required if no `administrators` object for AAD authentication is provided. |
 | [`administrators`](#parameter-administrators) | object | The Azure Active Directory (AAD) administrator authentication. Required if no `administratorLogin` & `administratorLoginPassword` is provided. |
 | [`primaryUserAssignedIdentityId`](#parameter-primaryuserassignedidentityid) | string | The resource ID of a user assigned identity to be used by default. Required if "userAssignedIdentities" is not empty. |
@@ -1869,7 +1869,7 @@ The name of the server.
 The administrator username for the server. Required if no `administrators` object for AAD authentication is provided.
 
 - Required: No
-- Type: securestring
+- Type: string
 - Default: `''`
 
 ### Parameter: `administratorLoginPassword`
@@ -1973,6 +1973,7 @@ The audit settings configuration.
 
 - Required: No
 - Type: object
+- Default: `{}`
 
 **Required parameters**
 
@@ -1998,7 +1999,7 @@ The audit settings configuration.
 
 Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.
 
-- Required: Yes
+- Required: No
 - Type: string
 - Allowed:
   ```Bicep

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -1834,7 +1834,7 @@ param vulnerabilityAssessmentsObj = {
 | [`elasticPools`](#parameter-elasticpools) | array | The Elastic Pools to create in the server. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`encryptionProtectorObj`](#parameter-encryptionprotectorobj) | object | The encryption protection configuration. |
-| [`federatedClientId`](#parameter-federatedclientid) | string | The Client id used for cross tenant CMK scenario |
+| [`federatedClientId`](#parameter-federatedclientid) | string | The Client id used for cross tenant CMK scenario. |
 | [`firewallRules`](#parameter-firewallrules) | array | The firewall rules to create in the server. |
 | [`isIPv6Enabled`](#parameter-isipv6enabled) | string | Whether or not to enable IPv6 support for this server. |
 | [`keyId`](#parameter-keyid) | string | A CMK URI of the key to use for encryption. |
@@ -2085,7 +2085,7 @@ The databases to create in the server.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`autoPauseDelay`](#parameter-databasesautopausedelay) | int | Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled |
+| [`autoPauseDelay`](#parameter-databasesautopausedelay) | int | Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled. |
 | [`availabilityZone`](#parameter-databasesavailabilityzone) | string | Specifies the availability zone the database is pinned to. |
 | [`catalogCollation`](#parameter-databasescatalogcollation) | string | Collation of the metadata catalog. |
 | [`collation`](#parameter-databasescollation) | string | The collation of the database. |
@@ -2131,7 +2131,7 @@ The name of the Elastic Pool.
 
 ### Parameter: `databases.autoPauseDelay`
 
-Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled
+Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled.
 
 - Required: No
 - Type: int
@@ -2560,7 +2560,7 @@ The database SKU.
 | :-- | :-- | :-- |
 | [`capacity`](#parameter-databasesskucapacity) | int | The capacity of the particular SKU. |
 | [`family`](#parameter-databasesskufamily) | string | If the service has different generations of hardware, for the same SKU, then that can be captured here. |
-| [`size`](#parameter-databasesskusize) | string | Size of the particular SKU |
+| [`size`](#parameter-databasesskusize) | string | Size of the particular SKU. |
 
 ### Parameter: `databases.sku.name`
 
@@ -2592,7 +2592,7 @@ If the service has different generations of hardware, for the same SKU, then tha
 
 ### Parameter: `databases.sku.size`
 
-Size of the particular SKU
+Size of the particular SKU.
 
 - Required: No
 - Type: string
@@ -2663,7 +2663,7 @@ The Elastic Pools to create in the server.
 | [`licenseType`](#parameter-elasticpoolslicensetype) | string | The license type to apply for this elastic pool. |
 | [`maintenanceConfigurationId`](#parameter-elasticpoolsmaintenanceconfigurationid) | string | Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur. |
 | [`maxSizeBytes`](#parameter-elasticpoolsmaxsizebytes) | int | The storage limit for the database elastic pool in bytes. |
-| [`minCapacity`](#parameter-elasticpoolsmincapacity) | int | Minimal capacity that serverless pool will not shrink below, if not paused |
+| [`minCapacity`](#parameter-elasticpoolsmincapacity) | int | Minimal capacity that serverless pool will not shrink below, if not paused. |
 | [`perDatabaseSettings`](#parameter-elasticpoolsperdatabasesettings) | object | The per database settings for the elastic pool. |
 | [`preferredEnclaveType`](#parameter-elasticpoolspreferredenclavetype) | string | Type of enclave requested on the elastic pool. |
 | [`sku`](#parameter-elasticpoolssku) | object | The elastic pool SKU. |
@@ -2737,7 +2737,7 @@ The storage limit for the database elastic pool in bytes.
 
 ### Parameter: `elasticPools.minCapacity`
 
-Minimal capacity that serverless pool will not shrink below, if not paused
+Minimal capacity that serverless pool will not shrink below, if not paused.
 
 - Required: No
 - Type: int
@@ -2753,37 +2753,37 @@ The per database settings for the elastic pool.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`minCapacity`](#parameter-elasticpoolsperdatabasesettingsmincapacity) | string | The minimum capacity all databases are guaranteed. Examples: '0.5', '1' |
+| [`minCapacity`](#parameter-elasticpoolsperdatabasesettingsmincapacity) | string | The minimum capacity all databases are guaranteed. Examples: '0.5', '1'. |
 
 **Optional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`autoPauseDelay`](#parameter-elasticpoolsperdatabasesettingsautopausedelay) | int | Auto Pause Delay for per database within pool |
+| [`autoPauseDelay`](#parameter-elasticpoolsperdatabasesettingsautopausedelay) | int | Auto Pause Delay for per database within pool. |
 
 **Reqired parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`maxCapacity`](#parameter-elasticpoolsperdatabasesettingsmaxcapacity) | string | The maximum capacity any one database can consume. Examples: '0.5', '2' |
+| [`maxCapacity`](#parameter-elasticpoolsperdatabasesettingsmaxcapacity) | string | The maximum capacity any one database can consume. Examples: '0.5', '2'. |
 
 ### Parameter: `elasticPools.perDatabaseSettings.minCapacity`
 
-The minimum capacity all databases are guaranteed. Examples: '0.5', '1'
+The minimum capacity all databases are guaranteed. Examples: '0.5', '1'.
 
 - Required: Yes
 - Type: string
 
 ### Parameter: `elasticPools.perDatabaseSettings.autoPauseDelay`
 
-Auto Pause Delay for per database within pool
+Auto Pause Delay for per database within pool.
 
 - Required: No
 - Type: int
 
 ### Parameter: `elasticPools.perDatabaseSettings.maxCapacity`
 
-The maximum capacity any one database can consume. Examples: '0.5', '2'
+The maximum capacity any one database can consume. Examples: '0.5', '2'.
 
 - Required: Yes
 - Type: string
@@ -2822,7 +2822,7 @@ The elastic pool SKU.
 | :-- | :-- | :-- |
 | [`capacity`](#parameter-elasticpoolsskucapacity) | int | The capacity of the particular SKU. |
 | [`family`](#parameter-elasticpoolsskufamily) | string | If the service has different generations of hardware, for the same SKU, then that can be captured here. |
-| [`size`](#parameter-elasticpoolsskusize) | string | Size of the particular SKU |
+| [`size`](#parameter-elasticpoolsskusize) | string | Size of the particular SKU. |
 
 ### Parameter: `elasticPools.sku.name`
 
@@ -2871,7 +2871,7 @@ If the service has different generations of hardware, for the same SKU, then tha
 
 ### Parameter: `elasticPools.sku.size`
 
-Size of the particular SKU
+Size of the particular SKU.
 
 - Required: No
 - Type: string
@@ -2908,7 +2908,7 @@ The encryption protection configuration.
 
 ### Parameter: `federatedClientId`
 
-The Client id used for cross tenant CMK scenario
+The Client id used for cross tenant CMK scenario.
 
 - Required: No
 - Type: string

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -338,8 +338,8 @@ module server 'br/public:avm/res/sql/server:<version>' = {
       {
         name: 'epool-ep-002'
         perDatabaseSettings: {
-          maxCapacity: 4
-          minCapacity: 1
+          maxCapacity: '4'
+          minCapacity: '0.5'
         }
         sku: {
           capacity: 4
@@ -384,8 +384,8 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         {
           "name": "epool-ep-002",
           "perDatabaseSettings": {
-            "maxCapacity": 4,
-            "minCapacity": 1
+            "maxCapacity": "4",
+            "minCapacity": "0.5"
           },
           "sku": {
             "capacity": 4,
@@ -424,8 +424,8 @@ param elasticPools = [
   {
     name: 'epool-ep-002'
     perDatabaseSettings: {
-      maxCapacity: 4
-      minCapacity: 1
+      maxCapacity: '4'
+      minCapacity: '0.5'
     }
     sku: {
       capacity: 4
@@ -2161,7 +2161,7 @@ The per database settings for the elastic pool.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`minCapacity`](#parameter-elasticpoolsperdatabasesettingsmincapacity) | int | The minimum capacity all databases are guaranteed. |
+| [`minCapacity`](#parameter-elasticpoolsperdatabasesettingsmincapacity) | string | The minimum capacity all databases are guaranteed. Examples: '0.5', '1' |
 
 **Optional parameters**
 
@@ -2173,14 +2173,14 @@ The per database settings for the elastic pool.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`maxCapacity`](#parameter-elasticpoolsperdatabasesettingsmaxcapacity) | int | The maximum capacity any one database can consume. |
+| [`maxCapacity`](#parameter-elasticpoolsperdatabasesettingsmaxcapacity) | string | The maximum capacity any one database can consume. Examples: '0.5', '2' |
 
 ### Parameter: `elasticPools.perDatabaseSettings.minCapacity`
 
-The minimum capacity all databases are guaranteed.
+The minimum capacity all databases are guaranteed. Examples: '0.5', '1'
 
 - Required: Yes
-- Type: int
+- Type: string
 
 ### Parameter: `elasticPools.perDatabaseSettings.autoPauseDelay`
 
@@ -2191,10 +2191,10 @@ Auto Pause Delay for per database within pool
 
 ### Parameter: `elasticPools.perDatabaseSettings.maxCapacity`
 
-The maximum capacity any one database can consume.
+The maximum capacity any one database can consume. Examples: '0.5', '2'
 
 - Required: Yes
-- Type: int
+- Type: string
 
 ### Parameter: `elasticPools.preferredEnclaveType`
 

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -592,17 +592,21 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         licenseType: 'LicenseIncluded'
         maxSizeBytes: 34359738368
         name: 'sqlsmaxdb-001'
-        skuCapacity: 0
-        skuName: 'ElasticPool'
-        skuTier: 'GeneralPurpose'
+        sku: {
+          capacity: 0
+          name: 'ElasticPool'
+          tier: 'GeneralPurpose'
+        }
       }
     ]
     elasticPools: [
       {
         name: 'sqlsmax-ep-001'
-        skuCapacity: 10
-        skuName: 'GP_Gen5'
-        skuTier: 'GeneralPurpose'
+        sku: {
+          capacity: 10
+          name: 'GP_Gen5'
+          tier: 'GeneralPurpose'
+        }
       }
     ]
     firewallRules: [
@@ -759,9 +763,11 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           "licenseType": "LicenseIncluded",
           "maxSizeBytes": 34359738368,
           "name": "sqlsmaxdb-001",
-          "skuCapacity": 0,
-          "skuName": "ElasticPool",
-          "skuTier": "GeneralPurpose"
+          "sku": {
+            "capacity": 0,
+            "name": "ElasticPool",
+            "tier": "GeneralPurpose"
+          }
         }
       ]
     },
@@ -769,9 +775,11 @@ module server 'br/public:avm/res/sql/server:<version>' = {
       "value": [
         {
           "name": "sqlsmax-ep-001",
-          "skuCapacity": 10,
-          "skuName": "GP_Gen5",
-          "skuTier": "GeneralPurpose"
+          "sku": {
+            "capacity": 10,
+            "name": "GP_Gen5",
+            "tier": "GeneralPurpose"
+          }
         }
       ]
     },
@@ -948,17 +956,21 @@ param databases = [
     licenseType: 'LicenseIncluded'
     maxSizeBytes: 34359738368
     name: 'sqlsmaxdb-001'
-    skuCapacity: 0
-    skuName: 'ElasticPool'
-    skuTier: 'GeneralPurpose'
+    sku: {
+      capacity: 0
+      name: 'ElasticPool'
+      tier: 'GeneralPurpose'
+    }
   }
 ]
 param elasticPools = [
   {
     name: 'sqlsmax-ep-001'
-    skuCapacity: 10
-    skuName: 'GP_Gen5'
-    skuTier: 'GeneralPurpose'
+    sku: {
+      capacity: 10
+      name: 'GP_Gen5'
+      tier: 'GeneralPurpose'
+    }
   }
 ]
 param firewallRules = [
@@ -1091,9 +1103,11 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         createMode: 'Secondary'
         maxSizeBytes: 2147483648
         name: '<name>'
-        skuName: 'Basic'
-        skuTier: 'Basic'
-        sourceDatabaseResourceId: '<sourceDatabaseResourceId>'
+        sku: {
+          name: 'Basic'
+          tier: 'Basic'
+        }
+        sourceDatabaseId: '<sourceDatabaseId>'
       }
     ]
     location: '<location>'
@@ -1135,9 +1149,11 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           "createMode": "Secondary",
           "maxSizeBytes": 2147483648,
           "name": "<name>",
-          "skuName": "Basic",
-          "skuTier": "Basic",
-          "sourceDatabaseResourceId": "<sourceDatabaseResourceId>"
+          "sku": {
+            "name": "Basic",
+            "tier": "Basic"
+          },
+          "sourceDatabaseId": "<sourceDatabaseId>"
         }
       ]
     },
@@ -1175,9 +1191,11 @@ param databases = [
     createMode: 'Secondary'
     maxSizeBytes: 2147483648
     name: '<name>'
-    skuName: 'Basic'
-    skuTier: 'Basic'
-    sourceDatabaseResourceId: '<sourceDatabaseResourceId>'
+    sku: {
+      name: 'Basic'
+      tier: 'Basic'
+    }
+    sourceDatabaseId: '<sourceDatabaseId>'
   }
 ]
 param location = '<location>'
@@ -1417,18 +1435,22 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         licenseType: 'LicenseIncluded'
         maxSizeBytes: 34359738368
         name: 'sqlswafdb-001'
-        skuCapacity: 0
-        skuName: 'ElasticPool'
-        skuTier: 'GeneralPurpose'
+        sku: {
+          capacity: 0
+          name: 'ElasticPool'
+          tier: 'GeneralPurpose'
+        }
       }
     ]
     elasticPools: [
       {
         maintenanceConfigurationId: '<maintenanceConfigurationId>'
         name: 'sqlswaf-ep-001'
-        skuCapacity: 10
-        skuName: 'GP_Gen5'
-        skuTier: 'GeneralPurpose'
+        sku: {
+          capacity: 10
+          name: 'GP_Gen5'
+          tier: 'GeneralPurpose'
+        }
       }
     ]
     keys: [
@@ -1548,9 +1570,11 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           "licenseType": "LicenseIncluded",
           "maxSizeBytes": 34359738368,
           "name": "sqlswafdb-001",
-          "skuCapacity": 0,
-          "skuName": "ElasticPool",
-          "skuTier": "GeneralPurpose"
+          "sku": {
+            "capacity": 0,
+            "name": "ElasticPool",
+            "tier": "GeneralPurpose"
+          }
         }
       ]
     },
@@ -1559,9 +1583,11 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         {
           "maintenanceConfigurationId": "<maintenanceConfigurationId>",
           "name": "sqlswaf-ep-001",
-          "skuCapacity": 10,
-          "skuName": "GP_Gen5",
-          "skuTier": "GeneralPurpose"
+          "sku": {
+            "capacity": 10,
+            "name": "GP_Gen5",
+            "tier": "GeneralPurpose"
+          }
         }
       ]
     },
@@ -1697,18 +1723,22 @@ param databases = [
     licenseType: 'LicenseIncluded'
     maxSizeBytes: 34359738368
     name: 'sqlswafdb-001'
-    skuCapacity: 0
-    skuName: 'ElasticPool'
-    skuTier: 'GeneralPurpose'
+    sku: {
+      capacity: 0
+      name: 'ElasticPool'
+      tier: 'GeneralPurpose'
+    }
   }
 ]
 param elasticPools = [
   {
     maintenanceConfigurationId: '<maintenanceConfigurationId>'
     name: 'sqlswaf-ep-001'
-    skuCapacity: 10
-    skuName: 'GP_Gen5'
-    skuTier: 'GeneralPurpose'
+    sku: {
+      capacity: 10
+      name: 'GP_Gen5'
+      tier: 'GeneralPurpose'
+    }
   }
 ]
 param keys = [
@@ -2062,6 +2092,7 @@ The databases to create in the server.
 | [`catalogCollation`](#parameter-databasescatalogcollation) | string | Collation of the metadata catalog. |
 | [`collation`](#parameter-databasescollation) | string | The collation of the database. |
 | [`createMode`](#parameter-databasescreatemode) | string | Specifies the mode of database creation. |
+| [`diagnosticSettings`](#parameter-databasesdiagnosticsettings) | array | The diagnostic settings of the service. |
 | [`elasticPoolId`](#parameter-databaseselasticpoolid) | string | The resource identifier of the elastic pool containing this database. |
 | [`encryptionProtector`](#parameter-databasesencryptionprotector) | string | The azure key vault URI of the database if it's configured with per Database Customer Managed Keys. |
 | [`encryptionProtectorAutoRotation`](#parameter-databasesencryptionprotectorautorotation) | bool | The flag to enable or disable auto rotation of database encryption protector AKV key. |
@@ -2158,6 +2189,152 @@ Specifies the mode of database creation.
     'Secondary'
   ]
   ```
+
+### Parameter: `databases.diagnosticSettings`
+
+The diagnostic settings of the service.
+
+- Required: No
+- Type: array
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`eventHubAuthorizationRuleResourceId`](#parameter-databasesdiagnosticsettingseventhubauthorizationruleresourceid) | string | Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to. |
+| [`eventHubName`](#parameter-databasesdiagnosticsettingseventhubname) | string | Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub. |
+| [`logAnalyticsDestinationType`](#parameter-databasesdiagnosticsettingsloganalyticsdestinationtype) | string | A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type. |
+| [`logCategoriesAndGroups`](#parameter-databasesdiagnosticsettingslogcategoriesandgroups) | array | The name of logs that will be streamed. "allLogs" includes all possible logs for the resource. Set to `[]` to disable log collection. |
+| [`marketplacePartnerResourceId`](#parameter-databasesdiagnosticsettingsmarketplacepartnerresourceid) | string | The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs. |
+| [`metricCategories`](#parameter-databasesdiagnosticsettingsmetriccategories) | array | The name of metrics that will be streamed. "allMetrics" includes all possible metrics for the resource. Set to `[]` to disable metric collection. |
+| [`name`](#parameter-databasesdiagnosticsettingsname) | string | The name of diagnostic setting. |
+| [`storageAccountResourceId`](#parameter-databasesdiagnosticsettingsstorageaccountresourceid) | string | Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub. |
+| [`workspaceResourceId`](#parameter-databasesdiagnosticsettingsworkspaceresourceid) | string | Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub. |
+
+### Parameter: `databases.diagnosticSettings.eventHubAuthorizationRuleResourceId`
+
+Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.diagnosticSettings.eventHubName`
+
+Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.diagnosticSettings.logAnalyticsDestinationType`
+
+A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'AzureDiagnostics'
+    'Dedicated'
+  ]
+  ```
+
+### Parameter: `databases.diagnosticSettings.logCategoriesAndGroups`
+
+The name of logs that will be streamed. "allLogs" includes all possible logs for the resource. Set to `[]` to disable log collection.
+
+- Required: No
+- Type: array
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`category`](#parameter-databasesdiagnosticsettingslogcategoriesandgroupscategory) | string | Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here. |
+| [`categoryGroup`](#parameter-databasesdiagnosticsettingslogcategoriesandgroupscategorygroup) | string | Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs. |
+| [`enabled`](#parameter-databasesdiagnosticsettingslogcategoriesandgroupsenabled) | bool | Enable or disable the category explicitly. Default is `true`. |
+
+### Parameter: `databases.diagnosticSettings.logCategoriesAndGroups.category`
+
+Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.diagnosticSettings.logCategoriesAndGroups.categoryGroup`
+
+Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.diagnosticSettings.logCategoriesAndGroups.enabled`
+
+Enable or disable the category explicitly. Default is `true`.
+
+- Required: No
+- Type: bool
+
+### Parameter: `databases.diagnosticSettings.marketplacePartnerResourceId`
+
+The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.diagnosticSettings.metricCategories`
+
+The name of metrics that will be streamed. "allMetrics" includes all possible metrics for the resource. Set to `[]` to disable metric collection.
+
+- Required: No
+- Type: array
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`category`](#parameter-databasesdiagnosticsettingsmetriccategoriescategory) | string | Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`enabled`](#parameter-databasesdiagnosticsettingsmetriccategoriesenabled) | bool | Enable or disable the category explicitly. Default is `true`. |
+
+### Parameter: `databases.diagnosticSettings.metricCategories.category`
+
+Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `databases.diagnosticSettings.metricCategories.enabled`
+
+Enable or disable the category explicitly. Default is `true`.
+
+- Required: No
+- Type: bool
+
+### Parameter: `databases.diagnosticSettings.name`
+
+The name of diagnostic setting.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.diagnosticSettings.storageAccountResourceId`
+
+Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.diagnosticSettings.workspaceResourceId`
+
+Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub.
+
+- Required: No
+- Type: string
 
 ### Parameter: `databases.elasticPoolId`
 

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -1824,7 +1824,7 @@ param vulnerabilityAssessmentsObj = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`administratorLogin`](#parameter-administratorlogin) | string | The administrator username for the server. Required if no `administrators` object for AAD authentication is provided. |
+| [`administratorLogin`](#parameter-administratorlogin) | securestring | The administrator username for the server. Required if no `administrators` object for AAD authentication is provided. |
 | [`administratorLoginPassword`](#parameter-administratorloginpassword) | securestring | The administrator login password. Required if no `administrators` object for AAD authentication is provided. |
 | [`administrators`](#parameter-administrators) | object | The Azure Active Directory (AAD) administrator authentication. Required if no `administratorLogin` & `administratorLoginPassword` is provided. |
 | [`primaryUserAssignedIdentityId`](#parameter-primaryuserassignedidentityid) | string | The resource ID of a user assigned identity to be used by default. Required if "userAssignedIdentities" is not empty. |
@@ -1869,7 +1869,7 @@ The name of the server.
 The administrator username for the server. Required if no `administrators` object for AAD authentication is provided.
 
 - Required: No
-- Type: string
+- Type: securestring
 - Default: `''`
 
 ### Parameter: `administratorLoginPassword`

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -1934,7 +1934,6 @@ SID (object ID) of the server administrator.
 
 - Required: Yes
 - Type: string
-- Example: `#_managementGroupId_#`
 
 ### Parameter: `administrators.administratorType`
 
@@ -1955,7 +1954,6 @@ Tenant ID of the administrator.
 
 - Required: No
 - Type: string
-- Example: `#_managementGroupId_#`
 
 ### Parameter: `primaryUserAssignedIdentityId`
 

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -2047,6 +2047,423 @@ The databases to create in the server.
 - Type: array
 - Default: `[]`
 
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-databasesname) | string | The name of the Elastic Pool. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`autoPauseDelay`](#parameter-databasesautopausedelay) | int | Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled |
+| [`availabilityZone`](#parameter-databasesavailabilityzone) | string | Specifies the availability zone the database is pinned to. |
+| [`catalogCollation`](#parameter-databasescatalogcollation) | string | Collation of the metadata catalog. |
+| [`collation`](#parameter-databasescollation) | string | The collation of the database. |
+| [`createMode`](#parameter-databasescreatemode) | string | Specifies the mode of database creation. |
+| [`elasticPoolId`](#parameter-databaseselasticpoolid) | string | The resource identifier of the elastic pool containing this database. |
+| [`encryptionProtector`](#parameter-databasesencryptionprotector) | string | The azure key vault URI of the database if it's configured with per Database Customer Managed Keys. |
+| [`encryptionProtectorAutoRotation`](#parameter-databasesencryptionprotectorautorotation) | bool | The flag to enable or disable auto rotation of database encryption protector AKV key. |
+| [`federatedClientId`](#parameter-databasesfederatedclientid) | string | The Client id used for cross tenant per database CMK scenario. |
+| [`freeLimitExhaustionBehavior`](#parameter-databasesfreelimitexhaustionbehavior) | string | Specifies the behavior when monthly free limits are exhausted for the free database. |
+| [`highAvailabilityReplicaCount`](#parameter-databaseshighavailabilityreplicacount) | int | The number of secondary replicas associated with the database that are used to provide high availability. Not applicable to a Hyperscale database within an elastic pool. |
+| [`isLedgerOn`](#parameter-databasesisledgeron) | bool | Whether or not this database is a ledger database, which means all tables in the database are ledger tables. |
+| [`licenseType`](#parameter-databaseslicensetype) | string | The license type to apply for this database. |
+| [`longTermRetentionBackupResourceId`](#parameter-databaseslongtermretentionbackupresourceid) | string | The resource identifier of the long term retention backup associated with create operation of this database. |
+| [`maintenanceConfigurationId`](#parameter-databasesmaintenanceconfigurationid) | string | Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur. |
+| [`manualCutover`](#parameter-databasesmanualcutover) | bool | Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier. |
+| [`maxSizeBytes`](#parameter-databasesmaxsizebytes) | int | The max size of the database expressed in bytes. |
+| [`minCapacity`](#parameter-databasesmincapacity) | string | Minimal capacity that database will always have allocated, if not paused. |
+| [`performCutover`](#parameter-databasesperformcutover) | bool | To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress. |
+| [`preferredEnclaveType`](#parameter-databasespreferredenclavetype) | string | Type of enclave requested on the database. |
+| [`readScale`](#parameter-databasesreadscale) | string | The state of read-only routing. If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale database within an elastic pool. |
+| [`recoverableDatabaseId`](#parameter-databasesrecoverabledatabaseid) | string | The resource identifier of the recoverable database associated with create operation of this database. |
+| [`recoveryServicesRecoveryPointId`](#parameter-databasesrecoveryservicesrecoverypointid) | string | The resource identifier of the recovery point associated with create operation of this database. |
+| [`requestedBackupStorageRedundancy`](#parameter-databasesrequestedbackupstorageredundancy) | string | The storage account type to be used to store backups for this database. |
+| [`restorableDroppedDatabaseId`](#parameter-databasesrestorabledroppeddatabaseid) | string | The resource identifier of the restorable dropped database associated with create operation of this database. |
+| [`restorePointInTime`](#parameter-databasesrestorepointintime) | string | Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database. |
+| [`sampleName`](#parameter-databasessamplename) | string | The name of the sample schema to apply when creating this database. |
+| [`secondaryType`](#parameter-databasessecondarytype) | string | The secondary type of the database if it is a secondary. |
+| [`sku`](#parameter-databasessku) | object | The database SKU. |
+| [`sourceDatabaseDeletionDate`](#parameter-databasessourcedatabasedeletiondate) | string | Specifies the time that the database was deleted. |
+| [`sourceDatabaseId`](#parameter-databasessourcedatabaseid) | string | The resource identifier of the source database associated with create operation of this database. |
+| [`sourceResourceId`](#parameter-databasessourceresourceid) | string | The resource identifier of the source associated with the create operation of this database. |
+| [`tags`](#parameter-databasestags) | object | Tags of the resource. |
+| [`useFreeLimit`](#parameter-databasesusefreelimit) | bool | Whether or not the database uses free monthly limits. Allowed on one database in a subscription. |
+| [`zoneRedundant`](#parameter-databaseszoneredundant) | bool | Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones. |
+
+### Parameter: `databases.name`
+
+The name of the Elastic Pool.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `databases.autoPauseDelay`
+
+Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled
+
+- Required: No
+- Type: int
+
+### Parameter: `databases.availabilityZone`
+
+Specifies the availability zone the database is pinned to.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    '1'
+    '2'
+    '3'
+    'NoPreference'
+  ]
+  ```
+
+### Parameter: `databases.catalogCollation`
+
+Collation of the metadata catalog.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.collation`
+
+The collation of the database.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.createMode`
+
+Specifies the mode of database creation.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Copy'
+    'Default'
+    'OnlineSecondary'
+    'PointInTimeRestore'
+    'Recovery'
+    'Restore'
+    'RestoreExternalBackup'
+    'RestoreExternalBackupSecondary'
+    'RestoreLongTermRetentionBackup'
+    'Secondary'
+  ]
+  ```
+
+### Parameter: `databases.elasticPoolId`
+
+The resource identifier of the elastic pool containing this database.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.encryptionProtector`
+
+The azure key vault URI of the database if it's configured with per Database Customer Managed Keys.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.encryptionProtectorAutoRotation`
+
+The flag to enable or disable auto rotation of database encryption protector AKV key.
+
+- Required: No
+- Type: bool
+
+### Parameter: `databases.federatedClientId`
+
+The Client id used for cross tenant per database CMK scenario.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.freeLimitExhaustionBehavior`
+
+Specifies the behavior when monthly free limits are exhausted for the free database.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'AutoPause'
+    'BillOverUsage'
+  ]
+  ```
+
+### Parameter: `databases.highAvailabilityReplicaCount`
+
+The number of secondary replicas associated with the database that are used to provide high availability. Not applicable to a Hyperscale database within an elastic pool.
+
+- Required: No
+- Type: int
+
+### Parameter: `databases.isLedgerOn`
+
+Whether or not this database is a ledger database, which means all tables in the database are ledger tables.
+
+- Required: No
+- Type: bool
+
+### Parameter: `databases.licenseType`
+
+The license type to apply for this database.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'BasePrice'
+    'LicenseIncluded'
+  ]
+  ```
+
+### Parameter: `databases.longTermRetentionBackupResourceId`
+
+The resource identifier of the long term retention backup associated with create operation of this database.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.maintenanceConfigurationId`
+
+Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.manualCutover`
+
+Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier.
+
+- Required: No
+- Type: bool
+
+### Parameter: `databases.maxSizeBytes`
+
+The max size of the database expressed in bytes.
+
+- Required: No
+- Type: int
+
+### Parameter: `databases.minCapacity`
+
+Minimal capacity that database will always have allocated, if not paused.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.performCutover`
+
+To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress.
+
+- Required: No
+- Type: bool
+
+### Parameter: `databases.preferredEnclaveType`
+
+Type of enclave requested on the database.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Default'
+    'VBS'
+  ]
+  ```
+
+### Parameter: `databases.readScale`
+
+The state of read-only routing. If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale database within an elastic pool.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Disabled'
+    'Enabled'
+  ]
+  ```
+
+### Parameter: `databases.recoverableDatabaseId`
+
+The resource identifier of the recoverable database associated with create operation of this database.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.recoveryServicesRecoveryPointId`
+
+The resource identifier of the recovery point associated with create operation of this database.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.requestedBackupStorageRedundancy`
+
+The storage account type to be used to store backups for this database.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Geo'
+    'GeoZone'
+    'Local'
+    'Zone'
+  ]
+  ```
+
+### Parameter: `databases.restorableDroppedDatabaseId`
+
+The resource identifier of the restorable dropped database associated with create operation of this database.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.restorePointInTime`
+
+Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.sampleName`
+
+The name of the sample schema to apply when creating this database.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.secondaryType`
+
+The secondary type of the database if it is a secondary.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Geo'
+    'Named'
+    'Standby'
+  ]
+  ```
+
+### Parameter: `databases.sku`
+
+The database SKU.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-databasesskuname) | string | The name of the SKU, typically, a letter + Number code, e.g. P3. |
+| [`tier`](#parameter-databasesskutier) | string | The tier or edition of the particular SKU, e.g. Basic, Premium. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`capacity`](#parameter-databasesskucapacity) | int | The capacity of the particular SKU. |
+| [`family`](#parameter-databasesskufamily) | string | If the service has different generations of hardware, for the same SKU, then that can be captured here. |
+| [`size`](#parameter-databasesskusize) | string | Size of the particular SKU |
+
+### Parameter: `databases.sku.name`
+
+The name of the SKU, typically, a letter + Number code, e.g. P3.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `databases.sku.tier`
+
+The tier or edition of the particular SKU, e.g. Basic, Premium.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.sku.capacity`
+
+The capacity of the particular SKU.
+
+- Required: No
+- Type: int
+
+### Parameter: `databases.sku.family`
+
+If the service has different generations of hardware, for the same SKU, then that can be captured here.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.sku.size`
+
+Size of the particular SKU
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.sourceDatabaseDeletionDate`
+
+Specifies the time that the database was deleted.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.sourceDatabaseId`
+
+The resource identifier of the source database associated with create operation of this database.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.sourceResourceId`
+
+The resource identifier of the source associated with the create operation of this database.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.tags`
+
+Tags of the resource.
+
+- Required: No
+- Type: object
+
+### Parameter: `databases.useFreeLimit`
+
+Whether or not the database uses free monthly limits. Allowed on one database in a subscription.
+
+- Required: No
+- Type: bool
+
+### Parameter: `databases.zoneRedundant`
+
+Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones.
+
+- Required: No
+- Type: bool
+
 ### Parameter: `elasticPools`
 
 The Elastic Pools to create in the server.

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -1975,12 +1975,6 @@ The audit settings configuration.
 - Type: object
 - Default: `{}`
 
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`state`](#parameter-auditsettingsstate) | string | Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required. |
-
 **Optional parameters**
 
 | Parameter | Type | Description |
@@ -1993,21 +1987,8 @@ The audit settings configuration.
 | [`name`](#parameter-auditsettingsname) | string | Specifies the name of the audit settings. |
 | [`queueDelayMs`](#parameter-auditsettingsqueuedelayms) | int | Specifies the amount of time in milliseconds that can elapse before audit actions are forced to be processed. |
 | [`retentionDays`](#parameter-auditsettingsretentiondays) | int | Specifies the number of days to keep in the audit logs in the storage account. |
+| [`state`](#parameter-auditsettingsstate) | string | Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required. |
 | [`storageAccountResourceId`](#parameter-auditsettingsstorageaccountresourceid) | string | Specifies the identifier key of the auditing storage account. |
-
-### Parameter: `auditSettings.state`
-
-Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.
-
-- Required: No
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'Disabled'
-    'Enabled'
-  ]
-  ```
 
 ### Parameter: `auditSettings.auditActionsAndGroups`
 
@@ -2064,6 +2045,20 @@ Specifies the number of days to keep in the audit logs in the storage account.
 
 - Required: No
 - Type: int
+
+### Parameter: `auditSettings.state`
+
+Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Disabled'
+    'Enabled'
+  ]
+  ```
 
 ### Parameter: `auditSettings.storageAccountResourceId`
 

--- a/avm/res/sql/server/audit-settings/README.md
+++ b/avm/res/sql/server/audit-settings/README.md
@@ -40,7 +40,7 @@ This module deploys an Azure SQL Server Audit Settings.
 | [`isStorageSecondaryKeyInUse`](#parameter-isstoragesecondarykeyinuse) | bool | Specifies whether storageAccountAccessKey value is the storage's secondary key. |
 | [`queueDelayMs`](#parameter-queuedelayms) | int | Specifies the amount of time in milliseconds that can elapse before audit actions are forced to be processed. |
 | [`retentionDays`](#parameter-retentiondays) | int | Specifies the number of days to keep in the audit logs in the storage account. |
-| [`state`](#parameter-state) | string | The resource group of the SQL Server. Required if the template is used in a standalone deployment. |
+| [`state`](#parameter-state) | string | Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required. |
 | [`storageAccountResourceId`](#parameter-storageaccountresourceid) | string | A blob storage to hold the auditing storage account. |
 
 ### Parameter: `name`
@@ -122,7 +122,7 @@ Specifies the number of days to keep in the audit logs in the storage account.
 
 ### Parameter: `state`
 
-The resource group of the SQL Server. Required if the template is used in a standalone deployment.
+Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.
 
 - Required: No
 - Type: string

--- a/avm/res/sql/server/audit-settings/README.md
+++ b/avm/res/sql/server/audit-settings/README.md
@@ -22,7 +22,6 @@ This module deploys an Azure SQL Server Audit Settings.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-name) | string | The name of the audit settings. |
-| [`state`](#parameter-state) | string | The resource group of the SQL Server. Required if the template is used in a standalone deployment. |
 
 **Conditional parameters**
 
@@ -41,6 +40,7 @@ This module deploys an Azure SQL Server Audit Settings.
 | [`isStorageSecondaryKeyInUse`](#parameter-isstoragesecondarykeyinuse) | bool | Specifies whether storageAccountAccessKey value is the storage's secondary key. |
 | [`queueDelayMs`](#parameter-queuedelayms) | int | Specifies the amount of time in milliseconds that can elapse before audit actions are forced to be processed. |
 | [`retentionDays`](#parameter-retentiondays) | int | Specifies the number of days to keep in the audit logs in the storage account. |
+| [`state`](#parameter-state) | string | The resource group of the SQL Server. Required if the template is used in a standalone deployment. |
 | [`storageAccountResourceId`](#parameter-storageaccountresourceid) | string | A blob storage to hold the auditing storage account. |
 
 ### Parameter: `name`
@@ -49,20 +49,6 @@ The name of the audit settings.
 
 - Required: Yes
 - Type: string
-
-### Parameter: `state`
-
-The resource group of the SQL Server. Required if the template is used in a standalone deployment.
-
-- Required: Yes
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'Disabled'
-    'Enabled'
-  ]
-  ```
 
 ### Parameter: `serverName`
 
@@ -77,6 +63,14 @@ Specifies the Actions-Groups and Actions to audit.
 
 - Required: No
 - Type: array
+- Default:
+  ```Bicep
+  [
+    'BATCH_COMPLETED_GROUP'
+    'FAILED_DATABASE_AUTHENTICATION_GROUP'
+    'SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP'
+  ]
+  ```
 
 ### Parameter: `isAzureMonitorTargetEnabled`
 
@@ -84,7 +78,7 @@ Specifies whether audit events are sent to Azure Monitor.
 
 - Required: No
 - Type: bool
-- Default: `False`
+- Default: `True`
 
 ### Parameter: `isDevopsAuditEnabled`
 
@@ -92,6 +86,7 @@ Specifies the state of devops audit. If state is Enabled, devops logs will be se
 
 - Required: No
 - Type: bool
+- Default: `False`
 
 ### Parameter: `isManagedIdentityInUse`
 
@@ -107,6 +102,7 @@ Specifies whether storageAccountAccessKey value is the storage's secondary key.
 
 - Required: No
 - Type: bool
+- Default: `False`
 
 ### Parameter: `queueDelayMs`
 
@@ -114,6 +110,7 @@ Specifies the amount of time in milliseconds that can elapse before audit action
 
 - Required: No
 - Type: int
+- Default: `1000`
 
 ### Parameter: `retentionDays`
 
@@ -121,6 +118,22 @@ Specifies the number of days to keep in the audit logs in the storage account.
 
 - Required: No
 - Type: int
+- Default: `90`
+
+### Parameter: `state`
+
+The resource group of the SQL Server. Required if the template is used in a standalone deployment.
+
+- Required: No
+- Type: string
+- Default: `'Enabled'`
+- Allowed:
+  ```Bicep
+  [
+    'Disabled'
+    'Enabled'
+  ]
+  ```
 
 ### Parameter: `storageAccountResourceId`
 

--- a/avm/res/sql/server/audit-settings/main.bicep
+++ b/avm/res/sql/server/audit-settings/main.bicep
@@ -16,7 +16,7 @@ param serverName string
 param state string = 'Enabled'
 
 @description('Optional. Specifies the Actions-Groups and Actions to audit.')
-param auditActionsAndGroups array = [
+param auditActionsAndGroups string[] = [
   'BATCH_COMPLETED_GROUP'
   'SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP'
   'FAILED_DATABASE_AUTHENTICATION_GROUP'

--- a/avm/res/sql/server/audit-settings/main.bicep
+++ b/avm/res/sql/server/audit-settings/main.bicep
@@ -8,7 +8,7 @@ param name string
 @description('Conditional. The Name of SQL Server. Required if the template is used in a standalone deployment.')
 param serverName string
 
-@description('Optional. The resource group of the SQL Server. Required if the template is used in a standalone deployment.')
+@description('Optional. Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.')
 @allowed([
   'Enabled'
   'Disabled'

--- a/avm/res/sql/server/audit-settings/main.bicep
+++ b/avm/res/sql/server/audit-settings/main.bicep
@@ -8,33 +8,37 @@ param name string
 @description('Conditional. The Name of SQL Server. Required if the template is used in a standalone deployment.')
 param serverName string
 
-@description('Required. The resource group of the SQL Server. Required if the template is used in a standalone deployment.')
+@description('Optional. The resource group of the SQL Server. Required if the template is used in a standalone deployment.')
 @allowed([
   'Enabled'
   'Disabled'
 ])
-param state string
+param state string = 'Enabled'
 
 @description('Optional. Specifies the Actions-Groups and Actions to audit.')
-param auditActionsAndGroups array?
+param auditActionsAndGroups array = [
+  'BATCH_COMPLETED_GROUP'
+  'SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP'
+  'FAILED_DATABASE_AUTHENTICATION_GROUP'
+]
 
 @description('Optional. Specifies whether audit events are sent to Azure Monitor.')
-param isAzureMonitorTargetEnabled bool = false
+param isAzureMonitorTargetEnabled bool = true
 
 @description('Optional. Specifies the state of devops audit. If state is Enabled, devops logs will be sent to Azure Monitor.')
-param isDevopsAuditEnabled bool?
+param isDevopsAuditEnabled bool = false
 
 @description('Optional. Specifies whether Managed Identity is used to access blob storage.')
 param isManagedIdentityInUse bool = false
 
 @description('Optional. Specifies whether storageAccountAccessKey value is the storage\'s secondary key.')
-param isStorageSecondaryKeyInUse bool?
+param isStorageSecondaryKeyInUse bool = false
 
 @description('Optional. Specifies the amount of time in milliseconds that can elapse before audit actions are forced to be processed.')
-param queueDelayMs int?
+param queueDelayMs int = 1000
 
 @description('Optional. Specifies the number of days to keep in the audit logs in the storage account.')
-param retentionDays int?
+param retentionDays int = 90
 
 @description('Optional. A blob storage to hold the auditing storage account.')
 param storageAccountResourceId string = ''

--- a/avm/res/sql/server/audit-settings/main.json
+++ b/avm/res/sql/server/audit-settings/main.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
   "contentVersion": "1.0.0.0",
   "metadata": {
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "4994120295983844637"
+      "templateHash": "15193713225079892162"
     },
     "name": "Azure SQL Server Audit Settings",
     "description": "This module deploys an Azure SQL Server Audit Settings.",
@@ -37,6 +38,9 @@
     },
     "auditActionsAndGroups": {
       "type": "array",
+      "items": {
+        "type": "string"
+      },
       "defaultValue": [
         "BATCH_COMPLETED_GROUP",
         "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
@@ -96,8 +100,14 @@
       }
     }
   },
-  "resources": [
-    {
+  "resources": {
+    "server": {
+      "existing": true,
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2023-08-01-preview",
+      "name": "[parameters('serverName')]"
+    },
+    "auditSettings": {
       "type": "Microsoft.Sql/servers/auditingSettings",
       "apiVersion": "2023-08-01-preview",
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
@@ -113,9 +123,12 @@
         "storageAccountAccessKey": "[if(and(not(empty(parameters('storageAccountResourceId'))), not(parameters('isManagedIdentityInUse'))), listKeys(parameters('storageAccountResourceId'), '2019-06-01').keys[0].value, null())]",
         "storageAccountSubscriptionId": "[if(not(empty(parameters('storageAccountResourceId'))), split(parameters('storageAccountResourceId'), '/')[2], null())]",
         "storageEndpoint": "[if(not(empty(parameters('storageAccountResourceId'))), format('https://{0}.blob.{1}', last(split(parameters('storageAccountResourceId'), '/')), environment().suffixes.storage), null())]"
-      }
+      },
+      "dependsOn": [
+        "server"
+      ]
     },
-    {
+    "storageAccount_sbdc_rbac": {
       "condition": "[and(parameters('isManagedIdentityInUse'), not(empty(parameters('storageAccountResourceId'))))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
@@ -130,7 +143,7 @@
             "value": "[last(split(parameters('storageAccountResourceId'), '/'))]"
           },
           "managedInstanceIdentityPrincipalId": {
-            "value": "[reference(resourceId('Microsoft.Sql/servers', parameters('serverName')), '2023-08-01-preview', 'full').identity.principalId]"
+            "value": "[reference('server', '2023-08-01-preview', 'full').identity.principalId]"
           }
         },
         "template": {
@@ -165,9 +178,12 @@
             }
           ]
         }
-      }
+      },
+      "dependsOn": [
+        "server"
+      ]
     }
-  ],
+  },
   "outputs": {
     "name": {
       "type": "string",

--- a/avm/res/sql/server/audit-settings/main.json
+++ b/avm/res/sql/server/audit-settings/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "2203194937155100618"
+      "templateHash": "4994120295983844637"
     },
     "name": "Azure SQL Server Audit Settings",
     "description": "This module deploys an Azure SQL Server Audit Settings.",
@@ -32,7 +32,7 @@
         "Disabled"
       ],
       "metadata": {
-        "description": "Optional. The resource group of the SQL Server. Required if the template is used in a standalone deployment."
+        "description": "Optional. Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
       }
     },
     "auditActionsAndGroups": {

--- a/avm/res/sql/server/audit-settings/main.json
+++ b/avm/res/sql/server/audit-settings/main.json
@@ -1,12 +1,11 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "languageVersion": "2.0",
   "contentVersion": "1.0.0.0",
   "metadata": {
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "4165841300638093382"
+      "templateHash": "2203194937155100618"
     },
     "name": "Azure SQL Server Audit Settings",
     "description": "This module deploys an Azure SQL Server Audit Settings.",
@@ -27,31 +26,36 @@
     },
     "state": {
       "type": "string",
+      "defaultValue": "Enabled",
       "allowedValues": [
         "Enabled",
         "Disabled"
       ],
       "metadata": {
-        "description": "Required. The resource group of the SQL Server. Required if the template is used in a standalone deployment."
+        "description": "Optional. The resource group of the SQL Server. Required if the template is used in a standalone deployment."
       }
     },
     "auditActionsAndGroups": {
       "type": "array",
-      "nullable": true,
+      "defaultValue": [
+        "BATCH_COMPLETED_GROUP",
+        "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
+        "FAILED_DATABASE_AUTHENTICATION_GROUP"
+      ],
       "metadata": {
         "description": "Optional. Specifies the Actions-Groups and Actions to audit."
       }
     },
     "isAzureMonitorTargetEnabled": {
       "type": "bool",
-      "defaultValue": false,
+      "defaultValue": true,
       "metadata": {
         "description": "Optional. Specifies whether audit events are sent to Azure Monitor."
       }
     },
     "isDevopsAuditEnabled": {
       "type": "bool",
-      "nullable": true,
+      "defaultValue": false,
       "metadata": {
         "description": "Optional. Specifies the state of devops audit. If state is Enabled, devops logs will be sent to Azure Monitor."
       }
@@ -65,21 +69,21 @@
     },
     "isStorageSecondaryKeyInUse": {
       "type": "bool",
-      "nullable": true,
+      "defaultValue": false,
       "metadata": {
         "description": "Optional. Specifies whether storageAccountAccessKey value is the storage's secondary key."
       }
     },
     "queueDelayMs": {
       "type": "int",
-      "nullable": true,
+      "defaultValue": 1000,
       "metadata": {
         "description": "Optional. Specifies the amount of time in milliseconds that can elapse before audit actions are forced to be processed."
       }
     },
     "retentionDays": {
       "type": "int",
-      "nullable": true,
+      "defaultValue": 90,
       "metadata": {
         "description": "Optional. Specifies the number of days to keep in the audit logs in the storage account."
       }
@@ -92,14 +96,8 @@
       }
     }
   },
-  "resources": {
-    "server": {
-      "existing": true,
-      "type": "Microsoft.Sql/servers",
-      "apiVersion": "2023-08-01-preview",
-      "name": "[parameters('serverName')]"
-    },
-    "auditSettings": {
+  "resources": [
+    {
       "type": "Microsoft.Sql/servers/auditingSettings",
       "apiVersion": "2023-08-01-preview",
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
@@ -115,12 +113,9 @@
         "storageAccountAccessKey": "[if(and(not(empty(parameters('storageAccountResourceId'))), not(parameters('isManagedIdentityInUse'))), listKeys(parameters('storageAccountResourceId'), '2019-06-01').keys[0].value, null())]",
         "storageAccountSubscriptionId": "[if(not(empty(parameters('storageAccountResourceId'))), split(parameters('storageAccountResourceId'), '/')[2], null())]",
         "storageEndpoint": "[if(not(empty(parameters('storageAccountResourceId'))), format('https://{0}.blob.{1}', last(split(parameters('storageAccountResourceId'), '/')), environment().suffixes.storage), null())]"
-      },
-      "dependsOn": [
-        "server"
-      ]
+      }
     },
-    "storageAccount_sbdc_rbac": {
+    {
       "condition": "[and(parameters('isManagedIdentityInUse'), not(empty(parameters('storageAccountResourceId'))))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
@@ -135,7 +130,7 @@
             "value": "[last(split(parameters('storageAccountResourceId'), '/'))]"
           },
           "managedInstanceIdentityPrincipalId": {
-            "value": "[reference('server', '2023-08-01-preview', 'full').identity.principalId]"
+            "value": "[reference(resourceId('Microsoft.Sql/servers', parameters('serverName')), '2023-08-01-preview', 'full').identity.principalId]"
           }
         },
         "template": {
@@ -170,12 +165,9 @@
             }
           ]
         }
-      },
-      "dependsOn": [
-        "server"
-      ]
+      }
     }
-  },
+  ],
   "outputs": {
     "name": {
       "type": "string",

--- a/avm/res/sql/server/database/README.md
+++ b/avm/res/sql/server/database/README.md
@@ -95,7 +95,7 @@ Time in minutes after which database is automatically paused. A value of -1 mean
 
 - Required: No
 - Type: int
-- Default: `0`
+- Default: `-1`
 
 ### Parameter: `availabilityZone`
 

--- a/avm/res/sql/server/database/README.md
+++ b/avm/res/sql/server/database/README.md
@@ -35,7 +35,7 @@ This module deploys an Azure SQL Server Database.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`autoPauseDelay`](#parameter-autopausedelay) | int | Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled |
+| [`autoPauseDelay`](#parameter-autopausedelay) | int | Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled. |
 | [`availabilityZone`](#parameter-availabilityzone) | string | Specifies the availability zone the database is pinned to. |
 | [`backupLongTermRetentionPolicy`](#parameter-backuplongtermretentionpolicy) | object | The long term backup retention policy to create for the database. |
 | [`backupShortTermRetentionPolicy`](#parameter-backupshorttermretentionpolicy) | object | The short term backup retention policy to create for the database. |
@@ -91,7 +91,7 @@ The name of the parent SQL Server. Required if the template is used in a standal
 
 ### Parameter: `autoPauseDelay`
 
-Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled
+Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled.
 
 - Required: No
 - Type: int
@@ -563,7 +563,7 @@ The database SKU.
 | :-- | :-- | :-- |
 | [`capacity`](#parameter-skucapacity) | int | The capacity of the particular SKU. |
 | [`family`](#parameter-skufamily) | string | If the service has different generations of hardware, for the same SKU, then that can be captured here. |
-| [`size`](#parameter-skusize) | string | Size of the particular SKU |
+| [`size`](#parameter-skusize) | string | Size of the particular SKU. |
 
 ### Parameter: `sku.name`
 
@@ -595,7 +595,7 @@ If the service has different generations of hardware, for the same SKU, then tha
 
 ### Parameter: `sku.size`
 
-Size of the particular SKU
+Size of the particular SKU.
 
 - Required: No
 - Type: string

--- a/avm/res/sql/server/database/README.md
+++ b/avm/res/sql/server/database/README.md
@@ -14,7 +14,7 @@ This module deploys an Azure SQL Server Database.
 | :-- | :-- |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.Sql/servers/databases` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/servers/databases) |
-| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies) |
+| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
 | `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies) |
 
 ## Parameters
@@ -120,7 +120,66 @@ The long term backup retention policy to create for the database.
 
 - Required: No
 - Type: object
-- Default: `{}`
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`backupStorageAccessTier`](#parameter-backuplongtermretentionpolicybackupstorageaccesstier) | string | The BackupStorageAccessTier for the LTR backups. |
+| [`makeBackupsImmutable`](#parameter-backuplongtermretentionpolicymakebackupsimmutable) | bool | The setting whether to make LTR backups immutable. |
+| [`monthlyRetention`](#parameter-backuplongtermretentionpolicymonthlyretention) | string | Monthly retention in ISO 8601 duration format. |
+| [`weeklyRetention`](#parameter-backuplongtermretentionpolicyweeklyretention) | string | Weekly retention in ISO 8601 duration format. |
+| [`weekOfYear`](#parameter-backuplongtermretentionpolicyweekofyear) | int | Week of year backup to keep for yearly retention. |
+| [`yearlyRetention`](#parameter-backuplongtermretentionpolicyyearlyretention) | string | Yearly retention in ISO 8601 duration format. |
+
+### Parameter: `backupLongTermRetentionPolicy.backupStorageAccessTier`
+
+The BackupStorageAccessTier for the LTR backups.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Archive'
+    'Hot'
+  ]
+  ```
+
+### Parameter: `backupLongTermRetentionPolicy.makeBackupsImmutable`
+
+The setting whether to make LTR backups immutable.
+
+- Required: No
+- Type: bool
+
+### Parameter: `backupLongTermRetentionPolicy.monthlyRetention`
+
+Monthly retention in ISO 8601 duration format.
+
+- Required: No
+- Type: string
+
+### Parameter: `backupLongTermRetentionPolicy.weeklyRetention`
+
+Weekly retention in ISO 8601 duration format.
+
+- Required: No
+- Type: string
+
+### Parameter: `backupLongTermRetentionPolicy.weekOfYear`
+
+Week of year backup to keep for yearly retention.
+
+- Required: No
+- Type: int
+
+### Parameter: `backupLongTermRetentionPolicy.yearlyRetention`
+
+Yearly retention in ISO 8601 duration format.
+
+- Required: No
+- Type: string
 
 ### Parameter: `backupShortTermRetentionPolicy`
 
@@ -128,7 +187,27 @@ The short term backup retention policy to create for the database.
 
 - Required: No
 - Type: object
-- Default: `{}`
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`diffBackupIntervalInHours`](#parameter-backupshorttermretentionpolicydiffbackupintervalinhours) | int | Differential backup interval in hours. |
+| [`retentionDays`](#parameter-backupshorttermretentionpolicyretentiondays) | int | Point-in-time retention in days. |
+
+### Parameter: `backupShortTermRetentionPolicy.diffBackupIntervalInHours`
+
+Differential backup interval in hours.
+
+- Required: No
+- Type: int
+
+### Parameter: `backupShortTermRetentionPolicy.retentionDays`
+
+Point-in-time retention in days.
+
+- Required: No
+- Type: int
 
 ### Parameter: `catalogCollation`
 

--- a/avm/res/sql/server/database/README.md
+++ b/avm/res/sql/server/database/README.md
@@ -35,34 +35,44 @@ This module deploys an Azure SQL Server Database.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`autoPauseDelay`](#parameter-autopausedelay) | int | Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled. |
+| [`autoPauseDelay`](#parameter-autopausedelay) | int | Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled |
+| [`availabilityZone`](#parameter-availabilityzone) | string | Specifies the availability zone the database is pinned to. |
 | [`backupLongTermRetentionPolicy`](#parameter-backuplongtermretentionpolicy) | object | The long term backup retention policy to create for the database. |
 | [`backupShortTermRetentionPolicy`](#parameter-backupshorttermretentionpolicy) | object | The short term backup retention policy to create for the database. |
+| [`catalogCollation`](#parameter-catalogcollation) | string | Collation of the metadata catalog. |
 | [`collation`](#parameter-collation) | string | The collation of the database. |
 | [`createMode`](#parameter-createmode) | string | Specifies the mode of database creation. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
 | [`elasticPoolId`](#parameter-elasticpoolid) | string | The resource ID of the elastic pool containing this database. |
+| [`encryptionProtector`](#parameter-encryptionprotector) | string | The azure key vault URI of the database if it's configured with per Database Customer Managed Keys. |
+| [`encryptionProtectorAutoRotation`](#parameter-encryptionprotectorautorotation) | bool | The flag to enable or disable auto rotation of database encryption protector AKV key. |
+| [`federatedClientId`](#parameter-federatedclientid) | string | The Client id used for cross tenant per database CMK scenario. |
+| [`freeLimitExhaustionBehavior`](#parameter-freelimitexhaustionbehavior) | string | Specifies the behavior when monthly free limits are exhausted for the free database. |
 | [`highAvailabilityReplicaCount`](#parameter-highavailabilityreplicacount) | int | The number of readonly secondary replicas associated with the database. |
 | [`isLedgerOn`](#parameter-isledgeron) | bool | Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created. |
 | [`licenseType`](#parameter-licensetype) | string | The license type to apply for this database. |
 | [`location`](#parameter-location) | string | Location for all resources. |
+| [`longTermRetentionBackupResourceId`](#parameter-longtermretentionbackupresourceid) | string | The resource identifier of the long term retention backup associated with create operation of this database. |
 | [`maintenanceConfigurationId`](#parameter-maintenanceconfigurationid) | string | Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur. |
+| [`manualCutover`](#parameter-manualcutover) | bool | Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier. |
 | [`maxSizeBytes`](#parameter-maxsizebytes) | int | The max size of the database expressed in bytes. |
 | [`minCapacity`](#parameter-mincapacity) | string | Minimal capacity that database will always have allocated. |
+| [`performCutover`](#parameter-performcutover) | bool | To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress. |
 | [`preferredEnclaveType`](#parameter-preferredenclavetype) | string | Type of enclave requested on the database i.e. Default or VBS enclaves. |
 | [`readScale`](#parameter-readscale) | string | The state of read-only routing. |
-| [`recoveryServicesRecoveryPointResourceId`](#parameter-recoveryservicesrecoverypointresourceid) | string | Resource ID of backup if createMode set to RestoreLongTermRetentionBackup. |
+| [`recoverableDatabaseId`](#parameter-recoverabledatabaseid) | string | The resource identifier of the recoverable database associated with create operation of this database. |
+| [`recoveryServicesRecoveryPointId`](#parameter-recoveryservicesrecoverypointid) | string | The resource identifier of the recovery point associated with create operation of this database. |
 | [`requestedBackupStorageRedundancy`](#parameter-requestedbackupstorageredundancy) | string | The storage account type to be used to store backups for this database. |
+| [`restorableDroppedDatabaseId`](#parameter-restorabledroppeddatabaseid) | string | The resource identifier of the restorable dropped database associated with create operation of this database. |
 | [`restorePointInTime`](#parameter-restorepointintime) | string | Point in time (ISO8601 format) of the source database to restore when createMode set to Restore or PointInTimeRestore. |
 | [`sampleName`](#parameter-samplename) | string | The name of the sample schema to apply when creating this database. |
-| [`skuCapacity`](#parameter-skucapacity) | int | Capacity of the particular SKU. |
-| [`skuFamily`](#parameter-skufamily) | string | If the service has different generations of hardware, for the same SKU, then that can be captured here. |
-| [`skuName`](#parameter-skuname) | string | The name of the SKU. |
-| [`skuSize`](#parameter-skusize) | string | Size of the particular SKU. |
-| [`skuTier`](#parameter-skutier) | string | The skuTier or edition of the particular SKU. |
+| [`secondaryType`](#parameter-secondarytype) | string | The secondary type of the database if it is a secondary. |
+| [`sku`](#parameter-sku) | object | The database SKU. |
 | [`sourceDatabaseDeletionDate`](#parameter-sourcedatabasedeletiondate) | string | The time that the database was deleted when restoring a deleted database. |
-| [`sourceDatabaseResourceId`](#parameter-sourcedatabaseresourceid) | string | Resource ID of database if createMode set to Copy, Secondary, PointInTimeRestore, Recovery or Restore. |
+| [`sourceDatabaseId`](#parameter-sourcedatabaseid) | string | The resource identifier of the source database associated with create operation of this database. |
+| [`sourceResourceId`](#parameter-sourceresourceid) | string | The resource identifier of the source associated with the create operation of this database. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
+| [`useFreeLimit`](#parameter-usefreelimit) | bool | Whether or not the database uses free monthly limits. Allowed on one database in a subscription. |
 | [`zoneRedundant`](#parameter-zoneredundant) | bool | Whether or not this database is zone redundant. |
 
 ### Parameter: `name`
@@ -81,11 +91,28 @@ The name of the parent SQL Server. Required if the template is used in a standal
 
 ### Parameter: `autoPauseDelay`
 
-Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled.
+Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled
 
 - Required: No
 - Type: int
 - Default: `0`
+
+### Parameter: `availabilityZone`
+
+Specifies the availability zone the database is pinned to.
+
+- Required: No
+- Type: string
+- Default: `'NoPreference'`
+- Allowed:
+  ```Bicep
+  [
+    '1'
+    '2'
+    '3'
+    'NoPreference'
+  ]
+  ```
 
 ### Parameter: `backupLongTermRetentionPolicy`
 
@@ -102,6 +129,14 @@ The short term backup retention policy to create for the database.
 - Required: No
 - Type: object
 - Default: `{}`
+
+### Parameter: `catalogCollation`
+
+Collation of the metadata catalog.
+
+- Required: No
+- Type: string
+- Default: `'DATABASE_DEFAULT'`
 
 ### Parameter: `collation`
 
@@ -127,6 +162,8 @@ Specifies the mode of database creation.
     'PointInTimeRestore'
     'Recovery'
     'Restore'
+    'RestoreExternalBackup'
+    'RestoreExternalBackupSecondary'
     'RestoreLongTermRetentionBackup'
     'Secondary'
   ]
@@ -284,7 +321,41 @@ The resource ID of the elastic pool containing this database.
 
 - Required: No
 - Type: string
-- Default: `''`
+
+### Parameter: `encryptionProtector`
+
+The azure key vault URI of the database if it's configured with per Database Customer Managed Keys.
+
+- Required: No
+- Type: string
+
+### Parameter: `encryptionProtectorAutoRotation`
+
+The flag to enable or disable auto rotation of database encryption protector AKV key.
+
+- Required: No
+- Type: bool
+
+### Parameter: `federatedClientId`
+
+The Client id used for cross tenant per database CMK scenario.
+
+- Required: No
+- Type: string
+
+### Parameter: `freeLimitExhaustionBehavior`
+
+Specifies the behavior when monthly free limits are exhausted for the free database.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'AutoPause'
+    'BillOverUsage'
+  ]
+  ```
 
 ### Parameter: `highAvailabilityReplicaCount`
 
@@ -308,7 +379,13 @@ The license type to apply for this database.
 
 - Required: No
 - Type: string
-- Default: `''`
+- Allowed:
+  ```Bicep
+  [
+    'BasePrice'
+    'LicenseIncluded'
+  ]
+  ```
 
 ### Parameter: `location`
 
@@ -318,12 +395,26 @@ Location for all resources.
 - Type: string
 - Default: `[resourceGroup().location]`
 
+### Parameter: `longTermRetentionBackupResourceId`
+
+The resource identifier of the long term retention backup associated with create operation of this database.
+
+- Required: No
+- Type: string
+
 ### Parameter: `maintenanceConfigurationId`
 
 Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur.
 
 - Required: No
 - Type: string
+
+### Parameter: `manualCutover`
+
+Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier.
+
+- Required: No
+- Type: bool
 
 ### Parameter: `maxSizeBytes`
 
@@ -339,7 +430,14 @@ Minimal capacity that database will always have allocated.
 
 - Required: No
 - Type: string
-- Default: `''`
+- Default: `'0'`
+
+### Parameter: `performCutover`
+
+To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress.
+
+- Required: No
+- Type: bool
 
 ### Parameter: `preferredEnclaveType`
 
@@ -347,11 +445,9 @@ Type of enclave requested on the database i.e. Default or VBS enclaves.
 
 - Required: No
 - Type: string
-- Default: `''`
 - Allowed:
   ```Bicep
   [
-    ''
     'Default'
     'VBS'
   ]
@@ -372,13 +468,19 @@ The state of read-only routing.
   ]
   ```
 
-### Parameter: `recoveryServicesRecoveryPointResourceId`
+### Parameter: `recoverableDatabaseId`
 
-Resource ID of backup if createMode set to RestoreLongTermRetentionBackup.
+The resource identifier of the recoverable database associated with create operation of this database.
 
 - Required: No
 - Type: string
-- Default: `''`
+
+### Parameter: `recoveryServicesRecoveryPointId`
+
+The resource identifier of the recovery point associated with create operation of this database.
+
+- Required: No
+- Type: string
 
 ### Parameter: `requestedBackupStorageRedundancy`
 
@@ -386,16 +488,23 @@ The storage account type to be used to store backups for this database.
 
 - Required: No
 - Type: string
-- Default: `''`
+- Default: `'Local'`
 - Allowed:
   ```Bicep
   [
-    ''
     'Geo'
+    'GeoZone'
     'Local'
     'Zone'
   ]
   ```
+
+### Parameter: `restorableDroppedDatabaseId`
+
+The resource identifier of the restorable dropped database associated with create operation of this database.
+
+- Required: No
+- Type: string
 
 ### Parameter: `restorePointInTime`
 
@@ -403,7 +512,6 @@ Point in time (ISO8601 format) of the source database to restore when createMode
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ### Parameter: `sampleName`
 
@@ -413,44 +521,84 @@ The name of the sample schema to apply when creating this database.
 - Type: string
 - Default: `''`
 
-### Parameter: `skuCapacity`
+### Parameter: `secondaryType`
 
-Capacity of the particular SKU.
+The secondary type of the database if it is a secondary.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Geo'
+    'Named'
+    'Standby'
+  ]
+  ```
+
+### Parameter: `sku`
+
+The database SKU.
+
+- Required: No
+- Type: object
+- Default:
+  ```Bicep
+  {
+      name: 'GP_Gen5_2'
+      tier: 'GeneralPurpose'
+  }
+  ```
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-skuname) | string | The name of the SKU, typically, a letter + Number code, e.g. P3. |
+| [`tier`](#parameter-skutier) | string | The tier or edition of the particular SKU, e.g. Basic, Premium. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`capacity`](#parameter-skucapacity) | int | The capacity of the particular SKU. |
+| [`family`](#parameter-skufamily) | string | If the service has different generations of hardware, for the same SKU, then that can be captured here. |
+| [`size`](#parameter-skusize) | string | Size of the particular SKU |
+
+### Parameter: `sku.name`
+
+The name of the SKU, typically, a letter + Number code, e.g. P3.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `sku.tier`
+
+The tier or edition of the particular SKU, e.g. Basic, Premium.
+
+- Required: No
+- Type: string
+
+### Parameter: `sku.capacity`
+
+The capacity of the particular SKU.
 
 - Required: No
 - Type: int
 
-### Parameter: `skuFamily`
+### Parameter: `sku.family`
 
 If the service has different generations of hardware, for the same SKU, then that can be captured here.
 
 - Required: No
 - Type: string
-- Default: `''`
 
-### Parameter: `skuName`
+### Parameter: `sku.size`
 
-The name of the SKU.
-
-- Required: No
-- Type: string
-- Default: `'GP_Gen5_2'`
-
-### Parameter: `skuSize`
-
-Size of the particular SKU.
+Size of the particular SKU
 
 - Required: No
 - Type: string
-- Default: `''`
-
-### Parameter: `skuTier`
-
-The skuTier or edition of the particular SKU.
-
-- Required: No
-- Type: string
-- Default: `'GeneralPurpose'`
 
 ### Parameter: `sourceDatabaseDeletionDate`
 
@@ -458,15 +606,20 @@ The time that the database was deleted when restoring a deleted database.
 
 - Required: No
 - Type: string
-- Default: `''`
 
-### Parameter: `sourceDatabaseResourceId`
+### Parameter: `sourceDatabaseId`
 
-Resource ID of database if createMode set to Copy, Secondary, PointInTimeRestore, Recovery or Restore.
+The resource identifier of the source database associated with create operation of this database.
 
 - Required: No
 - Type: string
-- Default: `''`
+
+### Parameter: `sourceResourceId`
+
+The resource identifier of the source associated with the create operation of this database.
+
+- Required: No
+- Type: string
 
 ### Parameter: `tags`
 
@@ -475,13 +628,19 @@ Tags of the resource.
 - Required: No
 - Type: object
 
+### Parameter: `useFreeLimit`
+
+Whether or not the database uses free monthly limits. Allowed on one database in a subscription.
+
+- Required: No
+- Type: bool
+
 ### Parameter: `zoneRedundant`
 
 Whether or not this database is zone redundant.
 
 - Required: No
 - Type: bool
-- Default: `True`
 
 ## Outputs
 

--- a/avm/res/sql/server/database/README.md
+++ b/avm/res/sql/server/database/README.md
@@ -43,7 +43,7 @@ This module deploys an Azure SQL Server Database.
 | [`collation`](#parameter-collation) | string | The collation of the database. |
 | [`createMode`](#parameter-createmode) | string | Specifies the mode of database creation. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
-| [`elasticPoolId`](#parameter-elasticpoolid) | string | The resource ID of the elastic pool containing this database. |
+| [`elasticPoolResourceId`](#parameter-elasticpoolresourceid) | string | The resource ID of the elastic pool containing this database. |
 | [`encryptionProtector`](#parameter-encryptionprotector) | string | The azure key vault URI of the database if it's configured with per Database Customer Managed Keys. |
 | [`encryptionProtectorAutoRotation`](#parameter-encryptionprotectorautorotation) | bool | The flag to enable or disable auto rotation of database encryption protector AKV key. |
 | [`federatedClientId`](#parameter-federatedclientid) | string | The Client id used for cross tenant per database CMK scenario. |
@@ -60,16 +60,16 @@ This module deploys an Azure SQL Server Database.
 | [`performCutover`](#parameter-performcutover) | bool | To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress. |
 | [`preferredEnclaveType`](#parameter-preferredenclavetype) | string | Type of enclave requested on the database i.e. Default or VBS enclaves. |
 | [`readScale`](#parameter-readscale) | string | The state of read-only routing. |
-| [`recoverableDatabaseId`](#parameter-recoverabledatabaseid) | string | The resource identifier of the recoverable database associated with create operation of this database. |
-| [`recoveryServicesRecoveryPointId`](#parameter-recoveryservicesrecoverypointid) | string | The resource identifier of the recovery point associated with create operation of this database. |
+| [`recoverableDatabaseResourceId`](#parameter-recoverabledatabaseresourceid) | string | The resource identifier of the recoverable database associated with create operation of this database. |
+| [`recoveryServicesRecoveryPointResourceId`](#parameter-recoveryservicesrecoverypointresourceid) | string | The resource identifier of the recovery point associated with create operation of this database. |
 | [`requestedBackupStorageRedundancy`](#parameter-requestedbackupstorageredundancy) | string | The storage account type to be used to store backups for this database. |
-| [`restorableDroppedDatabaseId`](#parameter-restorabledroppeddatabaseid) | string | The resource identifier of the restorable dropped database associated with create operation of this database. |
+| [`restorableDroppedDatabaseResourceId`](#parameter-restorabledroppeddatabaseresourceid) | string | The resource identifier of the restorable dropped database associated with create operation of this database. |
 | [`restorePointInTime`](#parameter-restorepointintime) | string | Point in time (ISO8601 format) of the source database to restore when createMode set to Restore or PointInTimeRestore. |
 | [`sampleName`](#parameter-samplename) | string | The name of the sample schema to apply when creating this database. |
 | [`secondaryType`](#parameter-secondarytype) | string | The secondary type of the database if it is a secondary. |
 | [`sku`](#parameter-sku) | object | The database SKU. |
 | [`sourceDatabaseDeletionDate`](#parameter-sourcedatabasedeletiondate) | string | The time that the database was deleted when restoring a deleted database. |
-| [`sourceDatabaseId`](#parameter-sourcedatabaseid) | string | The resource identifier of the source database associated with create operation of this database. |
+| [`sourceDatabaseResourceId`](#parameter-sourcedatabaseresourceid) | string | The resource identifier of the source database associated with create operation of this database. |
 | [`sourceResourceId`](#parameter-sourceresourceid) | string | The resource identifier of the source associated with the create operation of this database. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`useFreeLimit`](#parameter-usefreelimit) | bool | Whether or not the database uses free monthly limits. Allowed on one database in a subscription. |
@@ -315,7 +315,7 @@ Resource ID of the diagnostic log analytics workspace. For security reasons, it 
 - Required: No
 - Type: string
 
-### Parameter: `elasticPoolId`
+### Parameter: `elasticPoolResourceId`
 
 The resource ID of the elastic pool containing this database.
 
@@ -468,14 +468,14 @@ The state of read-only routing.
   ]
   ```
 
-### Parameter: `recoverableDatabaseId`
+### Parameter: `recoverableDatabaseResourceId`
 
 The resource identifier of the recoverable database associated with create operation of this database.
 
 - Required: No
 - Type: string
 
-### Parameter: `recoveryServicesRecoveryPointId`
+### Parameter: `recoveryServicesRecoveryPointResourceId`
 
 The resource identifier of the recovery point associated with create operation of this database.
 
@@ -499,7 +499,7 @@ The storage account type to be used to store backups for this database.
   ]
   ```
 
-### Parameter: `restorableDroppedDatabaseId`
+### Parameter: `restorableDroppedDatabaseResourceId`
 
 The resource identifier of the restorable dropped database associated with create operation of this database.
 
@@ -607,7 +607,7 @@ The time that the database was deleted when restoring a deleted database.
 - Required: No
 - Type: string
 
-### Parameter: `sourceDatabaseId`
+### Parameter: `sourceDatabaseResourceId`
 
 The resource identifier of the source database associated with create operation of this database.
 

--- a/avm/res/sql/server/database/README.md
+++ b/avm/res/sql/server/database/README.md
@@ -720,6 +720,7 @@ Whether or not this database is zone redundant.
 
 - Required: No
 - Type: bool
+- Default: `True`
 
 ## Outputs
 

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/README.md
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/README.md
@@ -12,7 +12,7 @@ This module deploys an Azure SQL Server Database Long-Term Backup Retention Poli
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies) |
+| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
 
 ## Parameters
 
@@ -27,6 +27,8 @@ This module deploys an Azure SQL Server Database Long-Term Backup Retention Poli
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`backupStorageAccessTier`](#parameter-backupstorageaccesstier) | string | The BackupStorageAccessTier for the LTR backups. |
+| [`makeBackupsImmutable`](#parameter-makebackupsimmutable) | bool | The setting whether to make LTR backups immutable. |
 | [`monthlyRetention`](#parameter-monthlyretention) | string | Weekly retention in ISO 8601 duration format. |
 | [`weeklyRetention`](#parameter-weeklyretention) | string | Monthly retention in ISO 8601 duration format. |
 | [`weekOfYear`](#parameter-weekofyear) | int | Week of year backup to keep for yearly retention. |
@@ -46,13 +48,33 @@ The name of the parent SQL Server.
 - Required: Yes
 - Type: string
 
+### Parameter: `backupStorageAccessTier`
+
+The BackupStorageAccessTier for the LTR backups.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Archive'
+    'Hot'
+  ]
+  ```
+
+### Parameter: `makeBackupsImmutable`
+
+The setting whether to make LTR backups immutable.
+
+- Required: No
+- Type: bool
+
 ### Parameter: `monthlyRetention`
 
 Weekly retention in ISO 8601 duration format.
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ### Parameter: `weeklyRetention`
 
@@ -60,7 +82,6 @@ Monthly retention in ISO 8601 duration format.
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ### Parameter: `weekOfYear`
 
@@ -76,7 +97,6 @@ Yearly retention in ISO 8601 duration format.
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ## Outputs
 

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/README.md
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/README.md
@@ -29,8 +29,8 @@ This module deploys an Azure SQL Server Database Long-Term Backup Retention Poli
 | :-- | :-- | :-- |
 | [`backupStorageAccessTier`](#parameter-backupstorageaccesstier) | string | The BackupStorageAccessTier for the LTR backups. |
 | [`makeBackupsImmutable`](#parameter-makebackupsimmutable) | bool | The setting whether to make LTR backups immutable. |
-| [`monthlyRetention`](#parameter-monthlyretention) | string | Weekly retention in ISO 8601 duration format. |
-| [`weeklyRetention`](#parameter-weeklyretention) | string | Monthly retention in ISO 8601 duration format. |
+| [`monthlyRetention`](#parameter-monthlyretention) | string | Monthly retention in ISO 8601 duration format. |
+| [`weeklyRetention`](#parameter-weeklyretention) | string | Weekly retention in ISO 8601 duration format. |
 | [`weekOfYear`](#parameter-weekofyear) | int | Week of year backup to keep for yearly retention. |
 | [`yearlyRetention`](#parameter-yearlyretention) | string | Yearly retention in ISO 8601 duration format. |
 
@@ -71,14 +71,14 @@ The setting whether to make LTR backups immutable.
 
 ### Parameter: `monthlyRetention`
 
-Weekly retention in ISO 8601 duration format.
+Monthly retention in ISO 8601 duration format.
 
 - Required: No
 - Type: string
 
 ### Parameter: `weeklyRetention`
 
-Monthly retention in ISO 8601 duration format.
+Weekly retention in ISO 8601 duration format.
 
 - Required: No
 - Type: string

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/main.bicep
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/main.bicep
@@ -14,10 +14,10 @@ param backupStorageAccessTier 'Archive' | 'Hot'?
 @description('Optional. The setting whether to make LTR backups immutable.')
 param makeBackupsImmutable bool?
 
-@description('Optional. Weekly retention in ISO 8601 duration format.')
+@description('Optional. Monthly retention in ISO 8601 duration format.')
 param monthlyRetention string?
 
-@description('Optional. Monthly retention in ISO 8601 duration format.')
+@description('Optional. Weekly retention in ISO 8601 duration format.')
 param weeklyRetention string?
 
 @description('Optional. Week of year backup to keep for yearly retention.')

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/main.bicep
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/main.bicep
@@ -8,17 +8,23 @@ param serverName string
 @description('Required. The name of the parent database.')
 param databaseName string
 
-@description('Optional. Monthly retention in ISO 8601 duration format.')
-param weeklyRetention string = ''
+@description('Optional. The BackupStorageAccessTier for the LTR backups.')
+param backupStorageAccessTier 'Archive' | 'Hot'?
+
+@description('Optional. The setting whether to make LTR backups immutable.')
+param makeBackupsImmutable bool?
 
 @description('Optional. Weekly retention in ISO 8601 duration format.')
-param monthlyRetention string = ''
+param monthlyRetention string?
+
+@description('Optional. Monthly retention in ISO 8601 duration format.')
+param weeklyRetention string?
 
 @description('Optional. Week of year backup to keep for yearly retention.')
 param weekOfYear int = 1
 
 @description('Optional. Yearly retention in ISO 8601 duration format.')
-param yearlyRetention string = ''
+param yearlyRetention string?
 
 resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
   name: serverName
@@ -28,10 +34,12 @@ resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
   }
 }
 
-resource backupLongTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@2023-08-01-preview' = {
+resource backupLongTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@2023-05-01-preview' = {
   name: 'default'
   parent: server::database
   properties: {
+    backupStorageAccessTier: backupStorageAccessTier
+    makeBackupsImmutable: makeBackupsImmutable
     monthlyRetention: monthlyRetention
     weeklyRetention: weeklyRetention
     weekOfYear: weekOfYear

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "13893387790480518080"
+      "templateHash": "16586251276572997423"
     },
     "name": "SQL Server Database Long Term Backup Retention Policies",
     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy.",
@@ -47,14 +47,14 @@
       "type": "string",
       "nullable": true,
       "metadata": {
-        "description": "Optional. Weekly retention in ISO 8601 duration format."
+        "description": "Optional. Monthly retention in ISO 8601 duration format."
       }
     },
     "weeklyRetention": {
       "type": "string",
       "nullable": true,
       "metadata": {
-        "description": "Optional. Monthly retention in ISO 8601 duration format."
+        "description": "Optional. Weekly retention in ISO 8601 duration format."
       }
     },
     "weekOfYear": {

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
   "contentVersion": "1.0.0.0",
   "metadata": {
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "2778016138108001251"
+      "templateHash": "13893387790480518080"
     },
     "name": "SQL Server Database Long Term Backup Retention Policies",
     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy.",
@@ -24,18 +25,36 @@
         "description": "Required. The name of the parent database."
       }
     },
-    "weeklyRetention": {
+    "backupStorageAccessTier": {
       "type": "string",
-      "defaultValue": "",
+      "allowedValues": [
+        "Archive",
+        "Hot"
+      ],
+      "nullable": true,
       "metadata": {
-        "description": "Optional. Monthly retention in ISO 8601 duration format."
+        "description": "Optional. The BackupStorageAccessTier for the LTR backups."
+      }
+    },
+    "makeBackupsImmutable": {
+      "type": "bool",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The setting whether to make LTR backups immutable."
       }
     },
     "monthlyRetention": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
       "metadata": {
         "description": "Optional. Weekly retention in ISO 8601 duration format."
+      }
+    },
+    "weeklyRetention": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Monthly retention in ISO 8601 duration format."
       }
     },
     "weekOfYear": {
@@ -47,25 +66,45 @@
     },
     "yearlyRetention": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
       "metadata": {
         "description": "Optional. Yearly retention in ISO 8601 duration format."
       }
     }
   },
-  "resources": [
-    {
-      "type": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies",
+  "resources": {
+    "server::database": {
+      "existing": true,
+      "type": "Microsoft.Sql/servers/databases",
       "apiVersion": "2023-08-01-preview",
+      "name": "[format('{0}/{1}', parameters('serverName'), parameters('databaseName'))]",
+      "dependsOn": [
+        "server"
+      ]
+    },
+    "server": {
+      "existing": true,
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2023-08-01-preview",
+      "name": "[parameters('serverName')]"
+    },
+    "backupLongTermRetentionPolicy": {
+      "type": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies",
+      "apiVersion": "2023-05-01-preview",
       "name": "[format('{0}/{1}/{2}', parameters('serverName'), parameters('databaseName'), 'default')]",
       "properties": {
+        "backupStorageAccessTier": "[parameters('backupStorageAccessTier')]",
+        "makeBackupsImmutable": "[parameters('makeBackupsImmutable')]",
         "monthlyRetention": "[parameters('monthlyRetention')]",
         "weeklyRetention": "[parameters('weeklyRetention')]",
         "weekOfYear": "[parameters('weekOfYear')]",
         "yearlyRetention": "[parameters('yearlyRetention')]"
-      }
+      },
+      "dependsOn": [
+        "server::database"
+      ]
     }
-  ],
+  },
   "outputs": {
     "resourceGroupName": {
       "type": "string",

--- a/avm/res/sql/server/database/backup-short-term-retention-policy/main.bicep
+++ b/avm/res/sql/server/database/backup-short-term-retention-policy/main.bicep
@@ -14,10 +14,10 @@ param diffBackupIntervalInHours int = 24
 @description('Optional. Poin-in-time retention in days.')
 param retentionDays int = 7
 
-resource server 'Microsoft.Sql/servers@2022-05-01-preview' existing = {
+resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
   name: serverName
 
-  resource database 'databases@2022-05-01-preview' existing = {
+  resource database 'databases@2023-08-01-preview' existing = {
     name: databaseName
   }
 }

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -42,7 +42,7 @@ param createMode
   | 'Secondary' = 'Default'
 
 @description('Optional. The resource ID of the elastic pool containing this database.')
-param elasticPoolId string?
+param elasticPoolResourceId string?
 
 @description('Optional. The azure key vault URI of the database if it\'s configured with per Database Customer Managed Keys.')
 param encryptionProtector string?
@@ -92,16 +92,16 @@ param preferredEnclaveType 'Default' | 'VBS'?
 param readScale 'Enabled' | 'Disabled' = 'Disabled'
 
 @description('Optional. The resource identifier of the recoverable database associated with create operation of this database.')
-param recoverableDatabaseId string?
+param recoverableDatabaseResourceId string?
 
 @description('Optional. The resource identifier of the recovery point associated with create operation of this database.')
-param recoveryServicesRecoveryPointId string?
+param recoveryServicesRecoveryPointResourceId string?
 
 @description('Optional. The storage account type to be used to store backups for this database.')
 param requestedBackupStorageRedundancy 'Geo' | 'GeoZone' | 'Local' | 'Zone' = 'Local'
 
 @description('Optional. The resource identifier of the restorable dropped database associated with create operation of this database.')
-param restorableDroppedDatabaseId string?
+param restorableDroppedDatabaseResourceId string?
 
 @description('Optional. Point in time (ISO8601 format) of the source database to restore when createMode set to Restore or PointInTimeRestore.')
 param restorePointInTime string?
@@ -116,7 +116,7 @@ param secondaryType 'Geo' | 'Named' | 'Standby'?
 param sourceDatabaseDeletionDate string?
 
 @description('Optional. The resource identifier of the source database associated with create operation of this database.')
-param sourceDatabaseId string?
+param sourceDatabaseResourceId string?
 
 @description('Optional. The resource identifier of the source associated with the create operation of this database.')
 param sourceResourceId string?
@@ -160,7 +160,7 @@ resource database 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
     catalogCollation: catalogCollation
     collation: collation
     createMode: createMode
-    elasticPoolId: elasticPoolId
+    elasticPoolId: elasticPoolResourceId
     encryptionProtector: encryptionProtector
     encryptionProtectorAutoRotation: encryptionProtectorAutoRotation
     federatedClientId: federatedClientId
@@ -177,15 +177,15 @@ resource database 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
     performCutover: performCutover
     preferredEnclaveType: preferredEnclaveType
     readScale: readScale
-    recoverableDatabaseId: recoverableDatabaseId
-    recoveryServicesRecoveryPointId: recoveryServicesRecoveryPointId
+    recoverableDatabaseId: recoverableDatabaseResourceId
+    recoveryServicesRecoveryPointId: recoveryServicesRecoveryPointResourceId
     requestedBackupStorageRedundancy: requestedBackupStorageRedundancy
-    restorableDroppedDatabaseId: restorableDroppedDatabaseId
+    restorableDroppedDatabaseId: restorableDroppedDatabaseResourceId
     restorePointInTime: restorePointInTime
     sampleName: sampleName
     secondaryType: secondaryType
     sourceDatabaseDeletionDate: sourceDatabaseDeletionDate
-    sourceDatabaseId: sourceDatabaseId
+    sourceDatabaseId: sourceDatabaseResourceId
     sourceResourceId: sourceResourceId
     useFreeLimit: useFreeLimit
     zoneRedundant: zoneRedundant
@@ -263,6 +263,7 @@ output location string = database.location
 //   Definitions   //
 // =============== //
 
+@export()
 type diagnosticSettingType = {
   @description('Optional. The name of diagnostic setting.')
   name: string?
@@ -324,132 +325,4 @@ type databaseSkuType = {
 
   @description('Required. The tier or edition of the particular SKU, e.g. Basic, Premium.')
   tier: string?
-}
-
-@export()
-type databasePropertyType = {
-  @description('Required. The name of the Elastic Pool.')
-  name: string
-
-  @description('Optional. Tags of the resource.')
-  tags: object?
-
-  @description('Optional. The database SKU.')
-  sku: databaseSkuType?
-
-  @description('Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled.')
-  autoPauseDelay: int?
-
-  @description('Optional. Specifies the availability zone the database is pinned to.')
-  availabilityZone: '1' | '2' | '3' | 'NoPreference'?
-
-  @description('Optional. Collation of the metadata catalog.')
-  catalogCollation: string?
-
-  @description('Optional. The collation of the database.')
-  collation: string?
-
-  @description('Optional. Specifies the mode of database creation.')
-  createMode:
-    | 'Copy'
-    | 'Default'
-    | 'OnlineSecondary'
-    | 'PointInTimeRestore'
-    | 'Recovery'
-    | 'Restore'
-    | 'RestoreExternalBackup'
-    | 'RestoreExternalBackupSecondary'
-    | 'RestoreLongTermRetentionBackup'
-    | 'Secondary'?
-
-  @description('Optional. The resource identifier of the elastic pool containing this database.')
-  elasticPoolId: string?
-
-  @description('Optional. The azure key vault URI of the database if it\'s configured with per Database Customer Managed Keys.')
-  encryptionProtector: string?
-
-  @description('Optional. The flag to enable or disable auto rotation of database encryption protector AKV key.')
-  encryptionProtectorAutoRotation: bool?
-
-  @description('Optional. The Client id used for cross tenant per database CMK scenario.')
-  @minLength(36)
-  @maxLength(36)
-  federatedClientId: string?
-
-  @description('Optional. Specifies the behavior when monthly free limits are exhausted for the free database.')
-  freeLimitExhaustionBehavior: 'AutoPause' | 'BillOverUsage'?
-
-  @description('Optional. The number of secondary replicas associated with the database that are used to provide high availability. Not applicable to a Hyperscale database within an elastic pool.')
-  highAvailabilityReplicaCount: int?
-
-  @description('Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables.')
-  isLedgerOn: bool?
-
-  // keys
-  @description('Optional. The license type to apply for this database.')
-  licenseType: 'BasePrice' | 'LicenseIncluded'?
-
-  @description('Optional. The resource identifier of the long term retention backup associated with create operation of this database.')
-  longTermRetentionBackupResourceId: string?
-
-  @description('Optional. Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur.')
-  maintenanceConfigurationId: string?
-
-  @description('Optional. Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier.')
-  manualCutover: bool?
-
-  @description('Optional. The max size of the database expressed in bytes.')
-  maxSizeBytes: int?
-
-  // string to enable fractional values
-  @description('Optional. Minimal capacity that database will always have allocated, if not paused.')
-  minCapacity: string?
-
-  @description('Optional. To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress.')
-  performCutover: bool?
-
-  @description('Optional. Type of enclave requested on the database.')
-  preferredEnclaveType: 'Default' | 'VBS'?
-
-  @description('Optional. The state of read-only routing. If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale database within an elastic pool.')
-  readScale: 'Disabled' | 'Enabled'?
-
-  @description('Optional. The resource identifier of the recoverable database associated with create operation of this database.')
-  recoverableDatabaseId: string?
-
-  @description('Optional. The resource identifier of the recovery point associated with create operation of this database.')
-  recoveryServicesRecoveryPointId: string?
-
-  @description('Optional. The storage account type to be used to store backups for this database.')
-  requestedBackupStorageRedundancy: 'Geo' | 'GeoZone' | 'Local' | 'Zone'?
-
-  @description('Optional. The resource identifier of the restorable dropped database associated with create operation of this database.')
-  restorableDroppedDatabaseId: string?
-
-  @description('Optional. Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database.')
-  restorePointInTime: string?
-
-  @description('Optional. The name of the sample schema to apply when creating this database.')
-  sampleName: string?
-
-  @description('Optional. The secondary type of the database if it is a secondary.')
-  secondaryType: 'Geo' | 'Named' | 'Standby'?
-
-  @description('Optional. Specifies the time that the database was deleted.')
-  sourceDatabaseDeletionDate: string?
-
-  @description('Optional. The resource identifier of the source database associated with create operation of this database.')
-  sourceDatabaseId: string?
-
-  @description('Optional. The resource identifier of the source associated with the create operation of this database.')
-  sourceResourceId: string?
-
-  @description('Optional. Whether or not the database uses free monthly limits. Allowed on one database in a subscription.')
-  useFreeLimit: bool?
-
-  @description('Optional. Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones.')
-  zoneRedundant: bool?
-
-  @description('Optional. The diagnostic settings of the service.')
-  diagnosticSettings: diagnosticSettingType?
 }

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -16,7 +16,7 @@ param sku databaseSkuType = {
   tier: 'GeneralPurpose'
 }
 
-@description('Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled')
+@description('Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled.')
 param autoPauseDelay int = 0
 
 @description('Optional. Specifies the availability zone the database is pinned to.')
@@ -319,7 +319,7 @@ type databaseSkuType = {
   @description('Required. The name of the SKU, typically, a letter + Number code, e.g. P3.')
   name: string
 
-  @description('Optional. Size of the particular SKU')
+  @description('Optional. Size of the particular SKU.')
   size: string?
 
   @description('Required. The tier or edition of the particular SKU, e.g. Basic, Premium.')
@@ -337,7 +337,7 @@ type databasePropertyType = {
   @description('Optional. The database SKU.')
   sku: databaseSkuType?
 
-  @description('Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled')
+  @description('Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled.')
   autoPauseDelay: int?
 
   @description('Optional. Specifies the availability zone the database is pinned to.')

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -17,7 +17,7 @@ param sku databaseSkuType = {
 }
 
 @description('Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled.')
-param autoPauseDelay int = 0
+param autoPauseDelay int = -1
 
 @description('Optional. Specifies the availability zone the database is pinned to.')
 param availabilityZone '1' | '2' | '3' | 'NoPreference' = 'NoPreference'

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -449,4 +449,7 @@ type databasePropertyType = {
 
   @description('Optional. Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones.')
   zoneRedundant: bool?
+
+  @description('Optional. The diagnostic settings of the service.')
+  diagnosticSettings: diagnosticSettingType?
 }

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -2,71 +2,135 @@ metadata name = 'SQL Server Database'
 metadata description = 'This module deploys an Azure SQL Server Database.'
 metadata owner = 'Azure/module-maintainers'
 
+// START OF DATABASE PROPERTIES
+
 @description('Required. The name of the database.')
 param name string
 
 @description('Conditional. The name of the parent SQL Server. Required if the template is used in a standalone deployment.')
 param serverName string
 
+@description('Optional. The database SKU.')
+param sku databaseSkuType = {
+  name: 'GP_Gen5_2'
+  tier: 'GeneralPurpose'
+}
+
+@description('Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled')
+param autoPauseDelay int = 0
+
+@description('Optional. Specifies the availability zone the database is pinned to.')
+param availabilityZone '1' | '2' | '3' | 'NoPreference' = 'NoPreference'
+
+@description('Optional. Collation of the metadata catalog.')
+param catalogCollation string = 'DATABASE_DEFAULT'
+
 @description('Optional. The collation of the database.')
 param collation string = 'SQL_Latin1_General_CP1_CI_AS'
 
-@description('Optional. The skuTier or edition of the particular SKU.')
-param skuTier string = 'GeneralPurpose'
+@description('Optional. Specifies the mode of database creation.')
+param createMode
+  | 'Default'
+  | 'Copy'
+  | 'OnlineSecondary'
+  | 'PointInTimeRestore'
+  | 'Recovery'
+  | 'Restore'
+  | 'RestoreExternalBackup'
+  | 'RestoreExternalBackupSecondary'
+  | 'RestoreLongTermRetentionBackup'
+  | 'Secondary' = 'Default'
 
-@description('Optional. The name of the SKU.')
-param skuName string = 'GP_Gen5_2'
+@description('Optional. The resource ID of the elastic pool containing this database.')
+param elasticPoolId string?
 
-@description('Optional. Capacity of the particular SKU.')
-param skuCapacity int?
+@description('Optional. The azure key vault URI of the database if it\'s configured with per Database Customer Managed Keys.')
+param encryptionProtector string?
 
-@description('Optional. Type of enclave requested on the database i.e. Default or VBS enclaves.')
-@allowed([
-  ''
-  'Default'
-  'VBS'
-])
-param preferredEnclaveType string = ''
+@description('Optional. The flag to enable or disable auto rotation of database encryption protector AKV key.')
+param encryptionProtectorAutoRotation bool?
 
-@description('Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here.')
-param skuFamily string = ''
+@description('Optional. The Client id used for cross tenant per database CMK scenario.')
+@minLength(36)
+@maxLength(36)
+param federatedClientId string?
 
-@description('Optional. Size of the particular SKU.')
-param skuSize string = ''
-
-@description('Optional. The max size of the database expressed in bytes.')
-param maxSizeBytes int = 34359738368
-
-@description('Optional. The name of the sample schema to apply when creating this database.')
-param sampleName string = ''
-
-@description('Optional. Whether or not this database is zone redundant.')
-param zoneRedundant bool = true
-
-@description('Optional. The license type to apply for this database.')
-param licenseType string = ''
-
-@description('Optional. The state of read-only routing.')
-@allowed([
-  'Enabled'
-  'Disabled'
-])
-param readScale string = 'Disabled'
+@description('Optional. Specifies the behavior when monthly free limits are exhausted for the free database.')
+param freeLimitExhaustionBehavior 'AutoPause' | 'BillOverUsage'?
 
 @description('Optional. The number of readonly secondary replicas associated with the database.')
 param highAvailabilityReplicaCount int = 0
 
-@description('Optional. Minimal capacity that database will always have allocated.')
-param minCapacity string = ''
+@description('Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created.')
+param isLedgerOn bool = false
 
-@description('Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled.')
-param autoPauseDelay int = 0
+@description('Optional. The license type to apply for this database.')
+param licenseType 'BasePrice' | 'LicenseIncluded'?
+
+@description('Optional. The resource identifier of the long term retention backup associated with create operation of this database.')
+param longTermRetentionBackupResourceId string?
+
+@description('Optional. Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur.')
+param maintenanceConfigurationId string?
+
+@description('Optional. Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier.')
+param manualCutover bool?
+
+@description('Optional. The max size of the database expressed in bytes.')
+param maxSizeBytes int = 34359738368
+
+@description('Optional. Minimal capacity that database will always have allocated.')
+param minCapacity string = '0'
+
+@description('Optional. To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress.')
+param performCutover bool?
+
+@description('Optional. Type of enclave requested on the database i.e. Default or VBS enclaves.')
+param preferredEnclaveType 'Default' | 'VBS'?
+
+@description('Optional. The state of read-only routing.')
+param readScale 'Enabled' | 'Disabled' = 'Disabled'
+
+@description('Optional. The resource identifier of the recoverable database associated with create operation of this database.')
+param recoverableDatabaseId string?
+
+@description('Optional. The resource identifier of the recovery point associated with create operation of this database.')
+param recoveryServicesRecoveryPointId string?
+
+@description('Optional. The storage account type to be used to store backups for this database.')
+param requestedBackupStorageRedundancy 'Geo' | 'GeoZone' | 'Local' | 'Zone' = 'Local'
+
+@description('Optional. The resource identifier of the restorable dropped database associated with create operation of this database.')
+param restorableDroppedDatabaseId string?
+
+@description('Optional. Point in time (ISO8601 format) of the source database to restore when createMode set to Restore or PointInTimeRestore.')
+param restorePointInTime string?
+
+@description('Optional. The name of the sample schema to apply when creating this database.')
+param sampleName string = ''
+
+@description('Optional. The secondary type of the database if it is a secondary.')
+param secondaryType 'Geo' | 'Named' | 'Standby'?
+
+@description('Optional. The time that the database was deleted when restoring a deleted database.')
+param sourceDatabaseDeletionDate string?
+
+@description('Optional. The resource identifier of the source database associated with create operation of this database.')
+param sourceDatabaseId string?
+
+@description('Optional. The resource identifier of the source associated with the create operation of this database.')
+param sourceResourceId string?
+
+@description('Optional. Whether or not the database uses free monthly limits. Allowed on one database in a subscription.')
+param useFreeLimit bool?
+
+@description('Optional. Whether or not this database is zone redundant.')
+param zoneRedundant bool?
+
+// END OF DATABASE PROPERTIES
 
 @description('Optional. Tags of the resource.')
 param tags object?
-
-@description('Optional. The resource ID of the elastic pool containing this database.')
-param elasticPoolId string = ''
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
@@ -74,73 +138,11 @@ param location string = resourceGroup().location
 @description('Optional. The diagnostic settings of the service.')
 param diagnosticSettings diagnosticSettingType
 
-@description('Optional. Specifies the mode of database creation.')
-@allowed([
-  'Default'
-  'Copy'
-  'OnlineSecondary'
-  'PointInTimeRestore'
-  'Recovery'
-  'Restore'
-  'RestoreLongTermRetentionBackup'
-  'Secondary'
-])
-param createMode string = 'Default'
-
-@description('Optional. Resource ID of database if createMode set to Copy, Secondary, PointInTimeRestore, Recovery or Restore.')
-param sourceDatabaseResourceId string = ''
-
-@description('Optional. The time that the database was deleted when restoring a deleted database.')
-param sourceDatabaseDeletionDate string = ''
-
-@description('Optional. Resource ID of backup if createMode set to RestoreLongTermRetentionBackup.')
-param recoveryServicesRecoveryPointResourceId string = ''
-
-@description('Optional. Point in time (ISO8601 format) of the source database to restore when createMode set to Restore or PointInTimeRestore.')
-param restorePointInTime string = ''
-
-@description('Optional. The storage account type to be used to store backups for this database.')
-@allowed([
-  'Geo'
-  'Local'
-  'Zone'
-  ''
-])
-param requestedBackupStorageRedundancy string = ''
-
-@description('Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created.')
-param isLedgerOn bool = false
-
-@description('Optional. Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur.')
-param maintenanceConfigurationId string?
-
 @description('Optional. The short term backup retention policy to create for the database.')
 param backupShortTermRetentionPolicy object = {}
 
 @description('Optional. The long term backup retention policy to create for the database.')
 param backupLongTermRetentionPolicy object = {}
-
-// The SKU object must be built in a variable
-// The alternative, 'null' as default values, leads to non-terminating deployments
-var skuVar = union(
-  {
-    name: skuName
-    tier: skuTier
-  },
-  (skuCapacity != null)
-    ? {
-        capacity: skuCapacity
-      }
-    : !empty(skuFamily)
-        ? {
-            family: skuFamily
-          }
-        : !empty(skuSize)
-            ? {
-                size: skuSize
-              }
-            : {}
-)
 
 resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
   name: serverName
@@ -151,30 +153,43 @@ resource database 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
   parent: server
   location: location
   tags: tags
+  sku: sku
   properties: {
-    preferredEnclaveType: !empty(preferredEnclaveType) ? preferredEnclaveType : null
-    collation: collation
-    maxSizeBytes: maxSizeBytes
-    sampleName: sampleName
-    zoneRedundant: zoneRedundant
-    licenseType: licenseType
-    readScale: readScale
-    minCapacity: !empty(minCapacity) ? json(minCapacity) : 0 // The json() function is used to allow specifying a decimal value.
     autoPauseDelay: autoPauseDelay
-    highAvailabilityReplicaCount: highAvailabilityReplicaCount
-    requestedBackupStorageRedundancy: any(requestedBackupStorageRedundancy)
-    isLedgerOn: isLedgerOn
-    maintenanceConfigurationId: maintenanceConfigurationId
-    elasticPoolId: elasticPoolId
+    availabilityZone: availabilityZone
+    catalogCollation: catalogCollation
+    collation: collation
     createMode: createMode
-    sourceDatabaseId: !empty(sourceDatabaseResourceId) ? sourceDatabaseResourceId : null
-    sourceDatabaseDeletionDate: !empty(sourceDatabaseDeletionDate) ? sourceDatabaseDeletionDate : null
-    recoveryServicesRecoveryPointId: !empty(recoveryServicesRecoveryPointResourceId)
-      ? recoveryServicesRecoveryPointResourceId
-      : null
-    restorePointInTime: !empty(restorePointInTime) ? restorePointInTime : null
+    elasticPoolId: elasticPoolId
+    encryptionProtector: encryptionProtector
+    encryptionProtectorAutoRotation: encryptionProtectorAutoRotation
+    federatedClientId: federatedClientId
+    freeLimitExhaustionBehavior: freeLimitExhaustionBehavior
+    highAvailabilityReplicaCount: highAvailabilityReplicaCount
+    isLedgerOn: isLedgerOn
+    licenseType: licenseType
+    longTermRetentionBackupResourceId: longTermRetentionBackupResourceId
+    maintenanceConfigurationId: maintenanceConfigurationId
+    manualCutover: manualCutover
+    maxSizeBytes: maxSizeBytes
+    // The json() function is used to allow specifying a decimal value.
+    minCapacity: !empty(minCapacity) ? json(minCapacity) : 0
+    performCutover: performCutover
+    preferredEnclaveType: preferredEnclaveType
+    readScale: readScale
+    recoverableDatabaseId: recoverableDatabaseId
+    recoveryServicesRecoveryPointId: recoveryServicesRecoveryPointId
+    requestedBackupStorageRedundancy: requestedBackupStorageRedundancy
+    restorableDroppedDatabaseId: restorableDroppedDatabaseId
+    restorePointInTime: restorePointInTime
+    sampleName: sampleName
+    secondaryType: secondaryType
+    sourceDatabaseDeletionDate: sourceDatabaseDeletionDate
+    sourceDatabaseId: sourceDatabaseId
+    sourceResourceId: sourceResourceId
+    useFreeLimit: useFreeLimit
+    zoneRedundant: zoneRedundant
   }
-  sku: skuVar
 }
 
 resource database_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = [
@@ -227,6 +242,10 @@ module database_backupLongTermRetentionPolicy 'backup-long-term-retention-policy
     weekOfYear: backupLongTermRetentionPolicy.?weekOfYear ?? 1
   }
 }
+
+// =============== //
+//     Outputs     //
+// =============== //
 
 @description('The name of the deployed database.')
 output name string = database.name
@@ -287,3 +306,147 @@ type diagnosticSettingType = {
   @description('Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs.')
   marketplacePartnerResourceId: string?
 }[]?
+
+@export()
+@description('The database SKU.')
+type databaseSkuType = {
+  @description('Optional. The capacity of the particular SKU.')
+  capacity: int?
+
+  @description('Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here.')
+  family: string?
+
+  @description('Required. The name of the SKU, typically, a letter + Number code, e.g. P3.')
+  name: string
+
+  @description('Optional. Size of the particular SKU')
+  size: string?
+
+  @description('Required. The tier or edition of the particular SKU, e.g. Basic, Premium.')
+  tier: string?
+}
+
+@export()
+type databasePropertyType = {
+  @description('Required. The name of the Elastic Pool.')
+  name: string
+
+  @description('Optional. Tags of the resource.')
+  tags: object?
+
+  @description('Optional. The database SKU.')
+  sku: databaseSkuType?
+
+  @description('Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled')
+  autoPauseDelay: int?
+
+  @description('Optional. Specifies the availability zone the database is pinned to.')
+  availabilityZone: '1' | '2' | '3' | 'NoPreference'?
+
+  @description('Optional. Collation of the metadata catalog.')
+  catalogCollation: string?
+
+  @description('Optional. The collation of the database.')
+  collation: string?
+
+  @description('Optional. Specifies the mode of database creation.')
+  createMode:
+    | 'Copy'
+    | 'Default'
+    | 'OnlineSecondary'
+    | 'PointInTimeRestore'
+    | 'Recovery'
+    | 'Restore'
+    | 'RestoreExternalBackup'
+    | 'RestoreExternalBackupSecondary'
+    | 'RestoreLongTermRetentionBackup'
+    | 'Secondary'?
+
+  @description('Optional. The resource identifier of the elastic pool containing this database.')
+  elasticPoolId: string?
+
+  @description('Optional. The azure key vault URI of the database if it\'s configured with per Database Customer Managed Keys.')
+  encryptionProtector: string?
+
+  @description('Optional. The flag to enable or disable auto rotation of database encryption protector AKV key.')
+  encryptionProtectorAutoRotation: bool?
+
+  @description('Optional. The Client id used for cross tenant per database CMK scenario.')
+  @minLength(36)
+  @maxLength(36)
+  federatedClientId: string?
+
+  @description('Optional. Specifies the behavior when monthly free limits are exhausted for the free database.')
+  freeLimitExhaustionBehavior: 'AutoPause' | 'BillOverUsage'?
+
+  @description('Optional. The number of secondary replicas associated with the database that are used to provide high availability. Not applicable to a Hyperscale database within an elastic pool.')
+  highAvailabilityReplicaCount: int?
+
+  @description('Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables.')
+  isLedgerOn: bool?
+
+  // keys
+  @description('Optional. The license type to apply for this database.')
+  licenseType: 'BasePrice' | 'LicenseIncluded'?
+
+  @description('Optional. The resource identifier of the long term retention backup associated with create operation of this database.')
+  longTermRetentionBackupResourceId: string?
+
+  @description('Optional. Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur.')
+  maintenanceConfigurationId: string?
+
+  @description('Optional. Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier.')
+  manualCutover: bool?
+
+  @description('Optional. The max size of the database expressed in bytes.')
+  maxSizeBytes: int?
+
+  // string to enable fractional values
+  @description('Optional. Minimal capacity that database will always have allocated, if not paused.')
+  minCapacity: string?
+
+  @description('Optional. To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress.')
+  performCutover: bool?
+
+  @description('Optional. Type of enclave requested on the database.')
+  preferredEnclaveType: 'Default' | 'VBS'?
+
+  @description('Optional. The state of read-only routing. If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale database within an elastic pool.')
+  readScale: 'Disabled' | 'Enabled'?
+
+  @description('Optional. The resource identifier of the recoverable database associated with create operation of this database.')
+  recoverableDatabaseId: string?
+
+  @description('Optional. The resource identifier of the recovery point associated with create operation of this database.')
+  recoveryServicesRecoveryPointId: string?
+
+  @description('Optional. The storage account type to be used to store backups for this database.')
+  requestedBackupStorageRedundancy: 'Geo' | 'GeoZone' | 'Local' | 'Zone'?
+
+  @description('Optional. The resource identifier of the restorable dropped database associated with create operation of this database.')
+  restorableDroppedDatabaseId: string?
+
+  @description('Optional. Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database.')
+  restorePointInTime: string?
+
+  @description('Optional. The name of the sample schema to apply when creating this database.')
+  sampleName: string?
+
+  @description('Optional. The secondary type of the database if it is a secondary.')
+  secondaryType: 'Geo' | 'Named' | 'Standby'?
+
+  @description('Optional. Specifies the time that the database was deleted.')
+  sourceDatabaseDeletionDate: string?
+
+  @description('Optional. The resource identifier of the source database associated with create operation of this database.')
+  sourceDatabaseId: string?
+
+  @description('Optional. The resource identifier of the source associated with the create operation of this database.')
+  sourceResourceId: string?
+
+  @description('Optional. Whether or not the database uses free monthly limits. Allowed on one database in a subscription.')
+  useFreeLimit: bool?
+
+  @description('Optional. Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones.')
+  zoneRedundant: bool?
+}

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -125,7 +125,7 @@ param sourceResourceId string?
 param useFreeLimit bool?
 
 @description('Optional. Whether or not this database is zone redundant.')
-param zoneRedundant bool?
+param zoneRedundant bool = true
 
 // END OF DATABASE PROPERTIES
 

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "9296721864796917258"
+      "templateHash": "8570245614970945119"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database.",
@@ -177,6 +177,84 @@
       "metadata": {
         "__bicep_export!": true,
         "description": "The database SKU."
+      }
+    },
+    "shortTermBackupRetentionPolicyType": {
+      "type": "object",
+      "properties": {
+        "diffBackupIntervalInHours": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Differential backup interval in hours."
+          }
+        },
+        "retentionDays": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Point-in-time retention in days."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The short-term backup retention policy for the database."
+      }
+    },
+    "longTermBackupRetentionPolicyType": {
+      "type": "object",
+      "properties": {
+        "backupStorageAccessTier": {
+          "type": "string",
+          "allowedValues": [
+            "Archive",
+            "Hot"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The BackupStorageAccessTier for the LTR backups."
+          }
+        },
+        "makeBackupsImmutable": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The setting whether to make LTR backups immutable."
+          }
+        },
+        "monthlyRetention": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Monthly retention in ISO 8601 duration format."
+          }
+        },
+        "weeklyRetention": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Weekly retention in ISO 8601 duration format."
+          }
+        },
+        "weekOfYear": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Week of year backup to keep for yearly retention."
+          }
+        },
+        "yearlyRetention": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Yearly retention in ISO 8601 duration format."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The long-term backup retention policy for the database."
       }
     }
   },
@@ -502,15 +580,15 @@
       }
     },
     "backupShortTermRetentionPolicy": {
-      "type": "object",
-      "defaultValue": {},
+      "$ref": "#/definitions/shortTermBackupRetentionPolicyType",
+      "nullable": true,
       "metadata": {
         "description": "Optional. The short term backup retention policy to create for the database."
       }
     },
     "backupLongTermRetentionPolicy": {
-      "type": "object",
-      "defaultValue": {},
+      "$ref": "#/definitions/longTermBackupRetentionPolicyType",
+      "nullable": true,
       "metadata": {
         "description": "Optional. The long term backup retention policy to create for the database."
       }
@@ -611,6 +689,7 @@
       ]
     },
     "database_backupShortTermRetentionPolicy": {
+      "condition": "[not(empty(parameters('backupShortTermRetentionPolicy')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
       "name": "[format('{0}-{1}-shBakRetPol', uniqueString(deployment().name, parameters('location')), parameters('name'))]",
@@ -627,10 +706,10 @@
             "value": "[parameters('name')]"
           },
           "diffBackupIntervalInHours": {
-            "value": "[coalesce(tryGet(parameters('backupShortTermRetentionPolicy'), 'diffBackupIntervalInHours'), 24)]"
+            "value": "[tryGet(parameters('backupShortTermRetentionPolicy'), 'diffBackupIntervalInHours')]"
           },
           "retentionDays": {
-            "value": "[coalesce(tryGet(parameters('backupShortTermRetentionPolicy'), 'retentionDays'), 7)]"
+            "value": "[tryGet(parameters('backupShortTermRetentionPolicy'), 'retentionDays')]"
           }
         },
         "template": {
@@ -715,6 +794,7 @@
       ]
     },
     "database_backupLongTermRetentionPolicy": {
+      "condition": "[not(empty(parameters('backupLongTermRetentionPolicy')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
       "name": "[format('{0}-{1}-lgBakRetPol', uniqueString(deployment().name, parameters('location')), parameters('name'))]",
@@ -730,27 +810,34 @@
           "databaseName": {
             "value": "[parameters('name')]"
           },
+          "backupStorageAccessTier": {
+            "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'backupStorageAccessTier')]"
+          },
+          "makeBackupsImmutable": {
+            "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'makeBackupsImmutable')]"
+          },
           "weeklyRetention": {
-            "value": "[coalesce(tryGet(parameters('backupLongTermRetentionPolicy'), 'weeklyRetention'), '')]"
+            "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'weeklyRetention')]"
           },
           "monthlyRetention": {
-            "value": "[coalesce(tryGet(parameters('backupLongTermRetentionPolicy'), 'monthlyRetention'), '')]"
+            "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'monthlyRetention')]"
           },
           "yearlyRetention": {
-            "value": "[coalesce(tryGet(parameters('backupLongTermRetentionPolicy'), 'yearlyRetention'), '')]"
+            "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'yearlyRetention')]"
           },
           "weekOfYear": {
-            "value": "[coalesce(tryGet(parameters('backupLongTermRetentionPolicy'), 'weekOfYear'), 1)]"
+            "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'weekOfYear')]"
           }
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.29.47.4906",
-              "templateHash": "2778016138108001251"
+              "templateHash": "13893387790480518080"
             },
             "name": "SQL Server Database Long Term Backup Retention Policies",
             "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy.",
@@ -769,18 +856,36 @@
                 "description": "Required. The name of the parent database."
               }
             },
-            "weeklyRetention": {
+            "backupStorageAccessTier": {
               "type": "string",
-              "defaultValue": "",
+              "allowedValues": [
+                "Archive",
+                "Hot"
+              ],
+              "nullable": true,
               "metadata": {
-                "description": "Optional. Monthly retention in ISO 8601 duration format."
+                "description": "Optional. The BackupStorageAccessTier for the LTR backups."
+              }
+            },
+            "makeBackupsImmutable": {
+              "type": "bool",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The setting whether to make LTR backups immutable."
               }
             },
             "monthlyRetention": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Weekly retention in ISO 8601 duration format."
+              }
+            },
+            "weeklyRetention": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Monthly retention in ISO 8601 duration format."
               }
             },
             "weekOfYear": {
@@ -792,25 +897,45 @@
             },
             "yearlyRetention": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Yearly retention in ISO 8601 duration format."
               }
             }
           },
-          "resources": [
-            {
-              "type": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies",
+          "resources": {
+            "server::database": {
+              "existing": true,
+              "type": "Microsoft.Sql/servers/databases",
               "apiVersion": "2023-08-01-preview",
+              "name": "[format('{0}/{1}', parameters('serverName'), parameters('databaseName'))]",
+              "dependsOn": [
+                "server"
+              ]
+            },
+            "server": {
+              "existing": true,
+              "type": "Microsoft.Sql/servers",
+              "apiVersion": "2023-08-01-preview",
+              "name": "[parameters('serverName')]"
+            },
+            "backupLongTermRetentionPolicy": {
+              "type": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies",
+              "apiVersion": "2023-05-01-preview",
               "name": "[format('{0}/{1}/{2}', parameters('serverName'), parameters('databaseName'), 'default')]",
               "properties": {
+                "backupStorageAccessTier": "[parameters('backupStorageAccessTier')]",
+                "makeBackupsImmutable": "[parameters('makeBackupsImmutable')]",
                 "monthlyRetention": "[parameters('monthlyRetention')]",
                 "weeklyRetention": "[parameters('weeklyRetention')]",
                 "weekOfYear": "[parameters('weekOfYear')]",
                 "yearlyRetention": "[parameters('yearlyRetention')]"
-              }
+              },
+              "dependsOn": [
+                "server::database"
+              ]
             }
-          ],
+          },
           "outputs": {
             "resourceGroupName": {
               "type": "string",

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "8570245614970945119"
+      "templateHash": "15066479282051878033"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database.",
@@ -283,7 +283,7 @@
     },
     "autoPauseDelay": {
       "type": "int",
-      "defaultValue": 0,
+      "defaultValue": -1,
       "metadata": {
         "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled."
       }
@@ -837,7 +837,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.29.47.4906",
-              "templateHash": "13893387790480518080"
+              "templateHash": "16586251276572997423"
             },
             "name": "SQL Server Database Long Term Backup Retention Policies",
             "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy.",
@@ -878,14 +878,14 @@
               "type": "string",
               "nullable": true,
               "metadata": {
-                "description": "Optional. Weekly retention in ISO 8601 duration format."
+                "description": "Optional. Monthly retention in ISO 8601 duration format."
               }
             },
             "weeklyRetention": {
               "type": "string",
               "nullable": true,
               "metadata": {
-                "description": "Optional. Monthly retention in ISO 8601 duration format."
+                "description": "Optional. Weekly retention in ISO 8601 duration format."
               }
             },
             "weekOfYear": {

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "4558221869591328265"
+      "templateHash": "9296721864796917258"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database.",
@@ -131,7 +131,10 @@
           }
         }
       },
-      "nullable": true
+      "nullable": true,
+      "metadata": {
+        "__bicep_export!": true
+      }
     },
     "databaseSkuType": {
       "type": "object",
@@ -174,319 +177,6 @@
       "metadata": {
         "__bicep_export!": true,
         "description": "The database SKU."
-      }
-    },
-    "databasePropertyType": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. The name of the Elastic Pool."
-          }
-        },
-        "tags": {
-          "type": "object",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Tags of the resource."
-          }
-        },
-        "sku": {
-          "$ref": "#/definitions/databaseSkuType",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The database SKU."
-          }
-        },
-        "autoPauseDelay": {
-          "type": "int",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled."
-          }
-        },
-        "availabilityZone": {
-          "type": "string",
-          "allowedValues": [
-            "1",
-            "2",
-            "3",
-            "NoPreference"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Specifies the availability zone the database is pinned to."
-          }
-        },
-        "catalogCollation": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Collation of the metadata catalog."
-          }
-        },
-        "collation": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The collation of the database."
-          }
-        },
-        "createMode": {
-          "type": "string",
-          "allowedValues": [
-            "Copy",
-            "Default",
-            "OnlineSecondary",
-            "PointInTimeRestore",
-            "Recovery",
-            "Restore",
-            "RestoreExternalBackup",
-            "RestoreExternalBackupSecondary",
-            "RestoreLongTermRetentionBackup",
-            "Secondary"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Specifies the mode of database creation."
-          }
-        },
-        "elasticPoolId": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The resource identifier of the elastic pool containing this database."
-          }
-        },
-        "encryptionProtector": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The azure key vault URI of the database if it's configured with per Database Customer Managed Keys."
-          }
-        },
-        "encryptionProtectorAutoRotation": {
-          "type": "bool",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The flag to enable or disable auto rotation of database encryption protector AKV key."
-          }
-        },
-        "federatedClientId": {
-          "type": "string",
-          "nullable": true,
-          "minLength": 36,
-          "maxLength": 36,
-          "metadata": {
-            "description": "Optional. The Client id used for cross tenant per database CMK scenario."
-          }
-        },
-        "freeLimitExhaustionBehavior": {
-          "type": "string",
-          "allowedValues": [
-            "AutoPause",
-            "BillOverUsage"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Specifies the behavior when monthly free limits are exhausted for the free database."
-          }
-        },
-        "highAvailabilityReplicaCount": {
-          "type": "int",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The number of secondary replicas associated with the database that are used to provide high availability. Not applicable to a Hyperscale database within an elastic pool."
-          }
-        },
-        "isLedgerOn": {
-          "type": "bool",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables."
-          }
-        },
-        "licenseType": {
-          "type": "string",
-          "allowedValues": [
-            "BasePrice",
-            "LicenseIncluded"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The license type to apply for this database."
-          }
-        },
-        "longTermRetentionBackupResourceId": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The resource identifier of the long term retention backup associated with create operation of this database."
-          }
-        },
-        "maintenanceConfigurationId": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur."
-          }
-        },
-        "manualCutover": {
-          "type": "bool",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier."
-          }
-        },
-        "maxSizeBytes": {
-          "type": "int",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The max size of the database expressed in bytes."
-          }
-        },
-        "minCapacity": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Minimal capacity that database will always have allocated, if not paused."
-          }
-        },
-        "performCutover": {
-          "type": "bool",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress."
-          }
-        },
-        "preferredEnclaveType": {
-          "type": "string",
-          "allowedValues": [
-            "Default",
-            "VBS"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Type of enclave requested on the database."
-          }
-        },
-        "readScale": {
-          "type": "string",
-          "allowedValues": [
-            "Disabled",
-            "Enabled"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The state of read-only routing. If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale database within an elastic pool."
-          }
-        },
-        "recoverableDatabaseId": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The resource identifier of the recoverable database associated with create operation of this database."
-          }
-        },
-        "recoveryServicesRecoveryPointId": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The resource identifier of the recovery point associated with create operation of this database."
-          }
-        },
-        "requestedBackupStorageRedundancy": {
-          "type": "string",
-          "allowedValues": [
-            "Geo",
-            "GeoZone",
-            "Local",
-            "Zone"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The storage account type to be used to store backups for this database."
-          }
-        },
-        "restorableDroppedDatabaseId": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The resource identifier of the restorable dropped database associated with create operation of this database."
-          }
-        },
-        "restorePointInTime": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database."
-          }
-        },
-        "sampleName": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The name of the sample schema to apply when creating this database."
-          }
-        },
-        "secondaryType": {
-          "type": "string",
-          "allowedValues": [
-            "Geo",
-            "Named",
-            "Standby"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The secondary type of the database if it is a secondary."
-          }
-        },
-        "sourceDatabaseDeletionDate": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Specifies the time that the database was deleted."
-          }
-        },
-        "sourceDatabaseId": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The resource identifier of the source database associated with create operation of this database."
-          }
-        },
-        "sourceResourceId": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The resource identifier of the source associated with the create operation of this database."
-          }
-        },
-        "useFreeLimit": {
-          "type": "bool",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Whether or not the database uses free monthly limits. Allowed on one database in a subscription."
-          }
-        },
-        "zoneRedundant": {
-          "type": "bool",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones."
-          }
-        },
-        "diagnosticSettings": {
-          "$ref": "#/definitions/diagnosticSettingType",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The diagnostic settings of the service."
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true
       }
     }
   },
@@ -566,7 +256,7 @@
         "description": "Optional. Specifies the mode of database creation."
       }
     },
-    "elasticPoolId": {
+    "elasticPoolResourceId": {
       "type": "string",
       "nullable": true,
       "metadata": {
@@ -696,14 +386,14 @@
         "description": "Optional. The state of read-only routing."
       }
     },
-    "recoverableDatabaseId": {
+    "recoverableDatabaseResourceId": {
       "type": "string",
       "nullable": true,
       "metadata": {
         "description": "Optional. The resource identifier of the recoverable database associated with create operation of this database."
       }
     },
-    "recoveryServicesRecoveryPointId": {
+    "recoveryServicesRecoveryPointResourceId": {
       "type": "string",
       "nullable": true,
       "metadata": {
@@ -723,7 +413,7 @@
         "description": "Optional. The storage account type to be used to store backups for this database."
       }
     },
-    "restorableDroppedDatabaseId": {
+    "restorableDroppedDatabaseResourceId": {
       "type": "string",
       "nullable": true,
       "metadata": {
@@ -763,7 +453,7 @@
         "description": "Optional. The time that the database was deleted when restoring a deleted database."
       }
     },
-    "sourceDatabaseId": {
+    "sourceDatabaseResourceId": {
       "type": "string",
       "nullable": true,
       "metadata": {
@@ -846,7 +536,7 @@
         "catalogCollation": "[parameters('catalogCollation')]",
         "collation": "[parameters('collation')]",
         "createMode": "[parameters('createMode')]",
-        "elasticPoolId": "[parameters('elasticPoolId')]",
+        "elasticPoolId": "[parameters('elasticPoolResourceId')]",
         "encryptionProtector": "[parameters('encryptionProtector')]",
         "encryptionProtectorAutoRotation": "[parameters('encryptionProtectorAutoRotation')]",
         "federatedClientId": "[parameters('federatedClientId')]",
@@ -862,15 +552,15 @@
         "performCutover": "[parameters('performCutover')]",
         "preferredEnclaveType": "[parameters('preferredEnclaveType')]",
         "readScale": "[parameters('readScale')]",
-        "recoverableDatabaseId": "[parameters('recoverableDatabaseId')]",
-        "recoveryServicesRecoveryPointId": "[parameters('recoveryServicesRecoveryPointId')]",
+        "recoverableDatabaseId": "[parameters('recoverableDatabaseResourceId')]",
+        "recoveryServicesRecoveryPointId": "[parameters('recoveryServicesRecoveryPointResourceId')]",
         "requestedBackupStorageRedundancy": "[parameters('requestedBackupStorageRedundancy')]",
-        "restorableDroppedDatabaseId": "[parameters('restorableDroppedDatabaseId')]",
+        "restorableDroppedDatabaseId": "[parameters('restorableDroppedDatabaseResourceId')]",
         "restorePointInTime": "[parameters('restorePointInTime')]",
         "sampleName": "[parameters('sampleName')]",
         "secondaryType": "[parameters('secondaryType')]",
         "sourceDatabaseDeletionDate": "[parameters('sourceDatabaseDeletionDate')]",
-        "sourceDatabaseId": "[parameters('sourceDatabaseId')]",
+        "sourceDatabaseId": "[parameters('sourceDatabaseResourceId')]",
         "sourceResourceId": "[parameters('sourceResourceId')]",
         "useFreeLimit": "[parameters('useFreeLimit')]",
         "zoneRedundant": "[parameters('zoneRedundant')]"

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "1692971524161973439"
+      "templateHash": "2532099399760155788"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database.",
@@ -475,6 +475,13 @@
           "nullable": true,
           "metadata": {
             "description": "Optional. Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones."
+          }
+        },
+        "diagnosticSettings": {
+          "$ref": "#/definitions/diagnosticSettingType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The diagnostic settings of the service."
           }
         }
       },

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "18021918128213514276"
+      "templateHash": "1692971524161973439"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database.",
@@ -132,6 +132,355 @@
         }
       },
       "nullable": true
+    },
+    "databaseSkuType": {
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The capacity of the particular SKU."
+          }
+        },
+        "family": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here."
+          }
+        },
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the SKU, typically, a letter + Number code, e.g. P3."
+          }
+        },
+        "size": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Size of the particular SKU"
+          }
+        },
+        "tier": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Required. The tier or edition of the particular SKU, e.g. Basic, Premium."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The database SKU."
+      }
+    },
+    "databasePropertyType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the Elastic Pool."
+          }
+        },
+        "tags": {
+          "type": "object",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Tags of the resource."
+          }
+        },
+        "sku": {
+          "$ref": "#/definitions/databaseSkuType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The database SKU."
+          }
+        },
+        "autoPauseDelay": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled"
+          }
+        },
+        "availabilityZone": {
+          "type": "string",
+          "allowedValues": [
+            "1",
+            "2",
+            "3",
+            "NoPreference"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the availability zone the database is pinned to."
+          }
+        },
+        "catalogCollation": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Collation of the metadata catalog."
+          }
+        },
+        "collation": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The collation of the database."
+          }
+        },
+        "createMode": {
+          "type": "string",
+          "allowedValues": [
+            "Copy",
+            "Default",
+            "OnlineSecondary",
+            "PointInTimeRestore",
+            "Recovery",
+            "Restore",
+            "RestoreExternalBackup",
+            "RestoreExternalBackupSecondary",
+            "RestoreLongTermRetentionBackup",
+            "Secondary"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the mode of database creation."
+          }
+        },
+        "elasticPoolId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the elastic pool containing this database."
+          }
+        },
+        "encryptionProtector": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The azure key vault URI of the database if it's configured with per Database Customer Managed Keys."
+          }
+        },
+        "encryptionProtectorAutoRotation": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The flag to enable or disable auto rotation of database encryption protector AKV key."
+          }
+        },
+        "federatedClientId": {
+          "type": "string",
+          "nullable": true,
+          "minLength": 36,
+          "maxLength": 36,
+          "metadata": {
+            "description": "Optional. The Client id used for cross tenant per database CMK scenario."
+          }
+        },
+        "freeLimitExhaustionBehavior": {
+          "type": "string",
+          "allowedValues": [
+            "AutoPause",
+            "BillOverUsage"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the behavior when monthly free limits are exhausted for the free database."
+          }
+        },
+        "highAvailabilityReplicaCount": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The number of secondary replicas associated with the database that are used to provide high availability. Not applicable to a Hyperscale database within an elastic pool."
+          }
+        },
+        "isLedgerOn": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables."
+          }
+        },
+        "licenseType": {
+          "type": "string",
+          "allowedValues": [
+            "BasePrice",
+            "LicenseIncluded"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The license type to apply for this database."
+          }
+        },
+        "longTermRetentionBackupResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the long term retention backup associated with create operation of this database."
+          }
+        },
+        "maintenanceConfigurationId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur."
+          }
+        },
+        "manualCutover": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier."
+          }
+        },
+        "maxSizeBytes": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The max size of the database expressed in bytes."
+          }
+        },
+        "minCapacity": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Minimal capacity that database will always have allocated, if not paused."
+          }
+        },
+        "performCutover": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress."
+          }
+        },
+        "preferredEnclaveType": {
+          "type": "string",
+          "allowedValues": [
+            "Default",
+            "VBS"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Type of enclave requested on the database."
+          }
+        },
+        "readScale": {
+          "type": "string",
+          "allowedValues": [
+            "Disabled",
+            "Enabled"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The state of read-only routing. If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale database within an elastic pool."
+          }
+        },
+        "recoverableDatabaseId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the recoverable database associated with create operation of this database."
+          }
+        },
+        "recoveryServicesRecoveryPointId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the recovery point associated with create operation of this database."
+          }
+        },
+        "requestedBackupStorageRedundancy": {
+          "type": "string",
+          "allowedValues": [
+            "Geo",
+            "GeoZone",
+            "Local",
+            "Zone"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The storage account type to be used to store backups for this database."
+          }
+        },
+        "restorableDroppedDatabaseId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the restorable dropped database associated with create operation of this database."
+          }
+        },
+        "restorePointInTime": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database."
+          }
+        },
+        "sampleName": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The name of the sample schema to apply when creating this database."
+          }
+        },
+        "secondaryType": {
+          "type": "string",
+          "allowedValues": [
+            "Geo",
+            "Named",
+            "Standby"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The secondary type of the database if it is a secondary."
+          }
+        },
+        "sourceDatabaseDeletionDate": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the time that the database was deleted."
+          }
+        },
+        "sourceDatabaseId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the source database associated with create operation of this database."
+          }
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the source associated with the create operation of this database."
+          }
+        },
+        "useFreeLimit": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Whether or not the database uses free monthly limits. Allowed on one database in a subscription."
+          }
+        },
+        "zoneRedundant": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true
+      }
     }
   },
   "parameters": {
@@ -147,6 +496,43 @@
         "description": "Conditional. The name of the parent SQL Server. Required if the template is used in a standalone deployment."
       }
     },
+    "sku": {
+      "$ref": "#/definitions/databaseSkuType",
+      "defaultValue": {
+        "name": "GP_Gen5_2",
+        "tier": "GeneralPurpose"
+      },
+      "metadata": {
+        "description": "Optional. The database SKU."
+      }
+    },
+    "autoPauseDelay": {
+      "type": "int",
+      "defaultValue": 0,
+      "metadata": {
+        "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled"
+      }
+    },
+    "availabilityZone": {
+      "type": "string",
+      "allowedValues": [
+        "1",
+        "2",
+        "3",
+        "NoPreference"
+      ],
+      "defaultValue": "NoPreference",
+      "metadata": {
+        "description": "Optional. Specifies the availability zone the database is pinned to."
+      }
+    },
+    "catalogCollation": {
+      "type": "string",
+      "defaultValue": "DATABASE_DEFAULT",
+      "metadata": {
+        "description": "Optional. Collation of the metadata catalog."
+      }
+    },
     "collation": {
       "type": "string",
       "defaultValue": "SQL_Latin1_General_CP1_CI_AS",
@@ -154,90 +540,64 @@
         "description": "Optional. The collation of the database."
       }
     },
-    "skuTier": {
+    "createMode": {
       "type": "string",
-      "defaultValue": "GeneralPurpose",
+      "allowedValues": [
+        "Copy",
+        "Default",
+        "OnlineSecondary",
+        "PointInTimeRestore",
+        "Recovery",
+        "Restore",
+        "RestoreExternalBackup",
+        "RestoreExternalBackupSecondary",
+        "RestoreLongTermRetentionBackup",
+        "Secondary"
+      ],
+      "defaultValue": "Default",
       "metadata": {
-        "description": "Optional. The skuTier or edition of the particular SKU."
+        "description": "Optional. Specifies the mode of database creation."
       }
     },
-    "skuName": {
+    "elasticPoolId": {
       "type": "string",
-      "defaultValue": "GP_Gen5_2",
-      "metadata": {
-        "description": "Optional. The name of the SKU."
-      }
-    },
-    "skuCapacity": {
-      "type": "int",
       "nullable": true,
       "metadata": {
-        "description": "Optional. Capacity of the particular SKU."
+        "description": "Optional. The resource ID of the elastic pool containing this database."
       }
     },
-    "preferredEnclaveType": {
+    "encryptionProtector": {
       "type": "string",
-      "defaultValue": "",
-      "allowedValues": [
-        "",
-        "Default",
-        "VBS"
-      ],
+      "nullable": true,
       "metadata": {
-        "description": "Optional. Type of enclave requested on the database i.e. Default or VBS enclaves."
+        "description": "Optional. The azure key vault URI of the database if it's configured with per Database Customer Managed Keys."
       }
     },
-    "skuFamily": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here."
-      }
-    },
-    "skuSize": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional. Size of the particular SKU."
-      }
-    },
-    "maxSizeBytes": {
-      "type": "int",
-      "defaultValue": 34359738368,
-      "metadata": {
-        "description": "Optional. The max size of the database expressed in bytes."
-      }
-    },
-    "sampleName": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional. The name of the sample schema to apply when creating this database."
-      }
-    },
-    "zoneRedundant": {
+    "encryptionProtectorAutoRotation": {
       "type": "bool",
-      "defaultValue": true,
+      "nullable": true,
       "metadata": {
-        "description": "Optional. Whether or not this database is zone redundant."
+        "description": "Optional. The flag to enable or disable auto rotation of database encryption protector AKV key."
       }
     },
-    "licenseType": {
+    "federatedClientId": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
+      "minLength": 36,
+      "maxLength": 36,
       "metadata": {
-        "description": "Optional. The license type to apply for this database."
+        "description": "Optional. The Client id used for cross tenant per database CMK scenario."
       }
     },
-    "readScale": {
+    "freeLimitExhaustionBehavior": {
       "type": "string",
-      "defaultValue": "Disabled",
       "allowedValues": [
-        "Enabled",
-        "Disabled"
+        "AutoPause",
+        "BillOverUsage"
       ],
+      "nullable": true,
       "metadata": {
-        "description": "Optional. The state of read-only routing."
+        "description": "Optional. Specifies the behavior when monthly free limits are exhausted for the free database."
       }
     },
     "highAvailabilityReplicaCount": {
@@ -247,18 +607,181 @@
         "description": "Optional. The number of readonly secondary replicas associated with the database."
       }
     },
+    "isLedgerOn": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created."
+      }
+    },
+    "licenseType": {
+      "type": "string",
+      "allowedValues": [
+        "BasePrice",
+        "LicenseIncluded"
+      ],
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The license type to apply for this database."
+      }
+    },
+    "longTermRetentionBackupResourceId": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The resource identifier of the long term retention backup associated with create operation of this database."
+      }
+    },
+    "maintenanceConfigurationId": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur."
+      }
+    },
+    "manualCutover": {
+      "type": "bool",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier."
+      }
+    },
+    "maxSizeBytes": {
+      "type": "int",
+      "defaultValue": 34359738368,
+      "metadata": {
+        "description": "Optional. The max size of the database expressed in bytes."
+      }
+    },
     "minCapacity": {
       "type": "string",
-      "defaultValue": "",
+      "defaultValue": "0",
       "metadata": {
         "description": "Optional. Minimal capacity that database will always have allocated."
       }
     },
-    "autoPauseDelay": {
-      "type": "int",
-      "defaultValue": 0,
+    "performCutover": {
+      "type": "bool",
+      "nullable": true,
       "metadata": {
-        "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled."
+        "description": "Optional. To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress."
+      }
+    },
+    "preferredEnclaveType": {
+      "type": "string",
+      "allowedValues": [
+        "Default",
+        "VBS"
+      ],
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Type of enclave requested on the database i.e. Default or VBS enclaves."
+      }
+    },
+    "readScale": {
+      "type": "string",
+      "allowedValues": [
+        "Disabled",
+        "Enabled"
+      ],
+      "defaultValue": "Disabled",
+      "metadata": {
+        "description": "Optional. The state of read-only routing."
+      }
+    },
+    "recoverableDatabaseId": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The resource identifier of the recoverable database associated with create operation of this database."
+      }
+    },
+    "recoveryServicesRecoveryPointId": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The resource identifier of the recovery point associated with create operation of this database."
+      }
+    },
+    "requestedBackupStorageRedundancy": {
+      "type": "string",
+      "allowedValues": [
+        "Geo",
+        "GeoZone",
+        "Local",
+        "Zone"
+      ],
+      "defaultValue": "Local",
+      "metadata": {
+        "description": "Optional. The storage account type to be used to store backups for this database."
+      }
+    },
+    "restorableDroppedDatabaseId": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The resource identifier of the restorable dropped database associated with create operation of this database."
+      }
+    },
+    "restorePointInTime": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Point in time (ISO8601 format) of the source database to restore when createMode set to Restore or PointInTimeRestore."
+      }
+    },
+    "sampleName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. The name of the sample schema to apply when creating this database."
+      }
+    },
+    "secondaryType": {
+      "type": "string",
+      "allowedValues": [
+        "Geo",
+        "Named",
+        "Standby"
+      ],
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The secondary type of the database if it is a secondary."
+      }
+    },
+    "sourceDatabaseDeletionDate": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The time that the database was deleted when restoring a deleted database."
+      }
+    },
+    "sourceDatabaseId": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The resource identifier of the source database associated with create operation of this database."
+      }
+    },
+    "sourceResourceId": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The resource identifier of the source associated with the create operation of this database."
+      }
+    },
+    "useFreeLimit": {
+      "type": "bool",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Whether or not the database uses free monthly limits. Allowed on one database in a subscription."
+      }
+    },
+    "zoneRedundant": {
+      "type": "bool",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Whether or not this database is zone redundant."
       }
     },
     "tags": {
@@ -266,13 +789,6 @@
       "nullable": true,
       "metadata": {
         "description": "Optional. Tags of the resource."
-      }
-    },
-    "elasticPoolId": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional. The resource ID of the elastic pool containing this database."
       }
     },
     "location": {
@@ -286,78 +802,6 @@
       "$ref": "#/definitions/diagnosticSettingType",
       "metadata": {
         "description": "Optional. The diagnostic settings of the service."
-      }
-    },
-    "createMode": {
-      "type": "string",
-      "defaultValue": "Default",
-      "allowedValues": [
-        "Default",
-        "Copy",
-        "OnlineSecondary",
-        "PointInTimeRestore",
-        "Recovery",
-        "Restore",
-        "RestoreLongTermRetentionBackup",
-        "Secondary"
-      ],
-      "metadata": {
-        "description": "Optional. Specifies the mode of database creation."
-      }
-    },
-    "sourceDatabaseResourceId": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional. Resource ID of database if createMode set to Copy, Secondary, PointInTimeRestore, Recovery or Restore."
-      }
-    },
-    "sourceDatabaseDeletionDate": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional. The time that the database was deleted when restoring a deleted database."
-      }
-    },
-    "recoveryServicesRecoveryPointResourceId": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional. Resource ID of backup if createMode set to RestoreLongTermRetentionBackup."
-      }
-    },
-    "restorePointInTime": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional. Point in time (ISO8601 format) of the source database to restore when createMode set to Restore or PointInTimeRestore."
-      }
-    },
-    "requestedBackupStorageRedundancy": {
-      "type": "string",
-      "defaultValue": "",
-      "allowedValues": [
-        "Geo",
-        "Local",
-        "Zone",
-        ""
-      ],
-      "metadata": {
-        "description": "Optional. The storage account type to be used to store backups for this database."
-      }
-    },
-    "isLedgerOn": {
-      "type": "bool",
-      "defaultValue": false,
-      "metadata": {
-        "description": "Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created."
-      }
-    },
-    "maintenanceConfigurationId": {
-      "type": "string",
-      "nullable": true,
-      "metadata": {
-        "description": "Optional. Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur."
       }
     },
     "backupShortTermRetentionPolicy": {
@@ -375,9 +819,6 @@
       }
     }
   },
-  "variables": {
-    "skuVar": "[union(createObject('name', parameters('skuName'), 'tier', parameters('skuTier')), if(not(equals(parameters('skuCapacity'), null())), createObject('capacity', parameters('skuCapacity')), if(not(empty(parameters('skuFamily'))), createObject('family', parameters('skuFamily')), if(not(empty(parameters('skuSize'))), createObject('size', parameters('skuSize')), createObject()))))]"
-  },
   "resources": {
     "server": {
       "existing": true,
@@ -391,28 +832,42 @@
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
+      "sku": "[parameters('sku')]",
       "properties": {
-        "preferredEnclaveType": "[if(not(empty(parameters('preferredEnclaveType'))), parameters('preferredEnclaveType'), null())]",
-        "collation": "[parameters('collation')]",
-        "maxSizeBytes": "[parameters('maxSizeBytes')]",
-        "sampleName": "[parameters('sampleName')]",
-        "zoneRedundant": "[parameters('zoneRedundant')]",
-        "licenseType": "[parameters('licenseType')]",
-        "readScale": "[parameters('readScale')]",
-        "minCapacity": "[if(not(empty(parameters('minCapacity'))), json(parameters('minCapacity')), 0)]",
         "autoPauseDelay": "[parameters('autoPauseDelay')]",
-        "highAvailabilityReplicaCount": "[parameters('highAvailabilityReplicaCount')]",
-        "requestedBackupStorageRedundancy": "[parameters('requestedBackupStorageRedundancy')]",
-        "isLedgerOn": "[parameters('isLedgerOn')]",
-        "maintenanceConfigurationId": "[parameters('maintenanceConfigurationId')]",
-        "elasticPoolId": "[parameters('elasticPoolId')]",
+        "availabilityZone": "[parameters('availabilityZone')]",
+        "catalogCollation": "[parameters('catalogCollation')]",
+        "collation": "[parameters('collation')]",
         "createMode": "[parameters('createMode')]",
-        "sourceDatabaseId": "[if(not(empty(parameters('sourceDatabaseResourceId'))), parameters('sourceDatabaseResourceId'), null())]",
-        "sourceDatabaseDeletionDate": "[if(not(empty(parameters('sourceDatabaseDeletionDate'))), parameters('sourceDatabaseDeletionDate'), null())]",
-        "recoveryServicesRecoveryPointId": "[if(not(empty(parameters('recoveryServicesRecoveryPointResourceId'))), parameters('recoveryServicesRecoveryPointResourceId'), null())]",
-        "restorePointInTime": "[if(not(empty(parameters('restorePointInTime'))), parameters('restorePointInTime'), null())]"
+        "elasticPoolId": "[parameters('elasticPoolId')]",
+        "encryptionProtector": "[parameters('encryptionProtector')]",
+        "encryptionProtectorAutoRotation": "[parameters('encryptionProtectorAutoRotation')]",
+        "federatedClientId": "[parameters('federatedClientId')]",
+        "freeLimitExhaustionBehavior": "[parameters('freeLimitExhaustionBehavior')]",
+        "highAvailabilityReplicaCount": "[parameters('highAvailabilityReplicaCount')]",
+        "isLedgerOn": "[parameters('isLedgerOn')]",
+        "licenseType": "[parameters('licenseType')]",
+        "longTermRetentionBackupResourceId": "[parameters('longTermRetentionBackupResourceId')]",
+        "maintenanceConfigurationId": "[parameters('maintenanceConfigurationId')]",
+        "manualCutover": "[parameters('manualCutover')]",
+        "maxSizeBytes": "[parameters('maxSizeBytes')]",
+        "minCapacity": "[if(not(empty(parameters('minCapacity'))), json(parameters('minCapacity')), 0)]",
+        "performCutover": "[parameters('performCutover')]",
+        "preferredEnclaveType": "[parameters('preferredEnclaveType')]",
+        "readScale": "[parameters('readScale')]",
+        "recoverableDatabaseId": "[parameters('recoverableDatabaseId')]",
+        "recoveryServicesRecoveryPointId": "[parameters('recoveryServicesRecoveryPointId')]",
+        "requestedBackupStorageRedundancy": "[parameters('requestedBackupStorageRedundancy')]",
+        "restorableDroppedDatabaseId": "[parameters('restorableDroppedDatabaseId')]",
+        "restorePointInTime": "[parameters('restorePointInTime')]",
+        "sampleName": "[parameters('sampleName')]",
+        "secondaryType": "[parameters('secondaryType')]",
+        "sourceDatabaseDeletionDate": "[parameters('sourceDatabaseDeletionDate')]",
+        "sourceDatabaseId": "[parameters('sourceDatabaseId')]",
+        "sourceResourceId": "[parameters('sourceResourceId')]",
+        "useFreeLimit": "[parameters('useFreeLimit')]",
+        "zoneRedundant": "[parameters('zoneRedundant')]"
       },
-      "sku": "[variables('skuVar')]",
       "dependsOn": [
         "server"
       ]

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "15066479282051878033"
+      "templateHash": "2290667128393523898"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database.",
@@ -554,7 +554,7 @@
     },
     "zoneRedundant": {
       "type": "bool",
-      "nullable": true,
+      "defaultValue": true,
       "metadata": {
         "description": "Optional. Whether or not this database is zone redundant."
       }

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "2532099399760155788"
+      "templateHash": "4558221869591328265"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database.",
@@ -160,7 +160,7 @@
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Size of the particular SKU"
+            "description": "Optional. Size of the particular SKU."
           }
         },
         "tier": {
@@ -203,7 +203,7 @@
           "type": "int",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled"
+            "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled."
           }
         },
         "availabilityZone": {
@@ -517,7 +517,7 @@
       "type": "int",
       "defaultValue": 0,
       "metadata": {
-        "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled"
+        "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled."
       }
     },
     "availabilityZone": {

--- a/avm/res/sql/server/elastic-pool/README.md
+++ b/avm/res/sql/server/elastic-pool/README.md
@@ -21,28 +21,23 @@ This module deploys an Azure SQL Server Elastic Pool.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-name) | string | The name of the Elastic Pool. |
-
-**Conditional parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
 | [`serverName`](#parameter-servername) | string | The name of the parent SQL Server. Required if the template is used in a standalone deployment. |
 
 **Optional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`databaseMaxCapacity`](#parameter-databasemaxcapacity) | int | The maximum capacity any one database can consume. |
-| [`databaseMinCapacity`](#parameter-databasemincapacity) | int | The minimum capacity all databases are guaranteed. |
+| [`autoPauseDelay`](#parameter-autopausedelay) | int | Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled. |
+| [`availabilityZone`](#parameter-availabilityzone) | string | Specifies the availability zone the pool's primary replica is pinned to. |
 | [`highAvailabilityReplicaCount`](#parameter-highavailabilityreplicacount) | int | The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools. |
 | [`licenseType`](#parameter-licensetype) | string | The license type to apply for this elastic pool. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`maintenanceConfigurationId`](#parameter-maintenanceconfigurationid) | string | Maintenance configuration resource ID assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur. |
 | [`maxSizeBytes`](#parameter-maxsizebytes) | int | The storage limit for the database elastic pool in bytes. |
 | [`minCapacity`](#parameter-mincapacity) | int | Minimal capacity that serverless pool will not shrink below, if not paused. |
-| [`skuCapacity`](#parameter-skucapacity) | int | Capacity of the particular SKU. |
-| [`skuName`](#parameter-skuname) | string | The name of the SKU, typically, a letter + Number code, e.g. P3. |
-| [`skuTier`](#parameter-skutier) | string | The tier or edition of the particular SKU, e.g. Basic, Premium. |
+| [`perDatabaseSettings`](#parameter-perdatabasesettings) | object | The per database settings for the elastic pool. |
+| [`preferredEnclaveType`](#parameter-preferredenclavetype) | string | Type of enclave requested on the elastic pool. |
+| [`sku`](#parameter-sku) | object | The elastic pool SKU. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`zoneRedundant`](#parameter-zoneredundant) | bool | Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones. |
 
@@ -60,21 +55,30 @@ The name of the parent SQL Server. Required if the template is used in a standal
 - Required: Yes
 - Type: string
 
-### Parameter: `databaseMaxCapacity`
+### Parameter: `autoPauseDelay`
 
-The maximum capacity any one database can consume.
-
-- Required: No
-- Type: int
-- Default: `2`
-
-### Parameter: `databaseMinCapacity`
-
-The minimum capacity all databases are guaranteed.
+Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled.
 
 - Required: No
 - Type: int
-- Default: `0`
+- Default: `-1`
+
+### Parameter: `availabilityZone`
+
+Specifies the availability zone the pool's primary replica is pinned to.
+
+- Required: No
+- Type: string
+- Default: `'NoPreference'`
+- Allowed:
+  ```Bicep
+  [
+    '1'
+    '2'
+    '3'
+    'NoPreference'
+  ]
+  ```
 
 ### Parameter: `highAvailabilityReplicaCount`
 
@@ -128,29 +132,156 @@ Minimal capacity that serverless pool will not shrink below, if not paused.
 - Required: No
 - Type: int
 
-### Parameter: `skuCapacity`
+### Parameter: `perDatabaseSettings`
 
-Capacity of the particular SKU.
+The per database settings for the elastic pool.
+
+- Required: No
+- Type: object
+- Default:
+  ```Bicep
+  {
+      autoPauseDelay: -1
+      maxCapacity: 2
+      minCapacity: 0
+  }
+  ```
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`minCapacity`](#parameter-perdatabasesettingsmincapacity) | int | The minimum capacity all databases are guaranteed. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`autoPauseDelay`](#parameter-perdatabasesettingsautopausedelay) | int | Auto Pause Delay for per database within pool |
+
+**Reqired parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`maxCapacity`](#parameter-perdatabasesettingsmaxcapacity) | int | The maximum capacity any one database can consume. |
+
+### Parameter: `perDatabaseSettings.minCapacity`
+
+The minimum capacity all databases are guaranteed.
+
+- Required: Yes
+- Type: int
+
+### Parameter: `perDatabaseSettings.autoPauseDelay`
+
+Auto Pause Delay for per database within pool
 
 - Required: No
 - Type: int
-- Default: `2`
 
-### Parameter: `skuName`
+### Parameter: `perDatabaseSettings.maxCapacity`
 
-The name of the SKU, typically, a letter + Number code, e.g. P3.
+The maximum capacity any one database can consume.
+
+- Required: Yes
+- Type: int
+
+### Parameter: `preferredEnclaveType`
+
+Type of enclave requested on the elastic pool.
 
 - Required: No
 - Type: string
-- Default: `'GP_Gen5'`
+- Default: `'Default'`
+- Allowed:
+  ```Bicep
+  [
+    'Default'
+    'VBS'
+  ]
+  ```
 
-### Parameter: `skuTier`
+### Parameter: `sku`
+
+The elastic pool SKU.
+
+- Required: No
+- Type: object
+- Default:
+  ```Bicep
+  {
+      capacity: 2
+      name: 'GP_Gen5'
+      tier: 'GeneralPurpose'
+  }
+  ```
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-skuname) | string | The name of the SKU, typically, a letter + Number code, e.g. P3. |
+| [`tier`](#parameter-skutier) | string | The tier or edition of the particular SKU, e.g. Basic, Premium. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`capacity`](#parameter-skucapacity) | int | The capacity of the particular SKU. |
+| [`family`](#parameter-skufamily) | string | If the service has different generations of hardware, for the same SKU, then that can be captured here. |
+| [`size`](#parameter-skusize) | string | Size of the particular SKU |
+
+### Parameter: `sku.name`
+
+The name of the SKU, typically, a letter + Number code, e.g. P3.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'BasicPool'
+    'BC_DC'
+    'BC_Gen5'
+    'GP_DC'
+    'GP_FSv2'
+    'GP_Gen5'
+    'HS_Gen5'
+    'HS_MOPRMS'
+    'HS_PRMS'
+    'PremiumPool'
+    'ServerlessPool'
+    'StandardPool'
+  ]
+  ```
+
+### Parameter: `sku.tier`
 
 The tier or edition of the particular SKU, e.g. Basic, Premium.
 
 - Required: No
 - Type: string
-- Default: `'GeneralPurpose'`
+
+### Parameter: `sku.capacity`
+
+The capacity of the particular SKU.
+
+- Required: No
+- Type: int
+
+### Parameter: `sku.family`
+
+If the service has different generations of hardware, for the same SKU, then that can be captured here.
+
+- Required: No
+- Type: string
+
+### Parameter: `sku.size`
+
+Size of the particular SKU
+
+- Required: No
+- Type: string
 
 ### Parameter: `tags`
 
@@ -165,7 +296,7 @@ Whether or not this elastic pool is zone redundant, which means the replicas of 
 
 - Required: No
 - Type: bool
-- Default: `True`
+- Default: `False`
 
 ## Outputs
 

--- a/avm/res/sql/server/elastic-pool/README.md
+++ b/avm/res/sql/server/elastic-pool/README.md
@@ -21,6 +21,11 @@ This module deploys an Azure SQL Server Elastic Pool.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-name) | string | The name of the Elastic Pool. |
+
+**Conditional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
 | [`serverName`](#parameter-servername) | string | The name of the parent SQL Server. Required if the template is used in a standalone deployment. |
 
 **Optional parameters**
@@ -221,7 +226,6 @@ The elastic pool SKU.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-skuname) | string | The name of the SKU, typically, a letter + Number code, e.g. P3. |
-| [`tier`](#parameter-skutier) | string | The tier or edition of the particular SKU, e.g. Basic, Premium. |
 
 **Optional parameters**
 
@@ -230,6 +234,7 @@ The elastic pool SKU.
 | [`capacity`](#parameter-skucapacity) | int | The capacity of the particular SKU. |
 | [`family`](#parameter-skufamily) | string | If the service has different generations of hardware, for the same SKU, then that can be captured here. |
 | [`size`](#parameter-skusize) | string | Size of the particular SKU. |
+| [`tier`](#parameter-skutier) | string | The tier or edition of the particular SKU, e.g. Basic, Premium. |
 
 ### Parameter: `sku.name`
 
@@ -255,13 +260,6 @@ The name of the SKU, typically, a letter + Number code, e.g. P3.
   ]
   ```
 
-### Parameter: `sku.tier`
-
-The tier or edition of the particular SKU, e.g. Basic, Premium.
-
-- Required: No
-- Type: string
-
 ### Parameter: `sku.capacity`
 
 The capacity of the particular SKU.
@@ -279,6 +277,13 @@ If the service has different generations of hardware, for the same SKU, then tha
 ### Parameter: `sku.size`
 
 Size of the particular SKU.
+
+- Required: No
+- Type: string
+
+### Parameter: `sku.tier`
+
+The tier or edition of the particular SKU, e.g. Basic, Premium.
 
 - Required: No
 - Type: string

--- a/avm/res/sql/server/elastic-pool/README.md
+++ b/avm/res/sql/server/elastic-pool/README.md
@@ -151,37 +151,37 @@ The per database settings for the elastic pool.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`minCapacity`](#parameter-perdatabasesettingsmincapacity) | string | The minimum capacity all databases are guaranteed. Examples: '0.5', '1' |
+| [`minCapacity`](#parameter-perdatabasesettingsmincapacity) | string | The minimum capacity all databases are guaranteed. Examples: '0.5', '1'. |
 
 **Optional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`autoPauseDelay`](#parameter-perdatabasesettingsautopausedelay) | int | Auto Pause Delay for per database within pool |
+| [`autoPauseDelay`](#parameter-perdatabasesettingsautopausedelay) | int | Auto Pause Delay for per database within pool. |
 
 **Reqired parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`maxCapacity`](#parameter-perdatabasesettingsmaxcapacity) | string | The maximum capacity any one database can consume. Examples: '0.5', '2' |
+| [`maxCapacity`](#parameter-perdatabasesettingsmaxcapacity) | string | The maximum capacity any one database can consume. Examples: '0.5', '2'. |
 
 ### Parameter: `perDatabaseSettings.minCapacity`
 
-The minimum capacity all databases are guaranteed. Examples: '0.5', '1'
+The minimum capacity all databases are guaranteed. Examples: '0.5', '1'.
 
 - Required: Yes
 - Type: string
 
 ### Parameter: `perDatabaseSettings.autoPauseDelay`
 
-Auto Pause Delay for per database within pool
+Auto Pause Delay for per database within pool.
 
 - Required: No
 - Type: int
 
 ### Parameter: `perDatabaseSettings.maxCapacity`
 
-The maximum capacity any one database can consume. Examples: '0.5', '2'
+The maximum capacity any one database can consume. Examples: '0.5', '2'.
 
 - Required: Yes
 - Type: string
@@ -229,7 +229,7 @@ The elastic pool SKU.
 | :-- | :-- | :-- |
 | [`capacity`](#parameter-skucapacity) | int | The capacity of the particular SKU. |
 | [`family`](#parameter-skufamily) | string | If the service has different generations of hardware, for the same SKU, then that can be captured here. |
-| [`size`](#parameter-skusize) | string | Size of the particular SKU |
+| [`size`](#parameter-skusize) | string | Size of the particular SKU. |
 
 ### Parameter: `sku.name`
 
@@ -278,7 +278,7 @@ If the service has different generations of hardware, for the same SKU, then tha
 
 ### Parameter: `sku.size`
 
-Size of the particular SKU
+Size of the particular SKU.
 
 - Required: No
 - Type: string

--- a/avm/res/sql/server/elastic-pool/README.md
+++ b/avm/res/sql/server/elastic-pool/README.md
@@ -301,7 +301,7 @@ Whether or not this elastic pool is zone redundant, which means the replicas of 
 
 - Required: No
 - Type: bool
-- Default: `False`
+- Default: `True`
 
 ## Outputs
 

--- a/avm/res/sql/server/elastic-pool/README.md
+++ b/avm/res/sql/server/elastic-pool/README.md
@@ -142,8 +142,8 @@ The per database settings for the elastic pool.
   ```Bicep
   {
       autoPauseDelay: -1
-      maxCapacity: 2
-      minCapacity: 0
+      maxCapacity: '2'
+      minCapacity: '0'
   }
   ```
 
@@ -151,7 +151,7 @@ The per database settings for the elastic pool.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`minCapacity`](#parameter-perdatabasesettingsmincapacity) | int | The minimum capacity all databases are guaranteed. |
+| [`minCapacity`](#parameter-perdatabasesettingsmincapacity) | string | The minimum capacity all databases are guaranteed. Examples: '0.5', '1' |
 
 **Optional parameters**
 
@@ -163,14 +163,14 @@ The per database settings for the elastic pool.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`maxCapacity`](#parameter-perdatabasesettingsmaxcapacity) | int | The maximum capacity any one database can consume. |
+| [`maxCapacity`](#parameter-perdatabasesettingsmaxcapacity) | string | The maximum capacity any one database can consume. Examples: '0.5', '2' |
 
 ### Parameter: `perDatabaseSettings.minCapacity`
 
-The minimum capacity all databases are guaranteed.
+The minimum capacity all databases are guaranteed. Examples: '0.5', '1'
 
 - Required: Yes
-- Type: int
+- Type: string
 
 ### Parameter: `perDatabaseSettings.autoPauseDelay`
 
@@ -181,10 +181,10 @@ Auto Pause Delay for per database within pool
 
 ### Parameter: `perDatabaseSettings.maxCapacity`
 
-The maximum capacity any one database can consume.
+The maximum capacity any one database can consume. Examples: '0.5', '2'
 
 - Required: Yes
-- Type: int
+- Type: string
 
 ### Parameter: `preferredEnclaveType`
 

--- a/avm/res/sql/server/elastic-pool/main.bicep
+++ b/avm/res/sql/server/elastic-pool/main.bicep
@@ -110,14 +110,14 @@ output location string = elasticPool.location
 @export()
 @description('The per database settings for the elastic pool.')
 type elasticPoolPerDatabaseSettingsType = {
-  @description('Optional. Auto Pause Delay for per database within pool')
+  @description('Optional. Auto Pause Delay for per database within pool.')
   autoPauseDelay: int?
 
-  @description('Reqired. The maximum capacity any one database can consume. Examples: \'0.5\', \'2\'')
+  @description('Reqired. The maximum capacity any one database can consume. Examples: \'0.5\', \'2\'.')
   maxCapacity: string
 
   // using string as minCapacity can be fractional
-  @description('Required. The minimum capacity all databases are guaranteed. Examples: \'0.5\', \'1\'')
+  @description('Required. The minimum capacity all databases are guaranteed. Examples: \'0.5\', \'1\'.')
   minCapacity: string
 }
 
@@ -145,7 +145,7 @@ type elasticPoolSkuType = {
     | 'HS_MOPRMS'
     | 'ServerlessPool'
 
-  @description('Optional. Size of the particular SKU')
+  @description('Optional. Size of the particular SKU.')
   size: string?
 
   @description('Required. The tier or edition of the particular SKU, e.g. Basic, Premium.')
@@ -181,7 +181,7 @@ type elasticPoolPropertyType = {
   @description('Optional. The storage limit for the database elastic pool in bytes.')
   maxSizeBytes: int?
 
-  @description('Optional. Minimal capacity that serverless pool will not shrink below, if not paused')
+  @description('Optional. Minimal capacity that serverless pool will not shrink below, if not paused.')
   minCapacity: int?
 
   @description('Optional. The per database settings for the elastic pool.')

--- a/avm/res/sql/server/elastic-pool/main.bicep
+++ b/avm/res/sql/server/elastic-pool/main.bicep
@@ -43,7 +43,6 @@ param maintenanceConfigurationId string?
 @description('Optional. The storage limit for the database elastic pool in bytes.')
 param maxSizeBytes int = 34359738368
 
-// TODO: Only for Serverless
 @description('Optional. Minimal capacity that serverless pool will not shrink below, if not paused.')
 param minCapacity int?
 
@@ -58,7 +57,7 @@ param perDatabaseSettings elasticPoolPerDatabaseSettingsType = {
 param preferredEnclaveType 'Default' | 'VBS' = 'Default'
 
 @description('Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones.')
-param zoneRedundant bool = false
+param zoneRedundant bool = true
 
 resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
   name: serverName

--- a/avm/res/sql/server/elastic-pool/main.bicep
+++ b/avm/res/sql/server/elastic-pool/main.bicep
@@ -50,8 +50,8 @@ param minCapacity int?
 @description('Optional. The per database settings for the elastic pool.')
 param perDatabaseSettings elasticPoolPerDatabaseSettingsType = {
   autoPauseDelay: -1
-  maxCapacity: 2
-  minCapacity: 0
+  maxCapacity: '2'
+  minCapacity: '0'
 }
 
 @description('Optional. Type of enclave requested on the elastic pool.')
@@ -78,7 +78,14 @@ resource elasticPool 'Microsoft.Sql/servers/elasticPools@2023-08-01-preview' = {
     maintenanceConfigurationId: maintenanceConfigurationId
     maxSizeBytes: maxSizeBytes
     minCapacity: minCapacity
-    perDatabaseSettings: perDatabaseSettings
+    perDatabaseSettings: !empty(perDatabaseSettings)
+      ? {
+          autoPauseDelay: perDatabaseSettings.?autoPauseDelay
+          // To handle fractional values, we need to convert from string :(
+          maxCapacity: json(perDatabaseSettings.?maxCapacity)
+          minCapacity: json(perDatabaseSettings.?minCapacity)
+        }
+      : null
     preferredEnclaveType: preferredEnclaveType
     zoneRedundant: zoneRedundant
   }
@@ -106,11 +113,12 @@ type elasticPoolPerDatabaseSettingsType = {
   @description('Optional. Auto Pause Delay for per database within pool')
   autoPauseDelay: int?
 
-  @description('Reqired. The maximum capacity any one database can consume.')
-  maxCapacity: int
+  @description('Reqired. The maximum capacity any one database can consume. Examples: \'0.5\', \'2\'')
+  maxCapacity: string
 
-  @description('Required. The minimum capacity all databases are guaranteed.')
-  minCapacity: int
+  // using string as minCapacity can be fractional
+  @description('Required. The minimum capacity all databases are guaranteed. Examples: \'0.5\', \'1\'')
+  minCapacity: string
 }
 
 @export()

--- a/avm/res/sql/server/elastic-pool/main.bicep
+++ b/avm/res/sql/server/elastic-pool/main.bicep
@@ -5,7 +5,7 @@ metadata owner = 'Azure/module-maintainers'
 @description('Required. The name of the Elastic Pool.')
 param name string
 
-@description('Conditional. The name of the parent SQL Server. Required if the template is used in a standalone deployment.')
+@description('Required. The name of the parent SQL Server. Required if the template is used in a standalone deployment.')
 param serverName string
 
 @description('Optional. Tags of the resource.')
@@ -14,14 +14,18 @@ param tags object?
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
-@description('Optional. Capacity of the particular SKU.')
-param skuCapacity int = 2
+@description('Optional. The elastic pool SKU.')
+param sku elasticPoolSkuType = {
+  capacity: 2
+  name: 'GP_Gen5'
+  tier: 'GeneralPurpose'
+}
 
-@description('Optional. The name of the SKU, typically, a letter + Number code, e.g. P3.')
-param skuName string = 'GP_Gen5'
+@description('Optional. Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled.')
+param autoPauseDelay int = -1
 
-@description('Optional. The tier or edition of the particular SKU, e.g. Basic, Premium.')
-param skuTier string = 'GeneralPurpose'
+@description('Optional. Specifies the availability zone the pool\'s primary replica is pinned to.')
+param availabilityZone '1' | '2' | '3' | 'NoPreference' = 'NoPreference'
 
 @description('Optional. The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools.')
 param highAvailabilityReplicaCount int?
@@ -39,17 +43,22 @@ param maintenanceConfigurationId string?
 @description('Optional. The storage limit for the database elastic pool in bytes.')
 param maxSizeBytes int = 34359738368
 
+// TODO: Only for Serverless
 @description('Optional. Minimal capacity that serverless pool will not shrink below, if not paused.')
 param minCapacity int?
 
-@description('Optional. The maximum capacity any one database can consume.')
-param databaseMaxCapacity int = 2
+@description('Optional. The per database settings for the elastic pool.')
+param perDatabaseSettings elasticPoolPerDatabaseSettingsType = {
+  autoPauseDelay: -1
+  maxCapacity: 2
+  minCapacity: 0
+}
 
-@description('Optional. The minimum capacity all databases are guaranteed.')
-param databaseMinCapacity int = 0
+@description('Optional. Type of enclave requested on the elastic pool.')
+param preferredEnclaveType 'Default' | 'VBS' = 'Default'
 
 @description('Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones.')
-param zoneRedundant bool = true
+param zoneRedundant bool = false
 
 resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
   name: serverName
@@ -60,21 +69,17 @@ resource elasticPool 'Microsoft.Sql/servers/elasticPools@2023-08-01-preview' = {
   location: location
   parent: server
   tags: tags
-  sku: {
-    capacity: skuCapacity
-    name: skuName
-    tier: skuTier
-  }
+  sku: sku
   properties: {
+    autoPauseDelay: autoPauseDelay
+    availabilityZone: availabilityZone
     highAvailabilityReplicaCount: highAvailabilityReplicaCount
     licenseType: licenseType
     maintenanceConfigurationId: maintenanceConfigurationId
     maxSizeBytes: maxSizeBytes
     minCapacity: minCapacity
-    perDatabaseSettings: {
-      minCapacity: databaseMinCapacity
-      maxCapacity: databaseMaxCapacity
-    }
+    perDatabaseSettings: perDatabaseSettings
+    preferredEnclaveType: preferredEnclaveType
     zoneRedundant: zoneRedundant
   }
 }
@@ -90,3 +95,93 @@ output resourceGroupName string = resourceGroup().name
 
 @description('The location the resource was deployed into.')
 output location string = elasticPool.location
+
+// =============== //
+//   Definitions   //
+// =============== //
+
+@export()
+@description('The per database settings for the elastic pool.')
+type elasticPoolPerDatabaseSettingsType = {
+  @description('Optional. Auto Pause Delay for per database within pool')
+  autoPauseDelay: int?
+
+  @description('Reqired. The maximum capacity any one database can consume.')
+  maxCapacity: int
+
+  @description('Required. The minimum capacity all databases are guaranteed.')
+  minCapacity: int
+}
+
+@export()
+@description('The elastic pool SKU.')
+type elasticPoolSkuType = {
+  @description('Optional. The capacity of the particular SKU.')
+  capacity: int?
+
+  @description('Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here.')
+  family: string?
+
+  @description('Required. The name of the SKU, typically, a letter + Number code, e.g. P3.')
+  name:
+    | 'BasicPool'
+    | 'StandardPool'
+    | 'PremiumPool'
+    | 'GP_Gen5'
+    | 'GP_DC'
+    | 'GP_FSv2'
+    | 'BC_Gen5'
+    | 'BC_DC'
+    | 'HS_Gen5'
+    | 'HS_PRMS'
+    | 'HS_MOPRMS'
+    | 'ServerlessPool'
+
+  @description('Optional. Size of the particular SKU')
+  size: string?
+
+  @description('Required. The tier or edition of the particular SKU, e.g. Basic, Premium.')
+  tier: string?
+}
+
+@export()
+type elasticPoolPropertyType = {
+  @description('Required. The name of the Elastic Pool.')
+  name: string
+
+  @description('Optional. Tags of the resource.')
+  tags: object?
+
+  @description('Optional. The elastic pool SKU.')
+  sku: elasticPoolSkuType?
+
+  @description('Optional. Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled.')
+  autoPauseDelay: int?
+
+  @description('Optional. Specifies the availability zone the pool\'s primary replica is pinned to.')
+  availabilityZone: '1' | '2' | '3' | 'NoPreference'?
+
+  @description('Optional. The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools.')
+  highAvailabilityReplicaCount: int?
+
+  @description('Optional. The license type to apply for this elastic pool.')
+  licenseType: 'BasePrice' | 'LicenseIncluded'?
+
+  @description('Optional. Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur.')
+  maintenanceConfigurationId: string?
+
+  @description('Optional. The storage limit for the database elastic pool in bytes.')
+  maxSizeBytes: int?
+
+  @description('Optional. Minimal capacity that serverless pool will not shrink below, if not paused')
+  minCapacity: int?
+
+  @description('Optional. The per database settings for the elastic pool.')
+  perDatabaseSettings: elasticPoolPerDatabaseSettingsType?
+
+  @description('Optional. Type of enclave requested on the elastic pool.')
+  preferredEnclaveType: 'Default' | 'VBS'?
+
+  @description('Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones.')
+  zoneRedundant: bool?
+}

--- a/avm/res/sql/server/elastic-pool/main.bicep
+++ b/avm/res/sql/server/elastic-pool/main.bicep
@@ -5,7 +5,7 @@ metadata owner = 'Azure/module-maintainers'
 @description('Required. The name of the Elastic Pool.')
 param name string
 
-@description('Required. The name of the parent SQL Server. Required if the template is used in a standalone deployment.')
+@description('Conditional. The name of the parent SQL Server. Required if the template is used in a standalone deployment.')
 param serverName string
 
 @description('Optional. Tags of the resource.')
@@ -148,48 +148,6 @@ type elasticPoolSkuType = {
   @description('Optional. Size of the particular SKU.')
   size: string?
 
-  @description('Required. The tier or edition of the particular SKU, e.g. Basic, Premium.')
+  @description('Optional. The tier or edition of the particular SKU, e.g. Basic, Premium.')
   tier: string?
-}
-
-@export()
-type elasticPoolPropertyType = {
-  @description('Required. The name of the Elastic Pool.')
-  name: string
-
-  @description('Optional. Tags of the resource.')
-  tags: object?
-
-  @description('Optional. The elastic pool SKU.')
-  sku: elasticPoolSkuType?
-
-  @description('Optional. Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled.')
-  autoPauseDelay: int?
-
-  @description('Optional. Specifies the availability zone the pool\'s primary replica is pinned to.')
-  availabilityZone: '1' | '2' | '3' | 'NoPreference'?
-
-  @description('Optional. The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools.')
-  highAvailabilityReplicaCount: int?
-
-  @description('Optional. The license type to apply for this elastic pool.')
-  licenseType: 'BasePrice' | 'LicenseIncluded'?
-
-  @description('Optional. Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur.')
-  maintenanceConfigurationId: string?
-
-  @description('Optional. The storage limit for the database elastic pool in bytes.')
-  maxSizeBytes: int?
-
-  @description('Optional. Minimal capacity that serverless pool will not shrink below, if not paused.')
-  minCapacity: int?
-
-  @description('Optional. The per database settings for the elastic pool.')
-  perDatabaseSettings: elasticPoolPerDatabaseSettingsType?
-
-  @description('Optional. Type of enclave requested on the elastic pool.')
-  preferredEnclaveType: 'Default' | 'VBS'?
-
-  @description('Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones.')
-  zoneRedundant: bool?
 }

--- a/avm/res/sql/server/elastic-pool/main.json
+++ b/avm/res/sql/server/elastic-pool/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "17075205316023541596"
+      "templateHash": "2259224988550504716"
     },
     "name": "SQL Server Elastic Pool",
     "description": "This module deploys an Azure SQL Server Elastic Pool.",
@@ -89,125 +89,13 @@
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Required. The tier or edition of the particular SKU, e.g. Basic, Premium."
+            "description": "Optional. The tier or edition of the particular SKU, e.g. Basic, Premium."
           }
         }
       },
       "metadata": {
         "__bicep_export!": true,
         "description": "The elastic pool SKU."
-      }
-    },
-    "elasticPoolPropertyType": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. The name of the Elastic Pool."
-          }
-        },
-        "tags": {
-          "type": "object",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Tags of the resource."
-          }
-        },
-        "sku": {
-          "$ref": "#/definitions/elasticPoolSkuType",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The elastic pool SKU."
-          }
-        },
-        "autoPauseDelay": {
-          "type": "int",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled."
-          }
-        },
-        "availabilityZone": {
-          "type": "string",
-          "allowedValues": [
-            "1",
-            "2",
-            "3",
-            "NoPreference"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Specifies the availability zone the pool's primary replica is pinned to."
-          }
-        },
-        "highAvailabilityReplicaCount": {
-          "type": "int",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools."
-          }
-        },
-        "licenseType": {
-          "type": "string",
-          "allowedValues": [
-            "BasePrice",
-            "LicenseIncluded"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The license type to apply for this elastic pool."
-          }
-        },
-        "maintenanceConfigurationId": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur."
-          }
-        },
-        "maxSizeBytes": {
-          "type": "int",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The storage limit for the database elastic pool in bytes."
-          }
-        },
-        "minCapacity": {
-          "type": "int",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused."
-          }
-        },
-        "perDatabaseSettings": {
-          "$ref": "#/definitions/elasticPoolPerDatabaseSettingsType",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The per database settings for the elastic pool."
-          }
-        },
-        "preferredEnclaveType": {
-          "type": "string",
-          "allowedValues": [
-            "Default",
-            "VBS"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Type of enclave requested on the elastic pool."
-          }
-        },
-        "zoneRedundant": {
-          "type": "bool",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones."
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true
       }
     }
   },
@@ -221,7 +109,7 @@
     "serverName": {
       "type": "string",
       "metadata": {
-        "description": "Required. The name of the parent SQL Server. Required if the template is used in a standalone deployment."
+        "description": "Conditional. The name of the parent SQL Server. Required if the template is used in a standalone deployment."
       }
     },
     "tags": {

--- a/avm/res/sql/server/elastic-pool/main.json
+++ b/avm/res/sql/server/elastic-pool/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "2259224988550504716"
+      "templateHash": "4618079193349998123"
     },
     "name": "SQL Server Elastic Pool",
     "description": "This module deploys an Azure SQL Server Elastic Pool.",
@@ -220,7 +220,7 @@
     },
     "zoneRedundant": {
       "type": "bool",
-      "defaultValue": false,
+      "defaultValue": true,
       "metadata": {
         "description": "Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones."
       }

--- a/avm/res/sql/server/elastic-pool/main.json
+++ b/avm/res/sql/server/elastic-pool/main.json
@@ -6,11 +6,210 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "17774091526328280898"
+      "templateHash": "8697391320806003846"
     },
     "name": "SQL Server Elastic Pool",
     "description": "This module deploys an Azure SQL Server Elastic Pool.",
     "owner": "Azure/module-maintainers"
+  },
+  "definitions": {
+    "elasticPoolPerDatabaseSettingsType": {
+      "type": "object",
+      "properties": {
+        "autoPauseDelay": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Auto Pause Delay for per database within pool"
+          }
+        },
+        "maxCapacity": {
+          "type": "int",
+          "metadata": {
+            "description": "Reqired. The maximum capacity any one database can consume."
+          }
+        },
+        "minCapacity": {
+          "type": "int",
+          "metadata": {
+            "description": "Required. The minimum capacity all databases are guaranteed."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The per database settings for the elastic pool."
+      }
+    },
+    "elasticPoolSkuType": {
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The capacity of the particular SKU."
+          }
+        },
+        "family": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here."
+          }
+        },
+        "name": {
+          "type": "string",
+          "allowedValues": [
+            "BC_DC",
+            "BC_Gen5",
+            "BasicPool",
+            "GP_DC",
+            "GP_FSv2",
+            "GP_Gen5",
+            "HS_Gen5",
+            "HS_MOPRMS",
+            "HS_PRMS",
+            "PremiumPool",
+            "ServerlessPool",
+            "StandardPool"
+          ],
+          "metadata": {
+            "description": "Required. The name of the SKU, typically, a letter + Number code, e.g. P3."
+          }
+        },
+        "size": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Size of the particular SKU"
+          }
+        },
+        "tier": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Required. The tier or edition of the particular SKU, e.g. Basic, Premium."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The elastic pool SKU."
+      }
+    },
+    "elasticPoolPropertyType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the Elastic Pool."
+          }
+        },
+        "tags": {
+          "type": "object",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Tags of the resource."
+          }
+        },
+        "sku": {
+          "$ref": "#/definitions/elasticPoolSkuType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The elastic pool SKU."
+          }
+        },
+        "autoPauseDelay": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled."
+          }
+        },
+        "availabilityZone": {
+          "type": "string",
+          "allowedValues": [
+            "1",
+            "2",
+            "3",
+            "NoPreference"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the availability zone the pool's primary replica is pinned to."
+          }
+        },
+        "highAvailabilityReplicaCount": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools."
+          }
+        },
+        "licenseType": {
+          "type": "string",
+          "allowedValues": [
+            "BasePrice",
+            "LicenseIncluded"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The license type to apply for this elastic pool."
+          }
+        },
+        "maintenanceConfigurationId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur."
+          }
+        },
+        "maxSizeBytes": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The storage limit for the database elastic pool in bytes."
+          }
+        },
+        "minCapacity": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused"
+          }
+        },
+        "perDatabaseSettings": {
+          "$ref": "#/definitions/elasticPoolPerDatabaseSettingsType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The per database settings for the elastic pool."
+          }
+        },
+        "preferredEnclaveType": {
+          "type": "string",
+          "allowedValues": [
+            "Default",
+            "VBS"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Type of enclave requested on the elastic pool."
+          }
+        },
+        "zoneRedundant": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true
+      }
+    }
   },
   "parameters": {
     "name": {
@@ -22,7 +221,7 @@
     "serverName": {
       "type": "string",
       "metadata": {
-        "description": "Conditional. The name of the parent SQL Server. Required if the template is used in a standalone deployment."
+        "description": "Required. The name of the parent SQL Server. Required if the template is used in a standalone deployment."
       }
     },
     "tags": {
@@ -39,25 +238,35 @@
         "description": "Optional. Location for all resources."
       }
     },
-    "skuCapacity": {
+    "sku": {
+      "$ref": "#/definitions/elasticPoolSkuType",
+      "defaultValue": {
+        "capacity": 2,
+        "name": "GP_Gen5",
+        "tier": "GeneralPurpose"
+      },
+      "metadata": {
+        "description": "Optional. The elastic pool SKU."
+      }
+    },
+    "autoPauseDelay": {
       "type": "int",
-      "defaultValue": 2,
+      "defaultValue": -1,
       "metadata": {
-        "description": "Optional. Capacity of the particular SKU."
+        "description": "Optional. Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled."
       }
     },
-    "skuName": {
+    "availabilityZone": {
       "type": "string",
-      "defaultValue": "GP_Gen5",
+      "allowedValues": [
+        "1",
+        "2",
+        "3",
+        "NoPreference"
+      ],
+      "defaultValue": "NoPreference",
       "metadata": {
-        "description": "Optional. The name of the SKU, typically, a letter + Number code, e.g. P3."
-      }
-    },
-    "skuTier": {
-      "type": "string",
-      "defaultValue": "GeneralPurpose",
-      "metadata": {
-        "description": "Optional. The tier or edition of the particular SKU, e.g. Basic, Premium."
+        "description": "Optional. Specifies the availability zone the pool's primary replica is pinned to."
       }
     },
     "highAvailabilityReplicaCount": {
@@ -99,23 +308,31 @@
         "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused."
       }
     },
-    "databaseMaxCapacity": {
-      "type": "int",
-      "defaultValue": 2,
+    "perDatabaseSettings": {
+      "$ref": "#/definitions/elasticPoolPerDatabaseSettingsType",
+      "defaultValue": {
+        "autoPauseDelay": -1,
+        "maxCapacity": 2,
+        "minCapacity": 0
+      },
       "metadata": {
-        "description": "Optional. The maximum capacity any one database can consume."
+        "description": "Optional. The per database settings for the elastic pool."
       }
     },
-    "databaseMinCapacity": {
-      "type": "int",
-      "defaultValue": 0,
+    "preferredEnclaveType": {
+      "type": "string",
+      "allowedValues": [
+        "Default",
+        "VBS"
+      ],
+      "defaultValue": "Default",
       "metadata": {
-        "description": "Optional. The minimum capacity all databases are guaranteed."
+        "description": "Optional. Type of enclave requested on the elastic pool."
       }
     },
     "zoneRedundant": {
       "type": "bool",
-      "defaultValue": true,
+      "defaultValue": false,
       "metadata": {
         "description": "Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones."
       }
@@ -134,21 +351,17 @@
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
-      "sku": {
-        "capacity": "[parameters('skuCapacity')]",
-        "name": "[parameters('skuName')]",
-        "tier": "[parameters('skuTier')]"
-      },
+      "sku": "[parameters('sku')]",
       "properties": {
+        "autoPauseDelay": "[parameters('autoPauseDelay')]",
+        "availabilityZone": "[parameters('availabilityZone')]",
         "highAvailabilityReplicaCount": "[parameters('highAvailabilityReplicaCount')]",
         "licenseType": "[parameters('licenseType')]",
         "maintenanceConfigurationId": "[parameters('maintenanceConfigurationId')]",
         "maxSizeBytes": "[parameters('maxSizeBytes')]",
         "minCapacity": "[parameters('minCapacity')]",
-        "perDatabaseSettings": {
-          "minCapacity": "[parameters('databaseMinCapacity')]",
-          "maxCapacity": "[parameters('databaseMaxCapacity')]"
-        },
+        "perDatabaseSettings": "[parameters('perDatabaseSettings')]",
+        "preferredEnclaveType": "[parameters('preferredEnclaveType')]",
         "zoneRedundant": "[parameters('zoneRedundant')]"
       },
       "dependsOn": [

--- a/avm/res/sql/server/elastic-pool/main.json
+++ b/avm/res/sql/server/elastic-pool/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "10347822602729915434"
+      "templateHash": "17075205316023541596"
     },
     "name": "SQL Server Elastic Pool",
     "description": "This module deploys an Azure SQL Server Elastic Pool.",
@@ -20,19 +20,19 @@
           "type": "int",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Auto Pause Delay for per database within pool"
+            "description": "Optional. Auto Pause Delay for per database within pool."
           }
         },
         "maxCapacity": {
           "type": "string",
           "metadata": {
-            "description": "Reqired. The maximum capacity any one database can consume. Examples: '0.5', '2'"
+            "description": "Reqired. The maximum capacity any one database can consume. Examples: '0.5', '2'."
           }
         },
         "minCapacity": {
           "type": "string",
           "metadata": {
-            "description": "Required. The minimum capacity all databases are guaranteed. Examples: '0.5', '1'"
+            "description": "Required. The minimum capacity all databases are guaranteed. Examples: '0.5', '1'."
           }
         }
       },
@@ -82,7 +82,7 @@
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Size of the particular SKU"
+            "description": "Optional. Size of the particular SKU."
           }
         },
         "tier": {
@@ -177,7 +177,7 @@
           "type": "int",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused"
+            "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused."
           }
         },
         "perDatabaseSettings": {

--- a/avm/res/sql/server/elastic-pool/main.json
+++ b/avm/res/sql/server/elastic-pool/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "8697391320806003846"
+      "templateHash": "10347822602729915434"
     },
     "name": "SQL Server Elastic Pool",
     "description": "This module deploys an Azure SQL Server Elastic Pool.",
@@ -24,15 +24,15 @@
           }
         },
         "maxCapacity": {
-          "type": "int",
+          "type": "string",
           "metadata": {
-            "description": "Reqired. The maximum capacity any one database can consume."
+            "description": "Reqired. The maximum capacity any one database can consume. Examples: '0.5', '2'"
           }
         },
         "minCapacity": {
-          "type": "int",
+          "type": "string",
           "metadata": {
-            "description": "Required. The minimum capacity all databases are guaranteed."
+            "description": "Required. The minimum capacity all databases are guaranteed. Examples: '0.5', '1'"
           }
         }
       },
@@ -312,8 +312,8 @@
       "$ref": "#/definitions/elasticPoolPerDatabaseSettingsType",
       "defaultValue": {
         "autoPauseDelay": -1,
-        "maxCapacity": 2,
-        "minCapacity": 0
+        "maxCapacity": "2",
+        "minCapacity": "0"
       },
       "metadata": {
         "description": "Optional. The per database settings for the elastic pool."
@@ -360,7 +360,7 @@
         "maintenanceConfigurationId": "[parameters('maintenanceConfigurationId')]",
         "maxSizeBytes": "[parameters('maxSizeBytes')]",
         "minCapacity": "[parameters('minCapacity')]",
-        "perDatabaseSettings": "[parameters('perDatabaseSettings')]",
+        "perDatabaseSettings": "[if(not(empty(parameters('perDatabaseSettings'))), createObject('autoPauseDelay', tryGet(parameters('perDatabaseSettings'), 'autoPauseDelay'), 'maxCapacity', json(tryGet(parameters('perDatabaseSettings'), 'maxCapacity')), 'minCapacity', json(tryGet(parameters('perDatabaseSettings'), 'minCapacity'))), null())]",
         "preferredEnclaveType": "[parameters('preferredEnclaveType')]",
         "zoneRedundant": "[parameters('zoneRedundant')]"
       },

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -739,15 +739,9 @@ type ServerExternalAdministratorType = {
   principalType: 'Application' | 'Group' | 'User'
 
   @description('Required. SID (object ID) of the server administrator.')
-  @metadata({
-    example: '#_managementGroupId_#'
-  })
   sid: string
 
   @description('Optional. Tenant ID of the administrator.')
-  @metadata({
-    example: '#_managementGroupId_#'
-  })
   tenantId: string?
 }
 

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -871,6 +871,12 @@ type databasePropertyType = {
 
   @description('Optional. The diagnostic settings of the service.')
   diagnosticSettings: diagnosticSettingType?
+
+  @description('Optional. The short term backup retention policy for the database.')
+  backupShortTermRetentionPolicy: shortTermBackupRetentionPolicyType?
+
+  @description('Optional. The long term backup retention policy for the database.')
+  backupLongTermRetentionPolicy: longTermBackupRetentionPolicyType?
 }
 
 @export()
@@ -916,7 +922,7 @@ type elasticPoolPropertyType = {
 }
 
 import { elasticPoolPerDatabaseSettingsType, elasticPoolSkuType } from 'elastic-pool/main.bicep'
-import { databaseSkuType, diagnosticSettingType } from 'database/main.bicep'
+import { databaseSkuType, diagnosticSettingType, shortTermBackupRetentionPolicyType, longTermBackupRetentionPolicyType } from 'database/main.bicep'
 
 import { secretSetType } from 'modules/keyVaultExport.bicep'
 type secretsOutputType = {

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -205,7 +205,7 @@ resource server 'Microsoft.Sql/servers@2023-08-01-preview' = {
   properties: {
     administratorLogin: !empty(administratorLogin) ? administratorLogin : null
     administratorLoginPassword: !empty(administratorLoginPassword) ? administratorLoginPassword : null
-    administrators: administrators
+    administrators: union({ administratorType: 'ActiveDirectory' }, administrators ?? {})
     federatedClientId: federatedClientId
     isIPv6Enabled: isIPv6Enabled
     keyId: keyId
@@ -705,7 +705,7 @@ type secretsExportConfigurationType = {
 
 type ServerExternalAdministratorType = {
   @description('Type of the sever administrator.')
-  administratorType: 'ActiveDirectory'
+  administratorType: 'ActiveDirectory'?
 
   @description('Required. Azure Active Directory only Authentication enabled.')
   azureADOnlyAuthentication: bool

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -265,7 +265,7 @@ module server_databases 'database/main.bicep' = [
       catalogCollation: database.?catalogCollation
       collation: database.?collation
       createMode: database.?createMode
-      elasticPoolId: database.?elasticPoolId
+      elasticPoolResourceId: database.?elasticPoolResourceId
       encryptionProtector: database.?encryptionProtector
       encryptionProtectorAutoRotation: database.?encryptionProtectorAutoRotation
       federatedClientId: database.?federatedClientId
@@ -281,14 +281,14 @@ module server_databases 'database/main.bicep' = [
       performCutover: database.?performCutover
       preferredEnclaveType: database.?preferredEnclaveType
       readScale: database.?readScale
-      recoverableDatabaseId: database.?recoverableDatabaseId
-      recoveryServicesRecoveryPointId: database.?recoveryServicesRecoveryPointId
+      recoverableDatabaseResourceId: database.?recoverableDatabaseResourceId
+      recoveryServicesRecoveryPointResourceId: database.?recoveryServicesRecoveryPointResourceId
       requestedBackupStorageRedundancy: database.?requestedBackupStorageRedundancy
-      restorableDroppedDatabaseId: database.?restorableDroppedDatabaseId
+      restorableDroppedDatabaseResourceId: database.?restorableDroppedDatabaseResourceId
       restorePointInTime: database.?restorePointInTime
       secondaryType: database.?secondaryType
       sourceDatabaseDeletionDate: database.?sourceDatabaseDeletionDate
-      sourceDatabaseId: database.?sourceDatabaseId
+      sourceDatabaseResourceId: database.?sourceDatabaseResourceId
       sourceResourceId: database.?sourceResourceId
       useFreeLimit: database.?useFreeLimit
       zoneRedundant: database.?zoneRedundant
@@ -745,8 +745,178 @@ type ServerExternalAdministratorType = {
   tenantId: string?
 }
 
-import { elasticPoolPropertyType } from 'elastic-pool/main.bicep'
-import { databasePropertyType } from 'database/main.bicep'
+@export()
+type databasePropertyType = {
+  @description('Required. The name of the Elastic Pool.')
+  name: string
+
+  @description('Optional. Tags of the resource.')
+  tags: object?
+
+  @description('Optional. The database SKU.')
+  sku: databaseSkuType?
+
+  @description('Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled.')
+  autoPauseDelay: int?
+
+  @description('Optional. Specifies the availability zone the database is pinned to.')
+  availabilityZone: '1' | '2' | '3' | 'NoPreference'?
+
+  @description('Optional. Collation of the metadata catalog.')
+  catalogCollation: string?
+
+  @description('Optional. The collation of the database.')
+  collation: string?
+
+  @description('Optional. Specifies the mode of database creation.')
+  createMode:
+    | 'Copy'
+    | 'Default'
+    | 'OnlineSecondary'
+    | 'PointInTimeRestore'
+    | 'Recovery'
+    | 'Restore'
+    | 'RestoreExternalBackup'
+    | 'RestoreExternalBackupSecondary'
+    | 'RestoreLongTermRetentionBackup'
+    | 'Secondary'?
+
+  @description('Optional. The resource identifier of the elastic pool containing this database.')
+  elasticPoolResourceId: string?
+
+  @description('Optional. The azure key vault URI of the database if it\'s configured with per Database Customer Managed Keys.')
+  encryptionProtector: string?
+
+  @description('Optional. The flag to enable or disable auto rotation of database encryption protector AKV key.')
+  encryptionProtectorAutoRotation: bool?
+
+  @description('Optional. The Client id used for cross tenant per database CMK scenario.')
+  @minLength(36)
+  @maxLength(36)
+  federatedClientId: string?
+
+  @description('Optional. Specifies the behavior when monthly free limits are exhausted for the free database.')
+  freeLimitExhaustionBehavior: 'AutoPause' | 'BillOverUsage'?
+
+  @description('Optional. The number of secondary replicas associated with the database that are used to provide high availability. Not applicable to a Hyperscale database within an elastic pool.')
+  highAvailabilityReplicaCount: int?
+
+  @description('Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables.')
+  isLedgerOn: bool?
+
+  // keys
+  @description('Optional. The license type to apply for this database.')
+  licenseType: 'BasePrice' | 'LicenseIncluded'?
+
+  @description('Optional. The resource identifier of the long term retention backup associated with create operation of this database.')
+  longTermRetentionBackupResourceId: string?
+
+  @description('Optional. Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur.')
+  maintenanceConfigurationId: string?
+
+  @description('Optional. Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier.')
+  manualCutover: bool?
+
+  @description('Optional. The max size of the database expressed in bytes.')
+  maxSizeBytes: int?
+
+  // string to enable fractional values
+  @description('Optional. Minimal capacity that database will always have allocated, if not paused.')
+  minCapacity: string?
+
+  @description('Optional. To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress.')
+  performCutover: bool?
+
+  @description('Optional. Type of enclave requested on the database.')
+  preferredEnclaveType: 'Default' | 'VBS'?
+
+  @description('Optional. The state of read-only routing. If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale database within an elastic pool.')
+  readScale: 'Disabled' | 'Enabled'?
+
+  @description('Optional. The resource identifier of the recoverable database associated with create operation of this database.')
+  recoverableDatabaseResourceId: string?
+
+  @description('Optional. The resource identifier of the recovery point associated with create operation of this database.')
+  recoveryServicesRecoveryPointResourceId: string?
+
+  @description('Optional. The storage account type to be used to store backups for this database.')
+  requestedBackupStorageRedundancy: 'Geo' | 'GeoZone' | 'Local' | 'Zone'?
+
+  @description('Optional. The resource identifier of the restorable dropped database associated with create operation of this database.')
+  restorableDroppedDatabaseResourceId: string?
+
+  @description('Optional. Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database.')
+  restorePointInTime: string?
+
+  @description('Optional. The name of the sample schema to apply when creating this database.')
+  sampleName: string?
+
+  @description('Optional. The secondary type of the database if it is a secondary.')
+  secondaryType: 'Geo' | 'Named' | 'Standby'?
+
+  @description('Optional. Specifies the time that the database was deleted.')
+  sourceDatabaseDeletionDate: string?
+
+  @description('Optional. The resource identifier of the source database associated with create operation of this database.')
+  sourceDatabaseResourceId: string?
+
+  @description('Optional. The resource identifier of the source associated with the create operation of this database.')
+  sourceResourceId: string?
+
+  @description('Optional. Whether or not the database uses free monthly limits. Allowed on one database in a subscription.')
+  useFreeLimit: bool?
+
+  @description('Optional. Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones.')
+  zoneRedundant: bool?
+
+  @description('Optional. The diagnostic settings of the service.')
+  diagnosticSettings: diagnosticSettingType?
+}
+
+@export()
+type elasticPoolPropertyType = {
+  @description('Required. The name of the Elastic Pool.')
+  name: string
+
+  @description('Optional. Tags of the resource.')
+  tags: object?
+
+  @description('Optional. The elastic pool SKU.')
+  sku: elasticPoolSkuType?
+
+  @description('Optional. Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled.')
+  autoPauseDelay: int?
+
+  @description('Optional. Specifies the availability zone the pool\'s primary replica is pinned to.')
+  availabilityZone: '1' | '2' | '3' | 'NoPreference'?
+
+  @description('Optional. The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools.')
+  highAvailabilityReplicaCount: int?
+
+  @description('Optional. The license type to apply for this elastic pool.')
+  licenseType: 'BasePrice' | 'LicenseIncluded'?
+
+  @description('Optional. Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur.')
+  maintenanceConfigurationId: string?
+
+  @description('Optional. The storage limit for the database elastic pool in bytes.')
+  maxSizeBytes: int?
+
+  @description('Optional. Minimal capacity that serverless pool will not shrink below, if not paused.')
+  minCapacity: int?
+
+  @description('Optional. The per database settings for the elastic pool.')
+  perDatabaseSettings: elasticPoolPerDatabaseSettingsType?
+
+  @description('Optional. Type of enclave requested on the elastic pool.')
+  preferredEnclaveType: 'Default' | 'VBS'?
+
+  @description('Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones.')
+  zoneRedundant: bool?
+}
+
+import { elasticPoolPerDatabaseSettingsType, elasticPoolSkuType } from 'elastic-pool/main.bicep'
+import { databaseSkuType, diagnosticSettingType } from 'database/main.bicep'
 
 import { secretSetType } from 'modules/keyVaultExport.bicep'
 type secretsOutputType = {

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -54,7 +54,7 @@ param keys array = []
 @description('Conditional. The Azure Active Directory (AAD) administrator authentication. Required if no `administratorLogin` & `administratorLoginPassword` is provided.')
 param administrators ServerExternalAdministratorType?
 
-@description('Optional. The Client id used for cross tenant CMK scenario')
+@description('Optional. The Client id used for cross tenant CMK scenario.')
 @minLength(36)
 @maxLength(36)
 param federatedClientId string?

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -34,7 +34,7 @@ param tags object?
 param enableTelemetry bool = true
 
 @description('Optional. The databases to create in the server.')
-param databases array = []
+param databases databasePropertyType[] = []
 
 @description('Optional. The Elastic Pools to create in the server.')
 param elasticPools elasticPoolPropertyType[] = []
@@ -250,36 +250,53 @@ module server_databases 'database/main.bicep' = [
   for (database, index) in databases: {
     name: '${uniqueString(deployment().name, location)}-Sql-DB-${index}'
     params: {
-      name: database.name
+      // properties derived from parent server resource, no override allowed
       serverName: server.name
-      skuTier: database.?skuTier ?? 'GeneralPurpose'
-      skuName: database.?skuName ?? 'GP_Gen5_2'
-      skuCapacity: database.?skuCapacity
-      skuFamily: database.?skuFamily ?? ''
-      skuSize: database.?skuSize ?? ''
-      collation: database.?collation ?? 'SQL_Latin1_General_CP1_CI_AS'
-      maxSizeBytes: database.?maxSizeBytes ?? 34359738368
-      autoPauseDelay: database.?autoPauseDelay ?? 0
-      diagnosticSettings: database.?diagnosticSettings
-      isLedgerOn: database.?isLedgerOn ?? false
       location: location
-      licenseType: database.?licenseType ?? ''
-      maintenanceConfigurationId: database.?maintenanceConfigurationId
-      minCapacity: database.?minCapacity ?? ''
-      highAvailabilityReplicaCount: database.?highAvailabilityReplicaCount ?? 0
-      readScale: database.?readScale ?? 'Disabled'
-      requestedBackupStorageRedundancy: database.?requestedBackupStorageRedundancy ?? ''
-      sampleName: database.?sampleName ?? ''
+
+      // properties from the database object. If not provided, parent server resource properties will be used
       tags: database.?tags ?? tags
-      zoneRedundant: database.?zoneRedundant ?? true
-      elasticPoolId: database.?elasticPoolId ?? ''
-      backupShortTermRetentionPolicy: database.?backupShortTermRetentionPolicy ?? {}
-      backupLongTermRetentionPolicy: database.?backupLongTermRetentionPolicy ?? {}
-      createMode: database.?createMode ?? 'Default'
-      sourceDatabaseResourceId: database.?sourceDatabaseResourceId ?? ''
-      sourceDatabaseDeletionDate: database.?sourceDatabaseDeletionDate ?? ''
-      recoveryServicesRecoveryPointResourceId: database.?recoveryServicesRecoveryPointResourceId ?? ''
-      restorePointInTime: database.?restorePointInTime ?? ''
+
+      // properties from the databse object. If not provided, defaults specified in the child resource will be used
+      name: database.name
+      sku: database.?sku
+      autoPauseDelay: database.?autoPauseDelay
+      availabilityZone: database.?availabilityZone
+      catalogCollation: database.?catalogCollation
+      collation: database.?collation
+      createMode: database.?createMode
+      elasticPoolId: database.?elasticPoolId
+      encryptionProtector: database.?encryptionProtector
+      encryptionProtectorAutoRotation: database.?encryptionProtectorAutoRotation
+      federatedClientId: database.?federatedClientId
+      freeLimitExhaustionBehavior: database.?freeLimitExhaustionBehavior
+      highAvailabilityReplicaCount: database.?highAvailabilityReplicaCount
+      isLedgerOn: database.?isLedgerOn
+      licenseType: database.?licenseType
+      longTermRetentionBackupResourceId: database.?longTermRetentionBackupResourceId
+      maintenanceConfigurationId: database.?maintenanceConfigurationId
+      manualCutover: database.?manualCutover
+      maxSizeBytes: database.?maxSizeBytes
+      minCapacity: database.?minCapacity
+      performCutover: database.?performCutover
+      preferredEnclaveType: database.?preferredEnclaveType
+      readScale: database.?readScale
+      recoverableDatabaseId: database.?recoverableDatabaseId
+      recoveryServicesRecoveryPointId: database.?recoveryServicesRecoveryPointId
+      requestedBackupStorageRedundancy: database.?requestedBackupStorageRedundancy
+      restorableDroppedDatabaseId: database.?restorableDroppedDatabaseId
+      restorePointInTime: database.?restorePointInTime
+      secondaryType: database.?secondaryType
+      sourceDatabaseDeletionDate: database.?sourceDatabaseDeletionDate
+      sourceDatabaseId: database.?sourceDatabaseId
+      sourceResourceId: database.?sourceResourceId
+      useFreeLimit: database.?useFreeLimit
+      zoneRedundant: database.?zoneRedundant
+
+      // diagnosticSettings: database.?diagnosticSettings
+      // sampleName: database.?sampleName ?? ''
+      // backupShortTermRetentionPolicy: database.?backupShortTermRetentionPolicy ?? {}
+      // backupLongTermRetentionPolicy: database.?backupLongTermRetentionPolicy ?? {}
     }
     dependsOn: [
       server_elasticPools // Enables us to add databases to existing elastic pools
@@ -735,6 +752,7 @@ type ServerExternalAdministratorType = {
 }
 
 import { elasticPoolPropertyType } from 'elastic-pool/main.bicep'
+import { databasePropertyType } from 'database/main.bicep'
 
 import { secretSetType } from 'modules/keyVaultExport.bicep'
 type secretsOutputType = {

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -3,6 +3,7 @@ metadata description = 'This module deploys an Azure SQL Server.'
 metadata owner = 'Azure/module-maintainers'
 
 @description('Conditional. The administrator username for the server. Required if no `administrators` object for AAD authentication is provided.')
+@secure()
 param administratorLogin string = ''
 
 @description('Conditional. The administrator login password. Required if no `administrators` object for AAD authentication is provided.')

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -286,6 +286,7 @@ module server_databases 'database/main.bicep' = [
       requestedBackupStorageRedundancy: database.?requestedBackupStorageRedundancy
       restorableDroppedDatabaseResourceId: database.?restorableDroppedDatabaseResourceId
       restorePointInTime: database.?restorePointInTime
+      sampleName: database.?sampleName
       secondaryType: database.?secondaryType
       sourceDatabaseDeletionDate: database.?sourceDatabaseDeletionDate
       sourceDatabaseResourceId: database.?sourceDatabaseResourceId
@@ -293,10 +294,9 @@ module server_databases 'database/main.bicep' = [
       useFreeLimit: database.?useFreeLimit
       zoneRedundant: database.?zoneRedundant
 
-      // diagnosticSettings: database.?diagnosticSettings
-      // sampleName: database.?sampleName ?? ''
-      // backupShortTermRetentionPolicy: database.?backupShortTermRetentionPolicy ?? {}
-      // backupLongTermRetentionPolicy: database.?backupLongTermRetentionPolicy ?? {}
+      diagnosticSettings: database.?diagnosticSettings
+      backupShortTermRetentionPolicy: database.?backupShortTermRetentionPolicy
+      backupLongTermRetentionPolicy: database.?backupLongTermRetentionPolicy
     }
     dependsOn: [
       server_elasticPools // Enables us to add databases to existing elastic pools
@@ -703,7 +703,7 @@ type auditSettingsType = {
   @description('Optional. Specifies the number of days to keep in the audit logs in the storage account.')
   retentionDays: int?
 
-  @description('Required. Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.')
+  @description('Optional. Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.')
   state: 'Enabled' | 'Disabled'?
 
   @description('Optional. Specifies the identifier key of the auditing storage account.')

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "12931751409452972364"
+      "templateHash": "11793309099204894215"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server.",
@@ -424,7 +424,7 @@
           ],
           "nullable": true,
           "metadata": {
-            "description": "Required. Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
+            "description": "Optional. Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
           }
         },
         "storageAccountResourceId": {
@@ -1758,6 +1758,9 @@
           "restorePointInTime": {
             "value": "[tryGet(parameters('databases')[copyIndex()], 'restorePointInTime')]"
           },
+          "sampleName": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'sampleName')]"
+          },
           "secondaryType": {
             "value": "[tryGet(parameters('databases')[copyIndex()], 'secondaryType')]"
           },
@@ -1775,6 +1778,15 @@
           },
           "zoneRedundant": {
             "value": "[tryGet(parameters('databases')[copyIndex()], 'zoneRedundant')]"
+          },
+          "diagnosticSettings": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'diagnosticSettings')]"
+          },
+          "backupShortTermRetentionPolicy": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'backupShortTermRetentionPolicy')]"
+          },
+          "backupLongTermRetentionPolicy": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'backupLongTermRetentionPolicy')]"
           }
         },
         "template": {

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -819,6 +819,20 @@
           "metadata": {
             "description": "Optional. The diagnostic settings of the service."
           }
+        },
+        "backupShortTermRetentionPolicy": {
+          "$ref": "#/definitions/shortTermBackupRetentionPolicyType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The short term backup retention policy for the database."
+          }
+        },
+        "backupLongTermRetentionPolicy": {
+          "$ref": "#/definitions/longTermBackupRetentionPolicyType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The long term backup retention policy for the database."
+          }
         }
       },
       "metadata": {
@@ -1206,6 +1220,63 @@
         }
       }
     },
+    "longTermBackupRetentionPolicyType": {
+      "type": "object",
+      "properties": {
+        "backupStorageAccessTier": {
+          "type": "string",
+          "allowedValues": [
+            "Archive",
+            "Hot"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The BackupStorageAccessTier for the LTR backups."
+          }
+        },
+        "makeBackupsImmutable": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The setting whether to make LTR backups immutable."
+          }
+        },
+        "monthlyRetention": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Monthly retention in ISO 8601 duration format."
+          }
+        },
+        "weeklyRetention": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Weekly retention in ISO 8601 duration format."
+          }
+        },
+        "weekOfYear": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Week of year backup to keep for yearly retention."
+          }
+        },
+        "yearlyRetention": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Yearly retention in ISO 8601 duration format."
+          }
+        }
+      },
+      "metadata": {
+        "description": "The long-term backup retention policy for the database.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "database/main.bicep"
+        }
+      }
+    },
     "secretSetType": {
       "type": "object",
       "properties": {
@@ -1225,6 +1296,31 @@
       "metadata": {
         "__bicep_imported_from!": {
           "sourceTemplate": "modules/keyVaultExport.bicep"
+        }
+      }
+    },
+    "shortTermBackupRetentionPolicyType": {
+      "type": "object",
+      "properties": {
+        "diffBackupIntervalInHours": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Differential backup interval in hours."
+          }
+        },
+        "retentionDays": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Point-in-time retention in days."
+          }
+        }
+      },
+      "metadata": {
+        "description": "The short-term backup retention policy for the database.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "database/main.bicep"
         }
       }
     }
@@ -1860,6 +1956,84 @@
                 "__bicep_export!": true,
                 "description": "The database SKU."
               }
+            },
+            "shortTermBackupRetentionPolicyType": {
+              "type": "object",
+              "properties": {
+                "diffBackupIntervalInHours": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Differential backup interval in hours."
+                  }
+                },
+                "retentionDays": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Point-in-time retention in days."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The short-term backup retention policy for the database."
+              }
+            },
+            "longTermBackupRetentionPolicyType": {
+              "type": "object",
+              "properties": {
+                "backupStorageAccessTier": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Archive",
+                    "Hot"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The BackupStorageAccessTier for the LTR backups."
+                  }
+                },
+                "makeBackupsImmutable": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The setting whether to make LTR backups immutable."
+                  }
+                },
+                "monthlyRetention": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Monthly retention in ISO 8601 duration format."
+                  }
+                },
+                "weeklyRetention": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Weekly retention in ISO 8601 duration format."
+                  }
+                },
+                "weekOfYear": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Week of year backup to keep for yearly retention."
+                  }
+                },
+                "yearlyRetention": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Yearly retention in ISO 8601 duration format."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The long-term backup retention policy for the database."
+              }
             }
           },
           "parameters": {
@@ -2184,15 +2358,15 @@
               }
             },
             "backupShortTermRetentionPolicy": {
-              "type": "object",
-              "defaultValue": {},
+              "$ref": "#/definitions/shortTermBackupRetentionPolicyType",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. The short term backup retention policy to create for the database."
               }
             },
             "backupLongTermRetentionPolicy": {
-              "type": "object",
-              "defaultValue": {},
+              "$ref": "#/definitions/longTermBackupRetentionPolicyType",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. The long term backup retention policy to create for the database."
               }
@@ -2293,6 +2467,7 @@
               ]
             },
             "database_backupShortTermRetentionPolicy": {
+              "condition": "[not(empty(parameters('backupShortTermRetentionPolicy')))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
               "name": "[format('{0}-{1}-shBakRetPol', uniqueString(deployment().name, parameters('location')), parameters('name'))]",
@@ -2309,10 +2484,10 @@
                     "value": "[parameters('name')]"
                   },
                   "diffBackupIntervalInHours": {
-                    "value": "[coalesce(tryGet(parameters('backupShortTermRetentionPolicy'), 'diffBackupIntervalInHours'), 24)]"
+                    "value": "[tryGet(parameters('backupShortTermRetentionPolicy'), 'diffBackupIntervalInHours')]"
                   },
                   "retentionDays": {
-                    "value": "[coalesce(tryGet(parameters('backupShortTermRetentionPolicy'), 'retentionDays'), 7)]"
+                    "value": "[tryGet(parameters('backupShortTermRetentionPolicy'), 'retentionDays')]"
                   }
                 },
                 "template": {
@@ -2397,6 +2572,7 @@
               ]
             },
             "database_backupLongTermRetentionPolicy": {
+              "condition": "[not(empty(parameters('backupLongTermRetentionPolicy')))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
               "name": "[format('{0}-{1}-lgBakRetPol', uniqueString(deployment().name, parameters('location')), parameters('name'))]",
@@ -2412,21 +2588,28 @@
                   "databaseName": {
                     "value": "[parameters('name')]"
                   },
+                  "backupStorageAccessTier": {
+                    "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'backupStorageAccessTier')]"
+                  },
+                  "makeBackupsImmutable": {
+                    "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'makeBackupsImmutable')]"
+                  },
                   "weeklyRetention": {
-                    "value": "[coalesce(tryGet(parameters('backupLongTermRetentionPolicy'), 'weeklyRetention'), '')]"
+                    "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'weeklyRetention')]"
                   },
                   "monthlyRetention": {
-                    "value": "[coalesce(tryGet(parameters('backupLongTermRetentionPolicy'), 'monthlyRetention'), '')]"
+                    "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'monthlyRetention')]"
                   },
                   "yearlyRetention": {
-                    "value": "[coalesce(tryGet(parameters('backupLongTermRetentionPolicy'), 'yearlyRetention'), '')]"
+                    "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'yearlyRetention')]"
                   },
                   "weekOfYear": {
-                    "value": "[coalesce(tryGet(parameters('backupLongTermRetentionPolicy'), 'weekOfYear'), 1)]"
+                    "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'weekOfYear')]"
                   }
                 },
                 "template": {
                   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
                   "contentVersion": "1.0.0.0",
                   "metadata": {
                     "_generator": {
@@ -2451,18 +2634,36 @@
                         "description": "Required. The name of the parent database."
                       }
                     },
-                    "weeklyRetention": {
+                    "backupStorageAccessTier": {
                       "type": "string",
-                      "defaultValue": "",
+                      "allowedValues": [
+                        "Archive",
+                        "Hot"
+                      ],
+                      "nullable": true,
                       "metadata": {
-                        "description": "Optional. Monthly retention in ISO 8601 duration format."
+                        "description": "Optional. The BackupStorageAccessTier for the LTR backups."
+                      }
+                    },
+                    "makeBackupsImmutable": {
+                      "type": "bool",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The setting whether to make LTR backups immutable."
                       }
                     },
                     "monthlyRetention": {
                       "type": "string",
-                      "defaultValue": "",
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. Weekly retention in ISO 8601 duration format."
+                      }
+                    },
+                    "weeklyRetention": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Monthly retention in ISO 8601 duration format."
                       }
                     },
                     "weekOfYear": {
@@ -2474,25 +2675,45 @@
                     },
                     "yearlyRetention": {
                       "type": "string",
-                      "defaultValue": "",
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. Yearly retention in ISO 8601 duration format."
                       }
                     }
                   },
-                  "resources": [
-                    {
-                      "type": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies",
+                  "resources": {
+                    "server::database": {
+                      "existing": true,
+                      "type": "Microsoft.Sql/servers/databases",
                       "apiVersion": "2023-08-01-preview",
+                      "name": "[format('{0}/{1}', parameters('serverName'), parameters('databaseName'))]",
+                      "dependsOn": [
+                        "server"
+                      ]
+                    },
+                    "server": {
+                      "existing": true,
+                      "type": "Microsoft.Sql/servers",
+                      "apiVersion": "2023-08-01-preview",
+                      "name": "[parameters('serverName')]"
+                    },
+                    "backupLongTermRetentionPolicy": {
+                      "type": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies",
+                      "apiVersion": "2023-05-01-preview",
                       "name": "[format('{0}/{1}/{2}', parameters('serverName'), parameters('databaseName'), 'default')]",
                       "properties": {
+                        "backupStorageAccessTier": "[parameters('backupStorageAccessTier')]",
+                        "makeBackupsImmutable": "[parameters('makeBackupsImmutable')]",
                         "monthlyRetention": "[parameters('monthlyRetention')]",
                         "weeklyRetention": "[parameters('weeklyRetention')]",
                         "weekOfYear": "[parameters('weekOfYear')]",
                         "yearlyRetention": "[parameters('yearlyRetention')]"
-                      }
+                      },
+                      "dependsOn": [
+                        "server::database"
+                      ]
                     }
-                  ],
+                  },
                   "outputs": {
                     "resourceGroupName": {
                       "type": "string",

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -422,6 +422,7 @@
             "Disabled",
             "Enabled"
           ],
+          "nullable": true,
           "metadata": {
             "description": "Required. Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
           }
@@ -1327,7 +1328,7 @@
   },
   "parameters": {
     "administratorLogin": {
-      "type": "securestring",
+      "type": "string",
       "defaultValue": "",
       "metadata": {
         "description": "Conditional. The administrator username for the server. Required if no `administrators` object for AAD authentication is provided."
@@ -1534,7 +1535,7 @@
     },
     "auditSettings": {
       "$ref": "#/definitions/auditSettingsType",
-      "nullable": true,
+      "defaultValue": {},
       "metadata": {
         "description": "Optional. The audit settings configuration."
       }
@@ -4727,7 +4728,7 @@
       ]
     },
     "server_audit_settings": {
-      "condition": "[not(empty(parameters('auditSettings')))]",
+      "condition": "[not(equals(parameters('auditSettings'), null()))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
       "name": "[format('{0}-Sql-AuditSettings', uniqueString(deployment().name, parameters('location')))]",
@@ -4744,28 +4745,28 @@
             "value": "[coalesce(tryGet(parameters('auditSettings'), 'name'), 'default')]"
           },
           "state": {
-            "value": "[coalesce(tryGet(parameters('auditSettings'), 'state'), 'Disabled')]"
+            "value": "[tryGet(parameters('auditSettings'), 'state')]"
           },
           "auditActionsAndGroups": {
-            "value": "[coalesce(tryGet(parameters('auditSettings'), 'auditActionsAndGroups'), createArray('BATCH_COMPLETED_GROUP', 'SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP', 'FAILED_DATABASE_AUTHENTICATION_GROUP'))]"
+            "value": "[tryGet(parameters('auditSettings'), 'auditActionsAndGroups')]"
           },
           "isAzureMonitorTargetEnabled": {
-            "value": "[coalesce(tryGet(parameters('auditSettings'), 'isAzureMonitorTargetEnabled'), false())]"
+            "value": "[tryGet(parameters('auditSettings'), 'isAzureMonitorTargetEnabled')]"
           },
           "isDevopsAuditEnabled": {
-            "value": "[coalesce(tryGet(parameters('auditSettings'), 'isDevopsAuditEnabled'), false())]"
+            "value": "[tryGet(parameters('auditSettings'), 'isDevopsAuditEnabled')]"
           },
           "isManagedIdentityInUse": {
-            "value": "[coalesce(tryGet(parameters('auditSettings'), 'isManagedIdentityInUse'), false())]"
+            "value": "[tryGet(parameters('auditSettings'), 'isManagedIdentityInUse')]"
           },
           "isStorageSecondaryKeyInUse": {
-            "value": "[coalesce(tryGet(parameters('auditSettings'), 'isStorageSecondaryKeyInUse'), false())]"
+            "value": "[tryGet(parameters('auditSettings'), 'isStorageSecondaryKeyInUse')]"
           },
           "queueDelayMs": {
-            "value": "[coalesce(tryGet(parameters('auditSettings'), 'queueDelayMs'), 1000)]"
+            "value": "[tryGet(parameters('auditSettings'), 'queueDelayMs')]"
           },
           "retentionDays": {
-            "value": "[coalesce(tryGet(parameters('auditSettings'), 'retentionDays'), 90)]"
+            "value": "[tryGet(parameters('auditSettings'), 'retentionDays')]"
           },
           "storageAccountResourceId": {
             "value": "[tryGet(parameters('auditSettings'), 'storageAccountResourceId')]"
@@ -4773,7 +4774,6 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
@@ -4800,31 +4800,36 @@
             },
             "state": {
               "type": "string",
+              "defaultValue": "Enabled",
               "allowedValues": [
                 "Enabled",
                 "Disabled"
               ],
               "metadata": {
-                "description": "Required. The resource group of the SQL Server. Required if the template is used in a standalone deployment."
+                "description": "Optional. The resource group of the SQL Server. Required if the template is used in a standalone deployment."
               }
             },
             "auditActionsAndGroups": {
               "type": "array",
-              "nullable": true,
+              "defaultValue": [
+                "BATCH_COMPLETED_GROUP",
+                "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
+                "FAILED_DATABASE_AUTHENTICATION_GROUP"
+              ],
               "metadata": {
                 "description": "Optional. Specifies the Actions-Groups and Actions to audit."
               }
             },
             "isAzureMonitorTargetEnabled": {
               "type": "bool",
-              "defaultValue": false,
+              "defaultValue": true,
               "metadata": {
                 "description": "Optional. Specifies whether audit events are sent to Azure Monitor."
               }
             },
             "isDevopsAuditEnabled": {
               "type": "bool",
-              "nullable": true,
+              "defaultValue": false,
               "metadata": {
                 "description": "Optional. Specifies the state of devops audit. If state is Enabled, devops logs will be sent to Azure Monitor."
               }
@@ -4838,21 +4843,21 @@
             },
             "isStorageSecondaryKeyInUse": {
               "type": "bool",
-              "nullable": true,
+              "defaultValue": false,
               "metadata": {
                 "description": "Optional. Specifies whether storageAccountAccessKey value is the storage's secondary key."
               }
             },
             "queueDelayMs": {
               "type": "int",
-              "nullable": true,
+              "defaultValue": 1000,
               "metadata": {
                 "description": "Optional. Specifies the amount of time in milliseconds that can elapse before audit actions are forced to be processed."
               }
             },
             "retentionDays": {
               "type": "int",
-              "nullable": true,
+              "defaultValue": 90,
               "metadata": {
                 "description": "Optional. Specifies the number of days to keep in the audit logs in the storage account."
               }
@@ -4865,14 +4870,8 @@
               }
             }
           },
-          "resources": {
-            "server": {
-              "existing": true,
-              "type": "Microsoft.Sql/servers",
-              "apiVersion": "2023-08-01-preview",
-              "name": "[parameters('serverName')]"
-            },
-            "auditSettings": {
+          "resources": [
+            {
               "type": "Microsoft.Sql/servers/auditingSettings",
               "apiVersion": "2023-08-01-preview",
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
@@ -4888,12 +4887,9 @@
                 "storageAccountAccessKey": "[if(and(not(empty(parameters('storageAccountResourceId'))), not(parameters('isManagedIdentityInUse'))), listKeys(parameters('storageAccountResourceId'), '2019-06-01').keys[0].value, null())]",
                 "storageAccountSubscriptionId": "[if(not(empty(parameters('storageAccountResourceId'))), split(parameters('storageAccountResourceId'), '/')[2], null())]",
                 "storageEndpoint": "[if(not(empty(parameters('storageAccountResourceId'))), format('https://{0}.blob.{1}', last(split(parameters('storageAccountResourceId'), '/')), environment().suffixes.storage), null())]"
-              },
-              "dependsOn": [
-                "server"
-              ]
+              }
             },
-            "storageAccount_sbdc_rbac": {
+            {
               "condition": "[and(parameters('isManagedIdentityInUse'), not(empty(parameters('storageAccountResourceId'))))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
@@ -4908,7 +4904,7 @@
                     "value": "[last(split(parameters('storageAccountResourceId'), '/'))]"
                   },
                   "managedInstanceIdentityPrincipalId": {
-                    "value": "[reference('server', '2023-08-01-preview', 'full').identity.principalId]"
+                    "value": "[reference(resourceId('Microsoft.Sql/servers', parameters('serverName')), '2023-08-01-preview', 'full').identity.principalId]"
                   }
                 },
                 "template": {
@@ -4943,12 +4939,9 @@
                     }
                   ]
                 }
-              },
-              "dependsOn": [
-                "server"
-              ]
+              }
             }
-          },
+          ],
           "outputs": {
             "name": {
               "type": "string",

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -2062,7 +2062,7 @@
             },
             "autoPauseDelay": {
               "type": "int",
-              "defaultValue": 0,
+              "defaultValue": -1,
               "metadata": {
                 "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled."
               }
@@ -2657,14 +2657,14 @@
                       "type": "string",
                       "nullable": true,
                       "metadata": {
-                        "description": "Optional. Weekly retention in ISO 8601 duration format."
+                        "description": "Optional. Monthly retention in ISO 8601 duration format."
                       }
                     },
                     "weeklyRetention": {
                       "type": "string",
                       "nullable": true,
                       "metadata": {
-                        "description": "Optional. Monthly retention in ISO 8601 duration format."
+                        "description": "Optional. Weekly retention in ISO 8601 duration format."
                       }
                     },
                     "weekOfYear": {
@@ -4806,7 +4806,7 @@
                 "Disabled"
               ],
               "metadata": {
-                "description": "Optional. The resource group of the SQL Server. Required if the template is used in a standalone deployment."
+                "description": "Optional. Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
               }
             },
             "auditActionsAndGroups": {

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,11 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
+<<<<<<< HEAD
       "templateHash": "12931751409452972364"
+=======
+      "templateHash": "6840329240992957872"
+>>>>>>> 78a8ab21 (Update README)
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server.",
@@ -500,7 +504,6 @@
         "sid": {
           "type": "string",
           "metadata": {
-            "example": "#_managementGroupId_#",
             "description": "Required. SID (object ID) of the server administrator."
           }
         },
@@ -508,7 +511,6 @@
           "type": "string",
           "nullable": true,
           "metadata": {
-            "example": "#_managementGroupId_#",
             "description": "Optional. Tenant ID of the administrator."
           }
         }

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -2333,7 +2333,7 @@
             },
             "zoneRedundant": {
               "type": "bool",
-              "nullable": true,
+              "defaultValue": true,
               "metadata": {
                 "description": "Optional. Whether or not this database is zone redundant."
               }
@@ -3064,7 +3064,7 @@
             },
             "zoneRedundant": {
               "type": "bool",
-              "defaultValue": false,
+              "defaultValue": true,
               "metadata": {
                 "description": "Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones."
               }
@@ -4774,6 +4774,7 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
@@ -4811,6 +4812,9 @@
             },
             "auditActionsAndGroups": {
               "type": "array",
+              "items": {
+                "type": "string"
+              },
               "defaultValue": [
                 "BATCH_COMPLETED_GROUP",
                 "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
@@ -4870,8 +4874,14 @@
               }
             }
           },
-          "resources": [
-            {
+          "resources": {
+            "server": {
+              "existing": true,
+              "type": "Microsoft.Sql/servers",
+              "apiVersion": "2023-08-01-preview",
+              "name": "[parameters('serverName')]"
+            },
+            "auditSettings": {
               "type": "Microsoft.Sql/servers/auditingSettings",
               "apiVersion": "2023-08-01-preview",
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
@@ -4887,9 +4897,12 @@
                 "storageAccountAccessKey": "[if(and(not(empty(parameters('storageAccountResourceId'))), not(parameters('isManagedIdentityInUse'))), listKeys(parameters('storageAccountResourceId'), '2019-06-01').keys[0].value, null())]",
                 "storageAccountSubscriptionId": "[if(not(empty(parameters('storageAccountResourceId'))), split(parameters('storageAccountResourceId'), '/')[2], null())]",
                 "storageEndpoint": "[if(not(empty(parameters('storageAccountResourceId'))), format('https://{0}.blob.{1}', last(split(parameters('storageAccountResourceId'), '/')), environment().suffixes.storage), null())]"
-              }
+              },
+              "dependsOn": [
+                "server"
+              ]
             },
-            {
+            "storageAccount_sbdc_rbac": {
               "condition": "[and(parameters('isManagedIdentityInUse'), not(empty(parameters('storageAccountResourceId'))))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
@@ -4904,7 +4917,7 @@
                     "value": "[last(split(parameters('storageAccountResourceId'), '/'))]"
                   },
                   "managedInstanceIdentityPrincipalId": {
-                    "value": "[reference(resourceId('Microsoft.Sql/servers', parameters('serverName')), '2023-08-01-preview', 'full').identity.principalId]"
+                    "value": "[reference('server', '2023-08-01-preview', 'full').identity.principalId]"
                   }
                 },
                 "template": {
@@ -4939,9 +4952,12 @@
                     }
                   ]
                 }
-              }
+              },
+              "dependsOn": [
+                "server"
+              ]
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,15 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-<<<<<<< HEAD
-<<<<<<< HEAD
       "templateHash": "12931751409452972364"
-=======
-      "templateHash": "6840329240992957872"
->>>>>>> 78a8ab21 (Update README)
-=======
-      "templateHash": "7649615845184764158"
->>>>>>> f5bd37d9 (Rerun generation)
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server.",
@@ -520,275 +512,6 @@
         }
       }
     },
-    "secretsOutputType": {
-      "type": "object",
-      "properties": {},
-      "additionalProperties": {
-        "$ref": "#/definitions/secretSetType",
-        "metadata": {
-          "description": "An exported secret's references."
-        }
-      }
-    },
-    "_1.databaseSkuType": {
-      "type": "object",
-      "properties": {
-        "capacity": {
-          "type": "int",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The capacity of the particular SKU."
-          }
-        },
-        "family": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here."
-          }
-        },
-        "name": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. The name of the SKU, typically, a letter + Number code, e.g. P3."
-          }
-        },
-        "size": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Size of the particular SKU."
-          }
-        },
-        "tier": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Required. The tier or edition of the particular SKU, e.g. Basic, Premium."
-          }
-        }
-      },
-      "metadata": {
-        "description": "The database SKU.",
-        "__bicep_imported_from!": {
-          "sourceTemplate": "database/main.bicep"
-        }
-      }
-    },
-    "_1.diagnosticSettingType": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The name of diagnostic setting."
-            }
-          },
-          "logCategoriesAndGroups": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "category": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
-                  }
-                },
-                "categoryGroup": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
-                  }
-                },
-                "enabled": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Enable or disable the category explicitly. Default is `true`."
-                  }
-                }
-              }
-            },
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
-            }
-          },
-          "metricCategories": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "category": {
-                  "type": "string",
-                  "metadata": {
-                    "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
-                  }
-                },
-                "enabled": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Enable or disable the category explicitly. Default is `true`."
-                  }
-                }
-              }
-            },
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
-            }
-          },
-          "logAnalyticsDestinationType": {
-            "type": "string",
-            "allowedValues": [
-              "AzureDiagnostics",
-              "Dedicated"
-            ],
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
-            }
-          },
-          "workspaceResourceId": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
-            }
-          },
-          "storageAccountResourceId": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
-            }
-          },
-          "eventHubAuthorizationRuleResourceId": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
-            }
-          },
-          "eventHubName": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
-            }
-          },
-          "marketplacePartnerResourceId": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
-            }
-          }
-        }
-      },
-      "nullable": true,
-      "metadata": {
-        "__bicep_imported_from!": {
-          "sourceTemplate": "database/main.bicep"
-        }
-      }
-    },
-    "_2.elasticPoolPerDatabaseSettingsType": {
-      "type": "object",
-      "properties": {
-        "autoPauseDelay": {
-          "type": "int",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Auto Pause Delay for per database within pool."
-          }
-        },
-        "maxCapacity": {
-          "type": "string",
-          "metadata": {
-            "description": "Reqired. The maximum capacity any one database can consume. Examples: '0.5', '2'."
-          }
-        },
-        "minCapacity": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. The minimum capacity all databases are guaranteed. Examples: '0.5', '1'."
-          }
-        }
-      },
-      "metadata": {
-        "description": "The per database settings for the elastic pool.",
-        "__bicep_imported_from!": {
-          "sourceTemplate": "elastic-pool/main.bicep"
-        }
-      }
-    },
-    "_2.elasticPoolSkuType": {
-      "type": "object",
-      "properties": {
-        "capacity": {
-          "type": "int",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The capacity of the particular SKU."
-          }
-        },
-        "family": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here."
-          }
-        },
-        "name": {
-          "type": "string",
-          "allowedValues": [
-            "BC_DC",
-            "BC_Gen5",
-            "BasicPool",
-            "GP_DC",
-            "GP_FSv2",
-            "GP_Gen5",
-            "HS_Gen5",
-            "HS_MOPRMS",
-            "HS_PRMS",
-            "PremiumPool",
-            "ServerlessPool",
-            "StandardPool"
-          ],
-          "metadata": {
-            "description": "Required. The name of the SKU, typically, a letter + Number code, e.g. P3."
-          }
-        },
-        "size": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Size of the particular SKU."
-          }
-        },
-        "tier": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Required. The tier or edition of the particular SKU, e.g. Basic, Premium."
-          }
-        }
-      },
-      "metadata": {
-        "description": "The elastic pool SKU.",
-        "__bicep_imported_from!": {
-          "sourceTemplate": "elastic-pool/main.bicep"
-        }
-      }
-    },
     "databasePropertyType": {
       "type": "object",
       "properties": {
@@ -806,7 +529,7 @@
           }
         },
         "sku": {
-          "$ref": "#/definitions/_1.databaseSkuType",
+          "$ref": "#/definitions/databaseSkuType",
           "nullable": true,
           "metadata": {
             "description": "Optional. The database SKU."
@@ -865,7 +588,7 @@
             "description": "Optional. Specifies the mode of database creation."
           }
         },
-        "elasticPoolId": {
+        "elasticPoolResourceId": {
           "type": "string",
           "nullable": true,
           "metadata": {
@@ -995,14 +718,14 @@
             "description": "Optional. The state of read-only routing. If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale database within an elastic pool."
           }
         },
-        "recoverableDatabaseId": {
+        "recoverableDatabaseResourceId": {
           "type": "string",
           "nullable": true,
           "metadata": {
             "description": "Optional. The resource identifier of the recoverable database associated with create operation of this database."
           }
         },
-        "recoveryServicesRecoveryPointId": {
+        "recoveryServicesRecoveryPointResourceId": {
           "type": "string",
           "nullable": true,
           "metadata": {
@@ -1022,7 +745,7 @@
             "description": "Optional. The storage account type to be used to store backups for this database."
           }
         },
-        "restorableDroppedDatabaseId": {
+        "restorableDroppedDatabaseResourceId": {
           "type": "string",
           "nullable": true,
           "metadata": {
@@ -1062,7 +785,7 @@
             "description": "Optional. Specifies the time that the database was deleted."
           }
         },
-        "sourceDatabaseId": {
+        "sourceDatabaseResourceId": {
           "type": "string",
           "nullable": true,
           "metadata": {
@@ -1091,7 +814,7 @@
           }
         },
         "diagnosticSettings": {
-          "$ref": "#/definitions/_1.diagnosticSettingType",
+          "$ref": "#/definitions/diagnosticSettingType",
           "nullable": true,
           "metadata": {
             "description": "Optional. The diagnostic settings of the service."
@@ -1099,9 +822,7 @@
         }
       },
       "metadata": {
-        "__bicep_imported_from!": {
-          "sourceTemplate": "database/main.bicep"
-        }
+        "__bicep_export!": true
       }
     },
     "elasticPoolPropertyType": {
@@ -1121,7 +842,7 @@
           }
         },
         "sku": {
-          "$ref": "#/definitions/_2.elasticPoolSkuType",
+          "$ref": "#/definitions/elasticPoolSkuType",
           "nullable": true,
           "metadata": {
             "description": "Optional. The elastic pool SKU."
@@ -1187,7 +908,7 @@
           }
         },
         "perDatabaseSettings": {
-          "$ref": "#/definitions/_2.elasticPoolPerDatabaseSettingsType",
+          "$ref": "#/definitions/elasticPoolPerDatabaseSettingsType",
           "nullable": true,
           "metadata": {
             "description": "Optional. The per database settings for the elastic pool."
@@ -1213,6 +934,273 @@
         }
       },
       "metadata": {
+        "__bicep_export!": true
+      }
+    },
+    "secretsOutputType": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": {
+        "$ref": "#/definitions/secretSetType",
+        "metadata": {
+          "description": "An exported secret's references."
+        }
+      }
+    },
+    "databaseSkuType": {
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The capacity of the particular SKU."
+          }
+        },
+        "family": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here."
+          }
+        },
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the SKU, typically, a letter + Number code, e.g. P3."
+          }
+        },
+        "size": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Size of the particular SKU."
+          }
+        },
+        "tier": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Required. The tier or edition of the particular SKU, e.g. Basic, Premium."
+          }
+        }
+      },
+      "metadata": {
+        "description": "The database SKU.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "database/main.bicep"
+        }
+      }
+    },
+    "diagnosticSettingType": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The name of diagnostic setting."
+            }
+          },
+          "logCategoriesAndGroups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "category": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                  }
+                },
+                "categoryGroup": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                  }
+                },
+                "enabled": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                  }
+                }
+              }
+            },
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+            }
+          },
+          "metricCategories": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "category": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                  }
+                },
+                "enabled": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                  }
+                }
+              }
+            },
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+            }
+          },
+          "logAnalyticsDestinationType": {
+            "type": "string",
+            "allowedValues": [
+              "AzureDiagnostics",
+              "Dedicated"
+            ],
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+            }
+          },
+          "workspaceResourceId": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+            }
+          },
+          "storageAccountResourceId": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+            }
+          },
+          "eventHubAuthorizationRuleResourceId": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+            }
+          },
+          "eventHubName": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+            }
+          },
+          "marketplacePartnerResourceId": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+            }
+          }
+        }
+      },
+      "nullable": true,
+      "metadata": {
+        "__bicep_imported_from!": {
+          "sourceTemplate": "database/main.bicep"
+        }
+      }
+    },
+    "elasticPoolPerDatabaseSettingsType": {
+      "type": "object",
+      "properties": {
+        "autoPauseDelay": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Auto Pause Delay for per database within pool."
+          }
+        },
+        "maxCapacity": {
+          "type": "string",
+          "metadata": {
+            "description": "Reqired. The maximum capacity any one database can consume. Examples: '0.5', '2'."
+          }
+        },
+        "minCapacity": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The minimum capacity all databases are guaranteed. Examples: '0.5', '1'."
+          }
+        }
+      },
+      "metadata": {
+        "description": "The per database settings for the elastic pool.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "elastic-pool/main.bicep"
+        }
+      }
+    },
+    "elasticPoolSkuType": {
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The capacity of the particular SKU."
+          }
+        },
+        "family": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here."
+          }
+        },
+        "name": {
+          "type": "string",
+          "allowedValues": [
+            "BC_DC",
+            "BC_Gen5",
+            "BasicPool",
+            "GP_DC",
+            "GP_FSv2",
+            "GP_Gen5",
+            "HS_Gen5",
+            "HS_MOPRMS",
+            "HS_PRMS",
+            "PremiumPool",
+            "ServerlessPool",
+            "StandardPool"
+          ],
+          "metadata": {
+            "description": "Required. The name of the SKU, typically, a letter + Number code, e.g. P3."
+          }
+        },
+        "size": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Size of the particular SKU."
+          }
+        },
+        "tier": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The tier or edition of the particular SKU, e.g. Basic, Premium."
+          }
+        }
+      },
+      "metadata": {
+        "description": "The elastic pool SKU.",
         "__bicep_imported_from!": {
           "sourceTemplate": "elastic-pool/main.bicep"
         }
@@ -1610,8 +1598,8 @@
           "createMode": {
             "value": "[tryGet(parameters('databases')[copyIndex()], 'createMode')]"
           },
-          "elasticPoolId": {
-            "value": "[tryGet(parameters('databases')[copyIndex()], 'elasticPoolId')]"
+          "elasticPoolResourceId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'elasticPoolResourceId')]"
           },
           "encryptionProtector": {
             "value": "[tryGet(parameters('databases')[copyIndex()], 'encryptionProtector')]"
@@ -1658,17 +1646,17 @@
           "readScale": {
             "value": "[tryGet(parameters('databases')[copyIndex()], 'readScale')]"
           },
-          "recoverableDatabaseId": {
-            "value": "[tryGet(parameters('databases')[copyIndex()], 'recoverableDatabaseId')]"
+          "recoverableDatabaseResourceId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'recoverableDatabaseResourceId')]"
           },
-          "recoveryServicesRecoveryPointId": {
-            "value": "[tryGet(parameters('databases')[copyIndex()], 'recoveryServicesRecoveryPointId')]"
+          "recoveryServicesRecoveryPointResourceId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'recoveryServicesRecoveryPointResourceId')]"
           },
           "requestedBackupStorageRedundancy": {
             "value": "[tryGet(parameters('databases')[copyIndex()], 'requestedBackupStorageRedundancy')]"
           },
-          "restorableDroppedDatabaseId": {
-            "value": "[tryGet(parameters('databases')[copyIndex()], 'restorableDroppedDatabaseId')]"
+          "restorableDroppedDatabaseResourceId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'restorableDroppedDatabaseResourceId')]"
           },
           "restorePointInTime": {
             "value": "[tryGet(parameters('databases')[copyIndex()], 'restorePointInTime')]"
@@ -1679,8 +1667,8 @@
           "sourceDatabaseDeletionDate": {
             "value": "[tryGet(parameters('databases')[copyIndex()], 'sourceDatabaseDeletionDate')]"
           },
-          "sourceDatabaseId": {
-            "value": "[tryGet(parameters('databases')[copyIndex()], 'sourceDatabaseId')]"
+          "sourceDatabaseResourceId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'sourceDatabaseResourceId')]"
           },
           "sourceResourceId": {
             "value": "[tryGet(parameters('databases')[copyIndex()], 'sourceResourceId')]"
@@ -1700,11 +1688,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.29.47.4906",
-<<<<<<< HEAD
               "templateHash": "18021918128213514276"
-=======
-              "templateHash": "4558221869591328265"
->>>>>>> f5bd37d9 (Rerun generation)
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database.",
@@ -1829,7 +1813,10 @@
                   }
                 }
               },
-              "nullable": true
+              "nullable": true,
+              "metadata": {
+                "__bicep_export!": true
+              }
             },
             "databaseSkuType": {
               "type": "object",
@@ -1872,319 +1859,6 @@
               "metadata": {
                 "__bicep_export!": true,
                 "description": "The database SKU."
-              }
-            },
-            "databasePropertyType": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "metadata": {
-                    "description": "Required. The name of the Elastic Pool."
-                  }
-                },
-                "tags": {
-                  "type": "object",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Tags of the resource."
-                  }
-                },
-                "sku": {
-                  "$ref": "#/definitions/databaseSkuType",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The database SKU."
-                  }
-                },
-                "autoPauseDelay": {
-                  "type": "int",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled."
-                  }
-                },
-                "availabilityZone": {
-                  "type": "string",
-                  "allowedValues": [
-                    "1",
-                    "2",
-                    "3",
-                    "NoPreference"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Specifies the availability zone the database is pinned to."
-                  }
-                },
-                "catalogCollation": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Collation of the metadata catalog."
-                  }
-                },
-                "collation": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The collation of the database."
-                  }
-                },
-                "createMode": {
-                  "type": "string",
-                  "allowedValues": [
-                    "Copy",
-                    "Default",
-                    "OnlineSecondary",
-                    "PointInTimeRestore",
-                    "Recovery",
-                    "Restore",
-                    "RestoreExternalBackup",
-                    "RestoreExternalBackupSecondary",
-                    "RestoreLongTermRetentionBackup",
-                    "Secondary"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Specifies the mode of database creation."
-                  }
-                },
-                "elasticPoolId": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The resource identifier of the elastic pool containing this database."
-                  }
-                },
-                "encryptionProtector": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The azure key vault URI of the database if it's configured with per Database Customer Managed Keys."
-                  }
-                },
-                "encryptionProtectorAutoRotation": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The flag to enable or disable auto rotation of database encryption protector AKV key."
-                  }
-                },
-                "federatedClientId": {
-                  "type": "string",
-                  "nullable": true,
-                  "minLength": 36,
-                  "maxLength": 36,
-                  "metadata": {
-                    "description": "Optional. The Client id used for cross tenant per database CMK scenario."
-                  }
-                },
-                "freeLimitExhaustionBehavior": {
-                  "type": "string",
-                  "allowedValues": [
-                    "AutoPause",
-                    "BillOverUsage"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Specifies the behavior when monthly free limits are exhausted for the free database."
-                  }
-                },
-                "highAvailabilityReplicaCount": {
-                  "type": "int",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The number of secondary replicas associated with the database that are used to provide high availability. Not applicable to a Hyperscale database within an elastic pool."
-                  }
-                },
-                "isLedgerOn": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables."
-                  }
-                },
-                "licenseType": {
-                  "type": "string",
-                  "allowedValues": [
-                    "BasePrice",
-                    "LicenseIncluded"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The license type to apply for this database."
-                  }
-                },
-                "longTermRetentionBackupResourceId": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The resource identifier of the long term retention backup associated with create operation of this database."
-                  }
-                },
-                "maintenanceConfigurationId": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur."
-                  }
-                },
-                "manualCutover": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier."
-                  }
-                },
-                "maxSizeBytes": {
-                  "type": "int",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The max size of the database expressed in bytes."
-                  }
-                },
-                "minCapacity": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Minimal capacity that database will always have allocated, if not paused."
-                  }
-                },
-                "performCutover": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress."
-                  }
-                },
-                "preferredEnclaveType": {
-                  "type": "string",
-                  "allowedValues": [
-                    "Default",
-                    "VBS"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Type of enclave requested on the database."
-                  }
-                },
-                "readScale": {
-                  "type": "string",
-                  "allowedValues": [
-                    "Disabled",
-                    "Enabled"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The state of read-only routing. If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale database within an elastic pool."
-                  }
-                },
-                "recoverableDatabaseId": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The resource identifier of the recoverable database associated with create operation of this database."
-                  }
-                },
-                "recoveryServicesRecoveryPointId": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The resource identifier of the recovery point associated with create operation of this database."
-                  }
-                },
-                "requestedBackupStorageRedundancy": {
-                  "type": "string",
-                  "allowedValues": [
-                    "Geo",
-                    "GeoZone",
-                    "Local",
-                    "Zone"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The storage account type to be used to store backups for this database."
-                  }
-                },
-                "restorableDroppedDatabaseId": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The resource identifier of the restorable dropped database associated with create operation of this database."
-                  }
-                },
-                "restorePointInTime": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database."
-                  }
-                },
-                "sampleName": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The name of the sample schema to apply when creating this database."
-                  }
-                },
-                "secondaryType": {
-                  "type": "string",
-                  "allowedValues": [
-                    "Geo",
-                    "Named",
-                    "Standby"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The secondary type of the database if it is a secondary."
-                  }
-                },
-                "sourceDatabaseDeletionDate": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Specifies the time that the database was deleted."
-                  }
-                },
-                "sourceDatabaseId": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The resource identifier of the source database associated with create operation of this database."
-                  }
-                },
-                "sourceResourceId": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The resource identifier of the source associated with the create operation of this database."
-                  }
-                },
-                "useFreeLimit": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Whether or not the database uses free monthly limits. Allowed on one database in a subscription."
-                  }
-                },
-                "zoneRedundant": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones."
-                  }
-                },
-                "diagnosticSettings": {
-                  "$ref": "#/definitions/diagnosticSettingType",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The diagnostic settings of the service."
-                  }
-                }
-              },
-              "metadata": {
-                "__bicep_export!": true
               }
             }
           },
@@ -2264,7 +1938,7 @@
                 "description": "Optional. Specifies the mode of database creation."
               }
             },
-            "elasticPoolId": {
+            "elasticPoolResourceId": {
               "type": "string",
               "nullable": true,
               "metadata": {
@@ -2394,14 +2068,14 @@
                 "description": "Optional. The state of read-only routing."
               }
             },
-            "recoverableDatabaseId": {
+            "recoverableDatabaseResourceId": {
               "type": "string",
               "nullable": true,
               "metadata": {
                 "description": "Optional. The resource identifier of the recoverable database associated with create operation of this database."
               }
             },
-            "recoveryServicesRecoveryPointId": {
+            "recoveryServicesRecoveryPointResourceId": {
               "type": "string",
               "nullable": true,
               "metadata": {
@@ -2421,7 +2095,7 @@
                 "description": "Optional. The storage account type to be used to store backups for this database."
               }
             },
-            "restorableDroppedDatabaseId": {
+            "restorableDroppedDatabaseResourceId": {
               "type": "string",
               "nullable": true,
               "metadata": {
@@ -2461,7 +2135,7 @@
                 "description": "Optional. The time that the database was deleted when restoring a deleted database."
               }
             },
-            "sourceDatabaseId": {
+            "sourceDatabaseResourceId": {
               "type": "string",
               "nullable": true,
               "metadata": {
@@ -2544,7 +2218,7 @@
                 "catalogCollation": "[parameters('catalogCollation')]",
                 "collation": "[parameters('collation')]",
                 "createMode": "[parameters('createMode')]",
-                "elasticPoolId": "[parameters('elasticPoolId')]",
+                "elasticPoolId": "[parameters('elasticPoolResourceId')]",
                 "encryptionProtector": "[parameters('encryptionProtector')]",
                 "encryptionProtectorAutoRotation": "[parameters('encryptionProtectorAutoRotation')]",
                 "federatedClientId": "[parameters('federatedClientId')]",
@@ -2560,15 +2234,15 @@
                 "performCutover": "[parameters('performCutover')]",
                 "preferredEnclaveType": "[parameters('preferredEnclaveType')]",
                 "readScale": "[parameters('readScale')]",
-                "recoverableDatabaseId": "[parameters('recoverableDatabaseId')]",
-                "recoveryServicesRecoveryPointId": "[parameters('recoveryServicesRecoveryPointId')]",
+                "recoverableDatabaseId": "[parameters('recoverableDatabaseResourceId')]",
+                "recoveryServicesRecoveryPointId": "[parameters('recoveryServicesRecoveryPointResourceId')]",
                 "requestedBackupStorageRedundancy": "[parameters('requestedBackupStorageRedundancy')]",
-                "restorableDroppedDatabaseId": "[parameters('restorableDroppedDatabaseId')]",
+                "restorableDroppedDatabaseId": "[parameters('restorableDroppedDatabaseResourceId')]",
                 "restorePointInTime": "[parameters('restorePointInTime')]",
                 "sampleName": "[parameters('sampleName')]",
                 "secondaryType": "[parameters('secondaryType')]",
                 "sourceDatabaseDeletionDate": "[parameters('sourceDatabaseDeletionDate')]",
-                "sourceDatabaseId": "[parameters('sourceDatabaseId')]",
+                "sourceDatabaseId": "[parameters('sourceDatabaseResourceId')]",
                 "sourceResourceId": "[parameters('sourceResourceId')]",
                 "useFreeLimit": "[parameters('useFreeLimit')]",
                 "zoneRedundant": "[parameters('zoneRedundant')]"
@@ -2954,11 +2628,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.29.47.4906",
-<<<<<<< HEAD
               "templateHash": "8697391320806003846"
-=======
-              "templateHash": "17075205316023541596"
->>>>>>> f5bd37d9 (Rerun generation)
             },
             "name": "SQL Server Elastic Pool",
             "description": "This module deploys an Azure SQL Server Elastic Pool.",
@@ -3041,125 +2711,13 @@
                   "type": "string",
                   "nullable": true,
                   "metadata": {
-                    "description": "Required. The tier or edition of the particular SKU, e.g. Basic, Premium."
+                    "description": "Optional. The tier or edition of the particular SKU, e.g. Basic, Premium."
                   }
                 }
               },
               "metadata": {
                 "__bicep_export!": true,
                 "description": "The elastic pool SKU."
-              }
-            },
-            "elasticPoolPropertyType": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "metadata": {
-                    "description": "Required. The name of the Elastic Pool."
-                  }
-                },
-                "tags": {
-                  "type": "object",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Tags of the resource."
-                  }
-                },
-                "sku": {
-                  "$ref": "#/definitions/elasticPoolSkuType",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The elastic pool SKU."
-                  }
-                },
-                "autoPauseDelay": {
-                  "type": "int",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled."
-                  }
-                },
-                "availabilityZone": {
-                  "type": "string",
-                  "allowedValues": [
-                    "1",
-                    "2",
-                    "3",
-                    "NoPreference"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Specifies the availability zone the pool's primary replica is pinned to."
-                  }
-                },
-                "highAvailabilityReplicaCount": {
-                  "type": "int",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools."
-                  }
-                },
-                "licenseType": {
-                  "type": "string",
-                  "allowedValues": [
-                    "BasePrice",
-                    "LicenseIncluded"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The license type to apply for this elastic pool."
-                  }
-                },
-                "maintenanceConfigurationId": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur."
-                  }
-                },
-                "maxSizeBytes": {
-                  "type": "int",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The storage limit for the database elastic pool in bytes."
-                  }
-                },
-                "minCapacity": {
-                  "type": "int",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused."
-                  }
-                },
-                "perDatabaseSettings": {
-                  "$ref": "#/definitions/elasticPoolPerDatabaseSettingsType",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The per database settings for the elastic pool."
-                  }
-                },
-                "preferredEnclaveType": {
-                  "type": "string",
-                  "allowedValues": [
-                    "Default",
-                    "VBS"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Type of enclave requested on the elastic pool."
-                  }
-                },
-                "zoneRedundant": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones."
-                  }
-                }
-              },
-              "metadata": {
-                "__bicep_export!": true
               }
             }
           },
@@ -3173,7 +2731,7 @@
             "serverName": {
               "type": "string",
               "metadata": {
-                "description": "Required. The name of the parent SQL Server. Required if the template is used in a standalone deployment."
+                "description": "Conditional. The name of the parent SQL Server. Required if the template is used in a standalone deployment."
               }
             },
             "tags": {

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -569,6 +569,131 @@
         }
       }
     },
+    "_1.diagnosticSettingType": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The name of diagnostic setting."
+            }
+          },
+          "logCategoriesAndGroups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "category": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                  }
+                },
+                "categoryGroup": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                  }
+                },
+                "enabled": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                  }
+                }
+              }
+            },
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+            }
+          },
+          "metricCategories": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "category": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                  }
+                },
+                "enabled": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                  }
+                }
+              }
+            },
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+            }
+          },
+          "logAnalyticsDestinationType": {
+            "type": "string",
+            "allowedValues": [
+              "AzureDiagnostics",
+              "Dedicated"
+            ],
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+            }
+          },
+          "workspaceResourceId": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+            }
+          },
+          "storageAccountResourceId": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+            }
+          },
+          "eventHubAuthorizationRuleResourceId": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+            }
+          },
+          "eventHubName": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+            }
+          },
+          "marketplacePartnerResourceId": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+            }
+          }
+        }
+      },
+      "nullable": true,
+      "metadata": {
+        "__bicep_imported_from!": {
+          "sourceTemplate": "database/main.bicep"
+        }
+      }
+    },
     "_2.elasticPoolPerDatabaseSettingsType": {
       "type": "object",
       "properties": {
@@ -957,6 +1082,13 @@
           "nullable": true,
           "metadata": {
             "description": "Optional. Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones."
+          }
+        },
+        "diagnosticSettings": {
+          "$ref": "#/definitions/_1.diagnosticSettingType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The diagnostic settings of the service."
           }
         }
       },
@@ -2031,6 +2163,13 @@
                   "nullable": true,
                   "metadata": {
                     "description": "Optional. Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones."
+                  }
+                },
+                "diagnosticSettings": {
+                  "$ref": "#/definitions/diagnosticSettingType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The diagnostic settings of the service."
                   }
                 }
               },

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -1327,7 +1327,7 @@
   },
   "parameters": {
     "administratorLogin": {
-      "type": "string",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "Conditional. The administrator username for the server. Required if no `administrators` object for AAD authentication is provided."

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -524,7 +524,52 @@
         }
       }
     },
-    "_1.elasticPoolPerDatabaseSettingsType": {
+    "_1.databaseSkuType": {
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The capacity of the particular SKU."
+          }
+        },
+        "family": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here."
+          }
+        },
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the SKU, typically, a letter + Number code, e.g. P3."
+          }
+        },
+        "size": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Size of the particular SKU"
+          }
+        },
+        "tier": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Required. The tier or edition of the particular SKU, e.g. Basic, Premium."
+          }
+        }
+      },
+      "metadata": {
+        "description": "The database SKU.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "database/main.bicep"
+        }
+      }
+    },
+    "_2.elasticPoolPerDatabaseSettingsType": {
       "type": "object",
       "properties": {
         "autoPauseDelay": {
@@ -554,7 +599,7 @@
         }
       }
     },
-    "_1.elasticPoolSkuType": {
+    "_2.elasticPoolSkuType": {
       "type": "object",
       "properties": {
         "capacity": {
@@ -613,6 +658,314 @@
         }
       }
     },
+    "databasePropertyType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the Elastic Pool."
+          }
+        },
+        "tags": {
+          "type": "object",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Tags of the resource."
+          }
+        },
+        "sku": {
+          "$ref": "#/definitions/_1.databaseSkuType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The database SKU."
+          }
+        },
+        "autoPauseDelay": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled"
+          }
+        },
+        "availabilityZone": {
+          "type": "string",
+          "allowedValues": [
+            "1",
+            "2",
+            "3",
+            "NoPreference"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the availability zone the database is pinned to."
+          }
+        },
+        "catalogCollation": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Collation of the metadata catalog."
+          }
+        },
+        "collation": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The collation of the database."
+          }
+        },
+        "createMode": {
+          "type": "string",
+          "allowedValues": [
+            "Copy",
+            "Default",
+            "OnlineSecondary",
+            "PointInTimeRestore",
+            "Recovery",
+            "Restore",
+            "RestoreExternalBackup",
+            "RestoreExternalBackupSecondary",
+            "RestoreLongTermRetentionBackup",
+            "Secondary"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the mode of database creation."
+          }
+        },
+        "elasticPoolId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the elastic pool containing this database."
+          }
+        },
+        "encryptionProtector": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The azure key vault URI of the database if it's configured with per Database Customer Managed Keys."
+          }
+        },
+        "encryptionProtectorAutoRotation": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The flag to enable or disable auto rotation of database encryption protector AKV key."
+          }
+        },
+        "federatedClientId": {
+          "type": "string",
+          "nullable": true,
+          "minLength": 36,
+          "maxLength": 36,
+          "metadata": {
+            "description": "Optional. The Client id used for cross tenant per database CMK scenario."
+          }
+        },
+        "freeLimitExhaustionBehavior": {
+          "type": "string",
+          "allowedValues": [
+            "AutoPause",
+            "BillOverUsage"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the behavior when monthly free limits are exhausted for the free database."
+          }
+        },
+        "highAvailabilityReplicaCount": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The number of secondary replicas associated with the database that are used to provide high availability. Not applicable to a Hyperscale database within an elastic pool."
+          }
+        },
+        "isLedgerOn": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables."
+          }
+        },
+        "licenseType": {
+          "type": "string",
+          "allowedValues": [
+            "BasePrice",
+            "LicenseIncluded"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The license type to apply for this database."
+          }
+        },
+        "longTermRetentionBackupResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the long term retention backup associated with create operation of this database."
+          }
+        },
+        "maintenanceConfigurationId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur."
+          }
+        },
+        "manualCutover": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier."
+          }
+        },
+        "maxSizeBytes": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The max size of the database expressed in bytes."
+          }
+        },
+        "minCapacity": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Minimal capacity that database will always have allocated, if not paused."
+          }
+        },
+        "performCutover": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress."
+          }
+        },
+        "preferredEnclaveType": {
+          "type": "string",
+          "allowedValues": [
+            "Default",
+            "VBS"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Type of enclave requested on the database."
+          }
+        },
+        "readScale": {
+          "type": "string",
+          "allowedValues": [
+            "Disabled",
+            "Enabled"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The state of read-only routing. If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale database within an elastic pool."
+          }
+        },
+        "recoverableDatabaseId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the recoverable database associated with create operation of this database."
+          }
+        },
+        "recoveryServicesRecoveryPointId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the recovery point associated with create operation of this database."
+          }
+        },
+        "requestedBackupStorageRedundancy": {
+          "type": "string",
+          "allowedValues": [
+            "Geo",
+            "GeoZone",
+            "Local",
+            "Zone"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The storage account type to be used to store backups for this database."
+          }
+        },
+        "restorableDroppedDatabaseId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the restorable dropped database associated with create operation of this database."
+          }
+        },
+        "restorePointInTime": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database."
+          }
+        },
+        "sampleName": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The name of the sample schema to apply when creating this database."
+          }
+        },
+        "secondaryType": {
+          "type": "string",
+          "allowedValues": [
+            "Geo",
+            "Named",
+            "Standby"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The secondary type of the database if it is a secondary."
+          }
+        },
+        "sourceDatabaseDeletionDate": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the time that the database was deleted."
+          }
+        },
+        "sourceDatabaseId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the source database associated with create operation of this database."
+          }
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource identifier of the source associated with the create operation of this database."
+          }
+        },
+        "useFreeLimit": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Whether or not the database uses free monthly limits. Allowed on one database in a subscription."
+          }
+        },
+        "zoneRedundant": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_imported_from!": {
+          "sourceTemplate": "database/main.bicep"
+        }
+      }
+    },
     "elasticPoolPropertyType": {
       "type": "object",
       "properties": {
@@ -630,7 +983,7 @@
           }
         },
         "sku": {
-          "$ref": "#/definitions/_1.elasticPoolSkuType",
+          "$ref": "#/definitions/_2.elasticPoolSkuType",
           "nullable": true,
           "metadata": {
             "description": "Optional. The elastic pool SKU."
@@ -696,7 +1049,7 @@
           }
         },
         "perDatabaseSettings": {
-          "$ref": "#/definitions/_1.elasticPoolPerDatabaseSettingsType",
+          "$ref": "#/definitions/_2.elasticPoolPerDatabaseSettingsType",
           "nullable": true,
           "metadata": {
             "description": "Optional. The per database settings for the elastic pool."
@@ -819,6 +1172,9 @@
     },
     "databases": {
       "type": "array",
+      "items": {
+        "$ref": "#/definitions/databasePropertyType"
+      },
       "defaultValue": [],
       "metadata": {
         "description": "Optional. The databases to create in the server."
@@ -1086,95 +1442,116 @@
         },
         "mode": "Incremental",
         "parameters": {
-          "name": {
-            "value": "[parameters('databases')[copyIndex()].name]"
-          },
           "serverName": {
             "value": "[parameters('name')]"
-          },
-          "skuTier": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'skuTier'), 'GeneralPurpose')]"
-          },
-          "skuName": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'skuName'), 'GP_Gen5_2')]"
-          },
-          "skuCapacity": {
-            "value": "[tryGet(parameters('databases')[copyIndex()], 'skuCapacity')]"
-          },
-          "skuFamily": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'skuFamily'), '')]"
-          },
-          "skuSize": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'skuSize'), '')]"
-          },
-          "collation": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'collation'), 'SQL_Latin1_General_CP1_CI_AS')]"
-          },
-          "maxSizeBytes": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'maxSizeBytes'), json('34359738368'))]"
-          },
-          "autoPauseDelay": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'autoPauseDelay'), 0)]"
-          },
-          "diagnosticSettings": {
-            "value": "[tryGet(parameters('databases')[copyIndex()], 'diagnosticSettings')]"
-          },
-          "isLedgerOn": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'isLedgerOn'), false())]"
           },
           "location": {
             "value": "[parameters('location')]"
           },
+          "tags": {
+            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'tags'), parameters('tags'))]"
+          },
+          "name": {
+            "value": "[parameters('databases')[copyIndex()].name]"
+          },
+          "sku": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'sku')]"
+          },
+          "autoPauseDelay": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'autoPauseDelay')]"
+          },
+          "availabilityZone": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'availabilityZone')]"
+          },
+          "catalogCollation": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'catalogCollation')]"
+          },
+          "collation": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'collation')]"
+          },
+          "createMode": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'createMode')]"
+          },
+          "elasticPoolId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'elasticPoolId')]"
+          },
+          "encryptionProtector": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'encryptionProtector')]"
+          },
+          "encryptionProtectorAutoRotation": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'encryptionProtectorAutoRotation')]"
+          },
+          "federatedClientId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'federatedClientId')]"
+          },
+          "freeLimitExhaustionBehavior": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'freeLimitExhaustionBehavior')]"
+          },
+          "highAvailabilityReplicaCount": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'highAvailabilityReplicaCount')]"
+          },
+          "isLedgerOn": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'isLedgerOn')]"
+          },
           "licenseType": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'licenseType'), '')]"
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'licenseType')]"
+          },
+          "longTermRetentionBackupResourceId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'longTermRetentionBackupResourceId')]"
           },
           "maintenanceConfigurationId": {
             "value": "[tryGet(parameters('databases')[copyIndex()], 'maintenanceConfigurationId')]"
           },
-          "minCapacity": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'minCapacity'), '')]"
+          "manualCutover": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'manualCutover')]"
           },
-          "highAvailabilityReplicaCount": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'highAvailabilityReplicaCount'), 0)]"
+          "maxSizeBytes": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'maxSizeBytes')]"
+          },
+          "minCapacity": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'minCapacity')]"
+          },
+          "performCutover": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'performCutover')]"
+          },
+          "preferredEnclaveType": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'preferredEnclaveType')]"
           },
           "readScale": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'readScale'), 'Disabled')]"
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'readScale')]"
+          },
+          "recoverableDatabaseId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'recoverableDatabaseId')]"
+          },
+          "recoveryServicesRecoveryPointId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'recoveryServicesRecoveryPointId')]"
           },
           "requestedBackupStorageRedundancy": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'requestedBackupStorageRedundancy'), '')]"
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'requestedBackupStorageRedundancy')]"
           },
-          "sampleName": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'sampleName'), '')]"
-          },
-          "tags": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'tags'), parameters('tags'))]"
-          },
-          "zoneRedundant": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'zoneRedundant'), true())]"
-          },
-          "elasticPoolId": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'elasticPoolId'), '')]"
-          },
-          "backupShortTermRetentionPolicy": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'backupShortTermRetentionPolicy'), createObject())]"
-          },
-          "backupLongTermRetentionPolicy": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'backupLongTermRetentionPolicy'), createObject())]"
-          },
-          "createMode": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'createMode'), 'Default')]"
-          },
-          "sourceDatabaseResourceId": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'sourceDatabaseResourceId'), '')]"
-          },
-          "sourceDatabaseDeletionDate": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'sourceDatabaseDeletionDate'), '')]"
-          },
-          "recoveryServicesRecoveryPointResourceId": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'recoveryServicesRecoveryPointResourceId'), '')]"
+          "restorableDroppedDatabaseId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'restorableDroppedDatabaseId')]"
           },
           "restorePointInTime": {
-            "value": "[coalesce(tryGet(parameters('databases')[copyIndex()], 'restorePointInTime'), '')]"
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'restorePointInTime')]"
+          },
+          "secondaryType": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'secondaryType')]"
+          },
+          "sourceDatabaseDeletionDate": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'sourceDatabaseDeletionDate')]"
+          },
+          "sourceDatabaseId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'sourceDatabaseId')]"
+          },
+          "sourceResourceId": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'sourceResourceId')]"
+          },
+          "useFreeLimit": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'useFreeLimit')]"
+          },
+          "zoneRedundant": {
+            "value": "[tryGet(parameters('databases')[copyIndex()], 'zoneRedundant')]"
           }
         },
         "template": {
@@ -1312,9 +1689,351 @@
               },
               "nullable": true
             },
+            "databaseSkuType": {
+              "type": "object",
+              "properties": {
+                "capacity": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The capacity of the particular SKU."
+                  }
+                },
+                "family": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here."
+                  }
+                },
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the SKU, typically, a letter + Number code, e.g. P3."
+                  }
+                },
+                "size": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Size of the particular SKU"
+                  }
+                },
+                "tier": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Required. The tier or edition of the particular SKU, e.g. Basic, Premium."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The database SKU."
+              }
+            },
             "databasePropertyType": {
               "type": "object",
-              "properties": {},
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the Elastic Pool."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Tags of the resource."
+                  }
+                },
+                "sku": {
+                  "$ref": "#/definitions/databaseSkuType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The database SKU."
+                  }
+                },
+                "autoPauseDelay": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled"
+                  }
+                },
+                "availabilityZone": {
+                  "type": "string",
+                  "allowedValues": [
+                    "1",
+                    "2",
+                    "3",
+                    "NoPreference"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specifies the availability zone the database is pinned to."
+                  }
+                },
+                "catalogCollation": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Collation of the metadata catalog."
+                  }
+                },
+                "collation": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The collation of the database."
+                  }
+                },
+                "createMode": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Copy",
+                    "Default",
+                    "OnlineSecondary",
+                    "PointInTimeRestore",
+                    "Recovery",
+                    "Restore",
+                    "RestoreExternalBackup",
+                    "RestoreExternalBackupSecondary",
+                    "RestoreLongTermRetentionBackup",
+                    "Secondary"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specifies the mode of database creation."
+                  }
+                },
+                "elasticPoolId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource identifier of the elastic pool containing this database."
+                  }
+                },
+                "encryptionProtector": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The azure key vault URI of the database if it's configured with per Database Customer Managed Keys."
+                  }
+                },
+                "encryptionProtectorAutoRotation": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The flag to enable or disable auto rotation of database encryption protector AKV key."
+                  }
+                },
+                "federatedClientId": {
+                  "type": "string",
+                  "nullable": true,
+                  "minLength": 36,
+                  "maxLength": 36,
+                  "metadata": {
+                    "description": "Optional. The Client id used for cross tenant per database CMK scenario."
+                  }
+                },
+                "freeLimitExhaustionBehavior": {
+                  "type": "string",
+                  "allowedValues": [
+                    "AutoPause",
+                    "BillOverUsage"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specifies the behavior when monthly free limits are exhausted for the free database."
+                  }
+                },
+                "highAvailabilityReplicaCount": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The number of secondary replicas associated with the database that are used to provide high availability. Not applicable to a Hyperscale database within an elastic pool."
+                  }
+                },
+                "isLedgerOn": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables."
+                  }
+                },
+                "licenseType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "BasePrice",
+                    "LicenseIncluded"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The license type to apply for this database."
+                  }
+                },
+                "longTermRetentionBackupResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource identifier of the long term retention backup associated with create operation of this database."
+                  }
+                },
+                "maintenanceConfigurationId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur."
+                  }
+                },
+                "manualCutover": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier."
+                  }
+                },
+                "maxSizeBytes": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The max size of the database expressed in bytes."
+                  }
+                },
+                "minCapacity": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Minimal capacity that database will always have allocated, if not paused."
+                  }
+                },
+                "performCutover": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress."
+                  }
+                },
+                "preferredEnclaveType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Default",
+                    "VBS"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Type of enclave requested on the database."
+                  }
+                },
+                "readScale": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Disabled",
+                    "Enabled"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The state of read-only routing. If enabled, connections that have application intent set to readonly in their connection string may be routed to a readonly secondary replica in the same region. Not applicable to a Hyperscale database within an elastic pool."
+                  }
+                },
+                "recoverableDatabaseId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource identifier of the recoverable database associated with create operation of this database."
+                  }
+                },
+                "recoveryServicesRecoveryPointId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource identifier of the recovery point associated with create operation of this database."
+                  }
+                },
+                "requestedBackupStorageRedundancy": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Geo",
+                    "GeoZone",
+                    "Local",
+                    "Zone"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The storage account type to be used to store backups for this database."
+                  }
+                },
+                "restorableDroppedDatabaseId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource identifier of the restorable dropped database associated with create operation of this database."
+                  }
+                },
+                "restorePointInTime": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database."
+                  }
+                },
+                "sampleName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the sample schema to apply when creating this database."
+                  }
+                },
+                "secondaryType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Geo",
+                    "Named",
+                    "Standby"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The secondary type of the database if it is a secondary."
+                  }
+                },
+                "sourceDatabaseDeletionDate": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specifies the time that the database was deleted."
+                  }
+                },
+                "sourceDatabaseId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource identifier of the source database associated with create operation of this database."
+                  }
+                },
+                "sourceResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource identifier of the source associated with the create operation of this database."
+                  }
+                },
+                "useFreeLimit": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Whether or not the database uses free monthly limits. Allowed on one database in a subscription."
+                  }
+                },
+                "zoneRedundant": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones."
+                  }
+                }
+              },
               "metadata": {
                 "__bicep_export!": true
               }
@@ -1333,6 +2052,43 @@
                 "description": "Conditional. The name of the parent SQL Server. Required if the template is used in a standalone deployment."
               }
             },
+            "sku": {
+              "$ref": "#/definitions/databaseSkuType",
+              "defaultValue": {
+                "name": "GP_Gen5_2",
+                "tier": "GeneralPurpose"
+              },
+              "metadata": {
+                "description": "Optional. The database SKU."
+              }
+            },
+            "autoPauseDelay": {
+              "type": "int",
+              "defaultValue": 0,
+              "metadata": {
+                "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled"
+              }
+            },
+            "availabilityZone": {
+              "type": "string",
+              "allowedValues": [
+                "1",
+                "2",
+                "3",
+                "NoPreference"
+              ],
+              "defaultValue": "NoPreference",
+              "metadata": {
+                "description": "Optional. Specifies the availability zone the database is pinned to."
+              }
+            },
+            "catalogCollation": {
+              "type": "string",
+              "defaultValue": "DATABASE_DEFAULT",
+              "metadata": {
+                "description": "Optional. Collation of the metadata catalog."
+              }
+            },
             "collation": {
               "type": "string",
               "defaultValue": "SQL_Latin1_General_CP1_CI_AS",
@@ -1340,90 +2096,64 @@
                 "description": "Optional. The collation of the database."
               }
             },
-            "skuTier": {
+            "createMode": {
               "type": "string",
-              "defaultValue": "GeneralPurpose",
+              "allowedValues": [
+                "Copy",
+                "Default",
+                "OnlineSecondary",
+                "PointInTimeRestore",
+                "Recovery",
+                "Restore",
+                "RestoreExternalBackup",
+                "RestoreExternalBackupSecondary",
+                "RestoreLongTermRetentionBackup",
+                "Secondary"
+              ],
+              "defaultValue": "Default",
               "metadata": {
-                "description": "Optional. The skuTier or edition of the particular SKU."
+                "description": "Optional. Specifies the mode of database creation."
               }
             },
-            "skuName": {
+            "elasticPoolId": {
               "type": "string",
-              "defaultValue": "GP_Gen5_2",
-              "metadata": {
-                "description": "Optional. The name of the SKU."
-              }
-            },
-            "skuCapacity": {
-              "type": "int",
               "nullable": true,
               "metadata": {
-                "description": "Optional. Capacity of the particular SKU."
+                "description": "Optional. The resource ID of the elastic pool containing this database."
               }
             },
-            "preferredEnclaveType": {
+            "encryptionProtector": {
               "type": "string",
-              "defaultValue": "",
-              "allowedValues": [
-                "",
-                "Default",
-                "VBS"
-              ],
+              "nullable": true,
               "metadata": {
-                "description": "Optional. Type of enclave requested on the database i.e. Default or VBS enclaves."
+                "description": "Optional. The azure key vault URI of the database if it's configured with per Database Customer Managed Keys."
               }
             },
-            "skuFamily": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here."
-              }
-            },
-            "skuSize": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Size of the particular SKU."
-              }
-            },
-            "maxSizeBytes": {
-              "type": "int",
-              "defaultValue": 34359738368,
-              "metadata": {
-                "description": "Optional. The max size of the database expressed in bytes."
-              }
-            },
-            "sampleName": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. The name of the sample schema to apply when creating this database."
-              }
-            },
-            "zoneRedundant": {
+            "encryptionProtectorAutoRotation": {
               "type": "bool",
-              "defaultValue": true,
+              "nullable": true,
               "metadata": {
-                "description": "Optional. Whether or not this database is zone redundant."
+                "description": "Optional. The flag to enable or disable auto rotation of database encryption protector AKV key."
               }
             },
-            "licenseType": {
+            "federatedClientId": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
+              "minLength": 36,
+              "maxLength": 36,
               "metadata": {
-                "description": "Optional. The license type to apply for this database."
+                "description": "Optional. The Client id used for cross tenant per database CMK scenario."
               }
             },
-            "readScale": {
+            "freeLimitExhaustionBehavior": {
               "type": "string",
-              "defaultValue": "Disabled",
               "allowedValues": [
-                "Enabled",
-                "Disabled"
+                "AutoPause",
+                "BillOverUsage"
               ],
+              "nullable": true,
               "metadata": {
-                "description": "Optional. The state of read-only routing."
+                "description": "Optional. Specifies the behavior when monthly free limits are exhausted for the free database."
               }
             },
             "highAvailabilityReplicaCount": {
@@ -1433,18 +2163,181 @@
                 "description": "Optional. The number of readonly secondary replicas associated with the database."
               }
             },
+            "isLedgerOn": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created."
+              }
+            },
+            "licenseType": {
+              "type": "string",
+              "allowedValues": [
+                "BasePrice",
+                "LicenseIncluded"
+              ],
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The license type to apply for this database."
+              }
+            },
+            "longTermRetentionBackupResourceId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The resource identifier of the long term retention backup associated with create operation of this database."
+              }
+            },
+            "maintenanceConfigurationId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur."
+              }
+            },
+            "manualCutover": {
+              "type": "bool",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Whether or not customer controlled manual cutover needs to be done during Update Database operation to Hyperscale tier."
+              }
+            },
+            "maxSizeBytes": {
+              "type": "int",
+              "defaultValue": 34359738368,
+              "metadata": {
+                "description": "Optional. The max size of the database expressed in bytes."
+              }
+            },
             "minCapacity": {
               "type": "string",
-              "defaultValue": "",
+              "defaultValue": "0",
               "metadata": {
                 "description": "Optional. Minimal capacity that database will always have allocated."
               }
             },
-            "autoPauseDelay": {
-              "type": "int",
-              "defaultValue": 0,
+            "performCutover": {
+              "type": "bool",
+              "nullable": true,
               "metadata": {
-                "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled."
+                "description": "Optional. To trigger customer controlled manual cutover during the wait state while Scaling operation is in progress."
+              }
+            },
+            "preferredEnclaveType": {
+              "type": "string",
+              "allowedValues": [
+                "Default",
+                "VBS"
+              ],
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Type of enclave requested on the database i.e. Default or VBS enclaves."
+              }
+            },
+            "readScale": {
+              "type": "string",
+              "allowedValues": [
+                "Disabled",
+                "Enabled"
+              ],
+              "defaultValue": "Disabled",
+              "metadata": {
+                "description": "Optional. The state of read-only routing."
+              }
+            },
+            "recoverableDatabaseId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The resource identifier of the recoverable database associated with create operation of this database."
+              }
+            },
+            "recoveryServicesRecoveryPointId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The resource identifier of the recovery point associated with create operation of this database."
+              }
+            },
+            "requestedBackupStorageRedundancy": {
+              "type": "string",
+              "allowedValues": [
+                "Geo",
+                "GeoZone",
+                "Local",
+                "Zone"
+              ],
+              "defaultValue": "Local",
+              "metadata": {
+                "description": "Optional. The storage account type to be used to store backups for this database."
+              }
+            },
+            "restorableDroppedDatabaseId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The resource identifier of the restorable dropped database associated with create operation of this database."
+              }
+            },
+            "restorePointInTime": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Point in time (ISO8601 format) of the source database to restore when createMode set to Restore or PointInTimeRestore."
+              }
+            },
+            "sampleName": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. The name of the sample schema to apply when creating this database."
+              }
+            },
+            "secondaryType": {
+              "type": "string",
+              "allowedValues": [
+                "Geo",
+                "Named",
+                "Standby"
+              ],
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The secondary type of the database if it is a secondary."
+              }
+            },
+            "sourceDatabaseDeletionDate": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The time that the database was deleted when restoring a deleted database."
+              }
+            },
+            "sourceDatabaseId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The resource identifier of the source database associated with create operation of this database."
+              }
+            },
+            "sourceResourceId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The resource identifier of the source associated with the create operation of this database."
+              }
+            },
+            "useFreeLimit": {
+              "type": "bool",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Whether or not the database uses free monthly limits. Allowed on one database in a subscription."
+              }
+            },
+            "zoneRedundant": {
+              "type": "bool",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Whether or not this database is zone redundant."
               }
             },
             "tags": {
@@ -1452,13 +2345,6 @@
               "nullable": true,
               "metadata": {
                 "description": "Optional. Tags of the resource."
-              }
-            },
-            "elasticPoolId": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. The resource ID of the elastic pool containing this database."
               }
             },
             "location": {
@@ -1472,78 +2358,6 @@
               "$ref": "#/definitions/diagnosticSettingType",
               "metadata": {
                 "description": "Optional. The diagnostic settings of the service."
-              }
-            },
-            "createMode": {
-              "type": "string",
-              "defaultValue": "Default",
-              "allowedValues": [
-                "Default",
-                "Copy",
-                "OnlineSecondary",
-                "PointInTimeRestore",
-                "Recovery",
-                "Restore",
-                "RestoreLongTermRetentionBackup",
-                "Secondary"
-              ],
-              "metadata": {
-                "description": "Optional. Specifies the mode of database creation."
-              }
-            },
-            "sourceDatabaseResourceId": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Resource ID of database if createMode set to Copy, Secondary, PointInTimeRestore, Recovery or Restore."
-              }
-            },
-            "sourceDatabaseDeletionDate": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. The time that the database was deleted when restoring a deleted database."
-              }
-            },
-            "recoveryServicesRecoveryPointResourceId": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Resource ID of backup if createMode set to RestoreLongTermRetentionBackup."
-              }
-            },
-            "restorePointInTime": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Point in time (ISO8601 format) of the source database to restore when createMode set to Restore or PointInTimeRestore."
-              }
-            },
-            "requestedBackupStorageRedundancy": {
-              "type": "string",
-              "defaultValue": "",
-              "allowedValues": [
-                "Geo",
-                "Local",
-                "Zone",
-                ""
-              ],
-              "metadata": {
-                "description": "Optional. The storage account type to be used to store backups for this database."
-              }
-            },
-            "isLedgerOn": {
-              "type": "bool",
-              "defaultValue": false,
-              "metadata": {
-                "description": "Optional. Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created."
-              }
-            },
-            "maintenanceConfigurationId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur."
               }
             },
             "backupShortTermRetentionPolicy": {
@@ -1561,9 +2375,6 @@
               }
             }
           },
-          "variables": {
-            "skuVar": "[union(createObject('name', parameters('skuName'), 'tier', parameters('skuTier')), if(not(equals(parameters('skuCapacity'), null())), createObject('capacity', parameters('skuCapacity')), if(not(empty(parameters('skuFamily'))), createObject('family', parameters('skuFamily')), if(not(empty(parameters('skuSize'))), createObject('size', parameters('skuSize')), createObject()))))]"
-          },
           "resources": {
             "server": {
               "existing": true,
@@ -1577,28 +2388,42 @@
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
+              "sku": "[parameters('sku')]",
               "properties": {
-                "preferredEnclaveType": "[if(not(empty(parameters('preferredEnclaveType'))), parameters('preferredEnclaveType'), null())]",
-                "collation": "[parameters('collation')]",
-                "maxSizeBytes": "[parameters('maxSizeBytes')]",
-                "sampleName": "[parameters('sampleName')]",
-                "zoneRedundant": "[parameters('zoneRedundant')]",
-                "licenseType": "[parameters('licenseType')]",
-                "readScale": "[parameters('readScale')]",
-                "minCapacity": "[if(not(empty(parameters('minCapacity'))), json(parameters('minCapacity')), 0)]",
                 "autoPauseDelay": "[parameters('autoPauseDelay')]",
-                "highAvailabilityReplicaCount": "[parameters('highAvailabilityReplicaCount')]",
-                "requestedBackupStorageRedundancy": "[parameters('requestedBackupStorageRedundancy')]",
-                "isLedgerOn": "[parameters('isLedgerOn')]",
-                "maintenanceConfigurationId": "[parameters('maintenanceConfigurationId')]",
-                "elasticPoolId": "[parameters('elasticPoolId')]",
+                "availabilityZone": "[parameters('availabilityZone')]",
+                "catalogCollation": "[parameters('catalogCollation')]",
+                "collation": "[parameters('collation')]",
                 "createMode": "[parameters('createMode')]",
-                "sourceDatabaseId": "[if(not(empty(parameters('sourceDatabaseResourceId'))), parameters('sourceDatabaseResourceId'), null())]",
-                "sourceDatabaseDeletionDate": "[if(not(empty(parameters('sourceDatabaseDeletionDate'))), parameters('sourceDatabaseDeletionDate'), null())]",
-                "recoveryServicesRecoveryPointId": "[if(not(empty(parameters('recoveryServicesRecoveryPointResourceId'))), parameters('recoveryServicesRecoveryPointResourceId'), null())]",
-                "restorePointInTime": "[if(not(empty(parameters('restorePointInTime'))), parameters('restorePointInTime'), null())]"
+                "elasticPoolId": "[parameters('elasticPoolId')]",
+                "encryptionProtector": "[parameters('encryptionProtector')]",
+                "encryptionProtectorAutoRotation": "[parameters('encryptionProtectorAutoRotation')]",
+                "federatedClientId": "[parameters('federatedClientId')]",
+                "freeLimitExhaustionBehavior": "[parameters('freeLimitExhaustionBehavior')]",
+                "highAvailabilityReplicaCount": "[parameters('highAvailabilityReplicaCount')]",
+                "isLedgerOn": "[parameters('isLedgerOn')]",
+                "licenseType": "[parameters('licenseType')]",
+                "longTermRetentionBackupResourceId": "[parameters('longTermRetentionBackupResourceId')]",
+                "maintenanceConfigurationId": "[parameters('maintenanceConfigurationId')]",
+                "manualCutover": "[parameters('manualCutover')]",
+                "maxSizeBytes": "[parameters('maxSizeBytes')]",
+                "minCapacity": "[if(not(empty(parameters('minCapacity'))), json(parameters('minCapacity')), 0)]",
+                "performCutover": "[parameters('performCutover')]",
+                "preferredEnclaveType": "[parameters('preferredEnclaveType')]",
+                "readScale": "[parameters('readScale')]",
+                "recoverableDatabaseId": "[parameters('recoverableDatabaseId')]",
+                "recoveryServicesRecoveryPointId": "[parameters('recoveryServicesRecoveryPointId')]",
+                "requestedBackupStorageRedundancy": "[parameters('requestedBackupStorageRedundancy')]",
+                "restorableDroppedDatabaseId": "[parameters('restorableDroppedDatabaseId')]",
+                "restorePointInTime": "[parameters('restorePointInTime')]",
+                "sampleName": "[parameters('sampleName')]",
+                "secondaryType": "[parameters('secondaryType')]",
+                "sourceDatabaseDeletionDate": "[parameters('sourceDatabaseDeletionDate')]",
+                "sourceDatabaseId": "[parameters('sourceDatabaseId')]",
+                "sourceResourceId": "[parameters('sourceResourceId')]",
+                "useFreeLimit": "[parameters('useFreeLimit')]",
+                "zoneRedundant": "[parameters('zoneRedundant')]"
               },
-              "sku": "[variables('skuVar')]",
               "dependsOn": [
                 "server"
               ]

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -7,10 +7,14 @@
       "name": "bicep",
       "version": "0.29.47.4906",
 <<<<<<< HEAD
+<<<<<<< HEAD
       "templateHash": "12931751409452972364"
 =======
       "templateHash": "6840329240992957872"
 >>>>>>> 78a8ab21 (Update README)
+=======
+      "templateHash": "7649615845184764158"
+>>>>>>> f5bd37d9 (Rerun generation)
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server.",
@@ -553,7 +557,7 @@
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Size of the particular SKU"
+            "description": "Optional. Size of the particular SKU."
           }
         },
         "tier": {
@@ -703,19 +707,19 @@
           "type": "int",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Auto Pause Delay for per database within pool"
+            "description": "Optional. Auto Pause Delay for per database within pool."
           }
         },
         "maxCapacity": {
           "type": "string",
           "metadata": {
-            "description": "Reqired. The maximum capacity any one database can consume. Examples: '0.5', '2'"
+            "description": "Reqired. The maximum capacity any one database can consume. Examples: '0.5', '2'."
           }
         },
         "minCapacity": {
           "type": "string",
           "metadata": {
-            "description": "Required. The minimum capacity all databases are guaranteed. Examples: '0.5', '1'"
+            "description": "Required. The minimum capacity all databases are guaranteed. Examples: '0.5', '1'."
           }
         }
       },
@@ -767,7 +771,7 @@
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Size of the particular SKU"
+            "description": "Optional. Size of the particular SKU."
           }
         },
         "tier": {
@@ -812,7 +816,7 @@
           "type": "int",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled"
+            "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled."
           }
         },
         "availabilityZone": {
@@ -1179,7 +1183,7 @@
           "type": "int",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused"
+            "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused."
           }
         },
         "perDatabaseSettings": {
@@ -1365,7 +1369,7 @@
       "minLength": 36,
       "maxLength": 36,
       "metadata": {
-        "description": "Optional. The Client id used for cross tenant CMK scenario"
+        "description": "Optional. The Client id used for cross tenant CMK scenario."
       }
     },
     "keyId": {
@@ -1696,7 +1700,11 @@
             "_generator": {
               "name": "bicep",
               "version": "0.29.47.4906",
+<<<<<<< HEAD
               "templateHash": "18021918128213514276"
+=======
+              "templateHash": "4558221869591328265"
+>>>>>>> f5bd37d9 (Rerun generation)
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database.",
@@ -1850,7 +1858,7 @@
                   "type": "string",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. Size of the particular SKU"
+                    "description": "Optional. Size of the particular SKU."
                   }
                 },
                 "tier": {
@@ -1893,7 +1901,7 @@
                   "type": "int",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled"
+                    "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled."
                   }
                 },
                 "availabilityZone": {
@@ -2207,7 +2215,7 @@
               "type": "int",
               "defaultValue": 0,
               "metadata": {
-                "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled"
+                "description": "Optional. Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled."
               }
             },
             "availabilityZone": {
@@ -2946,7 +2954,11 @@
             "_generator": {
               "name": "bicep",
               "version": "0.29.47.4906",
+<<<<<<< HEAD
               "templateHash": "8697391320806003846"
+=======
+              "templateHash": "17075205316023541596"
+>>>>>>> f5bd37d9 (Rerun generation)
             },
             "name": "SQL Server Elastic Pool",
             "description": "This module deploys an Azure SQL Server Elastic Pool.",
@@ -2960,19 +2972,19 @@
                   "type": "int",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. Auto Pause Delay for per database within pool"
+                    "description": "Optional. Auto Pause Delay for per database within pool."
                   }
                 },
                 "maxCapacity": {
                   "type": "string",
                   "metadata": {
-                    "description": "Reqired. The maximum capacity any one database can consume. Examples: '0.5', '2'"
+                    "description": "Reqired. The maximum capacity any one database can consume. Examples: '0.5', '2'."
                   }
                 },
                 "minCapacity": {
                   "type": "string",
                   "metadata": {
-                    "description": "Required. The minimum capacity all databases are guaranteed. Examples: '0.5', '1'"
+                    "description": "Required. The minimum capacity all databases are guaranteed. Examples: '0.5', '1'."
                   }
                 }
               },
@@ -3022,7 +3034,7 @@
                   "type": "string",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. Size of the particular SKU"
+                    "description": "Optional. Size of the particular SKU."
                   }
                 },
                 "tier": {
@@ -3117,7 +3129,7 @@
                   "type": "int",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused"
+                    "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused."
                   }
                 },
                 "perDatabaseSettings": {

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.29.47.4906",
-      "templateHash": "11793309099204894215"
+      "templateHash": "6235114069229783991"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server.",
@@ -1797,7 +1797,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.29.47.4906",
-              "templateHash": "18021918128213514276"
+              "templateHash": "2290667128393523898"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database.",
@@ -2509,8 +2509,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "10836519140305169908"
+                      "version": "0.29.47.4906",
+                      "templateHash": "8635162595153731245"
                     },
                     "name": "Azure SQL Server Database Short Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy.",
@@ -2627,8 +2627,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "10064519186693398262"
+                      "version": "0.29.47.4906",
+                      "templateHash": "16586251276572997423"
                     },
                     "name": "SQL Server Database Long Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy.",
@@ -2862,7 +2862,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.29.47.4906",
-              "templateHash": "8697391320806003846"
+              "templateHash": "4618079193349998123"
             },
             "name": "SQL Server Elastic Pool",
             "description": "This module deploys an Azure SQL Server Elastic Pool.",
@@ -3948,8 +3948,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "6449556555046717103"
+              "version": "0.29.47.4906",
+              "templateHash": "7779473510493338097"
             },
             "name": "Azure SQL Server Firewall Rule",
             "description": "This module deploys an Azure SQL Server Firewall Rule.",
@@ -4056,8 +4056,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "4969955763304077350"
+              "version": "0.29.47.4906",
+              "templateHash": "7859066741604114060"
             },
             "name": "Azure SQL Server Virtual Network Rules",
             "description": "This module deploys an Azure SQL Server Virtual Network Rule.",
@@ -4178,8 +4178,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "15406914222375641032"
+              "version": "0.29.47.4906",
+              "templateHash": "6025191760768766090"
             },
             "name": "Azure SQL Server Security Alert Policies",
             "description": "This module deploys an Azure SQL Server Security Alert Policy.",
@@ -4339,8 +4339,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "11004049200994426011"
+              "version": "0.29.47.4906",
+              "templateHash": "5682596516926040129"
             },
             "name": "Azure SQL Server Vulnerability Assessments",
             "description": "This module deploys an Azure SQL Server Vulnerability Assessment.",
@@ -4442,8 +4442,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "13956215614091387428"
+                      "version": "0.29.47.4906",
+                      "templateHash": "17251889896692066430"
                     }
                   },
                   "parameters": {
@@ -4535,8 +4535,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "17839617504395216689"
+              "version": "0.29.47.4906",
+              "templateHash": "5863771213375512760"
             },
             "name": "Azure SQL Server Keys",
             "description": "This module deploys an Azure SQL Server Key.",
@@ -4658,8 +4658,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "11473914706327458055"
+              "version": "0.29.47.4906",
+              "templateHash": "6914924378490463775"
             },
             "name": "Azure SQL Server Encryption Protector",
             "description": "This module deploys an Azure SQL Server Encryption Protector.",
@@ -4791,8 +4791,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "2456263707393734456"
+              "version": "0.29.47.4906",
+              "templateHash": "15193713225079892162"
             },
             "name": "Azure SQL Server Audit Settings",
             "description": "This module deploys an Azure SQL Server Audit Settings.",
@@ -4938,8 +4938,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "13956215614091387428"
+                      "version": "0.29.47.4906",
+                      "templateHash": "17251889896692066430"
                     }
                   },
                   "parameters": {
@@ -5026,8 +5026,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "16142913599202614386"
+              "version": "0.29.47.4906",
+              "templateHash": "594547303316002116"
             }
           },
           "definitions": {

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.30.23.60470",
-      "templateHash": "8810892363183845130"
+      "version": "0.29.47.4906",
+      "templateHash": "12931751409452972364"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server.",
@@ -535,15 +535,15 @@
           }
         },
         "maxCapacity": {
-          "type": "int",
+          "type": "string",
           "metadata": {
-            "description": "Reqired. The maximum capacity any one database can consume."
+            "description": "Reqired. The maximum capacity any one database can consume. Examples: '0.5', '2'"
           }
         },
         "minCapacity": {
-          "type": "int",
+          "type": "string",
           "metadata": {
-            "description": "Required. The minimum capacity all databases are guaranteed."
+            "description": "Required. The minimum capacity all databases are guaranteed. Examples: '0.5', '1'"
           }
         }
       },
@@ -1184,8 +1184,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "6415977783551326128"
+              "version": "0.29.47.4906",
+              "templateHash": "18021918128213514276"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database.",
@@ -1311,6 +1311,13 @@
                 }
               },
               "nullable": true
+            },
+            "databasePropertyType": {
+              "type": "object",
+              "properties": {},
+              "metadata": {
+                "__bicep_export!": true
+              }
             }
           },
           "parameters": {
@@ -1972,8 +1979,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "15389069656635651285"
+              "version": "0.29.47.4906",
+              "templateHash": "8697391320806003846"
             },
             "name": "SQL Server Elastic Pool",
             "description": "This module deploys an Azure SQL Server Elastic Pool.",
@@ -1991,15 +1998,15 @@
                   }
                 },
                 "maxCapacity": {
-                  "type": "int",
+                  "type": "string",
                   "metadata": {
-                    "description": "Reqired. The maximum capacity any one database can consume."
+                    "description": "Reqired. The maximum capacity any one database can consume. Examples: '0.5', '2'"
                   }
                 },
                 "minCapacity": {
-                  "type": "int",
+                  "type": "string",
                   "metadata": {
-                    "description": "Required. The minimum capacity all databases are guaranteed."
+                    "description": "Required. The minimum capacity all databases are guaranteed. Examples: '0.5', '1'"
                   }
                 }
               },
@@ -2279,8 +2286,8 @@
               "$ref": "#/definitions/elasticPoolPerDatabaseSettingsType",
               "defaultValue": {
                 "autoPauseDelay": -1,
-                "maxCapacity": 2,
-                "minCapacity": 0
+                "maxCapacity": "2",
+                "minCapacity": "0"
               },
               "metadata": {
                 "description": "Optional. The per database settings for the elastic pool."
@@ -2327,7 +2334,7 @@
                 "maintenanceConfigurationId": "[parameters('maintenanceConfigurationId')]",
                 "maxSizeBytes": "[parameters('maxSizeBytes')]",
                 "minCapacity": "[parameters('minCapacity')]",
-                "perDatabaseSettings": "[parameters('perDatabaseSettings')]",
+                "perDatabaseSettings": "[if(not(empty(parameters('perDatabaseSettings'))), createObject('autoPauseDelay', tryGet(parameters('perDatabaseSettings'), 'autoPauseDelay'), 'maxCapacity', json(tryGet(parameters('perDatabaseSettings'), 'maxCapacity')), 'minCapacity', json(tryGet(parameters('perDatabaseSettings'), 'minCapacity'))), null())]",
                 "preferredEnclaveType": "[parameters('preferredEnclaveType')]",
                 "zoneRedundant": "[parameters('zoneRedundant')]"
               },

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -461,6 +461,59 @@
       },
       "nullable": true
     },
+    "ServerExternalAdministratorType": {
+      "type": "object",
+      "properties": {
+        "administratorType": {
+          "type": "string",
+          "allowedValues": [
+            "ActiveDirectory"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Type of the sever administrator."
+          }
+        },
+        "azureADOnlyAuthentication": {
+          "type": "bool",
+          "metadata": {
+            "description": "Required. Azure Active Directory only Authentication enabled."
+          }
+        },
+        "login": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. Login name of the server administrator."
+          }
+        },
+        "principalType": {
+          "type": "string",
+          "allowedValues": [
+            "Application",
+            "Group",
+            "User"
+          ],
+          "metadata": {
+            "description": "Required. Principal Type of the sever administrator."
+          }
+        },
+        "sid": {
+          "type": "string",
+          "metadata": {
+            "example": "#_managementGroupId_#",
+            "description": "Required. SID (object ID) of the server administrator."
+          }
+        },
+        "tenantId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "example": "#_managementGroupId_#",
+            "description": "Optional. Tenant ID of the administrator."
+          }
+        }
+      }
+    },
     "secretsOutputType": {
       "type": "object",
       "properties": {},
@@ -468,6 +521,209 @@
         "$ref": "#/definitions/secretSetType",
         "metadata": {
           "description": "An exported secret's references."
+        }
+      }
+    },
+    "_1.elasticPoolPerDatabaseSettingsType": {
+      "type": "object",
+      "properties": {
+        "autoPauseDelay": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Auto Pause Delay for per database within pool"
+          }
+        },
+        "maxCapacity": {
+          "type": "int",
+          "metadata": {
+            "description": "Reqired. The maximum capacity any one database can consume."
+          }
+        },
+        "minCapacity": {
+          "type": "int",
+          "metadata": {
+            "description": "Required. The minimum capacity all databases are guaranteed."
+          }
+        }
+      },
+      "metadata": {
+        "description": "The per database settings for the elastic pool.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "elastic-pool/main.bicep"
+        }
+      }
+    },
+    "_1.elasticPoolSkuType": {
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The capacity of the particular SKU."
+          }
+        },
+        "family": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here."
+          }
+        },
+        "name": {
+          "type": "string",
+          "allowedValues": [
+            "BC_DC",
+            "BC_Gen5",
+            "BasicPool",
+            "GP_DC",
+            "GP_FSv2",
+            "GP_Gen5",
+            "HS_Gen5",
+            "HS_MOPRMS",
+            "HS_PRMS",
+            "PremiumPool",
+            "ServerlessPool",
+            "StandardPool"
+          ],
+          "metadata": {
+            "description": "Required. The name of the SKU, typically, a letter + Number code, e.g. P3."
+          }
+        },
+        "size": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Size of the particular SKU"
+          }
+        },
+        "tier": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Required. The tier or edition of the particular SKU, e.g. Basic, Premium."
+          }
+        }
+      },
+      "metadata": {
+        "description": "The elastic pool SKU.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "elastic-pool/main.bicep"
+        }
+      }
+    },
+    "elasticPoolPropertyType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the Elastic Pool."
+          }
+        },
+        "tags": {
+          "type": "object",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Tags of the resource."
+          }
+        },
+        "sku": {
+          "$ref": "#/definitions/_1.elasticPoolSkuType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The elastic pool SKU."
+          }
+        },
+        "autoPauseDelay": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled."
+          }
+        },
+        "availabilityZone": {
+          "type": "string",
+          "allowedValues": [
+            "1",
+            "2",
+            "3",
+            "NoPreference"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the availability zone the pool's primary replica is pinned to."
+          }
+        },
+        "highAvailabilityReplicaCount": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools."
+          }
+        },
+        "licenseType": {
+          "type": "string",
+          "allowedValues": [
+            "BasePrice",
+            "LicenseIncluded"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The license type to apply for this elastic pool."
+          }
+        },
+        "maintenanceConfigurationId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur."
+          }
+        },
+        "maxSizeBytes": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The storage limit for the database elastic pool in bytes."
+          }
+        },
+        "minCapacity": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused"
+          }
+        },
+        "perDatabaseSettings": {
+          "$ref": "#/definitions/_1.elasticPoolPerDatabaseSettingsType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The per database settings for the elastic pool."
+          }
+        },
+        "preferredEnclaveType": {
+          "type": "string",
+          "allowedValues": [
+            "Default",
+            "VBS"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Type of enclave requested on the elastic pool."
+          }
+        },
+        "zoneRedundant": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_imported_from!": {
+          "sourceTemplate": "elastic-pool/main.bicep"
         }
       }
     },
@@ -570,6 +826,9 @@
     },
     "elasticPools": {
       "type": "array",
+      "items": {
+        "$ref": "#/definitions/elasticPoolPropertyType"
+      },
       "defaultValue": [],
       "metadata": {
         "description": "Optional. The Elastic Pools to create in the server."
@@ -604,10 +863,26 @@
       }
     },
     "administrators": {
-      "type": "object",
-      "defaultValue": {},
+      "$ref": "#/definitions/ServerExternalAdministratorType",
+      "nullable": true,
       "metadata": {
         "description": "Conditional. The Azure Active Directory (AAD) administrator authentication. Required if no `administratorLogin` & `administratorLoginPassword` is provided."
+      }
+    },
+    "federatedClientId": {
+      "type": "string",
+      "nullable": true,
+      "minLength": 36,
+      "maxLength": 36,
+      "metadata": {
+        "description": "Optional. The Client id used for cross tenant CMK scenario"
+      }
+    },
+    "keyId": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. A CMK URI of the key to use for encryption."
       }
     },
     "minimalTlsVersion": {
@@ -750,13 +1025,15 @@
       "properties": {
         "administratorLogin": "[if(not(empty(parameters('administratorLogin'))), parameters('administratorLogin'), null())]",
         "administratorLoginPassword": "[if(not(empty(parameters('administratorLoginPassword'))), parameters('administratorLoginPassword'), null())]",
-        "administrators": "[if(not(empty(parameters('administrators'))), createObject('administratorType', 'ActiveDirectory', 'azureADOnlyAuthentication', parameters('administrators').azureADOnlyAuthentication, 'login', parameters('administrators').login, 'principalType', parameters('administrators').principalType, 'sid', parameters('administrators').sid, 'tenantId', coalesce(tryGet(parameters('administrators'), 'tenantId'), tenant().tenantId)), null())]",
+        "administrators": "[union(createObject('administratorType', 'ActiveDirectory'), coalesce(parameters('administrators'), createObject()))]",
+        "federatedClientId": "[parameters('federatedClientId')]",
+        "isIPv6Enabled": "[parameters('isIPv6Enabled')]",
+        "keyId": "[parameters('keyId')]",
         "version": "12.0",
         "minimalTlsVersion": "[parameters('minimalTlsVersion')]",
         "primaryUserAssignedIdentityId": "[if(not(empty(parameters('primaryUserAssignedIdentityId'))), parameters('primaryUserAssignedIdentityId'), null())]",
         "publicNetworkAccess": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(and(and(not(empty(parameters('privateEndpoints'))), empty(parameters('firewallRules'))), empty(parameters('virtualNetworkRules'))), 'Disabled', null()))]",
-        "restrictOutboundNetworkAccess": "[if(not(empty(parameters('restrictOutboundNetworkAccess'))), parameters('restrictOutboundNetworkAccess'), null())]",
-        "isIPv6Enabled": "[parameters('isIPv6Enabled')]"
+        "restrictOutboundNetworkAccess": "[if(not(empty(parameters('restrictOutboundNetworkAccess'))), parameters('restrictOutboundNetworkAccess'), null())]"
       }
     },
     "server_lock": {
@@ -1642,50 +1919,50 @@
         },
         "mode": "Incremental",
         "parameters": {
-          "name": {
-            "value": "[parameters('elasticPools')[copyIndex()].name]"
-          },
           "serverName": {
             "value": "[parameters('name')]"
-          },
-          "databaseMaxCapacity": {
-            "value": "[coalesce(tryGet(parameters('elasticPools')[copyIndex()], 'databaseMaxCapacity'), 2)]"
-          },
-          "databaseMinCapacity": {
-            "value": "[coalesce(tryGet(parameters('elasticPools')[copyIndex()], 'databaseMinCapacity'), 0)]"
-          },
-          "highAvailabilityReplicaCount": {
-            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'highAvailabilityReplicaCount')]"
-          },
-          "licenseType": {
-            "value": "[coalesce(tryGet(parameters('elasticPools')[copyIndex()], 'licenseType'), 'LicenseIncluded')]"
-          },
-          "maintenanceConfigurationId": {
-            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'maintenanceConfigurationId')]"
-          },
-          "maxSizeBytes": {
-            "value": "[coalesce(tryGet(parameters('elasticPools')[copyIndex()], 'maxSizeBytes'), json('34359738368'))]"
-          },
-          "minCapacity": {
-            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'minCapacity')]"
-          },
-          "skuCapacity": {
-            "value": "[coalesce(tryGet(parameters('elasticPools')[copyIndex()], 'skuCapacity'), 2)]"
-          },
-          "skuName": {
-            "value": "[coalesce(tryGet(parameters('elasticPools')[copyIndex()], 'skuName'), 'GP_Gen5')]"
-          },
-          "skuTier": {
-            "value": "[coalesce(tryGet(parameters('elasticPools')[copyIndex()], 'skuTier'), 'GeneralPurpose')]"
-          },
-          "zoneRedundant": {
-            "value": "[coalesce(tryGet(parameters('elasticPools')[copyIndex()], 'zoneRedundant'), true())]"
           },
           "location": {
             "value": "[parameters('location')]"
           },
           "tags": {
             "value": "[coalesce(tryGet(parameters('elasticPools')[copyIndex()], 'tags'), parameters('tags'))]"
+          },
+          "name": {
+            "value": "[parameters('elasticPools')[copyIndex()].name]"
+          },
+          "sku": {
+            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'sku')]"
+          },
+          "autoPauseDelay": {
+            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'autoPauseDelay')]"
+          },
+          "availabilityZone": {
+            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'availabilityZone')]"
+          },
+          "highAvailabilityReplicaCount": {
+            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'highAvailabilityReplicaCount')]"
+          },
+          "licenseType": {
+            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'licenseType')]"
+          },
+          "maintenanceConfigurationId": {
+            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'maintenanceConfigurationId')]"
+          },
+          "maxSizeBytes": {
+            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'maxSizeBytes')]"
+          },
+          "minCapacity": {
+            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'minCapacity')]"
+          },
+          "perDatabaseSettings": {
+            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'perDatabaseSettings')]"
+          },
+          "preferredEnclaveType": {
+            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'preferredEnclaveType')]"
+          },
+          "zoneRedundant": {
+            "value": "[tryGet(parameters('elasticPools')[copyIndex()], 'zoneRedundant')]"
           }
         },
         "template": {
@@ -1702,6 +1979,205 @@
             "description": "This module deploys an Azure SQL Server Elastic Pool.",
             "owner": "Azure/module-maintainers"
           },
+          "definitions": {
+            "elasticPoolPerDatabaseSettingsType": {
+              "type": "object",
+              "properties": {
+                "autoPauseDelay": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Auto Pause Delay for per database within pool"
+                  }
+                },
+                "maxCapacity": {
+                  "type": "int",
+                  "metadata": {
+                    "description": "Reqired. The maximum capacity any one database can consume."
+                  }
+                },
+                "minCapacity": {
+                  "type": "int",
+                  "metadata": {
+                    "description": "Required. The minimum capacity all databases are guaranteed."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The per database settings for the elastic pool."
+              }
+            },
+            "elasticPoolSkuType": {
+              "type": "object",
+              "properties": {
+                "capacity": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The capacity of the particular SKU."
+                  }
+                },
+                "family": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. If the service has different generations of hardware, for the same SKU, then that can be captured here."
+                  }
+                },
+                "name": {
+                  "type": "string",
+                  "allowedValues": [
+                    "BC_DC",
+                    "BC_Gen5",
+                    "BasicPool",
+                    "GP_DC",
+                    "GP_FSv2",
+                    "GP_Gen5",
+                    "HS_Gen5",
+                    "HS_MOPRMS",
+                    "HS_PRMS",
+                    "PremiumPool",
+                    "ServerlessPool",
+                    "StandardPool"
+                  ],
+                  "metadata": {
+                    "description": "Required. The name of the SKU, typically, a letter + Number code, e.g. P3."
+                  }
+                },
+                "size": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Size of the particular SKU"
+                  }
+                },
+                "tier": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Required. The tier or edition of the particular SKU, e.g. Basic, Premium."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The elastic pool SKU."
+              }
+            },
+            "elasticPoolPropertyType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the Elastic Pool."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Tags of the resource."
+                  }
+                },
+                "sku": {
+                  "$ref": "#/definitions/elasticPoolSkuType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The elastic pool SKU."
+                  }
+                },
+                "autoPauseDelay": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled."
+                  }
+                },
+                "availabilityZone": {
+                  "type": "string",
+                  "allowedValues": [
+                    "1",
+                    "2",
+                    "3",
+                    "NoPreference"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specifies the availability zone the pool's primary replica is pinned to."
+                  }
+                },
+                "highAvailabilityReplicaCount": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools."
+                  }
+                },
+                "licenseType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "BasePrice",
+                    "LicenseIncluded"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The license type to apply for this elastic pool."
+                  }
+                },
+                "maintenanceConfigurationId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur."
+                  }
+                },
+                "maxSizeBytes": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The storage limit for the database elastic pool in bytes."
+                  }
+                },
+                "minCapacity": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused"
+                  }
+                },
+                "perDatabaseSettings": {
+                  "$ref": "#/definitions/elasticPoolPerDatabaseSettingsType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The per database settings for the elastic pool."
+                  }
+                },
+                "preferredEnclaveType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Default",
+                    "VBS"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Type of enclave requested on the elastic pool."
+                  }
+                },
+                "zoneRedundant": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            }
+          },
           "parameters": {
             "name": {
               "type": "string",
@@ -1712,7 +2188,7 @@
             "serverName": {
               "type": "string",
               "metadata": {
-                "description": "Conditional. The name of the parent SQL Server. Required if the template is used in a standalone deployment."
+                "description": "Required. The name of the parent SQL Server. Required if the template is used in a standalone deployment."
               }
             },
             "tags": {
@@ -1729,25 +2205,35 @@
                 "description": "Optional. Location for all resources."
               }
             },
-            "skuCapacity": {
+            "sku": {
+              "$ref": "#/definitions/elasticPoolSkuType",
+              "defaultValue": {
+                "capacity": 2,
+                "name": "GP_Gen5",
+                "tier": "GeneralPurpose"
+              },
+              "metadata": {
+                "description": "Optional. The elastic pool SKU."
+              }
+            },
+            "autoPauseDelay": {
               "type": "int",
-              "defaultValue": 2,
+              "defaultValue": -1,
               "metadata": {
-                "description": "Optional. Capacity of the particular SKU."
+                "description": "Optional. Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled."
               }
             },
-            "skuName": {
+            "availabilityZone": {
               "type": "string",
-              "defaultValue": "GP_Gen5",
+              "allowedValues": [
+                "1",
+                "2",
+                "3",
+                "NoPreference"
+              ],
+              "defaultValue": "NoPreference",
               "metadata": {
-                "description": "Optional. The name of the SKU, typically, a letter + Number code, e.g. P3."
-              }
-            },
-            "skuTier": {
-              "type": "string",
-              "defaultValue": "GeneralPurpose",
-              "metadata": {
-                "description": "Optional. The tier or edition of the particular SKU, e.g. Basic, Premium."
+                "description": "Optional. Specifies the availability zone the pool's primary replica is pinned to."
               }
             },
             "highAvailabilityReplicaCount": {
@@ -1789,23 +2275,31 @@
                 "description": "Optional. Minimal capacity that serverless pool will not shrink below, if not paused."
               }
             },
-            "databaseMaxCapacity": {
-              "type": "int",
-              "defaultValue": 2,
+            "perDatabaseSettings": {
+              "$ref": "#/definitions/elasticPoolPerDatabaseSettingsType",
+              "defaultValue": {
+                "autoPauseDelay": -1,
+                "maxCapacity": 2,
+                "minCapacity": 0
+              },
               "metadata": {
-                "description": "Optional. The maximum capacity any one database can consume."
+                "description": "Optional. The per database settings for the elastic pool."
               }
             },
-            "databaseMinCapacity": {
-              "type": "int",
-              "defaultValue": 0,
+            "preferredEnclaveType": {
+              "type": "string",
+              "allowedValues": [
+                "Default",
+                "VBS"
+              ],
+              "defaultValue": "Default",
               "metadata": {
-                "description": "Optional. The minimum capacity all databases are guaranteed."
+                "description": "Optional. Type of enclave requested on the elastic pool."
               }
             },
             "zoneRedundant": {
               "type": "bool",
-              "defaultValue": true,
+              "defaultValue": false,
               "metadata": {
                 "description": "Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones."
               }
@@ -1824,21 +2318,17 @@
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
-              "sku": {
-                "capacity": "[parameters('skuCapacity')]",
-                "name": "[parameters('skuName')]",
-                "tier": "[parameters('skuTier')]"
-              },
+              "sku": "[parameters('sku')]",
               "properties": {
+                "autoPauseDelay": "[parameters('autoPauseDelay')]",
+                "availabilityZone": "[parameters('availabilityZone')]",
                 "highAvailabilityReplicaCount": "[parameters('highAvailabilityReplicaCount')]",
                 "licenseType": "[parameters('licenseType')]",
                 "maintenanceConfigurationId": "[parameters('maintenanceConfigurationId')]",
                 "maxSizeBytes": "[parameters('maxSizeBytes')]",
                 "minCapacity": "[parameters('minCapacity')]",
-                "perDatabaseSettings": {
-                  "minCapacity": "[parameters('databaseMinCapacity')]",
-                  "maxCapacity": "[parameters('databaseMaxCapacity')]"
-                },
+                "perDatabaseSettings": "[parameters('perDatabaseSettings')]",
+                "preferredEnclaveType": "[parameters('preferredEnclaveType')]",
                 "zoneRedundant": "[parameters('zoneRedundant')]"
               },
               "dependsOn": [

--- a/avm/res/sql/server/tests/e2e/admin/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/admin/main.test.bicep
@@ -51,7 +51,6 @@ module testDeployment '../../../main.bicep' = {
     name: '${namePrefix}-${serviceShort}'
     location: resourceLocation
     administrators: {
-      administratorType: 'ActiveDirectory'
       azureADOnlyAuthentication: true
       login: 'myspn'
       sid: nestedDependencies.outputs.managedIdentityPrincipalId

--- a/avm/res/sql/server/tests/e2e/admin/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/admin/main.test.bicep
@@ -51,6 +51,7 @@ module testDeployment '../../../main.bicep' = {
     name: '${namePrefix}-${serviceShort}'
     location: resourceLocation
     administrators: {
+      administratorType: 'ActiveDirectory'
       azureADOnlyAuthentication: true
       login: 'myspn'
       sid: nestedDependencies.outputs.managedIdentityPrincipalId

--- a/avm/res/sql/server/tests/e2e/elasticPool/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/elasticPool/main.test.bicep
@@ -1,0 +1,73 @@
+targetScope = 'subscription'
+
+metadata name = 'Using elastic pool'
+metadata description = 'This instance deploys the module with an elastic pool.'
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Optional. The name of the resource group to deploy for testing purposes.')
+@maxLength(90)
+param resourceGroupName string = 'dep-${namePrefix}-sql.servers-${serviceShort}-rg'
+
+@description('Optional. The location to deploy resources to.')
+param resourceLocation string = deployment().location
+
+@description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
+param serviceShort string = 'epool'
+
+@description('Optional. The password to leverage for the login.')
+@secure()
+param password string = newGuid()
+
+@description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
+param namePrefix string = '#_namePrefix_#'
+
+// ============ //
+// Dependencies //
+// ============ //
+
+// General resources
+// =================
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: resourceGroupName
+  location: resourceLocation
+}
+
+// ============== //
+// Test Execution //
+// ============== //
+
+@batchSize(1)
+module testDeployment '../../../main.bicep' = [
+  for iteration in ['init', 'idem']: {
+    scope: resourceGroup
+    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
+    params: {
+      name: '${namePrefix}${serviceShort}001'
+      location: resourceLocation
+      administratorLogin: 'adminUserName'
+      administratorLoginPassword: password
+      elasticPools: [
+        // bare minimum elastic pool: only a name is specified
+        {
+          name: '${namePrefix}-${serviceShort}-ep-001'
+        }
+        // more complex elastic pool with non-default SKU and per database settings
+        {
+          name: '${namePrefix}-${serviceShort}-ep-002'
+          sku: {
+            name: 'GP_Gen5'
+            tier: 'GeneralPurpose'
+            capacity: 4
+          }
+          perDatabaseSettings: {
+            minCapacity: 1
+            maxCapacity: 4
+          }
+        }
+      ]
+    }
+  }
+]

--- a/avm/res/sql/server/tests/e2e/elasticPool/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/elasticPool/main.test.bicep
@@ -63,8 +63,8 @@ module testDeployment '../../../main.bicep' = [
             capacity: 4
           }
           perDatabaseSettings: {
-            minCapacity: 1
-            maxCapacity: 4
+            minCapacity: '0.5'
+            maxCapacity: '4'
           }
         }
       ]

--- a/avm/res/sql/server/tests/e2e/elasticPool/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/elasticPool/main.test.bicep
@@ -15,7 +15,7 @@ param resourceGroupName string = 'dep-${namePrefix}-sql.servers-${serviceShort}-
 param resourceLocation string = deployment().location
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
-param serviceShort string = 'epool'
+param serviceShort string = 'ssep'
 
 @description('Optional. The password to leverage for the login.')
 @secure()

--- a/avm/res/sql/server/tests/e2e/max/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/max/main.test.bicep
@@ -113,18 +113,22 @@ module testDeployment '../../../main.bicep' = {
     elasticPools: [
       {
         name: '${namePrefix}-${serviceShort}-ep-001'
-        skuName: 'GP_Gen5'
-        skuTier: 'GeneralPurpose'
-        skuCapacity: 10
+        sku: {
+          name: 'GP_Gen5'
+          tier: 'GeneralPurpose'
+          capacity: 10
+        }
       }
     ]
     databases: [
       {
         name: '${namePrefix}-${serviceShort}db-001'
         collation: 'SQL_Latin1_General_CP1_CI_AS'
-        skuTier: 'GeneralPurpose'
-        skuName: 'ElasticPool'
-        skuCapacity: 0
+        sku: {
+          name: 'ElasticPool'
+          tier: 'GeneralPurpose'
+          capacity: 0
+        }
         maxSizeBytes: 34359738368
         licenseType: 'LicenseIncluded'
         diagnosticSettings: [

--- a/avm/res/sql/server/tests/e2e/max/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/max/main.test.bicep
@@ -140,7 +140,7 @@ module testDeployment '../../../main.bicep' = {
             workspaceResourceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
           }
         ]
-        elasticPoolId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/${namePrefix}-${serviceShort}/elasticPools/${namePrefix}-${serviceShort}-ep-001'
+        elasticPoolResourceId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/${namePrefix}-${serviceShort}/elasticPools/${namePrefix}-${serviceShort}-ep-001'
         encryptionProtectorObj: {
           serverKeyType: 'AzureKeyVault'
           serverKeyName: '${nestedDependencies.outputs.keyVaultName}_${nestedDependencies.outputs.keyVaultKeyName}_${last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))}'

--- a/avm/res/sql/server/tests/e2e/max/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/max/main.test.bicep
@@ -141,10 +141,6 @@ module testDeployment '../../../main.bicep' = {
           }
         ]
         elasticPoolResourceId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/${namePrefix}-${serviceShort}/elasticPools/${namePrefix}-${serviceShort}-ep-001'
-        encryptionProtectorObj: {
-          serverKeyType: 'AzureKeyVault'
-          serverKeyName: '${nestedDependencies.outputs.keyVaultName}_${nestedDependencies.outputs.keyVaultKeyName}_${last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))}'
-        }
         backupShortTermRetentionPolicy: {
           retentionDays: 14
         }
@@ -153,6 +149,10 @@ module testDeployment '../../../main.bicep' = {
         }
       }
     ]
+    encryptionProtectorObj: {
+      serverKeyType: 'AzureKeyVault'
+      serverKeyName: '${nestedDependencies.outputs.keyVaultName}_${nestedDependencies.outputs.keyVaultKeyName}_${last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))}'
+    }
     firewallRules: [
       {
         name: 'AllowAllWindowsAzureIps'

--- a/avm/res/sql/server/tests/e2e/secondary/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/secondary/main.test.bicep
@@ -59,11 +59,13 @@ module testDeployment '../../../main.bicep' = {
     databases: [
       {
         name: nestedDependencies.outputs.databaseName
-        skuTier: 'Basic'
-        skuName: 'Basic'
+        sku: {
+          name: 'Basic'
+          tier: 'Basic'
+        }
         maxSizeBytes: 2147483648
         createMode: 'Secondary'
-        sourceDatabaseResourceId: nestedDependencies.outputs.databaseResourceId
+        sourceDatabaseId: nestedDependencies.outputs.databaseResourceId
       }
     ]
     tags: {

--- a/avm/res/sql/server/tests/e2e/secondary/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/secondary/main.test.bicep
@@ -65,7 +65,7 @@ module testDeployment '../../../main.bicep' = {
         }
         maxSizeBytes: 2147483648
         createMode: 'Secondary'
-        sourceDatabaseId: nestedDependencies.outputs.databaseResourceId
+        sourceDatabaseResourceId: nestedDependencies.outputs.databaseResourceId
       }
     ]
     tags: {

--- a/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
@@ -68,7 +68,6 @@ module testDeployment '../../../main.bicep' = {
     name: '${namePrefix}-${serviceShort}'
     primaryUserAssignedIdentityId: nestedDependencies.outputs.managedIdentityResourceId
     administrators: {
-      administratorType: 'ActiveDirectory'
       azureADOnlyAuthentication: true
       login: 'myspn'
       sid: nestedDependencies.outputs.managedIdentityPrincipalId

--- a/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
@@ -88,9 +88,11 @@ module testDeployment '../../../main.bicep' = {
     elasticPools: [
       {
         name: '${namePrefix}-${serviceShort}-ep-001'
-        skuName: 'GP_Gen5'
-        skuTier: 'GeneralPurpose'
-        skuCapacity: 10
+        sku: {
+          name: 'GP_Gen5'
+          tier: 'GeneralPurpose'
+          capacity: 10
+        }
         maintenanceConfigurationId: '${subscription().id}/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_${enforcedLocation}_DB_1'
       }
     ]
@@ -98,9 +100,11 @@ module testDeployment '../../../main.bicep' = {
       {
         name: '${namePrefix}-${serviceShort}db-001'
         collation: 'SQL_Latin1_General_CP1_CI_AS'
-        skuTier: 'GeneralPurpose'
-        skuName: 'ElasticPool'
-        skuCapacity: 0
+        sku: {
+          name: 'ElasticPool'
+          tier: 'GeneralPurpose'
+          capacity: 0
+        }
         maxSizeBytes: 34359738368
         licenseType: 'LicenseIncluded'
         diagnosticSettings: [

--- a/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
@@ -116,7 +116,7 @@ module testDeployment '../../../main.bicep' = {
             workspaceResourceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
           }
         ]
-        elasticPoolId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/${namePrefix}-${serviceShort}/elasticPools/${namePrefix}-${serviceShort}-ep-001'
+        elasticPoolResourceId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/${namePrefix}-${serviceShort}/elasticPools/${namePrefix}-${serviceShort}-ep-001'
         encryptionProtectorObj: {
           serverKeyType: 'AzureKeyVault'
           serverKeyName: '${nestedDependencies.outputs.keyVaultName}_${nestedDependencies.outputs.keyVaultKeyName}_${last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))}'

--- a/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
@@ -117,10 +117,6 @@ module testDeployment '../../../main.bicep' = {
           }
         ]
         elasticPoolResourceId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/${namePrefix}-${serviceShort}/elasticPools/${namePrefix}-${serviceShort}-ep-001'
-        encryptionProtectorObj: {
-          serverKeyType: 'AzureKeyVault'
-          serverKeyName: '${nestedDependencies.outputs.keyVaultName}_${nestedDependencies.outputs.keyVaultKeyName}_${last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))}'
-        }
         backupShortTermRetentionPolicy: {
           retentionDays: 14
         }
@@ -129,6 +125,10 @@ module testDeployment '../../../main.bicep' = {
         }
       }
     ]
+    encryptionProtectorObj: {
+      serverKeyType: 'AzureKeyVault'
+      serverKeyName: '${nestedDependencies.outputs.keyVaultName}_${nestedDependencies.outputs.keyVaultKeyName}_${last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))}'
+    }
     securityAlertPolicies: [
       {
         name: 'Default'

--- a/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
@@ -68,6 +68,7 @@ module testDeployment '../../../main.bicep' = {
     name: '${namePrefix}-${serviceShort}'
     primaryUserAssignedIdentityId: nestedDependencies.outputs.managedIdentityResourceId
     administrators: {
+      administratorType: 'ActiveDirectory'
       azureADOnlyAuthentication: true
       login: 'myspn'
       sid: nestedDependencies.outputs.managedIdentityPrincipalId

--- a/avm/res/sql/server/version.json
+++ b/avm/res/sql/server/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.9",
+    "version": "0.10",
     "pathFilters": [
         "./main.json"
     ]


### PR DESCRIPTION
## Description

This PR is aiming to add strong types to parameters for `avm/res/sq/server` and it's children.

This PR contains typing for the `server`, `database` and `elastic-pool`. Other modules will be tackled later, as I'd like to see first that this is a good direction and approach adding these.

* Types are exported from children and imported into the main module
* To align with the latest API there is an SKU object for databases and elastic pools, instead of individual `skuName`, `skuTier` etc.
* Default values are provided in the child module, and the parent is not duplicating those default value assignment
* Also I have checked the latest API, and turned out that some of the new parameters were missing, so I went ahead and added them to have a complete coverage
* Updated `minCapacity` to enable fractional values both at database and elastic-pool modules
* As a consequence version number has been increased
* Updated tests where it was necessary. All tests are successfully completed

### Questions

* What is the best way to expose the types of the parameters of the child module with the least repetition? Currently I need to define a given module parameter for the module (with it's description), and then add the same to the type again with the same description. Is there a better  DRY way to do this?
* Also is there a better way to assign the values in the parent module to the parameters to the child module? Currently every parameter is assigned individually, maybe there is a better and shorter way to do that?

Contributes to #1141

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.sql.server](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg)](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml)      |

Pls note that in my subscription Maintenance Window feature is not available, hence the WAF test is failing

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
