### PR TITLE
test: `avm/res/event-grid/namespace` - fixed duplicate metadata of a test case

### DIFF
--- a/avm/res/event-grid/namespace/README.md
+++ b/avm/res/event-grid/namespace/README.md
@@ -40,7 +40,7 @@ The following section provides usage examples for the module, which were used to
 - [Using only defaults](#example-1-using-only-defaults)
 - [Using large parameter set](#example-2-using-large-parameter-set)
 - [MQTT Broker with routing to a namespace topic](#example-3-mqtt-broker-with-routing-to-a-namespace-topic)
-- [MQTT Broker with routing to a namespace topic](#example-4-mqtt-broker-with-routing-to-a-namespace-topic)
+- [MQTT Broker with routing to a custom topic](#example-4-mqtt-broker-with-routing-to-a-custom-topic)
 - [WAF-aligned](#example-5-waf-aligned)
 
 ### Example 1: _Using only defaults_
@@ -1214,9 +1214,9 @@ param topicSpacesState = 'Enabled'
 </details>
 <p>
 
-### Example 4: _MQTT Broker with routing to a namespace topic_
+### Example 4: _MQTT Broker with routing to a custom topic_
 
-This instance deploys the module as a MQTT Broker with routing to a topic within the same Eventgrid namespace.
+This instance deploys the module as a MQTT Broker with routing to a custom topic.
 
 
 <details>

--- a/avm/res/event-grid/namespace/tests/e2e/mqttnt/main.test.bicep
+++ b/avm/res/event-grid/namespace/tests/e2e/mqttnt/main.test.bicep
@@ -1,7 +1,7 @@
 targetScope = 'subscription'
 
-metadata name = 'MQTT Broker with routing to a namespace topic'
-metadata description = 'This instance deploys the module as a MQTT Broker with routing to a topic within the same Eventgrid namespace.'
+metadata name = 'MQTT Broker with routing to a custom topic'
+metadata description = 'This instance deploys the module as a MQTT Broker with routing to a custom topic.'
 
 // ========== //
 // Parameters //


### PR DESCRIPTION
## Description

Two of the module test cases had the same metadata (name and description) causing confusion of the documentation. This PR fixes the metadata of the one of them.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.event-grid.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.namespace.yml/badge.svg?branch=user%2Fkrbar%2FeventGridTestFix)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.namespace.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
