### PR TITLE
API Management Service - link fix

### DIFF
--- a/avm/res/api-management/service/README.md
+++ b/avm/res/api-management/service/README.md
@@ -2431,7 +2431,7 @@ A list of availability zones denoting where the resource needs to come from. Onl
 
 ## Notes
 
-The latest version of this module only includes supported versions of the API Management resource. All unsupported versions of API Management have been removed from the related parameters. See the [API Management stv1 platform retirement](!https://learn.microsoft.com/en-us/azure/api-management/breaking-changes/stv1-platform-retirement-august-2024) article for more details.
+The latest version of this module only includes supported versions of the API Management resource. All unsupported versions of API Management have been removed from the related parameters. See the [API Management stv1 platform retirement](https://learn.microsoft.com/en-us/azure/api-management/breaking-changes/stv1-platform-retirement-august-2024) article for more details.
 
 ### Parameter Usage: `apiManagementServicePolicy`
 


### PR DESCRIPTION
Fixing link in the notes section of for API Management / Service.