### PR TITLE
fix: Common-Types - Fixed incorrect parameter description

### DIFF
--- a/avm/res/app-configuration/configuration-store/README.md
+++ b/avm/res/app-configuration/configuration-store/README.md
@@ -1324,12 +1324,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/app-configuration/configuration-store/main.bicep
+++ b/avm/res/app-configuration/configuration-store/main.bicep
@@ -447,7 +447,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/batch/batch-account/README.md
+++ b/avm/res/batch/batch-account/README.md
@@ -1436,12 +1436,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/batch/batch-account/main.bicep
+++ b/avm/res/batch/batch-account/main.bicep
@@ -469,7 +469,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/cache/redis/README.md
+++ b/avm/res/cache/redis/README.md
@@ -1370,12 +1370,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/cache/redis/main.bicep
+++ b/avm/res/cache/redis/main.bicep
@@ -421,7 +421,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/cdn/profile/secret/main.bicep
+++ b/avm/res/cdn/profile/secret/main.bicep
@@ -14,7 +14,7 @@ param profileName string
   'ManagedCertificate'
   'UrlSigningKey'
 ])
-@description('Required. The type of the secrect.')
+@description('Optional. The type of the secrect.')
 param type string = 'AzureFirstPartyManagedCertificate'
 
 @description('Conditional. The resource ID of the secret source. Required if the `type` is "CustomerCertificate".')

--- a/avm/res/cognitive-services/account/README.md
+++ b/avm/res/cognitive-services/account/README.md
@@ -2260,15 +2260,13 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
-### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
+**Optional parameters**
 
-Fqdn that resolves to private endpoint IP address.
-
-- Required: No
-- Type: string
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.ipAddresses`
 
@@ -2276,6 +2274,13 @@ A list of private IP addresses of the private endpoint.
 
 - Required: Yes
 - Type: array
+
+### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
+
+FQDN that resolves to private endpoint IP address.
+
+- Required: No
+- Type: string
 
 ### Parameter: `privateEndpoints.customNetworkInterfaceName`
 

--- a/avm/res/cognitive-services/account/main.bicep
+++ b/avm/res/cognitive-services/account/main.bicep
@@ -652,7 +652,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Optional. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/consumption/budget/README.md
+++ b/avm/res/consumption/budget/README.md
@@ -422,8 +422,6 @@ param thresholds = [
 | :-- | :-- | :-- |
 | [`amount`](#parameter-amount) | int | The total amount of cost or usage to track with the budget. |
 | [`name`](#parameter-name) | string | The name of the budget. |
-| [`operator`](#parameter-operator) | string | The comparison operator. The operator can be either `EqualTo`, `GreaterThan`, or `GreaterThanOrEqualTo`. |
-| [`thresholdType`](#parameter-thresholdtype) | string | The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecasted`. |
 
 **Conditional parameters**
 
