### PR TITLE
fix: Do not set differential backup interval for Hyperscale tiers

### DIFF
--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -2232,12 +2232,12 @@ The short term backup retention policy for the database.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`diffBackupIntervalInHours`](#parameter-databasesbackupshorttermretentionpolicydiffbackupintervalinhours) | int | Differential backup interval in hours. |
+| [`diffBackupIntervalInHours`](#parameter-databasesbackupshorttermretentionpolicydiffbackupintervalinhours) | int | Differential backup interval in hours. For Hyperscale tiers this value will be ignored. |
 | [`retentionDays`](#parameter-databasesbackupshorttermretentionpolicyretentiondays) | int | Point-in-time retention in days. |
 
 ### Parameter: `databases.backupShortTermRetentionPolicy.diffBackupIntervalInHours`
 
-Differential backup interval in hours.
+Differential backup interval in hours. For Hyperscale tiers this value will be ignored.
 
 - Required: No
 - Type: int

--- a/avm/res/sql/server/database/README.md
+++ b/avm/res/sql/server/database/README.md
@@ -193,12 +193,12 @@ The short term backup retention policy to create for the database.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`diffBackupIntervalInHours`](#parameter-backupshorttermretentionpolicydiffbackupintervalinhours) | int | Differential backup interval in hours. |
+| [`diffBackupIntervalInHours`](#parameter-backupshorttermretentionpolicydiffbackupintervalinhours) | int | Differential backup interval in hours. For Hyperscale tiers this value will be ignored. |
 | [`retentionDays`](#parameter-backupshorttermretentionpolicyretentiondays) | int | Point-in-time retention in days. |
 
 ### Parameter: `backupShortTermRetentionPolicy.diffBackupIntervalInHours`
 
-Differential backup interval in hours.
+Differential backup interval in hours. For Hyperscale tiers this value will be ignored.
 
 - Required: No
 - Type: int

--- a/avm/res/sql/server/database/backup-short-term-retention-policy/README.md
+++ b/avm/res/sql/server/database/backup-short-term-retention-policy/README.md
@@ -27,7 +27,7 @@ This module deploys an Azure SQL Server Database Short-Term Backup Retention Pol
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`diffBackupIntervalInHours`](#parameter-diffbackupintervalinhours) | int | Differential backup interval in hours. |
+| [`diffBackupIntervalInHours`](#parameter-diffbackupintervalinhours) | int | Differential backup interval in hours. For Hyperscal tiers this value will be ignored. |
 | [`retentionDays`](#parameter-retentiondays) | int | Poin-in-time retention in days. |
 
 ### Parameter: `databaseName`
@@ -46,7 +46,7 @@ The name of the parent SQL Server.
 
 ### Parameter: `diffBackupIntervalInHours`
 
-Differential backup interval in hours.
+Differential backup interval in hours. For Hyperscal tiers this value will be ignored.
 
 - Required: No
 - Type: int

--- a/avm/res/sql/server/database/backup-short-term-retention-policy/main.bicep
+++ b/avm/res/sql/server/database/backup-short-term-retention-policy/main.bicep
@@ -8,7 +8,7 @@ param serverName string
 @description('Required. The name of the parent database.')
 param databaseName string
 
-@description('Optional. Differential backup interval in hours.')
+@description('Optional. Differential backup interval in hours. For Hyperscal tiers this value will be ignored.')
 param diffBackupIntervalInHours int = 24
 
 @description('Optional. Poin-in-time retention in days.')
@@ -26,7 +26,7 @@ resource backupShortTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupS
   name: 'default'
   parent: server::database
   properties: {
-    diffBackupIntervalInHours: diffBackupIntervalInHours
+    diffBackupIntervalInHours: server::database.sku.tier == 'Hyperscale' ? null : diffBackupIntervalInHours
     retentionDays: retentionDays
   }
 }

--- a/avm/res/sql/server/database/backup-short-term-retention-policy/main.json
+++ b/avm/res/sql/server/database/backup-short-term-retention-policy/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "10836519140305169908"
+      "templateHash": "14890409200962565555"
     },
     "name": "Azure SQL Server Database Short Term Backup Retention Policies",
     "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy.",
@@ -28,7 +28,7 @@
       "type": "int",
       "defaultValue": 24,
       "metadata": {
-        "description": "Optional. Differential backup interval in hours."
+        "description": "Optional. Differential backup interval in hours. For Hyperscal tiers this value will be ignored."
       }
     },
     "retentionDays": {
@@ -45,7 +45,7 @@
       "apiVersion": "2023-08-01-preview",
       "name": "[format('{0}/{1}/{2}', parameters('serverName'), parameters('databaseName'), 'default')]",
       "properties": {
-        "diffBackupIntervalInHours": "[parameters('diffBackupIntervalInHours')]",
+        "diffBackupIntervalInHours": "[if(equals(reference(resourceId('Microsoft.Sql/servers/databases', parameters('serverName'), parameters('databaseName')), '2023-08-01-preview', 'full').sku.tier, 'Hyperscale'), null(), parameters('diffBackupIntervalInHours'))]",
         "retentionDays": "[parameters('retentionDays')]"
       }
     }

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -288,7 +288,7 @@ type databaseSkuType = {
 @export()
 @description('The short-term backup retention policy for the database.')
 type shortTermBackupRetentionPolicyType = {
-  @description('Optional. Differential backup interval in hours.')
+  @description('Optional. Differential backup interval in hours. For Hyperscale tiers this value will be ignored.')
   diffBackupIntervalInHours: int?
 
   @description('Optional. Point-in-time retention in days.')

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "16852610103772351522"
+      "templateHash": "18018827030977470456"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database.",
@@ -63,7 +63,7 @@
           "type": "int",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Differential backup interval in hours."
+            "description": "Optional. Differential backup interval in hours. For Hyperscale tiers this value will be ignored."
           }
         },
         "retentionDays": {
@@ -722,7 +722,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.30.23.60470",
-              "templateHash": "10836519140305169908"
+              "templateHash": "14890409200962565555"
             },
             "name": "Azure SQL Server Database Short Term Backup Retention Policies",
             "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy.",
@@ -745,7 +745,7 @@
               "type": "int",
               "defaultValue": 24,
               "metadata": {
-                "description": "Optional. Differential backup interval in hours."
+                "description": "Optional. Differential backup interval in hours. For Hyperscal tiers this value will be ignored."
               }
             },
             "retentionDays": {
@@ -762,7 +762,7 @@
               "apiVersion": "2023-08-01-preview",
               "name": "[format('{0}/{1}/{2}', parameters('serverName'), parameters('databaseName'), 'default')]",
               "properties": {
-                "diffBackupIntervalInHours": "[parameters('diffBackupIntervalInHours')]",
+                "diffBackupIntervalInHours": "[if(equals(reference(resourceId('Microsoft.Sql/servers/databases', parameters('serverName'), parameters('databaseName')), '2023-08-01-preview', 'full').sku.tier, 'Hyperscale'), null(), parameters('diffBackupIntervalInHours'))]",
                 "retentionDays": "[parameters('retentionDays')]"
               }
             }

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.30.23.60470",
-      "templateHash": "7056733976380310540"
+      "templateHash": "14327182870559615261"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server.",
@@ -1371,7 +1371,7 @@
           "type": "int",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Differential backup interval in hours."
+            "description": "Optional. Differential backup interval in hours. For Hyperscale tiers this value will be ignored."
           }
         },
         "retentionDays": {
@@ -1871,7 +1871,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.30.23.60470",
-              "templateHash": "16852610103772351522"
+              "templateHash": "18018827030977470456"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database.",
@@ -1928,7 +1928,7 @@
                   "type": "int",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. Differential backup interval in hours."
+                    "description": "Optional. Differential backup interval in hours. For Hyperscale tiers this value will be ignored."
                   }
                 },
                 "retentionDays": {
@@ -2587,7 +2587,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.30.23.60470",
-                      "templateHash": "10836519140305169908"
+                      "templateHash": "14890409200962565555"
                     },
                     "name": "Azure SQL Server Database Short Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy.",
