### PR TITLE
feat: Removed 'default-value' workaround for secrets that was originally needed to be PSRule compatible

### DIFF
--- a/avm/res/compute/virtual-machine/tests/e2e/linux.max/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/linux.max/main.test.bicep
@@ -23,7 +23,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the Backup Management Service Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-BackupManagementServiceEnterpriseApplicationObjectId\'.')
 @secure()
-param backupManagementServiceEnterpriseApplicationObjectId string = ''
+param backupManagementServiceEnterpriseApplicationObjectId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/compute/virtual-machine/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/waf-aligned/main.test.bicep
@@ -27,7 +27,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the Backup Management Service Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-BackupManagementServiceEnterpriseApplicationObjectId\'.')
 @secure()
-param backupManagementServiceEnterpriseApplicationObjectId string = ''
+param backupManagementServiceEnterpriseApplicationObjectId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/compute/virtual-machine/tests/e2e/windows.max/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/windows.max/main.test.bicep
@@ -27,7 +27,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the Backup Management Service Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-BackupManagementServiceEnterpriseApplicationObjectId\'.')
 @secure()
-param backupManagementServiceEnterpriseApplicationObjectId string = ''
+param backupManagementServiceEnterpriseApplicationObjectId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/databricks/workspace/tests/e2e/max/main.test.bicep
+++ b/avm/res/databricks/workspace/tests/e2e/max/main.test.bicep
@@ -25,7 +25,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the AzureDatabricks Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-AzureDatabricksEnterpriseApplicationObjectId\'.')
 @secure()
-param azureDatabricksEnterpriseApplicationObjectId string = ''
+param azureDatabricksEnterpriseApplicationObjectId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/databricks/workspace/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/databricks/workspace/tests/e2e/waf-aligned/main.test.bicep
@@ -25,7 +25,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The object id of the AzureDatabricks Enterprise Application. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-AzureDatabricksEnterpriseApplicationObjectId\'.')
 @secure()
-param azureDatabricksEnterpriseApplicationObjectId string = ''
+param azureDatabricksEnterpriseApplicationObjectId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/dev-ops-infrastructure/pool/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/dev-ops-infrastructure/pool/tests/e2e/defaults/main.test.bicep
@@ -18,7 +18,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. Name of the Azure DevOps organization. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-AzureDevOpsOrganizationName\'.')
 @secure()
-param azureDevOpsOrganizationName string = ''
+param azureDevOpsOrganizationName string
 
 // The Managed DevOps Pools resource is not available in all regions
 #disable-next-line no-hardcoded-location

--- a/avm/res/dev-ops-infrastructure/pool/tests/e2e/max/main.test.bicep
+++ b/avm/res/dev-ops-infrastructure/pool/tests/e2e/max/main.test.bicep
@@ -19,15 +19,15 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. Name of the Azure DevOps organization. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-AzureDevOpsOrganizationName\'.')
 @secure()
-param azureDevOpsOrganizationName string = ''
+param azureDevOpsOrganizationName string
 
 @description('Required. Name of the Azure DevOps Max Project. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-AzureDevOpsProjectName\'.')
 @secure()
-param azureDevOpsProjectName string = ''
+param azureDevOpsProjectName string
 
 @description('Required. The object ID of the Entra ID-provided DevOpsInfrastructure principal. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-DevOpsInfrastructureObjectID\'.')
 @secure()
-param devOpsInfrastructureObjectID string = ''
+param devOpsInfrastructureObjectID string
 
 // The Managed DevOps Pools resource is not available in all regions
 #disable-next-line no-hardcoded-location

--- a/avm/res/dev-ops-infrastructure/pool/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/dev-ops-infrastructure/pool/tests/e2e/waf-aligned/main.test.bicep
@@ -19,15 +19,15 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. Name of the Azure DevOps organization. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-AzureDevOpsOrganizationName\'.')
 @secure()
-param azureDevOpsOrganizationName string = ''
+param azureDevOpsOrganizationName string
 
 @description('Required. Name of the Azure DevOps WAF Project. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-AzureDevOpsProjectName\'.')
 @secure()
-param azureDevOpsProjectName string = ''
+param azureDevOpsProjectName string
 
 @description('Required. The object ID of the Entra ID-provided DevOpsInfrastructure principal. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-DevOpsInfrastructureObjectID\'.')
 @secure()