@@ -442,10 +440,12 @@ param thresholds = [
 | [`endDate`](#parameter-enddate) | string | The end date for the budget. If not provided, it will default to 10 years from the start date. |
 | [`filter`](#parameter-filter) | object | The filter to use for restricting which resources are considered within the budget. |
 | [`location`](#parameter-location) | string | Location deployment metadata. |
+| [`operator`](#parameter-operator) | string | The comparison operator. The operator can be either `EqualTo`, `GreaterThan`, or `GreaterThanOrEqualTo`. |
 | [`resetPeriod`](#parameter-resetperiod) | string | The time covered by a budget. Tracking of the amount will be reset based on the time grain. BillingMonth, BillingQuarter, and BillingAnnual are only supported by WD customers. |
 | [`resourceGroupFilter`](#parameter-resourcegroupfilter) | array | The list of resource groups that contain the resources that are to be considered within the budget. |
 | [`startDate`](#parameter-startdate) | string | The start date for the budget. Start date should be the first day of the month and cannot be in the past (except for the current month). |
 | [`thresholds`](#parameter-thresholds) | array | Percent thresholds of budget for when to get a notification. Can be up to 5 thresholds, where each must be between 1 and 1000. |
+| [`thresholdType`](#parameter-thresholdtype) | string | The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecasted`. |
 
 ### Parameter: `amount`
 
@@ -460,37 +460,6 @@ The name of the budget.
 
 - Required: Yes
 - Type: string
-
-### Parameter: `operator`
-
-The comparison operator. The operator can be either `EqualTo`, `GreaterThan`, or `GreaterThanOrEqualTo`.
-
-- Required: No
-- Type: string
-- Default: `'GreaterThan'`
-- Allowed:
-  ```Bicep
-  [
-    'EqualTo'
-    'GreaterThan'
-    'GreaterThanOrEqualTo'
-  ]
-  ```
-
-### Parameter: `thresholdType`
-
-The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecasted`.
-
-- Required: No
-- Type: string
-- Default: `'Actual'`
-- Allowed:
-  ```Bicep
-  [
-    'Actual'
-    'Forecasted'
-  ]
-  ```
 
 ### Parameter: `actionGroups`
 
@@ -559,6 +528,22 @@ Location deployment metadata.
 - Type: string
 - Default: `[deployment().location]`
 
+### Parameter: `operator`
+
+The comparison operator. The operator can be either `EqualTo`, `GreaterThan`, or `GreaterThanOrEqualTo`.
+
+- Required: No
+- Type: string
+- Default: `'GreaterThan'`
+- Allowed:
+  ```Bicep
+  [
+    'EqualTo'
+    'GreaterThan'
+    'GreaterThanOrEqualTo'
+  ]
+  ```
+
 ### Parameter: `resetPeriod`
 
 The time covered by a budget. Tracking of the amount will be reset based on the time grain. BillingMonth, BillingQuarter, and BillingAnnual are only supported by WD customers.
@@ -608,6 +593,21 @@ Percent thresholds of budget for when to get a notification. Can be up to 5 thre
     90
     100
     110
+  ]
+  ```
+
+### Parameter: `thresholdType`
+
+The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecasted`.
+
+- Required: No
+- Type: string
+- Default: `'Actual'`
+- Allowed:
+  ```Bicep
+  [
+    'Actual'
+    'Forecasted'
   ]
   ```
 

--- a/avm/res/consumption/budget/main.bicep
+++ b/avm/res/consumption/budget/main.bicep
@@ -39,7 +39,7 @@ param endDate string = ''
   'GreaterThan'
   'GreaterThanOrEqualTo'
 ])
-@description('Required. The comparison operator. The operator can be either `EqualTo`, `GreaterThan`, or `GreaterThanOrEqualTo`.')
+@description('Optional. The comparison operator. The operator can be either `EqualTo`, `GreaterThan`, or `GreaterThanOrEqualTo`.')
 param operator string = 'GreaterThan'
 
 @maxLength(5)
@@ -65,7 +65,7 @@ param actionGroups array?
   'Actual'
   'Forecasted'
 ])
-@description('Required. The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecasted`.')
+@description('Optional. The type of threshold to use for the budget. The threshold type can be either `Actual` or `Forecasted`.')
 param thresholdType string = 'Actual'
 
 @description('Optional. The filter to use for restricting which resources are considered within the budget.')

--- a/avm/res/container-registry/registry/README.md
+++ b/avm/res/container-registry/registry/README.md
@@ -1580,12 +1580,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/container-registry/registry/main.bicep
+++ b/avm/res/container-registry/registry/main.bicep
@@ -620,7 +620,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/container-service/managed-cluster/README.md
+++ b/avm/res/container-service/managed-cluster/README.md
@@ -3973,13 +3973,6 @@ Settings and configurations for the flux extension.
 - Required: No
 - Type: object
 
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`name`](#parameter-fluxextensionname) | string | The name of the extension. |
-| [`releaseTrain`](#parameter-fluxextensionreleasetrain) | string | The release train of the extension. |
-
 **Optional parameters**
 
 | Parameter | Type | Description |
@@ -3987,23 +3980,11 @@ Settings and configurations for the flux extension.
 | [`configurationProtectedSettings`](#parameter-fluxextensionconfigurationprotectedsettings) | object | The configuration protected settings of the extension. |
 | [`configurations`](#parameter-fluxextensionconfigurations) | array | The flux configurations of the extension. |
 | [`configurationSettings`](#parameter-fluxextensionconfigurationsettings) | object | The configuration settings of the extension. |
+| [`name`](#parameter-fluxextensionname) | string | The name of the extension. |
 | [`releaseNamespace`](#parameter-fluxextensionreleasenamespace) | string | Namespace where the extension Release must be placed. |
+| [`releaseTrain`](#parameter-fluxextensionreleasetrain) | string | The release train of the extension. |
 | [`targetNamespace`](#parameter-fluxextensiontargetnamespace) | string | Namespace where the extension will be created for an Namespace scoped extension. |
 | [`version`](#parameter-fluxextensionversion) | string | The version of the extension. |
-
-### Parameter: `fluxExtension.name`
-
-The name of the extension.
-
-- Required: No
-- Type: string
-
-### Parameter: `fluxExtension.releaseTrain`
-
-The release train of the extension.
-
-- Required: No
-- Type: string
 
 ### Parameter: `fluxExtension.configurationProtectedSettings`
 
@@ -4039,9 +4020,23 @@ The configuration settings of the extension.
 - Required: No
 - Type: object
 
+### Parameter: `fluxExtension.name`
+
+The name of the extension.
+
+- Required: No
+- Type: string
+
 ### Parameter: `fluxExtension.releaseNamespace`
 
 Namespace where the extension Release must be placed.
+
+- Required: No
+- Type: string
+
+### Parameter: `fluxExtension.releaseTrain`
+
+The release train of the extension.
 
 - Required: No
 - Type: string

--- a/avm/res/container-service/managed-cluster/main.bicep
+++ b/avm/res/container-service/managed-cluster/main.bicep
@@ -879,7 +879,7 @@ module managedCluster_extension 'br/public:avm/res/kubernetes-configuration/exte
     extensionType: 'microsoft.flux'
     fluxConfigurations: fluxExtension.?configurations
     location: location
-    name: 'flux'
+    name: fluxExtension.?name ?? 'flux'
     releaseNamespace: fluxExtension.?releaseNamespace ?? 'flux-system'
     releaseTrain: fluxExtension.?releaseTrain ?? 'Stable'
     version: fluxExtension.?version
@@ -1229,7 +1229,7 @@ type fluxConfigurationProtectedSettingsType = {
 
 @export()
 type extensionType = {
-  @description('Required. The name of the extension.')
+  @description('Optional. The name of the extension.')
   name: string?
 
   @description('Optional. Namespace where the extension Release must be placed.')
@@ -1238,7 +1238,7 @@ type extensionType = {
   @description('Optional. Namespace where the extension will be created for an Namespace scoped extension.')
   targetNamespace: string?
 
-  @description('Required. The release train of the extension.')
+  @description('Optional. The release train of the extension.')
   releaseTrain: string?
 
   @description('Optional. The configuration protected settings of the extension.')

--- a/avm/res/data-factory/factory/README.md
+++ b/avm/res/data-factory/factory/README.md
@@ -1401,12 +1401,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/data-factory/factory/main.bicep
+++ b/avm/res/data-factory/factory/main.bicep
@@ -483,7 +483,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/databricks/workspace/README.md
+++ b/avm/res/databricks/workspace/README.md
@@ -1520,12 +1520,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string
@@ -2115,12 +2115,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-storageaccountprivateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-storageaccountprivateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-storageaccountprivateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `storageAccountPrivateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/databricks/workspace/main.bicep
+++ b/avm/res/databricks/workspace/main.bicep
@@ -649,7 +649,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/desktop-virtualization/host-pool/README.md
+++ b/avm/res/desktop-virtualization/host-pool/README.md
@@ -1006,12 +1006,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/desktop-virtualization/host-pool/main.bicep
+++ b/avm/res/desktop-virtualization/host-pool/main.bicep
@@ -447,7 +447,7 @@ type privateEndpointType = {
 
   @sys.description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @sys.description('Required. Fqdn that resolves to private endpoint IP address.')
+    @sys.description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @sys.description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/desktop-virtualization/workspace/README.md
+++ b/avm/res/desktop-virtualization/workspace/README.md
@@ -924,12 +924,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/desktop-virtualization/workspace/main.bicep
+++ b/avm/res/desktop-virtualization/workspace/main.bicep
@@ -330,7 +330,7 @@ type privateEndpointType = {
 
   @sys.description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @sys.description('Required. Fqdn that resolves to private endpoint IP address.')
+    @sys.description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @sys.description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/digital-twins/digital-twins-instance/README.md
+++ b/avm/res/digital-twins/digital-twins-instance/README.md
@@ -988,12 +988,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/digital-twins/digital-twins-instance/main.bicep
+++ b/avm/res/digital-twins/digital-twins-instance/main.bicep
@@ -385,7 +385,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/document-db/database-account/README.md
+++ b/avm/res/document-db/database-account/README.md
@@ -4066,12 +4066,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint ip address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint ip address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private ip addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint ip address.
+FQDN that resolves to private endpoint ip address.
 
 - Required: No
 - Type: string

--- a/avm/res/document-db/database-account/main.bicep
+++ b/avm/res/document-db/database-account/main.bicep
@@ -742,7 +742,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint ip address.')
+    @description('Required. FQDN that resolves to private endpoint ip address.')
     fqdn: string?
 
     @description('Required. A list of private ip addresses of the private endpoint.')

--- a/avm/res/document-db/database-account/sql-role/sql-role-assignments/main.bicep
+++ b/avm/res/document-db/database-account/sql-role/sql-role-assignments/main.bicep
@@ -8,7 +8,7 @@ param databaseAccountName string
 @description('Required. Name of the SQL Role Assignment.')
 param name string
 
-@description('Required. Id needs to be granted.')
+@description('Optional. Id needs to be granted.')
 param principalId string = ''
 
 @description('Required. Id of the SQL Role Definition.')

--- a/avm/res/document-db/mongo-cluster/README.md
+++ b/avm/res/document-db/mongo-cluster/README.md
@@ -1039,12 +1039,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint ip address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint ip address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private ip addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint ip address.
+FQDN that resolves to private endpoint ip address.
 
 - Required: No
 - Type: string

--- a/avm/res/document-db/mongo-cluster/main.bicep
+++ b/avm/res/document-db/mongo-cluster/main.bicep
@@ -447,7 +447,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint ip address.')
+    @description('Required. FQDN that resolves to private endpoint ip address.')
     fqdn: string?
 
     @description('Required. A list of private ip addresses of the private endpoint.')

--- a/avm/res/event-grid/domain/README.md
+++ b/avm/res/event-grid/domain/README.md
@@ -973,12 +973,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/event-grid/domain/main.bicep
+++ b/avm/res/event-grid/domain/main.bicep
@@ -376,7 +376,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/event-grid/namespace/README.md
+++ b/avm/res/event-grid/namespace/README.md
@@ -2356,12 +2356,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/event-grid/namespace/main.bicep
+++ b/avm/res/event-grid/namespace/main.bicep
@@ -543,7 +543,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/event-grid/topic/README.md
+++ b/avm/res/event-grid/topic/README.md
@@ -1119,12 +1119,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/event-grid/topic/main.bicep
+++ b/avm/res/event-grid/topic/main.bicep
@@ -386,7 +386,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/event-hub/namespace/README.md
+++ b/avm/res/event-hub/namespace/README.md
@@ -1777,12 +1777,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/event-hub/namespace/main.bicep
+++ b/avm/res/event-hub/namespace/main.bicep
@@ -578,7 +578,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/healthcare-apis/workspace/iotconnector/fhirdestination/main.bicep
+++ b/avm/res/healthcare-apis/workspace/iotconnector/fhirdestination/main.bicep
@@ -6,7 +6,7 @@ metadata owner = 'Azure/module-maintainers'
 @maxLength(24)
 param name string
 
-@description('Required. The mapping JSON that determines how normalized data is converted to FHIR Observations.')
+@description('Optional. The mapping JSON that determines how normalized data is converted to FHIR Observations.')
 param destinationMapping object = {
   templateType: 'CollectionFhir'
   template: []

--- a/avm/res/healthcare-apis/workspace/iotconnector/main.bicep
+++ b/avm/res/healthcare-apis/workspace/iotconnector/main.bicep
@@ -19,7 +19,7 @@ param consumerGroup string = name
 @description('Required. Namespace of the Event Hub to connect to.')
 param eventHubNamespaceName string
 
-@description('Required. The mapping JSON that determines how incoming device data is normalized.')
+@description('Optional. The mapping JSON that determines how incoming device data is normalized.')
 param deviceMapping object = {
   templateType: 'CollectionContent'
   template: []

--- a/avm/res/insights/private-link-scope/README.md
+++ b/avm/res/insights/private-link-scope/README.md
@@ -1319,12 +1319,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/insights/private-link-scope/main.bicep
+++ b/avm/res/insights/private-link-scope/main.bicep
@@ -326,7 +326,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/key-vault/vault/README.md
+++ b/avm/res/key-vault/vault/README.md
@@ -2477,12 +2477,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/key-vault/vault/main.bicep
+++ b/avm/res/key-vault/vault/main.bicep
@@ -512,7 +512,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/kusto/cluster/README.md
+++ b/avm/res/kusto/cluster/README.md
@@ -1341,12 +1341,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/kusto/cluster/main.bicep
+++ b/avm/res/kusto/cluster/main.bicep
@@ -531,7 +531,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/machine-learning-services/workspace/README.md
+++ b/avm/res/machine-learning-services/workspace/README.md
@@ -2174,12 +2174,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/machine-learning-services/workspace/main.bicep
+++ b/avm/res/machine-learning-services/workspace/main.bicep
@@ -540,7 +540,7 @@ type privateEndpointType = {
 
   @sys.description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @sys.description('Required. Fqdn that resolves to private endpoint IP address.')
+    @sys.description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @sys.description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/net-app/net-app-account/backup-policies/main.bicep
+++ b/avm/res/net-app/net-app-account/backup-policies/main.bicep
@@ -5,7 +5,7 @@ metadata owner = 'Azure/module-maintainers'
 @description('Conditional. The name of the parent NetApp account. Required if the template is used in a standalone deployment.')
 param netAppAccountName string
 
-@description('Required. The name of the backup policy.')
+@description('Optional. The name of the backup policy.')
 param backupPolicyName string = 'backupPolicy'
 
 @description('Optional. The location of the backup policy. Required if the template is used in a standalone deployment.')

--- a/avm/res/net-app/net-app-account/capacity-pool/main.bicep
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.bicep
@@ -23,9 +23,6 @@ param tags object?
 ])
 param serviceLevel string = 'Standard'
 
-@description('Required. Network features available to the volume, or current state of update (Basic/Standard).')
-param networkFeatures string = 'Standard'
-
 @description('Required. Provisioned size of the pool (in bytes). Allowed values are in 4TiB chunks (value must be multiply of 4398046511104).')
 param size int
 

--- a/avm/res/network/application-gateway/README.md
+++ b/avm/res/network/application-gateway/README.md
@@ -3571,12 +3571,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/network/application-gateway/main.bicep
+++ b/avm/res/network/application-gateway/main.bicep
@@ -560,7 +560,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/network/private-endpoint/README.md
+++ b/avm/res/network/private-endpoint/README.md
@@ -830,12 +830,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-customdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-customdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-customdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: Yes
 - Type: string

--- a/avm/res/network/private-endpoint/main.bicep
+++ b/avm/res/network/private-endpoint/main.bicep
@@ -290,7 +290,7 @@ type privateLinkServiceConnectionsType = {
 }[]?
 
 type customDnsConfigType = {
-  @description('Required. Fqdn that resolves to private endpoint IP address.')
+  @description('Required. FQDN that resolves to private endpoint IP address.')
   fqdn: string
 
   @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/operational-insights/workspace/linked-service/main.bicep
+++ b/avm/res/operational-insights/workspace/linked-service/main.bicep
@@ -8,7 +8,7 @@ param logAnalyticsWorkspaceName string
 @description('Required. Name of the link.')
 param name string
 
-@description('Required. The resource ID of the resource that will be linked to the workspace. This should be used for linking resources which require read access.')
+@description('Optional. The resource ID of the resource that will be linked to the workspace. This should be used for linking resources which require read access.')
 param resourceId string = ''
 
 @description('Optional. The resource ID of the resource that will be linked to the workspace. This should be used for linking resources which require write access.')

--- a/avm/res/purview/account/README.md
+++ b/avm/res/purview/account/README.md
@@ -1078,12 +1078,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-accountprivateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-accountprivateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-accountprivateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `accountPrivateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string
@@ -1627,12 +1627,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-eventhubprivateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-eventhubprivateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-eventhubprivateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `eventHubPrivateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string
@@ -2094,12 +2094,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-portalprivateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-portalprivateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-portalprivateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `portalPrivateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string
@@ -2608,12 +2608,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-storageblobprivateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-storageblobprivateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-storageblobprivateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `storageBlobPrivateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string
@@ -3009,12 +3009,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-storagequeueprivateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-storagequeueprivateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-storagequeueprivateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `storageQueuePrivateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/purview/account/main.bicep
+++ b/avm/res/purview/account/main.bicep
@@ -650,7 +650,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/recovery-services/vault/README.md
+++ b/avm/res/recovery-services/vault/README.md
@@ -3061,12 +3061,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/recovery-services/vault/main.bicep
+++ b/avm/res/recovery-services/vault/main.bicep
@@ -493,7 +493,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/recovery-services/vault/replication-fabric/main.bicep
+++ b/avm/res/recovery-services/vault/replication-fabric/main.bicep
@@ -7,7 +7,7 @@ metadata owner = 'Azure/module-maintainers'
 @description('Conditional. The name of the parent Azure Recovery Service Vault. Required if the template is used in a standalone deployment.')
 param recoveryVaultName string
 
-@description('Required. The recovery location the fabric represents.')
+@description('Optional. The recovery location the fabric represents.')
 param location string = resourceGroup().location
 
 @description('Optional. The name of the fabric.')
@@ -33,9 +33,7 @@ module fabric_replicationContainers 'replication-protection-container/main.bicep
       name: container.name
       recoveryVaultName: recoveryVaultName
       replicationFabricName: name
-      replicationContainerMappings: contains(container, 'replicationContainerMappings')
-        ? container.replicationContainerMappings
-        : []
+      replicationContainerMappings: container.?replicationContainerMappings
     }
     dependsOn: [
       replicationFabric

--- a/avm/res/recovery-services/vault/replication-fabric/replication-protection-container/main.bicep
+++ b/avm/res/recovery-services/vault/replication-fabric/replication-protection-container/main.bicep
@@ -31,19 +31,15 @@ module fabric_container_containerMappings 'replication-protection-container-mapp
   for (mapping, index) in replicationContainerMappings: {
     name: '${deployment().name}-Map-${index}'
     params: {
-      name: contains(mapping, 'name') ? mapping.name : ''
-      policyId: contains(mapping, 'policyId') ? mapping.policyId : ''
-      policyName: contains(mapping, 'policyName') ? mapping.policyName : ''
+      name: mapping.?name
+      policyId: mapping.?policyId
+      policyName: mapping.?policyName
       recoveryVaultName: recoveryVaultName
       replicationFabricName: replicationFabricName
       sourceProtectionContainerName: name
-      targetProtectionContainerId: contains(mapping, 'targetProtectionContainerId')
-        ? mapping.targetProtectionContainerId
-        : ''
-      targetContainerFabricName: contains(mapping, 'targetContainerFabricName')
-        ? mapping.targetContainerFabricName
-        : replicationFabricName
-      targetContainerName: contains(mapping, 'targetContainerName') ? mapping.targetContainerName : ''
+      targetProtectionContainerId: mapping.?targetProtectionContainerId
+      targetContainerFabricName: mapping.?targetContainerFabricName
+      targetContainerName: mapping.?targetContainerName
     }
     dependsOn: [
       replicationContainer

--- a/avm/res/relay/namespace/README.md
+++ b/avm/res/relay/namespace/README.md
@@ -1250,12 +1250,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/relay/namespace/main.bicep
+++ b/avm/res/relay/namespace/main.bicep
@@ -433,7 +433,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/search/search-service/README.md
+++ b/avm/res/search/search-service/README.md
@@ -1340,12 +1340,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/search/search-service/main.bicep
+++ b/avm/res/search/search-service/main.bicep
@@ -467,7 +467,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/service-bus/namespace/README.md
+++ b/avm/res/service-bus/namespace/README.md
@@ -1527,7 +1527,6 @@ param topics = [
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-name) | string | Name of the Service Bus Namespace. |
-| [`skuObject`](#parameter-skuobject) | object | The SKU of the Service Bus Namespace. Defaulted to Premium for ZoneRedundant configurations by default. |
 
 **Optional parameters**
 
@@ -1552,6 +1551,7 @@ param topics = [
 | [`queues`](#parameter-queues) | array | The queues to create in the service bus namespace. |
 | [`requireInfrastructureEncryption`](#parameter-requireinfrastructureencryption) | bool | Enable infrastructure encryption (double encryption). Note, this setting requires the configuration of Customer-Managed-Keys (CMK) via the corresponding module parameters. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
+| [`skuObject`](#parameter-skuobject) | object | The SKU of the Service Bus Namespace. Defaulted to Premium for ZoneRedundant configurations by default. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`topics`](#parameter-topics) | array | The topics to create in the service bus namespace. |
 | [`zoneRedundant`](#parameter-zoneredundant) | bool | Enabled by default in order to align with resiliency best practices, thus requires Premium SKU. |
@@ -1562,54 +1562,6 @@ Name of the Service Bus Namespace.
 
 - Required: Yes
 - Type: string
-
-### Parameter: `skuObject`
-
-The SKU of the Service Bus Namespace. Defaulted to Premium for ZoneRedundant configurations by default.
-
-- Required: No
-- Type: object
-- Default:
-  ```Bicep
-  {
-      capacity: 2
-      name: 'Premium'
-  }
-  ```
-
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`name`](#parameter-skuobjectname) | string | Name of this SKU. - Basic, Standard, Premium. |
-
-**Optional parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`capacity`](#parameter-skuobjectcapacity) | int | The specified messaging units for the tier. Only used for Premium Sku tier. |
-
-### Parameter: `skuObject.name`
-
-Name of this SKU. - Basic, Standard, Premium.
-
-- Required: Yes
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'Basic'
-    'Premium'
-    'Standard'
-  ]
-  ```
-
-### Parameter: `skuObject.capacity`
-
-The specified messaging units for the tier. Only used for Premium Sku tier.
-
-- Required: No
-- Type: int
 
 ### Parameter: `alternateName`
 
@@ -2217,12 +2169,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string
@@ -3047,6 +2999,54 @@ The principal type of the assigned principal ID.
     'User'
   ]
   ```
+
+### Parameter: `skuObject`
+
+The SKU of the Service Bus Namespace. Defaulted to Premium for ZoneRedundant configurations by default.
+
+- Required: No
+- Type: object
+- Default:
+  ```Bicep
+  {
+      capacity: 2
+      name: 'Premium'
+  }
+  ```
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-skuobjectname) | string | Name of this SKU. - Basic, Standard, Premium. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`capacity`](#parameter-skuobjectcapacity) | int | The specified messaging units for the tier. Only used for Premium Sku tier. |
+
+### Parameter: `skuObject.name`
+
+Name of this SKU. - Basic, Standard, Premium.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Basic'
+    'Premium'
+    'Standard'
+  ]
+  ```
+
+### Parameter: `skuObject.capacity`
+
+The specified messaging units for the tier. Only used for Premium Sku tier.
+
+- Required: No
+- Type: int
 
 ### Parameter: `tags`
 

--- a/avm/res/service-bus/namespace/main.bicep
+++ b/avm/res/service-bus/namespace/main.bicep
@@ -552,7 +552,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/service-bus/namespace/main.bicep
+++ b/avm/res/service-bus/namespace/main.bicep
@@ -9,7 +9,7 @@ param name string
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
-@description('Required. The SKU of the Service Bus Namespace. Defaulted to Premium for ZoneRedundant configurations by default.')
+@description('Optional. The SKU of the Service Bus Namespace. Defaulted to Premium for ZoneRedundant configurations by default.')
 param skuObject skuType = {
   name: 'Premium'
   capacity: 2

--- a/avm/res/signal-r-service/signal-r/README.md
+++ b/avm/res/signal-r-service/signal-r/README.md
@@ -935,12 +935,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/signal-r-service/signal-r/main.bicep
+++ b/avm/res/signal-r-service/signal-r/main.bicep
@@ -420,7 +420,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/signal-r-service/web-pub-sub/README.md
+++ b/avm/res/signal-r-service/web-pub-sub/README.md
@@ -910,12 +910,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/signal-r-service/web-pub-sub/main.bicep
+++ b/avm/res/signal-r-service/web-pub-sub/main.bicep
@@ -392,7 +392,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -2047,12 +2047,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -612,7 +612,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/storage/storage-account/README.md
+++ b/avm/res/storage/storage-account/README.md
@@ -3830,12 +3830,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint ip address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint ip address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private ip addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint ip address.
+FQDN that resolves to private endpoint ip address.
 
 - Required: No
 - Type: string

--- a/avm/res/storage/storage-account/main.bicep
+++ b/avm/res/storage/storage-account/main.bicep
@@ -831,7 +831,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint ip address.')
+    @description('Required. FQDN that resolves to private endpoint ip address.')
     fqdn: string?
 
     @description('Required. A list of private ip addresses of the private endpoint.')

--- a/avm/res/storage/storage-account/queue-service/queue/main.bicep
+++ b/avm/res/storage/storage-account/queue-service/queue/main.bicep
@@ -9,7 +9,7 @@ param storageAccountName string
 @description('Required. The name of the storage queue to deploy.')
 param name string
 
-@description('Required. A name-value pair that represents queue metadata.')
+@description('Optional. A name-value pair that represents queue metadata.')
 param metadata object = {}
 
 @description('Optional. Array of role assignments to create.')

--- a/avm/res/synapse/private-link-hub/README.md
+++ b/avm/res/synapse/private-link-hub/README.md
@@ -598,12 +598,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/synapse/private-link-hub/main.bicep
+++ b/avm/res/synapse/private-link-hub/main.bicep
@@ -256,7 +256,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/synapse/workspace/README.md
+++ b/avm/res/synapse/workspace/README.md
@@ -1742,12 +1742,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/synapse/workspace/main.bicep
+++ b/avm/res/synapse/workspace/main.bicep
@@ -532,7 +532,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/web/site/README.md
+++ b/avm/res/web/site/README.md
@@ -3563,15 +3563,13 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
-### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
+**Optional parameters**
 
-Fqdn that resolves to private endpoint IP address.
-
-- Required: No
-- Type: string
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.ipAddresses`
 
@@ -3579,6 +3577,13 @@ A list of private IP addresses of the private endpoint.
 
 - Required: Yes
 - Type: array
+
+### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
+
+FQDN that resolves to private endpoint IP address.
+
+- Required: No
+- Type: string
 
 ### Parameter: `privateEndpoints.customNetworkInterfaceName`
 

--- a/avm/res/web/site/config--logs/main.bicep
+++ b/avm/res/web/site/config--logs/main.bicep
@@ -5,7 +5,7 @@ metadata owner = 'Azure/module-maintainers'
 @description('Required. The name of the parent site resource.')
 param appName string
 
-@description('Required. The logs settings configuration.')
+@description('Optional. The logs settings configuration.')
 param logsConfiguration object?
 
 resource app 'Microsoft.Web/sites@2023-12-01' existing = {

--- a/avm/res/web/site/config--web/main.bicep
+++ b/avm/res/web/site/config--web/main.bicep
@@ -5,7 +5,7 @@ metadata owner = 'Azure/module-maintainers'
 @description('Required. The name of the parent site resource.')
 param appName string
 
-@description('Required. The web settings api management configuration.')
+@description('Optional. The web settings api management configuration.')
 param apiManagementConfiguration object?
 
 resource app 'Microsoft.Web/sites@2023-12-01' existing = {

--- a/avm/res/web/site/extensions--msdeploy/main.bicep
+++ b/avm/res/web/site/extensions--msdeploy/main.bicep
@@ -5,7 +5,7 @@ metadata owner = 'Azure/module-maintainers'
 @description('Required. The name of the parent site resource.')
 param appName string
 
-@description('Required. Sets the MSDeployment Properties.')
+@description('Optional. Sets the MSDeployment Properties.')
 param msDeployConfiguration object?
 
 resource app 'Microsoft.Web/sites@2023-12-01' existing = {

--- a/avm/res/web/site/main.bicep
+++ b/avm/res/web/site/main.bicep
@@ -657,7 +657,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/web/site/main.bicep
+++ b/avm/res/web/site/main.bicep
@@ -657,7 +657,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. FQDN that resolves to private endpoint IP address.')
+    @description('Optional. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/web/site/slot/extensions--msdeploy/main.bicep
+++ b/avm/res/web/site/slot/extensions--msdeploy/main.bicep
@@ -5,7 +5,7 @@ metadata owner = 'Azure/module-maintainers'
 @description('Required. The name of the parent site resource.')
 param appName string
 
-@description('Required. Sets the MSDeployment Properties.')
+@description('Optional. Sets the MSDeployment Properties.')
 param msDeployConfiguration object?
 
 resource app 'Microsoft.Web/sites@2023-12-01' existing = {

--- a/avm/res/web/site/slot/main.bicep
+++ b/avm/res/web/site/slot/main.bicep
@@ -534,7 +534,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/res/web/static-site/README.md
+++ b/avm/res/web/static-site/README.md
@@ -874,12 +874,12 @@ Custom DNS configurations.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | Fqdn that resolves to private endpoint IP address. |
+| [`fqdn`](#parameter-privateendpointscustomdnsconfigsfqdn) | string | FQDN that resolves to private endpoint IP address. |
 | [`ipAddresses`](#parameter-privateendpointscustomdnsconfigsipaddresses) | array | A list of private IP addresses of the private endpoint. |
 
 ### Parameter: `privateEndpoints.customDnsConfigs.fqdn`
 
-Fqdn that resolves to private endpoint IP address.
+FQDN that resolves to private endpoint IP address.
 
 - Required: No
 - Type: string

--- a/avm/res/web/static-site/main.bicep
+++ b/avm/res/web/static-site/main.bicep
@@ -408,7 +408,7 @@ type privateEndpointType = {
 
   @description('Optional. Custom DNS configurations.')
   customDnsConfigs: {
-    @description('Required. Fqdn that resolves to private endpoint IP address.')
+    @description('Required. FQDN that resolves to private endpoint IP address.')
     fqdn: string?
 
     @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/utl/types/avm-common-types/main.bicep
+++ b/avm/utl/types/avm-common-types/main.bicep
@@ -221,7 +221,7 @@ type privateEndpointPrivateDnsZoneGroupType = {
 }
 
 type privateEndpointCustomDnsConfigType = {
-  @description('Optional. Fqdn that resolves to private endpoint IP address.')
+  @description('Optional. FQDN that resolves to private endpoint IP address.')
   fqdn: string?
 
   @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/utl/types/avm-common-types/main.bicep
+++ b/avm/utl/types/avm-common-types/main.bicep
@@ -221,7 +221,7 @@ type privateEndpointPrivateDnsZoneGroupType = {
 }
 
 type privateEndpointCustomDnsConfigType = {
-  @description('Required. Fqdn that resolves to private endpoint IP address.')
+  @description('Optional. Fqdn that resolves to private endpoint IP address.')
   fqdn: string?
 
   @description('Required. A list of private IP addresses of the private endpoint.')

--- a/avm/utl/types/avm-common-types/main.json
+++ b/avm/utl/types/avm-common-types/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "3702359687684026662"
+      "templateHash": "5379800043788600368"
     },
     "name": "Default interface types for AVM modules",
     "description": "This module provides you with all common variants for AVM interfaces to be used in AVM modules.\n\nDetails for how to implement these interfaces can be found in the AVM documentation [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/interfaces).\n",
@@ -520,7 +520,7 @@
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Required. Fqdn that resolves to private endpoint IP address."
+            "description": "Optional. Fqdn that resolves to private endpoint IP address."
           }
         },
         "ipAddresses": {

--- a/avm/utl/types/avm-common-types/main.json
+++ b/avm/utl/types/avm-common-types/main.json
@@ -520,7 +520,7 @@
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Fqdn that resolves to private endpoint IP address."
+            "description": "Optional. FQDN that resolves to private endpoint IP address."
           }
         },
         "ipAddresses": {


### PR DESCRIPTION
## Description

- Fixed incorrect parameter description: The FQDN parameter is optional, yet the description said it was required.
- Fixed static test validating parameter descriptions
   - It checked for a line that looke like `('Required.` even though the value of the `$description` variable at the time only has the description's value, that is `Required.`
- Added test that tests the reverse, that is, that a parameter's description starts with `Required.` in its title if it is required

> Linked to https://github.com/Azure/Azure-Verified-Modules/pull/1591

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.utl.types.avm-common-types](https://github.com/AlexanderSehr/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml/badge.svg?branch=users%2Falsehr%2FudtModuleMetaFix&event=workflow_dispatch)](https://github.com/AlexanderSehr/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
