### PR TITLE
fix: Common Types - Added missing `export()` annotation

### DIFF
--- a/avm/utl/types/avm-common-types/README.md
+++ b/avm/utl/types/avm-common-types/README.md
@@ -65,7 +65,7 @@ import {
   privateEndpointMultiServiceType
   privateEndpointSingleServiceType
   secretToSetType
-  secretSetType
+  secretSetOutputType
 } from '../../../main.bicep' // Would be: br/public:avm/utl/types/avm-common-types:<version>
 
 //  ====================== //
@@ -309,14 +309,14 @@ param secretToSet secretToSetType[] = [
 #disable-next-line outputs-should-not-contain-secrets // Does not contain a secret
 output secretToSetOutput secretToSetType[] = secretToSet
 
-param secretSet secretSetType[] = [
+param secretSet secretSetOutputType[] = [
   {
     secretResourceId: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.KeyVault/vaults/myVault/secrets/mySecret'
     secretUri: 'https://myVault.${az.environment().suffixes.keyvaultDns}/secrets/mySecret'
     secretUriWithVersion: 'https://myVault.${az.environment().suffixes.keyvaultDns}/secrets/mySecret/2f4783701d724537a4e0c2d473c31846'
   }
 ]
-output secretSetOutput secretSetType[] = secretSet
+output secretSetOutput secretSetOutputType[] = secretSet
 ```
 
 </details>

--- a/avm/utl/types/avm-common-types/main.bicep
+++ b/avm/utl/types/avm-common-types/main.bicep
@@ -380,20 +380,6 @@ type customerManagedKeyType = {
 // ================== //
 //   Secrets Export   //
 // ================== //
-
-@export()
-@description('An AVM-aligned type for the output of the secret set via the secrets export feature.')
-type secretSetType = {
-  @description('The resourceId of the exported secret.')
-  secretResourceId: string
-
-  @description('The secret URI of the exported secret.')
-  secretUri: string
-
-  @description('The secret URI with version of the exported secret.')
-  secretUriWithVersion: string
-}
-
 @export()
 @description('An AVM-aligned type for the secret to set via the secrets export feature.')
 type secretToSetType = {
@@ -406,7 +392,20 @@ type secretToSetType = {
 }
 
 @export()
+@description('An AVM-aligned type for the output of the secret set via the secrets export feature.')
+type secretSetOutputType = {
+  @description('The resourceId of the exported secret.')
+  secretResourceId: string
+
+  @description('The secret URI of the exported secret.')
+  secretUri: string
+
+  @description('The secret URI with version of the exported secret.')
+  secretUriWithVersion: string
+}
+
+@export()
 type secretsOutputType = {
   @description('An exported secret\'s references.')
-  *: secretSetType
+  *: secretSetOutputType
 }

--- a/avm/utl/types/avm-common-types/main.bicep
+++ b/avm/utl/types/avm-common-types/main.bicep
@@ -405,6 +405,7 @@ type secretToSetType = {
   value: string
 }
 
+@export()
 type secretsOutputType = {
   @description('An exported secret\'s references.')
   *: secretSetType

--- a/avm/utl/types/avm-common-types/main.bicep
+++ b/avm/utl/types/avm-common-types/main.bicep
@@ -405,6 +405,7 @@ type secretSetOutputType = {
 }
 
 @export()
+@description('A map of the exported secrets')
 type secretsOutputType = {
   @description('An exported secret\'s references.')
   *: secretSetOutputType

--- a/avm/utl/types/avm-common-types/main.json
+++ b/avm/utl/types/avm-common-types/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "582259741550098970"
+      "templateHash": "16862752319174543465"
     },
     "name": "Default interface types for AVM modules",
     "description": "This module provides you with all common variants for AVM interfaces to be used in AVM modules.\n\nDetails for how to implement these interfaces can be found in the AVM documentation [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/interfaces).\n",
@@ -885,7 +885,28 @@
         "description": "An AVM-aligned type for a customer-managed key."
       }
     },
-    "secretSetType": {
+    "secretToSetType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the secret to set."
+          }
+        },
+        "value": {
+          "type": "securestring",
+          "metadata": {
+            "description": "Required. The value of the secret to set."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "An AVM-aligned type for the secret to set via the secrets export feature."
+      }
+    },
+    "secretSetOutputType": {
       "type": "object",
       "properties": {
         "secretResourceId": {
@@ -912,38 +933,18 @@
         "description": "An AVM-aligned type for the output of the secret set via the secrets export feature."
       }
     },
-    "secretToSetType": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. The name of the secret to set."
-          }
-        },
-        "value": {
-          "type": "securestring",
-          "metadata": {
-            "description": "Required. The value of the secret to set."
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true,
-        "description": "An AVM-aligned type for the secret to set via the secrets export feature."
-      }
-    },
     "secretsOutputType": {
       "type": "object",
       "properties": {},
       "additionalProperties": {
-        "$ref": "#/definitions/secretSetType",
+        "$ref": "#/definitions/secretSetOutputType",
         "metadata": {
           "description": "An exported secret's references."
         }
       },
       "metadata": {
-        "__bicep_export!": true
+        "__bicep_export!": true,
+        "description": "A map of the exported secrets"
       }
     }
   },

--- a/avm/utl/types/avm-common-types/main.json
+++ b/avm/utl/types/avm-common-types/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "3702359687684026662"
+      "templateHash": "582259741550098970"
     },
     "name": "Default interface types for AVM modules",
     "description": "This module provides you with all common variants for AVM interfaces to be used in AVM modules.\n\nDetails for how to implement these interfaces can be found in the AVM documentation [here](https://azure.github.io/Azure-Verified-Modules/specs/shared/interfaces).\n",
@@ -941,6 +941,9 @@
         "metadata": {
           "description": "An exported secret's references."
         }
+      },
+      "metadata": {
+        "__bicep_export!": true
       }
     }
   },

--- a/avm/utl/types/avm-common-types/tests/e2e/import/main.test.bicep
+++ b/avm/utl/types/avm-common-types/tests/e2e/import/main.test.bicep
@@ -24,7 +24,7 @@ import {
   privateEndpointMultiServiceType
   privateEndpointSingleServiceType
   secretToSetType
-  secretSetType
+  secretSetOutputType
 } from '../../../main.bicep' // Would be: br/public:avm/utl/types/avm-common-types:<version>
 
 //  ====================== //
@@ -268,11 +268,11 @@ param secretToSet secretToSetType[] = [
 #disable-next-line outputs-should-not-contain-secrets // Does not contain a secret
 output secretToSetOutput secretToSetType[] = secretToSet
 
-param secretSet secretSetType[] = [
+param secretSet secretSetOutputType[] = [
   {
     secretResourceId: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.KeyVault/vaults/myVault/secrets/mySecret'
     secretUri: 'https://myVault.${az.environment().suffixes.keyvaultDns}/secrets/mySecret'
     secretUriWithVersion: 'https://myVault.${az.environment().suffixes.keyvaultDns}/secrets/mySecret/2f4783701d724537a4e0c2d473c31846'
   }
 ]
-output secretSetOutput secretSetType[] = secretSet
+output secretSetOutput secretSetOutputType[] = secretSet

--- a/avm/utl/types/avm-common-types/version.json
+++ b/avm/utl/types/avm-common-types/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.1",
+    "version": "0.2",
     "pathFilters": [
         "./main.json"
     ]


### PR DESCRIPTION
## Description

- Added missing `export()` annotation

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|  [![avm.utl.types.avm-common-types](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml/badge.svg?branch=users%2Falsehr%2FsecretExportFix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml)        |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