@@ -2610,7 +2610,7 @@
                       "type": "int",
                       "defaultValue": 24,
                       "metadata": {
-                        "description": "Optional. Differential backup interval in hours."
+                        "description": "Optional. Differential backup interval in hours. For Hyperscal tiers this value will be ignored."
                       }
                     },
                     "retentionDays": {
@@ -2627,7 +2627,7 @@
                       "apiVersion": "2023-08-01-preview",
                       "name": "[format('{0}/{1}/{2}', parameters('serverName'), parameters('databaseName'), 'default')]",
                       "properties": {
-                        "diffBackupIntervalInHours": "[parameters('diffBackupIntervalInHours')]",
+                        "diffBackupIntervalInHours": "[if(equals(reference(resourceId('Microsoft.Sql/servers/databases', parameters('serverName'), parameters('databaseName')), '2023-08-01-preview', 'full').sku.tier, 'Hyperscale'), null(), parameters('diffBackupIntervalInHours'))]",
                         "retentionDays": "[parameters('retentionDays')]"
                       }
                     }


### PR DESCRIPTION
There are no Hyperscale tests in the repo (if needed we can add), but I have tested it with an ad-hoc test.

Fixes #2469

## Description

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.sql.server](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg)](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml)     |

pls note: Maintenance window is not available in my subscription, hence WAF test is failing.

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
