### PR TITLE
fix: res/network/vpn-gateway - IPsec Policies Reset on Subsequent Deployments

### DIFF
--- a/avm/res/network/vpn-gateway/main.bicep
+++ b/avm/res/network/vpn-gateway/main.bicep
@@ -143,6 +143,7 @@ module vpnGateway_vpnConnections 'vpn-connection/main.bicep' = [
       useLocalAzureIpAddress: connection.?useLocalAzureIpAddress
       usePolicyBasedTrafficSelectors: connection.?usePolicyBasedTrafficSelectors
       vpnConnectionProtocolType: connection.?vpnConnectionProtocolType
+      ipsecPolicies: connection.?ipsecPolicies
       trafficSelectorPolicies: connection.?trafficSelectorPolicies
       vpnLinkConnections: connection.?vpnLinkConnections
     }


### PR DESCRIPTION
## Description

This commit resolves an issue where IPsec policies for VPN connections are correctly configured on the initial deployment but reset to default ([]) on subsequent deployments. The fix ensures that the IPsec policies remain properly set across all deployments.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