-param devOpsInfrastructureObjectID string = ''
+param devOpsInfrastructureObjectID string
 
 // The Managed DevOps Pools resource is not available in all regions
 #disable-next-line no-hardcoded-location

--- a/avm/res/fabric/capacity/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/fabric/capacity/tests/e2e/defaults/main.test.bicep
@@ -22,8 +22,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. Email address used by resource. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-adminMembersSecret\'.')
 @secure()
-param adminMembersSecret string = ''
-
+param adminMembersSecret string
 
 // ============ //
 // Dependencies //

--- a/avm/res/fabric/capacity/tests/e2e/max/main.test.bicep
+++ b/avm/res/fabric/capacity/tests/e2e/max/main.test.bicep
@@ -22,7 +22,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. Email address used by resource. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-adminMembersSecret\'.')
 @secure()
-param adminMembersSecret string = ''
+param adminMembersSecret string
 
 // ============ //
 // Dependencies //

--- a/avm/res/fabric/capacity/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/fabric/capacity/tests/e2e/waf-aligned/main.test.bicep
@@ -22,7 +22,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. Email address used by resource. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-adminMembersSecret\'.')
 @secure()
-param adminMembersSecret string = ''
+param adminMembersSecret string
 
 // ============ //
 // Dependencies //

--- a/avm/res/managed-services/registration-definition/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/managed-services/registration-definition/tests/e2e/defaults/main.test.bicep
@@ -18,7 +18,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The tenant Id of the lighthouse tenant. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-LighthouseManagedByTenantId\'.')
 @secure()
-param lighthouseManagedByTenantId string = ''
+param lighthouseManagedByTenantId string
 
 // ============== //
 // Test Execution //

--- a/avm/res/managed-services/registration-definition/tests/e2e/max/main.test.bicep
+++ b/avm/res/managed-services/registration-definition/tests/e2e/max/main.test.bicep
@@ -18,7 +18,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The tenant Id of the lighthouse tenant. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-LighthouseManagedByTenantId\'.')
 @secure()
-param lighthouseManagedByTenantId string = ''
+param lighthouseManagedByTenantId string
 
 // ============== //
 // Test Execution //

--- a/avm/res/managed-services/registration-definition/tests/e2e/rg/main.test.bicep
+++ b/avm/res/managed-services/registration-definition/tests/e2e/rg/main.test.bicep
@@ -22,7 +22,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The tenant Id of the lighthouse tenant. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-LighthouseManagedByTenantId\'.')
 @secure()
-param lighthouseManagedByTenantId string = ''
+param lighthouseManagedByTenantId string
 
 // ============ //
 // Dependencies //

--- a/avm/res/managed-services/registration-definition/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/managed-services/registration-definition/tests/e2e/waf-aligned/main.test.bicep
@@ -22,7 +22,7 @@ param namePrefix string = '#_namePrefix_#'
 
 @description('Required. The tenant Id of the lighthouse tenant. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-LighthouseManagedByTenantId\'.')
 @secure()
-param lighthouseManagedByTenantId string = ''
+param lighthouseManagedByTenantId string
 
 // ============ //
 // Dependencies //


### PR DESCRIPTION
## Description

Removed 'default-value' workaround for secrets that was originally needed to be PSRule compatible

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.compute.virtual-machine](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine.yml/badge.svg?branch=users%2Falsehr%2FremovedPSRuleWorkaroundForSecrets&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine.yml)
[![avm.res.databricks.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.workspace.yml/badge.svg?branch=users%2Falsehr%2FremovedPSRuleWorkaroundForSecrets&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.workspace.yml)
[![avm.res.dev-ops-infrastructure.pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-ops-infrastructure.pool.yml/badge.svg?branch=users%2Falsehr%2FremovedPSRuleWorkaroundForSecrets&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-ops-infrastructure.pool.yml)
[![avm.res.fabric.capacity](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.fabric.capacity.yml/badge.svg?branch=users%2Falsehr%2FremovedPSRuleWorkaroundForSecrets&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.fabric.capacity.yml)
[![avm.res.managed-services.registration-definition](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-services.registration-definition.yml/badge.svg?branch=users%2Falsehr%2FremovedPSRuleWorkaroundForSecrets&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-services.registration-definition.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
