### PR TITLE
feat: `avm/res/compute/gallery`: Added UDT applicationsType

### DIFF
--- a/avm/res/compute/gallery/README.md
+++ b/avm/res/compute/gallery/README.md
@@ -1089,7 +1089,6 @@ The parameters that this custom action uses.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-applicationscustomactionsparametersname) | string | The name of the parameter. |
-| [`type`](#parameter-applicationscustomactionsparameterstype) | string | Specifies the type of the custom action parameter. |
 
 **Optional parameters**
 
@@ -1098,6 +1097,7 @@ The parameters that this custom action uses.
 | [`defaultValue`](#parameter-applicationscustomactionsparametersdefaultvalue) | string | The default value of the parameter. Only applies to string types. |
 | [`description`](#parameter-applicationscustomactionsparametersdescription) | string | A description to help users understand what this parameter means. |
 | [`required`](#parameter-applicationscustomactionsparametersrequired) | bool | Indicates whether this parameter must be passed when running the custom action. |
+| [`type`](#parameter-applicationscustomactionsparameterstype) | string | Specifies the type of the custom action parameter. |
 
 ### Parameter: `applications.customActions.parameters.name`
 
@@ -1105,21 +1105,6 @@ The name of the parameter.
 
 - Required: Yes
 - Type: string
-
-### Parameter: `applications.customActions.parameters.type`
-
-Specifies the type of the custom action parameter.
-
-- Required: No
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'ConfigurationDataBlob'
-    'LogOutputBlob'
-    'String'
-  ]
-  ```
 
 ### Parameter: `applications.customActions.parameters.defaultValue`
 
@@ -1141,6 +1126,21 @@ Indicates whether this parameter must be passed when running the custom action.
 
 - Required: No
 - Type: bool
+
+### Parameter: `applications.customActions.parameters.type`
+
+Specifies the type of the custom action parameter.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'ConfigurationDataBlob'
+    'LogOutputBlob'
+    'String'
+  ]
+  ```
 
 ### Parameter: `applications.description`
 

--- a/avm/res/compute/gallery/README.md
+++ b/avm/res/compute/gallery/README.md
@@ -8,6 +8,7 @@ This module deploys an Azure Compute Gallery (formerly known as Shared Image Gal
 - [Usage examples](#Usage-examples)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
 - [Data Collection](#Data-Collection)
 
 ## Resource Types
@@ -1760,6 +1761,14 @@ Tags for all resources.
 | `name` | string | The name of the deployed image gallery. |
 | `resourceGroupName` | string | The resource group of the deployed image gallery. |
 | `resourceId` | string | The resource ID of the deployed image gallery. |
+
+## Cross-referenced modules
+
+This section gives you an overview of all local-referenced module files (i.e., other modules that are referenced in this module) and all remote-referenced files (i.e., Bicep modules that are referenced from a Bicep Registry or Template Specs).
+
+| Reference | Type |
+| :-- | :-- |
+| `br/public:avm/utl/types/avm-common-types:0.3.0` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/compute/gallery/README.md
+++ b/avm/res/compute/gallery/README.md
@@ -314,14 +314,6 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
         roleDefinitionIdOrName: '<roleDefinitionIdOrName>'
       }
     ]
-    sharingProfile: {
-      eula: 'test Eula'
-      permissions: 'Community'
-      publicNamePrefix: 'avmtest'
-      publisherContact: 'avmtest@contoso.com'
-      publisherUri: 'https://aka.ms/avm'
-    }
-    softDeletePolicy: false
     tags: {
       Environment: 'Non-Prod'
       'hidden-title': 'This is visible in the resource name'
@@ -562,18 +554,6 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
         }
       ]
     },
-    "sharingProfile": {
-      "value": {
-        "eula": "test Eula",
-        "permissions": "Community",
-        "publicNamePrefix": "avmtest",
-        "publisherContact": "avmtest@contoso.com",
-        "publisherUri": "https://aka.ms/avm"
-      }
-    },
-    "softDeletePolicy": {
-      "value": false
-    },
     "tags": {
       "value": {
         "Environment": "Non-Prod",
@@ -800,14 +780,6 @@ param roleAssignments = [
     roleDefinitionIdOrName: '<roleDefinitionIdOrName>'
   }
 ]
-param sharingProfile = {
-  eula: 'test Eula'
-  permissions: 'Community'
-  publicNamePrefix: 'avmtest'
-  publisherContact: 'avmtest@contoso.com'
-  publisherUri: 'https://aka.ms/avm'
-}
-param softDeletePolicy = false
 param tags = {
   Environment: 'Non-Prod'
   'hidden-title': 'This is visible in the resource name'
@@ -977,7 +949,7 @@ param tags = {
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`sharingProfile`](#parameter-sharingprofile) | object | Profile for gallery sharing to subscription or tenant. |
-| [`softDeletePolicy`](#parameter-softdeletepolicy) | bool | Enables soft-deletion for resources in this gallery, allowing them to be recovered within retention time. |
+| [`softDeletePolicy`](#parameter-softdeletepolicy) | object | Soft deletion policy of the gallery. |
 | [`tags`](#parameter-tags) | object | Tags for all resources. |
 
 ### Parameter: `name`
@@ -1758,65 +1730,12 @@ Profile for gallery sharing to subscription or tenant.
 - Required: No
 - Type: object
 
-**Optional parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`eula`](#parameter-sharingprofileeula) | string | End-user license agreement for community gallery image. |
-| [`permissions`](#parameter-sharingprofilepermissions) | string | This property allows you to specify the permission of sharing gallery. |
-| [`publicNamePrefix`](#parameter-sharingprofilepublicnameprefix) | string | The prefix of the gallery name that will be displayed publicly. Visible to all users. |
-| [`publisherContact`](#parameter-sharingprofilepublishercontact) | string | Community gallery publisher support email. The email address of the publisher. Visible to all users. |
-| [`publisherUri`](#parameter-sharingprofilepublisheruri) | string | The link to the publisher website. Visible to all users. |
-
-### Parameter: `sharingProfile.eula`
-
-End-user license agreement for community gallery image.
-
-- Required: No
-- Type: string
-
-### Parameter: `sharingProfile.permissions`
-
-This property allows you to specify the permission of sharing gallery.
-
-- Required: No
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'Community'
-    'Groups'
-    'Private'
-  ]
-  ```
-
-### Parameter: `sharingProfile.publicNamePrefix`
-
-The prefix of the gallery name that will be displayed publicly. Visible to all users.
-
-- Required: No
-- Type: string
-
-### Parameter: `sharingProfile.publisherContact`
-
-Community gallery publisher support email. The email address of the publisher. Visible to all users.
-
-- Required: No
-- Type: string
-
-### Parameter: `sharingProfile.publisherUri`
-
-The link to the publisher website. Visible to all users.
-
-- Required: No
-- Type: string
-
 ### Parameter: `softDeletePolicy`
 
-Enables soft-deletion for resources in this gallery, allowing them to be recovered within retention time.
+Soft deletion policy of the gallery.
 
 - Required: No
-- Type: bool
+- Type: object
 
 ### Parameter: `tags`
 

--- a/avm/res/compute/gallery/README.md
+++ b/avm/res/compute/gallery/README.md
@@ -316,7 +316,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
     ]
     sharingProfile: {
       eula: 'test Eula'
-      permissions: 'Private'
+      permissions: 'Community'
       publicNamePrefix: 'avmtest'
       publisherContact: 'avmtest@contoso.com'
       publisherUri: 'https://aka.ms/avm'
@@ -565,7 +565,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
     "sharingProfile": {
       "value": {
         "eula": "test Eula",
-        "permissions": "Private",
+        "permissions": "Community",
         "publicNamePrefix": "avmtest",
         "publisherContact": "avmtest@contoso.com",
         "publisherUri": "https://aka.ms/avm"
@@ -802,7 +802,7 @@ param roleAssignments = [
 ]
 param sharingProfile = {
   eula: 'test Eula'
-  permissions: 'Private'
+  permissions: 'Community'
   publicNamePrefix: 'avmtest'
   publisherContact: 'avmtest@contoso.com'
   publisherUri: 'https://aka.ms/avm'

--- a/avm/res/compute/gallery/README.md
+++ b/avm/res/compute/gallery/README.md
@@ -140,6 +140,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
         supportedOSType: 'Windows'
       }
     ]
+    description: 'This is a test deployment.'
     images: [
       {
         architecture: 'x64'
@@ -313,6 +314,14 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
         roleDefinitionIdOrName: '<roleDefinitionIdOrName>'
       }
     ]
+    sharingProfile: {
+      eula: 'test Eula'
+      permissions: 'Private'
+      publicNamePrefix: 'avmtest'
+      publisherContact: 'avmtest@contoso.com'
+      publisherUri: 'https://aka.ms/avm'
+    }
+    softDeletePolicy: false
     tags: {
       Environment: 'Non-Prod'
       'hidden-title': 'This is visible in the resource name'
@@ -368,6 +377,9 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
           "supportedOSType": "Windows"
         }
       ]
+    },
+    "description": {
+      "value": "This is a test deployment."
     },
     "images": {
       "value": [
@@ -550,6 +562,18 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
         }
       ]
     },
+    "sharingProfile": {
+      "value": {
+        "eula": "test Eula",
+        "permissions": "Private",
+        "publicNamePrefix": "avmtest",
+        "publisherContact": "avmtest@contoso.com",
+        "publisherUri": "https://aka.ms/avm"
+      }
+    },
+    "softDeletePolicy": {
+      "value": false
+    },
     "tags": {
       "value": {
         "Environment": "Non-Prod",
@@ -602,6 +626,7 @@ param applications = [
     supportedOSType: 'Windows'
   }
 ]
+param description = 'This is a test deployment.'
 param images = [
   {
     architecture: 'x64'
@@ -775,6 +800,14 @@ param roleAssignments = [
     roleDefinitionIdOrName: '<roleDefinitionIdOrName>'
   }
 ]
+param sharingProfile = {
+  eula: 'test Eula'
+  permissions: 'Private'
+  publicNamePrefix: 'avmtest'
+  publisherContact: 'avmtest@contoso.com'
+  publisherUri: 'https://aka.ms/avm'
+}
+param softDeletePolicy = false
 param tags = {
   Environment: 'Non-Prod'
   'hidden-title': 'This is visible in the resource name'
@@ -944,7 +977,7 @@ param tags = {
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`sharingProfile`](#parameter-sharingprofile) | object | Profile for gallery sharing to subscription or tenant. |
-| [`softDeletePolicy`](#parameter-softdeletepolicy) | object | Soft deletion policy of the gallery. |
+| [`softDeletePolicy`](#parameter-softdeletepolicy) | bool | Enables soft-deletion for resources in this gallery, allowing them to be recovered within retention time. |
 | [`tags`](#parameter-tags) | object | Tags for all resources. |
 
 ### Parameter: `name`
@@ -960,6 +993,300 @@ Applications to create.
 
 - Required: No
 - Type: array
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-applicationsname) | string | Name of the application definition. |
+| [`supportedOSType`](#parameter-applicationssupportedostype) | string | The OS type of the application. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`customActions`](#parameter-applicationscustomactions) | array | A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application. |
+| [`description`](#parameter-applicationsdescription) | string | The description of this gallery application definition resource. This property is updatable. |
+| [`endOfLifeDate`](#parameter-applicationsendoflifedate) | string | The end of life date of the gallery application definition. This property can be used for decommissioning purposes. This property is updatable. |
+| [`eula`](#parameter-applicationseula) | string | The Eula agreement for the gallery application definition. |
+| [`privacyStatementUri`](#parameter-applicationsprivacystatementuri) | string | The privacy statement uri. |
+| [`releaseNoteUri`](#parameter-applicationsreleasenoteuri) | string | The release note uri. Has to be a valid URL. |
+| [`roleAssignments`](#parameter-applicationsroleassignments) | array | Array of role assignments to create. |
+| [`tags`](#parameter-applicationstags) | object | Tags for all resources. |
+
+### Parameter: `applications.name`
+
+Name of the application definition.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `applications.supportedOSType`
+
+The OS type of the application.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Linux'
+    'Windows'
+  ]
+  ```
+
+### Parameter: `applications.customActions`
+
+A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application.
+
+- Required: No
+- Type: array
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-applicationscustomactionsname) | string | The name of the custom action. Must be unique within the Gallery Application Version. |
+| [`script`](#parameter-applicationscustomactionsscript) | string | The script to run when executing this custom action. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`description`](#parameter-applicationscustomactionsdescription) | string | Description to help the users understand what this custom action does. |
+| [`parameters`](#parameter-applicationscustomactionsparameters) | array | The parameters that this custom action uses. |
+
+### Parameter: `applications.customActions.name`
+
+The name of the custom action. Must be unique within the Gallery Application Version.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `applications.customActions.script`
+
+The script to run when executing this custom action.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `applications.customActions.description`
+
+Description to help the users understand what this custom action does.
+
+- Required: No
+- Type: string
+
+### Parameter: `applications.customActions.parameters`
+
+The parameters that this custom action uses.
+
+- Required: No
+- Type: array
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-applicationscustomactionsparametersname) | string | The name of the parameter. |
+| [`type`](#parameter-applicationscustomactionsparameterstype) | string | Specifies the type of the custom action parameter. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`defaultValue`](#parameter-applicationscustomactionsparametersdefaultvalue) | string | The default value of the parameter. Only applies to string types. |
+| [`description`](#parameter-applicationscustomactionsparametersdescription) | string | A description to help users understand what this parameter means. |
+| [`required`](#parameter-applicationscustomactionsparametersrequired) | bool | Indicates whether this parameter must be passed when running the custom action. |
+
+### Parameter: `applications.customActions.parameters.name`
+
+The name of the parameter.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `applications.customActions.parameters.type`
+
+Specifies the type of the custom action parameter.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'ConfigurationDataBlob'
+    'LogOutputBlob'
+    'String'
+  ]
+  ```
+
+### Parameter: `applications.customActions.parameters.defaultValue`
+
+The default value of the parameter. Only applies to string types.
+
+- Required: No
+- Type: string
+
+### Parameter: `applications.customActions.parameters.description`
+
+A description to help users understand what this parameter means.
+
+- Required: No
+- Type: string
+
+### Parameter: `applications.customActions.parameters.required`
+
+Indicates whether this parameter must be passed when running the custom action.
+
+- Required: No
+- Type: bool
+
+### Parameter: `applications.description`
+
+The description of this gallery application definition resource. This property is updatable.
+
+- Required: No
+- Type: string
+
+### Parameter: `applications.endOfLifeDate`
+
+The end of life date of the gallery application definition. This property can be used for decommissioning purposes. This property is updatable.
+
+- Required: No
+- Type: string
+
+### Parameter: `applications.eula`
+
+The Eula agreement for the gallery application definition.
+
+- Required: No
+- Type: string
+
+### Parameter: `applications.privacyStatementUri`
+
+The privacy statement uri.
+
+- Required: No
+- Type: string
+
+### Parameter: `applications.releaseNoteUri`
+
+The release note uri. Has to be a valid URL.
+
+- Required: No
+- Type: string
+
+### Parameter: `applications.roleAssignments`
+
+Array of role assignments to create.
+
+- Required: No
+- Type: array
+- Roles configurable by name:
+  - `'Compute Gallery Sharing Admin'`
+  - `'Contributor'`
+  - `'Owner'`
+  - `'Reader'`
+  - `'Role Based Access Control Administrator'`
+  - `'User Access Administrator'`
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`principalId`](#parameter-applicationsroleassignmentsprincipalid) | string | The principal ID of the principal (user/group/identity) to assign the role to. |
+| [`roleDefinitionIdOrName`](#parameter-applicationsroleassignmentsroledefinitionidorname) | string | The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`condition`](#parameter-applicationsroleassignmentscondition) | string | The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container". |
+| [`conditionVersion`](#parameter-applicationsroleassignmentsconditionversion) | string | Version of the condition. |
+| [`delegatedManagedIdentityResourceId`](#parameter-applicationsroleassignmentsdelegatedmanagedidentityresourceid) | string | The Resource Id of the delegated managed identity resource. |
+| [`description`](#parameter-applicationsroleassignmentsdescription) | string | The description of the role assignment. |
+| [`name`](#parameter-applicationsroleassignmentsname) | string | The name (as GUID) of the role assignment. If not provided, a GUID will be generated. |
+| [`principalType`](#parameter-applicationsroleassignmentsprincipaltype) | string | The principal type of the assigned principal ID. |
+
+### Parameter: `applications.roleAssignments.principalId`
+
+The principal ID of the principal (user/group/identity) to assign the role to.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `applications.roleAssignments.roleDefinitionIdOrName`
+
+The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `applications.roleAssignments.condition`
+
+The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container".
+
+- Required: No
+- Type: string
+
+### Parameter: `applications.roleAssignments.conditionVersion`
+
+Version of the condition.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    '2.0'
+  ]
+  ```
+
+### Parameter: `applications.roleAssignments.delegatedManagedIdentityResourceId`
+
+The Resource Id of the delegated managed identity resource.
+
+- Required: No
+- Type: string
+
+### Parameter: `applications.roleAssignments.description`
+
+The description of the role assignment.
+
+- Required: No
+- Type: string
+
+### Parameter: `applications.roleAssignments.name`
+
+The name (as GUID) of the role assignment. If not provided, a GUID will be generated.
+
+- Required: No
+- Type: string
+
+### Parameter: `applications.roleAssignments.principalType`
+
+The principal type of the assigned principal ID.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Device'
+    'ForeignGroup'
+    'Group'
+    'ServicePrincipal'
+    'User'
+  ]
+  ```
+
+### Parameter: `applications.tags`
+
+Tags for all resources.
+
+- Required: No
+- Type: object
 
 ### Parameter: `description`
 
@@ -1431,12 +1758,65 @@ Profile for gallery sharing to subscription or tenant.
 - Required: No
 - Type: object
 
-### Parameter: `softDeletePolicy`
+**Optional parameters**
 
-Soft deletion policy of the gallery.
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`eula`](#parameter-sharingprofileeula) | string | End-user license agreement for community gallery image. |
+| [`permissions`](#parameter-sharingprofilepermissions) | string | This property allows you to specify the permission of sharing gallery. |
+| [`publicNamePrefix`](#parameter-sharingprofilepublicnameprefix) | string | The prefix of the gallery name that will be displayed publicly. Visible to all users. |
+| [`publisherContact`](#parameter-sharingprofilepublishercontact) | string | Community gallery publisher support email. The email address of the publisher. Visible to all users. |
+| [`publisherUri`](#parameter-sharingprofilepublisheruri) | string | The link to the publisher website. Visible to all users. |
+
+### Parameter: `sharingProfile.eula`
+
+End-user license agreement for community gallery image.
 
 - Required: No
-- Type: object
+- Type: string
+
+### Parameter: `sharingProfile.permissions`
+
+This property allows you to specify the permission of sharing gallery.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Community'
+    'Groups'
+    'Private'
+  ]
+  ```
+
+### Parameter: `sharingProfile.publicNamePrefix`
+
+The prefix of the gallery name that will be displayed publicly. Visible to all users.
+
+- Required: No
+- Type: string
+
+### Parameter: `sharingProfile.publisherContact`
+
+Community gallery publisher support email. The email address of the publisher. Visible to all users.
+
+- Required: No
+- Type: string
+
+### Parameter: `sharingProfile.publisherUri`
+
+The link to the publisher website. Visible to all users.
+
+- Required: No
+- Type: string
+
+### Parameter: `softDeletePolicy`
+
+Enables soft-deletion for resources in this gallery, allowing them to be recovered within retention time.
+
+- Required: No
+- Type: bool
 
 ### Parameter: `tags`
 

--- a/avm/res/compute/gallery/README.md
+++ b/avm/res/compute/gallery/README.md
@@ -1303,7 +1303,7 @@ Images to create.
 | [`excludedDiskTypes`](#parameter-imagesexcludeddisktypes) | array | Describes the disallowed disk types. |
 | [`hyperVGeneration`](#parameter-imageshypervgeneration) | string | The hypervisor generation of the Virtual Machine. If this value is not specified, then it is determined by the securityType parameter. If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1. |
 | [`isAcceleratedNetworkSupported`](#parameter-imagesisacceleratednetworksupported) | bool | Specify if the image supports accelerated networking. Defaults to true. |
-| [`isHibernateSupported`](#parameter-imagesishibernatesupported) | bool | Specifiy if the image supports hibernation. |
+| [`isHibernateSupported`](#parameter-imagesishibernatesupported) | bool | Specify if the image supports hibernation. |
 | [`memory`](#parameter-imagesmemory) | object | Describes the resource range (1-4000 GB RAM). Defaults to min=4, max=16. |
 | [`privacyStatementUri`](#parameter-imagesprivacystatementuri) | string | The privacy statement uri. |
 | [`purchasePlan`](#parameter-imagespurchaseplan) | object | Describes the gallery image definition purchase plan. This is used by marketplace images. |
@@ -1447,7 +1447,7 @@ Specify if the image supports accelerated networking. Defaults to true.
 
 ### Parameter: `images.isHibernateSupported`
 
-Specifiy if the image supports hibernation.
+Specify if the image supports hibernation.
 
 - Required: No
 - Type: bool

--- a/avm/res/compute/gallery/application/README.md
+++ b/avm/res/compute/gallery/application/README.md
@@ -80,6 +80,106 @@ A list of custom actions that can be performed with all of the Gallery Applicati
 - Required: No
 - Type: array
 
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-customactionsname) | string | The name of the custom action. Must be unique within the Gallery Application Version. |
+| [`script`](#parameter-customactionsscript) | string | The script to run when executing this custom action. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`description`](#parameter-customactionsdescription) | string | Description to help the users understand what this custom action does. |
+| [`parameters`](#parameter-customactionsparameters) | array | The parameters that this custom action uses. |
+
+### Parameter: `customActions.name`
+
+The name of the custom action. Must be unique within the Gallery Application Version.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `customActions.script`
+
+The script to run when executing this custom action.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `customActions.description`
+
+Description to help the users understand what this custom action does.
+
+- Required: No
+- Type: string
+
+### Parameter: `customActions.parameters`
+
+The parameters that this custom action uses.
+
+- Required: No
+- Type: array
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-customactionsparametersname) | string | The name of the parameter. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`defaultValue`](#parameter-customactionsparametersdefaultvalue) | string | The default value of the parameter. Only applies to string types. |
+| [`description`](#parameter-customactionsparametersdescription) | string | A description to help users understand what this parameter means. |
+| [`required`](#parameter-customactionsparametersrequired) | bool | Indicates whether this parameter must be passed when running the custom action. |
+| [`type`](#parameter-customactionsparameterstype) | string | Specifies the type of the custom action parameter. |
+
+### Parameter: `customActions.parameters.name`
+
+The name of the parameter.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `customActions.parameters.defaultValue`
+
+The default value of the parameter. Only applies to string types.
+
+- Required: No
+- Type: string
+
+### Parameter: `customActions.parameters.description`
+
+A description to help users understand what this parameter means.
+
+- Required: No
+- Type: string
+
+### Parameter: `customActions.parameters.required`
+
+Indicates whether this parameter must be passed when running the custom action.
+
+- Required: No
+- Type: bool
+
+### Parameter: `customActions.parameters.type`
+
+Specifies the type of the custom action parameter.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'ConfigurationDataBlob'
+    'LogOutputBlob'
+    'String'
+  ]
+  ```
+
 ### Parameter: `description`
 
 The description of this gallery Application Definition resource. This property is updatable.

--- a/avm/res/compute/gallery/application/README.md
+++ b/avm/res/compute/gallery/application/README.md
@@ -7,6 +7,7 @@ This module deploys an Azure Compute Gallery Application.
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
 - [Notes](#Notes)
 
 ## Resource Types
@@ -342,6 +343,14 @@ Tags for all resources.
 | `name` | string | The name of the image. |
 | `resourceGroupName` | string | The resource group the image was deployed into. |
 | `resourceId` | string | The resource ID of the image. |
+
+## Cross-referenced modules
+
+This section gives you an overview of all local-referenced module files (i.e., other modules that are referenced in this module) and all remote-referenced files (i.e., Bicep modules that are referenced from a Bicep Registry or Template Specs).
+
+| Reference | Type |
+| :-- | :-- |
+| `br/public:avm/utl/types/avm-common-types:0.3.0` | Remote reference |
 
 ## Notes
 

--- a/avm/res/compute/gallery/application/main.bicep
+++ b/avm/res/compute/gallery/application/main.bicep
@@ -35,13 +35,13 @@ param supportedOSType string
 param endOfLifeDate string?
 
 @sys.description('Optional. Array of role assignments to create.')
-param roleAssignments roleAssignmentType
+param roleAssignments roleAssignmentType[]?
 
 @sys.description('Optional. Tags for all resources.')
 param tags object?
 
 @sys.description('Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application.')
-param customActions customActionType
+param customActions customActionType[]?
 
 var builtInRoleNames = {
   'Compute Gallery Sharing Admin': subscriptionResourceId(
@@ -124,31 +124,7 @@ output location string = application.location
 //   Definitions   //
 // =============== //
 
-type roleAssignmentType = {
-  @sys.description('Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated.')
-  name: string?
-
-  @sys.description('Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.')
-  roleDefinitionIdOrName: string
-
-  @sys.description('Required. The principal ID of the principal (user/group/identity) to assign the role to.')
-  principalId: string
-
-  @sys.description('Optional. The principal type of the assigned principal ID.')
-  principalType: ('ServicePrincipal' | 'Group' | 'User' | 'ForeignGroup' | 'Device')?
-
-  @sys.description('Optional. The description of the role assignment.')
-  description: string?
-
-  @sys.description('Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container".')
-  condition: string?
-
-  @sys.description('Optional. Version of the condition.')
-  conditionVersion: '2.0'?
-
-  @sys.description('Optional. The Resource Id of the delegated managed identity resource.')
-  delegatedManagedIdentityResourceId: string?
-}[]?
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.3.0'
 
 @export()
 type customActionType = {
@@ -178,4 +154,4 @@ type customActionType = {
     @sys.description('Optional. Indicates whether this parameter must be passed when running the custom action.')
     required: bool?
   }[]?
-}[]?
+}

--- a/avm/res/compute/gallery/application/main.bicep
+++ b/avm/res/compute/gallery/application/main.bicep
@@ -41,7 +41,7 @@ param roleAssignments roleAssignmentType
 param tags object?
 
 @sys.description('Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application.')
-param customActions array?
+param customActions customActionType
 
 var builtInRoleNames = {
   'Compute Gallery Sharing Admin': subscriptionResourceId(
@@ -148,4 +148,34 @@ type roleAssignmentType = {
 
   @sys.description('Optional. The Resource Id of the delegated managed identity resource.')
   delegatedManagedIdentityResourceId: string?
+}[]?
+
+@export()
+type customActionType = {
+  @sys.description('Required. The name of the custom action. Must be unique within the Gallery Application Version.')
+  name: string
+
+  @sys.description('Required. The script to run when executing this custom action.')
+  script: string
+
+  @sys.description('Optional. Description to help the users understand what this custom action does.')
+  description: string?
+
+  @sys.description('Optional. The parameters that this custom action uses.')
+  parameters: {
+    @sys.description('Required. The name of the parameter.')
+    name: string
+
+    @sys.description('Optional. Specifies the type of the custom action parameter.')
+    type: ('ConfigurationDataBlob' | 'LogOutputBlob' | 'String')?
+
+    @sys.description('Optional. A description to help users understand what this parameter means.')
+    description: string?
+
+    @sys.description('Optional. The default value of the parameter. Only applies to string types.')
+    defaultValue: string?
+
+    @sys.description('Optional. Indicates whether this parameter must be passed when running the custom action.')
+    required: bool?
+  }[]?
 }[]?

--- a/avm/res/compute/gallery/application/main.bicep
+++ b/avm/res/compute/gallery/application/main.bicep
@@ -34,6 +34,7 @@ param supportedOSType string
 @sys.description('Optional. The end of life date of the gallery Image Definition. This property can be used for decommissioning purposes. This property is updatable. Allowed format: 2020-01-10T23:00:00.000Z.')
 param endOfLifeDate string?
 
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.3.0'
 @sys.description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
@@ -123,8 +124,6 @@ output location string = application.location
 // =============== //
 //   Definitions   //
 // =============== //
-
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.3.0'
 
 @export()
 type customActionType = {

--- a/avm/res/compute/gallery/application/main.json
+++ b/avm/res/compute/gallery/application/main.json
@@ -6,166 +6,164 @@
     "_generator": {
       "name": "bicep",
       "version": "0.31.92.45157",
-      "templateHash": "3840736055128275990"
+      "templateHash": "11162019331609283814"
     },
     "name": "Compute Galleries Applications",
     "description": "This module deploys an Azure Compute Gallery Application.",
     "owner": "Azure/module-maintainers"
   },
   "definitions": {
-    "roleAssignmentType": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
-            }
-          },
-          "roleDefinitionIdOrName": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-            }
-          },
-          "principalId": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-            }
-          },
-          "principalType": {
-            "type": "string",
-            "allowedValues": [
-              "Device",
-              "ForeignGroup",
-              "Group",
-              "ServicePrincipal",
-              "User"
-            ],
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The principal type of the assigned principal ID."
-            }
-          },
-          "description": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The description of the role assignment."
-            }
-          },
-          "condition": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-            }
-          },
-          "conditionVersion": {
-            "type": "string",
-            "allowedValues": [
-              "2.0"
-            ],
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Version of the condition."
-            }
-          },
-          "delegatedManagedIdentityResourceId": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The Resource Id of the delegated managed identity resource."
-            }
-          }
-        }
-      },
-      "nullable": true
-    },
     "customActionType": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The name of the custom action. Must be unique within the Gallery Application Version."
-            }
-          },
-          "script": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The script to run when executing this custom action."
-            }
-          },
-          "description": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Description to help the users understand what this custom action does."
-            }
-          },
-          "parameters": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "metadata": {
-                    "description": "Required. The name of the parameter."
-                  }
-                },
-                "type": {
-                  "type": "string",
-                  "allowedValues": [
-                    "ConfigurationDataBlob",
-                    "LogOutputBlob",
-                    "String"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Specifies the type of the custom action parameter."
-                  }
-                },
-                "description": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. A description to help users understand what this parameter means."
-                  }
-                },
-                "defaultValue": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The default value of the parameter. Only applies to string types."
-                  }
-                },
-                "required": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Indicates whether this parameter must be passed when running the custom action."
-                  }
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the custom action. Must be unique within the Gallery Application Version."
+          }
+        },
+        "script": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The script to run when executing this custom action."
+          }
+        },
+        "description": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Description to help the users understand what this custom action does."
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "metadata": {
+                  "description": "Required. The name of the parameter."
+                }
+              },
+              "type": {
+                "type": "string",
+                "allowedValues": [
+                  "ConfigurationDataBlob",
+                  "LogOutputBlob",
+                  "String"
+                ],
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Specifies the type of the custom action parameter."
+                }
+              },
+              "description": {
+                "type": "string",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. A description to help users understand what this parameter means."
+                }
+              },
+              "defaultValue": {
+                "type": "string",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. The default value of the parameter. Only applies to string types."
+                }
+              },
+              "required": {
+                "type": "bool",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Indicates whether this parameter must be passed when running the custom action."
                 }
               }
-            },
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The parameters that this custom action uses."
             }
+          },
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The parameters that this custom action uses."
           }
         }
       },
-      "nullable": true,
       "metadata": {
         "__bicep_export!": true
+      }
+    },
+    "roleAssignmentType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+          }
+        },
+        "roleDefinitionIdOrName": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+          }
+        },
+        "principalId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+          }
+        },
+        "principalType": {
+          "type": "string",
+          "allowedValues": [
+            "Device",
+            "ForeignGroup",
+            "Group",
+            "ServicePrincipal",
+            "User"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The principal type of the assigned principal ID."
+          }
+        },
+        "description": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The description of the role assignment."
+          }
+        },
+        "condition": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+          }
+        },
+        "conditionVersion": {
+          "type": "string",
+          "allowedValues": [
+            "2.0"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Version of the condition."
+          }
+        },
+        "delegatedManagedIdentityResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The Resource Id of the delegated managed identity resource."
+          }
+        }
+      },
+      "metadata": {
+        "description": "An AVM-aligned type for a role assignment.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.3.0"
+        }
       }
     }
   },
@@ -236,7 +234,11 @@
       }
     },
     "roleAssignments": {
-      "$ref": "#/definitions/roleAssignmentType",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/roleAssignmentType"
+      },
+      "nullable": true,
       "metadata": {
         "description": "Optional. Array of role assignments to create."
       }
@@ -249,7 +251,11 @@
       }
     },
     "customActions": {
-      "$ref": "#/definitions/customActionType",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/customActionType"
+      },
+      "nullable": true,
       "metadata": {
         "description": "Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application."
       }

--- a/avm/res/compute/gallery/application/main.json
+++ b/avm/res/compute/gallery/application/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.30.23.60470",
-      "templateHash": "13081960860160182257"
+      "version": "0.31.92.45157",
+      "templateHash": "12025997665546901388"
     },
     "name": "Compute Galleries Applications",
     "description": "This module deploys an Azure Compute Gallery Application.",

--- a/avm/res/compute/gallery/application/main.json
+++ b/avm/res/compute/gallery/application/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.31.92.45157",
-      "templateHash": "12025997665546901388"
+      "templateHash": "3840736055128275990"
     },
     "name": "Compute Galleries Applications",
     "description": "This module deploys an Azure Compute Gallery Application.",
@@ -85,6 +85,88 @@
         }
       },
       "nullable": true
+    },
+    "customActionType": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "metadata": {
+              "description": "Required. The name of the custom action. Must be unique within the Gallery Application Version."
+            }
+          },
+          "script": {
+            "type": "string",
+            "metadata": {
+              "description": "Required. The script to run when executing this custom action."
+            }
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Description to help the users understand what this custom action does."
+            }
+          },
+          "parameters": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the parameter."
+                  }
+                },
+                "type": {
+                  "type": "string",
+                  "allowedValues": [
+                    "ConfigurationDataBlob",
+                    "LogOutputBlob",
+                    "String"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specifies the type of the custom action parameter."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. A description to help users understand what this parameter means."
+                  }
+                },
+                "defaultValue": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The default value of the parameter. Only applies to string types."
+                  }
+                },
+                "required": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Indicates whether this parameter must be passed when running the custom action."
+                  }
+                }
+              }
+            },
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The parameters that this custom action uses."
+            }
+          }
+        }
+      },
+      "nullable": true,
+      "metadata": {
+        "__bicep_export!": true
+      }
     }
   },
   "parameters": {
@@ -167,8 +249,7 @@
       }
     },
     "customActions": {
-      "type": "array",
-      "nullable": true,
+      "$ref": "#/definitions/customActionType",
       "metadata": {
         "description": "Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application."
       }

--- a/avm/res/compute/gallery/image/main.json
+++ b/avm/res/compute/gallery/image/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.30.23.60470",
-      "templateHash": "5984025187928110337"
+      "version": "0.31.92.45157",
+      "templateHash": "14463616698185324661"
     },
     "name": "Compute Galleries Image Definitions",
     "description": "This module deploys an Azure Compute Gallery Image Definition.",

--- a/avm/res/compute/gallery/main.bicep
+++ b/avm/res/compute/gallery/main.bicep
@@ -107,22 +107,22 @@ resource gallery 'Microsoft.Compute/galleries@2023-07-03' = {
   properties: {
     description: description
     // identifier: {} // Contains only read-only properties
-    sharingProfile: null
-    softDeletePolicy: null
-    // sharingProfile: !empty(sharingProfile)
-    //   ? {
-    //       communityGalleryInfo: {
-    //         eula: sharingProfile.?eula
-    //         publicNamePrefix: sharingProfile.?publicNamePrefix
-    //         publisherContact: sharingProfile.?publisherContact
-    //         publisherUri: sharingProfile.?publisherUri
-    //       }
-    //       permissions: sharingProfile.?permissions
-    //     }
-    //   : null
-    // softDeletePolicy: {
-    //   isSoftDeleteEnabled: softDeletePolicy
-    // }
+    sharingProfile: !empty(sharingProfile)
+      ? {
+          communityGalleryInfo: {
+            eula: sharingProfile.?eula
+            publicNamePrefix: sharingProfile.?publicNamePrefix
+            publisherContact: sharingProfile.?publisherContact
+            publisherUri: sharingProfile.?publisherUri
+          }
+          permissions: sharingProfile.?permissions
+        }
+      : null
+    softDeletePolicy: softDeletePolicy != null
+      ? {
+          isSoftDeleteEnabled: softDeletePolicy
+        }
+      : null
   }
 }
 

--- a/avm/res/compute/gallery/main.bicep
+++ b/avm/res/compute/gallery/main.bicep
@@ -376,7 +376,7 @@ type customActionType = {
     @sys.description('Required. The name of the parameter.')
     name: string
 
-    @sys.description('Required. Specifies the type of the custom action parameter.')
+    @sys.description('Optional. Specifies the type of the custom action parameter.')
     type: ('ConfigurationDataBlob' | 'LogOutputBlob' | 'String')?
 
     @sys.description('Optional. A description to help users understand what this parameter means.')

--- a/avm/res/compute/gallery/main.bicep
+++ b/avm/res/compute/gallery/main.bicep
@@ -20,7 +20,7 @@ param enableTelemetry bool = true
 param description string?
 
 @sys.description('Optional. Applications to create.')
-param applications applicationsType
+param applications applicationsType[]?
 
 @sys.description('Optional. Images to create.')
 param images imageType[]? // use a UDT here to not overload the main module, as it has images and applications parameters
@@ -315,4 +315,4 @@ type applicationsType = {
 
   @sys.description('Optional. Tags for all resources.')
   tags: object?
-}[]?
+}

--- a/avm/res/compute/gallery/main.bicep
+++ b/avm/res/compute/gallery/main.bicep
@@ -107,18 +107,22 @@ resource gallery 'Microsoft.Compute/galleries@2023-07-03' = {
   properties: {
     description: description
     // identifier: {} // Contains only read-only properties
-    sharingProfile: {
-      communityGalleryInfo: {
-        eula: sharingProfile.?eula
-        publicNamePrefix: sharingProfile.?publicNamePrefix
-        publisherContact: sharingProfile.?publisherContact
-        publisherUri: sharingProfile.?publisherUri
-      }
-      permissions: sharingProfile.?permissions
-    }
-    softDeletePolicy: {
-      isSoftDeleteEnabled: softDeletePolicy
-    }
+    sharingProfile: null
+    softDeletePolicy: null
+    // sharingProfile: !empty(sharingProfile)
+    //   ? {
+    //       communityGalleryInfo: {
+    //         eula: sharingProfile.?eula
+    //         publicNamePrefix: sharingProfile.?publicNamePrefix
+    //         publisherContact: sharingProfile.?publisherContact
+    //         publisherUri: sharingProfile.?publisherUri
+    //       }
+    //       permissions: sharingProfile.?permissions
+    //     }
+    //   : null
+    // softDeletePolicy: {
+    //   isSoftDeleteEnabled: softDeletePolicy
+    // }
   }
 }
 

--- a/avm/res/compute/gallery/main.bicep
+++ b/avm/res/compute/gallery/main.bicep
@@ -27,9 +27,11 @@ param images imageType[]? // use a UDT here to not overload the main module, as 
 
 @sys.description('Optional. The lock settings of the service.')
 param lock lockType?
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.3.0'
 
 @sys.description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.3.0'
 
 @sys.description('Optional. Tags for all resources.')
 @metadata({
@@ -214,10 +216,6 @@ output imageResourceIds array = [
 //   Definitions   //
 // =============== //
 
-import { identifierType, purchasePlanType, resourceRangeType } from './image/main.bicep'
-import { customActionType } from './application/main.bicep'
-import { roleAssignmentType, lockType } from 'br/public:avm/utl/types/avm-common-types:0.3.0'
-
 @export()
 type imageType = {
   @sys.description('Required. Name of the image definition.')
@@ -282,6 +280,7 @@ type imageType = {
   @sys.description('Optional. Describes the disallowed disk types.')
   excludedDiskTypes: string[]?
 }
+import { identifierType, purchasePlanType, resourceRangeType } from './image/main.bicep'
 
 type applicationsType = {
   @sys.description('Required. Name of the application definition.')
@@ -316,3 +315,4 @@ type applicationsType = {
   @sys.description('Optional. Tags for all resources.')
   tags: object?
 }
+import { customActionType } from './application/main.bicep'

--- a/avm/res/compute/gallery/main.bicep
+++ b/avm/res/compute/gallery/main.bicep
@@ -25,13 +25,13 @@ param applications applicationsType[]?
 @sys.description('Optional. Images to create.')
 param images imageType[]? // use a UDT here to not overload the main module, as it has images and applications parameters
 
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.3.0'
 @sys.description('Optional. The lock settings of the service.')
 param lock lockType?
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.3.0'
 
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.3.0'
 @sys.description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.3.0'
 
 @sys.description('Optional. Tags for all resources.')
 @metadata({
@@ -216,6 +216,7 @@ output imageResourceIds array = [
 //   Definitions   //
 // =============== //
 
+import { identifierType, purchasePlanType, resourceRangeType } from './image/main.bicep'
 @export()
 type imageType = {
   @sys.description('Required. Name of the image definition.')
@@ -256,7 +257,7 @@ type imageType = {
   @sys.description('Optional. Specify if the image supports accelerated networking. Defaults to true.')
   isAcceleratedNetworkSupported: bool?
 
-  @sys.description('Optional. Specifiy if the image supports hibernation.')
+  @sys.description('Optional. Specify if the image supports hibernation.')
   isHibernateSupported: bool?
 
   @sys.description('Optional. The architecture of the image. Applicable to OS disks only.')
@@ -280,8 +281,8 @@ type imageType = {
   @sys.description('Optional. Describes the disallowed disk types.')
   excludedDiskTypes: string[]?
 }
-import { identifierType, purchasePlanType, resourceRangeType } from './image/main.bicep'
 
+import { customActionType } from './application/main.bicep'
 type applicationsType = {
   @sys.description('Required. Name of the application definition.')
   @minLength(1)
@@ -315,4 +316,3 @@ type applicationsType = {
   @sys.description('Optional. Tags for all resources.')
   tags: object?
 }
-import { customActionType } from './application/main.bicep'

--- a/avm/res/compute/gallery/main.bicep
+++ b/avm/res/compute/gallery/main.bicep
@@ -29,7 +29,7 @@ param images imageType[]? // use a UDT here to not overload the main module, as 
 param lock lockType?
 
 @sys.description('Optional. Array of role assignments to create.')
-param roleAssignments roleAssignmentType?
+param roleAssignments roleAssignmentType[]?
 
 @sys.description('Optional. Tags for all resources.')
 @metadata({
@@ -214,44 +214,9 @@ output imageResourceIds array = [
 //   Definitions   //
 // =============== //
 
-@export()
-type lockType = {
-  @sys.description('Optional. Specify the name of lock.')
-  name: string?
-
-  @sys.description('Optional. Specify the type of lock.')
-  kind: ('CanNotDelete' | 'ReadOnly' | 'None')?
-}
-
-@export()
-type roleAssignmentType = {
-  @sys.description('Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated.')
-  name: string?
-
-  @sys.description('Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.')
-  roleDefinitionIdOrName: string
-
-  @sys.description('Required. The principal ID of the principal (user/group/identity) to assign the role to.')
-  principalId: string
-
-  @sys.description('Optional. The principal type of the assigned principal ID.')
-  principalType: ('ServicePrincipal' | 'Group' | 'User' | 'ForeignGroup' | 'Device')?
-
-  @sys.description('Optional. The description of the role assignment.')
-  description: string?
-
-  @sys.description('Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container".')
-  condition: string?
-
-  @sys.description('Optional. Version of the condition.')
-  conditionVersion: '2.0'?
-
-  @sys.description('Optional. The Resource Id of the delegated managed identity resource.')
-  delegatedManagedIdentityResourceId: string?
-}[]
-
 import { identifierType, purchasePlanType, resourceRangeType } from './image/main.bicep'
 import { customActionType } from './application/main.bicep'
+import { roleAssignmentType, lockType } from 'br/public:avm/utl/types/avm-common-types:0.3.0'
 
 @export()
 type imageType = {
@@ -343,10 +308,10 @@ type applicationsType = {
   endOfLifeDate: string?
 
   @sys.description('Optional. Array of role assignments to create.')
-  roleAssignments: roleAssignmentType?
+  roleAssignments: roleAssignmentType[]?
 
   @sys.description('Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application.')
-  customActions: customActionType
+  customActions: customActionType[]?
 
   @sys.description('Optional. Tags for all resources.')
   tags: object?

--- a/avm/res/compute/gallery/main.bicep
+++ b/avm/res/compute/gallery/main.bicep
@@ -43,10 +43,10 @@ param roleAssignments roleAssignmentType?
 param tags object?
 
 @sys.description('Optional. Profile for gallery sharing to subscription or tenant.')
-param sharingProfile sharingProfileType?
+param sharingProfile object?
 
-@sys.description('Optional. Enables soft-deletion for resources in this gallery, allowing them to be recovered within retention time.')
-param softDeletePolicy bool?
+@sys.description('Optional. Soft deletion policy of the gallery.')
+param softDeletePolicy object?
 
 var builtInRoleNames = {
   'Compute Gallery Sharing Admin': subscriptionResourceId(
@@ -107,22 +107,8 @@ resource gallery 'Microsoft.Compute/galleries@2023-07-03' = {
   properties: {
     description: description
     // identifier: {} // Contains only read-only properties
-    sharingProfile: !empty(sharingProfile)
-      ? {
-          communityGalleryInfo: {
-            eula: sharingProfile.?eula
-            publicNamePrefix: sharingProfile.?publicNamePrefix
-            publisherContact: sharingProfile.?publisherContact
-            publisherUri: sharingProfile.?publisherUri
-          }
-          permissions: sharingProfile.?permissions
-        }
-      : null
-    softDeletePolicy: softDeletePolicy != null
-      ? {
-          isSoftDeleteEnabled: softDeletePolicy
-        }
-      : null
+    sharingProfile: sharingProfile
+    softDeletePolicy: softDeletePolicy
   }
 }
 
@@ -265,6 +251,7 @@ type roleAssignmentType = {
 }[]
 
 import { identifierType, purchasePlanType, resourceRangeType } from './image/main.bicep'
+import { customActionType } from './application/main.bicep'
 
 @export()
 type imageType = {
@@ -359,54 +346,8 @@ type applicationsType = {
   roleAssignments: roleAssignmentType?
 
   @sys.description('Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application.')
-  customActions: customActionType[]?
+  customActions: customActionType
 
   @sys.description('Optional. Tags for all resources.')
   tags: object?
 }[]?
-
-type customActionType = {
-  @sys.description('Required. The name of the custom action. Must be unique within the Gallery Application Version.')
-  name: string
-
-  @sys.description('Required. The script to run when executing this custom action.')
-  script: string
-
-  @sys.description('Optional. Description to help the users understand what this custom action does.')
-  description: string?
-
-  @sys.description('Optional. The parameters that this custom action uses.')
-  parameters: {
-    @sys.description('Required. The name of the parameter.')
-    name: string
-
-    @sys.description('Optional. Specifies the type of the custom action parameter.')
-    type: ('ConfigurationDataBlob' | 'LogOutputBlob' | 'String')?
-
-    @sys.description('Optional. A description to help users understand what this parameter means.')
-    description: string?
-
-    @sys.description('Optional. The default value of the parameter. Only applies to string types.')
-    defaultValue: string?
-
-    @sys.description('Optional. Indicates whether this parameter must be passed when running the custom action.')
-    required: bool?
-  }[]?
-}[]
-
-type sharingProfileType = {
-  @sys.description('Optional. End-user license agreement for community gallery image.')
-  eula: string?
-
-  @sys.description('Optional. The prefix of the gallery name that will be displayed publicly. Visible to all users.')
-  publicNamePrefix: string?
-
-  @sys.description('Optional. Community gallery publisher support email. The email address of the publisher. Visible to all users.')
-  publisherContact: string?
-
-  @sys.description('Optional. The link to the publisher website. Visible to all users.')
-  publisherUri: string?
-
-  @sys.description('Optional. This property allows you to specify the permission of sharing gallery.')
-  permissions: ('Community' | 'Groups' | 'Private')?
-}

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.31.92.45157",
-      "templateHash": "13946388819897175743"
+      "templateHash": "9991159892229520493"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery).",
@@ -694,18 +694,8 @@
       "tags": "[parameters('tags')]",
       "properties": {
         "description": "[parameters('description')]",
-        "sharingProfile": {
-          "communityGalleryInfo": {
-            "eula": "[tryGet(parameters('sharingProfile'), 'eula')]",
-            "publicNamePrefix": "[tryGet(parameters('sharingProfile'), 'publicNamePrefix')]",
-            "publisherContact": "[tryGet(parameters('sharingProfile'), 'publisherContact')]",
-            "publisherUri": "[tryGet(parameters('sharingProfile'), 'publisherUri')]"
-          },
-          "permissions": "[tryGet(parameters('sharingProfile'), 'permissions')]"
-        },
-        "softDeletePolicy": {
-          "isSoftDeleteEnabled": "[parameters('softDeletePolicy')]"
-        }
+        "sharingProfile": "[if(not(empty(parameters('sharingProfile'))), createObject('communityGalleryInfo', createObject('eula', tryGet(parameters('sharingProfile'), 'eula'), 'publicNamePrefix', tryGet(parameters('sharingProfile'), 'publicNamePrefix'), 'publisherContact', tryGet(parameters('sharingProfile'), 'publisherContact'), 'publisherUri', tryGet(parameters('sharingProfile'), 'publisherUri')), 'permissions', tryGet(parameters('sharingProfile'), 'permissions')), null())]",
+        "softDeletePolicy": "[if(not(equals(parameters('softDeletePolicy'), null())), createObject('isSoftDeleteEnabled', parameters('softDeletePolicy')), null())]"
       }
     },
     "gallery_lock": {

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.31.92.45157",
-      "templateHash": "2270335166910547426"
+      "templateHash": "13069593327789090653"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery).",
@@ -108,7 +108,7 @@
           "type": "bool",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Specifiy if the image supports hibernation."
+            "description": "Optional. Specify if the image supports hibernation."
           }
         },
         "architecture": {

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.30.23.60470",
-      "templateHash": "17783194818453553981"
+      "version": "0.31.92.45157",
+      "templateHash": "6434598529291924522"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery).",
@@ -274,6 +274,215 @@
         "__bicep_export!": true
       }
     },
+    "applicationsType": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "metadata": {
+              "description": "Required. Name of the application definition."
+            }
+          },
+          "supportedOSType": {
+            "type": "string",
+            "allowedValues": [
+              "Linux",
+              "Windows"
+            ],
+            "metadata": {
+              "description": "Required. The OS type of the application."
+            }
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The description of this gallery application definition resource. This property is updatable."
+            }
+          },
+          "eula": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The Eula agreement for the gallery application definition."
+            }
+          },
+          "privacyStatementUri": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The privacy statement uri."
+            }
+          },
+          "releaseNoteUri": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The release note uri. Has to be a valid URL."
+            }
+          },
+          "endOfLifeDate": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The end of life date of the gallery application definition. This property can be used for decommissioning purposes. This property is updatable."
+            }
+          },
+          "roleAssignments": {
+            "$ref": "#/definitions/roleAssignmentType",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Array of role assignments to create."
+            }
+          },
+          "customActions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/customActionType"
+            },
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application."
+            }
+          },
+          "tags": {
+            "type": "object",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Tags for all resources."
+            }
+          }
+        }
+      },
+      "nullable": true
+    },
+    "customActionType": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "metadata": {
+              "description": "Required. The name of the custom action. Must be unique within the Gallery Application Version."
+            }
+          },
+          "script": {
+            "type": "string",
+            "metadata": {
+              "description": "Required. The script to run when executing this custom action."
+            }
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. Description to help the users understand what this custom action does."
+            }
+          },
+          "parameters": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the parameter."
+                  }
+                },
+                "type": {
+                  "type": "string",
+                  "allowedValues": [
+                    "ConfigurationDataBlob",
+                    "LogOutputBlob",
+                    "String"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Required. Specifies the type of the custom action parameter."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. A description to help users understand what this parameter means."
+                  }
+                },
+                "defaultValue": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The default value of the parameter. Only applies to string types."
+                  }
+                },
+                "required": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Indicates whether this parameter must be passed when running the custom action."
+                  }
+                }
+              }
+            },
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The parameters that this custom action uses."
+            }
+          }
+        }
+      }
+    },
+    "sharingProfileType": {
+      "type": "object",
+      "properties": {
+        "eula": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. End-user license agreement for community gallery image."
+          }
+        },
+        "publicNamePrefix": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The prefix of the gallery name that will be displayed publicly. Visible to all users."
+          }
+        },
+        "publisherContact": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Community gallery publisher support email. The email address of the publisher. Visible to all users."
+          }
+        },
+        "publisherUri": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The link to the publisher website. Visible to all users."
+          }
+        },
+        "permissions": {
+          "type": "string",
+          "allowedValues": [
+            "Community",
+            "Groups",
+            "Private"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. This property allows you to specify the permission of sharing gallery."
+          }
+        }
+      }
+    },
     "identifierType": {
       "type": "object",
       "properties": {
@@ -387,8 +596,7 @@
       }
     },
     "applications": {
-      "type": "array",
-      "nullable": true,
+      "$ref": "#/definitions/applicationsType",
       "metadata": {
         "description": "Optional. Applications to create."
       }
@@ -426,17 +634,17 @@
       }
     },
     "sharingProfile": {
-      "type": "object",
+      "$ref": "#/definitions/sharingProfileType",
       "nullable": true,
       "metadata": {
         "description": "Optional. Profile for gallery sharing to subscription or tenant."
       }
     },
     "softDeletePolicy": {
-      "type": "object",
+      "type": "bool",
       "nullable": true,
       "metadata": {
-        "description": "Optional. Soft deletion policy of the gallery."
+        "description": "Optional. Enables soft-deletion for resources in this gallery, allowing them to be recovered within retention time."
       }
     }
   },
@@ -486,8 +694,18 @@
       "tags": "[parameters('tags')]",
       "properties": {
         "description": "[parameters('description')]",
-        "sharingProfile": "[parameters('sharingProfile')]",
-        "softDeletePolicy": "[parameters('softDeletePolicy')]"
+        "sharingProfile": {
+          "communityGalleryInfo": {
+            "eula": "[tryGet(parameters('sharingProfile'), 'eula')]",
+            "publicNamePrefix": "[tryGet(parameters('sharingProfile'), 'publicNamePrefix')]",
+            "publisherContact": "[tryGet(parameters('sharingProfile'), 'publisherContact')]",
+            "publisherUri": "[tryGet(parameters('sharingProfile'), 'publisherUri')]"
+          },
+          "permissions": "[tryGet(parameters('sharingProfile'), 'permissions')]"
+        },
+        "softDeletePolicy": {
+          "isSoftDeleteEnabled": "[parameters('softDeletePolicy')]"
+        }
       }
     },
     "gallery_lock": {
@@ -584,8 +802,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "13081960860160182257"
+              "version": "0.31.92.45157",
+              "templateHash": "12025997665546901388"
             },
             "name": "Compute Galleries Applications",
             "description": "This module deploys an Azure Compute Gallery Application.",
@@ -945,8 +1163,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "5984025187928110337"
+              "version": "0.31.92.45157",
+              "templateHash": "14463616698185324661"
             },
             "name": "Compute Galleries Image Definitions",
             "description": "This module deploys an Azure Compute Gallery Image Definition.",

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.31.92.45157",
-      "templateHash": "17941721932056607182"
+      "templateHash": "2270335166910547426"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery).",
@@ -173,93 +173,89 @@
       }
     },
     "applicationsType": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 80,
-            "metadata": {
-              "description": "Required. Name of the application definition."
-            }
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80,
+          "metadata": {
+            "description": "Required. Name of the application definition."
+          }
+        },
+        "supportedOSType": {
+          "type": "string",
+          "allowedValues": [
+            "Linux",
+            "Windows"
+          ],
+          "metadata": {
+            "description": "Required. The OS type of the application."
+          }
+        },
+        "description": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The description of this gallery application definition resource. This property is updatable."
+          }
+        },
+        "eula": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The Eula agreement for the gallery application definition."
+          }
+        },
+        "privacyStatementUri": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The privacy statement uri."
+          }
+        },
+        "releaseNoteUri": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The release note uri. Has to be a valid URL."
+          }
+        },
+        "endOfLifeDate": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The end of life date of the gallery application definition. This property can be used for decommissioning purposes. This property is updatable."
+          }
+        },
+        "roleAssignments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/roleAssignmentType"
           },
-          "supportedOSType": {
-            "type": "string",
-            "allowedValues": [
-              "Linux",
-              "Windows"
-            ],
-            "metadata": {
-              "description": "Required. The OS type of the application."
-            }
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Array of role assignments to create."
+          }
+        },
+        "customActions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/customActionType"
           },
-          "description": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The description of this gallery application definition resource. This property is updatable."
-            }
-          },
-          "eula": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The Eula agreement for the gallery application definition."
-            }
-          },
-          "privacyStatementUri": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The privacy statement uri."
-            }
-          },
-          "releaseNoteUri": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The release note uri. Has to be a valid URL."
-            }
-          },
-          "endOfLifeDate": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The end of life date of the gallery application definition. This property can be used for decommissioning purposes. This property is updatable."
-            }
-          },
-          "roleAssignments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/roleAssignmentType"
-            },
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Array of role assignments to create."
-            }
-          },
-          "customActions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/customActionType"
-            },
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application."
-            }
-          },
-          "tags": {
-            "type": "object",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Tags for all resources."
-            }
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application."
+          }
+        },
+        "tags": {
+          "type": "object",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Tags for all resources."
           }
         }
-      },
-      "nullable": true
+      }
     },
     "customActionType": {
       "type": "object",
@@ -559,7 +555,11 @@
       }
     },
     "applications": {
-      "$ref": "#/definitions/applicationsType",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/applicationsType"
+      },
+      "nullable": true,
       "metadata": {
         "description": "Optional. Applications to create."
       }

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.31.92.45157",
-      "templateHash": "6434598529291924522"
+      "templateHash": "13946388819897175743"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery).",
@@ -404,7 +404,7 @@
                   ],
                   "nullable": true,
                   "metadata": {
-                    "description": "Required. Specifies the type of the custom action parameter."
+                    "description": "Optional. Specifies the type of the custom action parameter."
                   }
                 },
                 "description": {

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -6,115 +6,13 @@
     "_generator": {
       "name": "bicep",
       "version": "0.31.92.45157",
-      "templateHash": "6141616962265242947"
+      "templateHash": "17941721932056607182"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery).",
     "owner": "Azure/module-maintainers"
   },
   "definitions": {
-    "lockType": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Specify the name of lock."
-          }
-        },
-        "kind": {
-          "type": "string",
-          "allowedValues": [
-            "CanNotDelete",
-            "None",
-            "ReadOnly"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Specify the type of lock."
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true
-      }
-    },
-    "roleAssignmentType": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
-            }
-          },
-          "roleDefinitionIdOrName": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-            }
-          },
-          "principalId": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-            }
-          },
-          "principalType": {
-            "type": "string",
-            "allowedValues": [
-              "Device",
-              "ForeignGroup",
-              "Group",
-              "ServicePrincipal",
-              "User"
-            ],
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The principal type of the assigned principal ID."
-            }
-          },
-          "description": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The description of the role assignment."
-            }
-          },
-          "condition": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-            }
-          },
-          "conditionVersion": {
-            "type": "string",
-            "allowedValues": [
-              "2.0"
-            ],
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Version of the condition."
-            }
-          },
-          "delegatedManagedIdentityResourceId": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The Resource Id of the delegated managed identity resource."
-            }
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true
-      }
-    },
     "imageType": {
       "type": "object",
       "properties": {
@@ -333,14 +231,21 @@
             }
           },
           "roleAssignments": {
-            "$ref": "#/definitions/roleAssignmentType",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/roleAssignmentType"
+            },
             "nullable": true,
             "metadata": {
               "description": "Optional. Array of role assignments to create."
             }
           },
           "customActions": {
-            "$ref": "#/definitions/customActionType",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/customActionType"
+            },
+            "nullable": true,
             "metadata": {
               "description": "Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application."
             }
@@ -357,83 +262,79 @@
       "nullable": true
     },
     "customActionType": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The name of the custom action. Must be unique within the Gallery Application Version."
-            }
-          },
-          "script": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The script to run when executing this custom action."
-            }
-          },
-          "description": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Description to help the users understand what this custom action does."
-            }
-          },
-          "parameters": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "metadata": {
-                    "description": "Required. The name of the parameter."
-                  }
-                },
-                "type": {
-                  "type": "string",
-                  "allowedValues": [
-                    "ConfigurationDataBlob",
-                    "LogOutputBlob",
-                    "String"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Specifies the type of the custom action parameter."
-                  }
-                },
-                "description": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. A description to help users understand what this parameter means."
-                  }
-                },
-                "defaultValue": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The default value of the parameter. Only applies to string types."
-                  }
-                },
-                "required": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Indicates whether this parameter must be passed when running the custom action."
-                  }
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the custom action. Must be unique within the Gallery Application Version."
+          }
+        },
+        "script": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The script to run when executing this custom action."
+          }
+        },
+        "description": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Description to help the users understand what this custom action does."
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "metadata": {
+                  "description": "Required. The name of the parameter."
+                }
+              },
+              "type": {
+                "type": "string",
+                "allowedValues": [
+                  "ConfigurationDataBlob",
+                  "LogOutputBlob",
+                  "String"
+                ],
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Specifies the type of the custom action parameter."
+                }
+              },
+              "description": {
+                "type": "string",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. A description to help users understand what this parameter means."
+                }
+              },
+              "defaultValue": {
+                "type": "string",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. The default value of the parameter. Only applies to string types."
+                }
+              },
+              "required": {
+                "type": "bool",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Indicates whether this parameter must be passed when running the custom action."
                 }
               }
-            },
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The parameters that this custom action uses."
             }
+          },
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The parameters that this custom action uses."
           }
         }
       },
-      "nullable": true,
       "metadata": {
         "__bicep_imported_from!": {
           "sourceTemplate": "application/main.bicep"
@@ -465,6 +366,36 @@
       "metadata": {
         "__bicep_imported_from!": {
           "sourceTemplate": "image/main.bicep"
+        }
+      }
+    },
+    "lockType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specify the name of lock."
+          }
+        },
+        "kind": {
+          "type": "string",
+          "allowedValues": [
+            "CanNotDelete",
+            "None",
+            "ReadOnly"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specify the type of lock."
+          }
+        }
+      },
+      "metadata": {
+        "description": "An AVM-aligned type for a lock.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.3.0"
         }
       }
     },
@@ -519,6 +450,81 @@
       "metadata": {
         "__bicep_imported_from!": {
           "sourceTemplate": "image/main.bicep"
+        }
+      }
+    },
+    "roleAssignmentType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+          }
+        },
+        "roleDefinitionIdOrName": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+          }
+        },
+        "principalId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+          }
+        },
+        "principalType": {
+          "type": "string",
+          "allowedValues": [
+            "Device",
+            "ForeignGroup",
+            "Group",
+            "ServicePrincipal",
+            "User"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The principal type of the assigned principal ID."
+          }
+        },
+        "description": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The description of the role assignment."
+          }
+        },
+        "condition": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+          }
+        },
+        "conditionVersion": {
+          "type": "string",
+          "allowedValues": [
+            "2.0"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Version of the condition."
+          }
+        },
+        "delegatedManagedIdentityResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The Resource Id of the delegated managed identity resource."
+          }
+        }
+      },
+      "metadata": {
+        "description": "An AVM-aligned type for a role assignment.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.3.0"
         }
       }
     }
@@ -576,7 +582,10 @@
       }
     },
     "roleAssignments": {
-      "$ref": "#/definitions/roleAssignmentType",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/roleAssignmentType"
+      },
       "nullable": true,
       "metadata": {
         "description": "Optional. Array of role assignments to create."
@@ -750,166 +759,164 @@
             "_generator": {
               "name": "bicep",
               "version": "0.31.92.45157",
-              "templateHash": "3840736055128275990"
+              "templateHash": "11162019331609283814"
             },
             "name": "Compute Galleries Applications",
             "description": "This module deploys an Azure Compute Gallery Application.",
             "owner": "Azure/module-maintainers"
           },
           "definitions": {
-            "roleAssignmentType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
-                    }
-                  },
-                  "roleDefinitionIdOrName": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-                    }
-                  },
-                  "principalId": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-                    }
-                  },
-                  "principalType": {
-                    "type": "string",
-                    "allowedValues": [
-                      "Device",
-                      "ForeignGroup",
-                      "Group",
-                      "ServicePrincipal",
-                      "User"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The principal type of the assigned principal ID."
-                    }
-                  },
-                  "description": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The description of the role assignment."
-                    }
-                  },
-                  "condition": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-                    }
-                  },
-                  "conditionVersion": {
-                    "type": "string",
-                    "allowedValues": [
-                      "2.0"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Version of the condition."
-                    }
-                  },
-                  "delegatedManagedIdentityResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The Resource Id of the delegated managed identity resource."
-                    }
-                  }
-                }
-              },
-              "nullable": true
-            },
             "customActionType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The name of the custom action. Must be unique within the Gallery Application Version."
-                    }
-                  },
-                  "script": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The script to run when executing this custom action."
-                    }
-                  },
-                  "description": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Description to help the users understand what this custom action does."
-                    }
-                  },
-                  "parameters": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "metadata": {
-                            "description": "Required. The name of the parameter."
-                          }
-                        },
-                        "type": {
-                          "type": "string",
-                          "allowedValues": [
-                            "ConfigurationDataBlob",
-                            "LogOutputBlob",
-                            "String"
-                          ],
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Specifies the type of the custom action parameter."
-                          }
-                        },
-                        "description": {
-                          "type": "string",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. A description to help users understand what this parameter means."
-                          }
-                        },
-                        "defaultValue": {
-                          "type": "string",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. The default value of the parameter. Only applies to string types."
-                          }
-                        },
-                        "required": {
-                          "type": "bool",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Indicates whether this parameter must be passed when running the custom action."
-                          }
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the custom action. Must be unique within the Gallery Application Version."
+                  }
+                },
+                "script": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The script to run when executing this custom action."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Description to help the users understand what this custom action does."
+                  }
+                },
+                "parameters": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "metadata": {
+                          "description": "Required. The name of the parameter."
+                        }
+                      },
+                      "type": {
+                        "type": "string",
+                        "allowedValues": [
+                          "ConfigurationDataBlob",
+                          "LogOutputBlob",
+                          "String"
+                        ],
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Specifies the type of the custom action parameter."
+                        }
+                      },
+                      "description": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. A description to help users understand what this parameter means."
+                        }
+                      },
+                      "defaultValue": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. The default value of the parameter. Only applies to string types."
+                        }
+                      },
+                      "required": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Indicates whether this parameter must be passed when running the custom action."
                         }
                       }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The parameters that this custom action uses."
                     }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The parameters that this custom action uses."
                   }
                 }
               },
-              "nullable": true,
               "metadata": {
                 "__bicep_export!": true
+              }
+            },
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.3.0"
+                }
               }
             }
           },
@@ -980,7 +987,11 @@
               }
             },
             "roleAssignments": {
-              "$ref": "#/definitions/roleAssignmentType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Array of role assignments to create."
               }
@@ -993,7 +1004,11 @@
               }
             },
             "customActions": {
-              "$ref": "#/definitions/customActionType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/customActionType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application."
               }

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.31.92.45157",
-      "templateHash": "9991159892229520493"
+      "templateHash": "6141616962265242947"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery).",
@@ -340,11 +340,7 @@
             }
           },
           "customActions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/customActionType"
-            },
-            "nullable": true,
+            "$ref": "#/definitions/customActionType",
             "metadata": {
               "description": "Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application."
             }
@@ -436,50 +432,11 @@
             }
           }
         }
-      }
-    },
-    "sharingProfileType": {
-      "type": "object",
-      "properties": {
-        "eula": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. End-user license agreement for community gallery image."
-          }
-        },
-        "publicNamePrefix": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The prefix of the gallery name that will be displayed publicly. Visible to all users."
-          }
-        },
-        "publisherContact": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Community gallery publisher support email. The email address of the publisher. Visible to all users."
-          }
-        },
-        "publisherUri": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The link to the publisher website. Visible to all users."
-          }
-        },
-        "permissions": {
-          "type": "string",
-          "allowedValues": [
-            "Community",
-            "Groups",
-            "Private"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. This property allows you to specify the permission of sharing gallery."
-          }
+      },
+      "nullable": true,
+      "metadata": {
+        "__bicep_imported_from!": {
+          "sourceTemplate": "application/main.bicep"
         }
       }
     },
@@ -634,17 +591,17 @@
       }
     },
     "sharingProfile": {
-      "$ref": "#/definitions/sharingProfileType",
+      "type": "object",
       "nullable": true,
       "metadata": {
         "description": "Optional. Profile for gallery sharing to subscription or tenant."
       }
     },
     "softDeletePolicy": {
-      "type": "bool",
+      "type": "object",
       "nullable": true,
       "metadata": {
-        "description": "Optional. Enables soft-deletion for resources in this gallery, allowing them to be recovered within retention time."
+        "description": "Optional. Soft deletion policy of the gallery."
       }
     }
   },
@@ -694,8 +651,8 @@
       "tags": "[parameters('tags')]",
       "properties": {
         "description": "[parameters('description')]",
-        "sharingProfile": "[if(not(empty(parameters('sharingProfile'))), createObject('communityGalleryInfo', createObject('eula', tryGet(parameters('sharingProfile'), 'eula'), 'publicNamePrefix', tryGet(parameters('sharingProfile'), 'publicNamePrefix'), 'publisherContact', tryGet(parameters('sharingProfile'), 'publisherContact'), 'publisherUri', tryGet(parameters('sharingProfile'), 'publisherUri')), 'permissions', tryGet(parameters('sharingProfile'), 'permissions')), null())]",
-        "softDeletePolicy": "[if(not(equals(parameters('softDeletePolicy'), null())), createObject('isSoftDeleteEnabled', parameters('softDeletePolicy')), null())]"
+        "sharingProfile": "[parameters('sharingProfile')]",
+        "softDeletePolicy": "[parameters('softDeletePolicy')]"
       }
     },
     "gallery_lock": {
@@ -793,7 +750,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.31.92.45157",
-              "templateHash": "12025997665546901388"
+              "templateHash": "3840736055128275990"
             },
             "name": "Compute Galleries Applications",
             "description": "This module deploys an Azure Compute Gallery Application.",
@@ -872,6 +829,88 @@
                 }
               },
               "nullable": true
+            },
+            "customActionType": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "metadata": {
+                      "description": "Required. The name of the custom action. Must be unique within the Gallery Application Version."
+                    }
+                  },
+                  "script": {
+                    "type": "string",
+                    "metadata": {
+                      "description": "Required. The script to run when executing this custom action."
+                    }
+                  },
+                  "description": {
+                    "type": "string",
+                    "nullable": true,
+                    "metadata": {
+                      "description": "Optional. Description to help the users understand what this custom action does."
+                    }
+                  },
+                  "parameters": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the parameter."
+                          }
+                        },
+                        "type": {
+                          "type": "string",
+                          "allowedValues": [
+                            "ConfigurationDataBlob",
+                            "LogOutputBlob",
+                            "String"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specifies the type of the custom action parameter."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. A description to help users understand what this parameter means."
+                          }
+                        },
+                        "defaultValue": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The default value of the parameter. Only applies to string types."
+                          }
+                        },
+                        "required": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Indicates whether this parameter must be passed when running the custom action."
+                          }
+                        }
+                      }
+                    },
+                    "nullable": true,
+                    "metadata": {
+                      "description": "Optional. The parameters that this custom action uses."
+                    }
+                  }
+                }
+              },
+              "nullable": true,
+              "metadata": {
+                "__bicep_export!": true
+              }
             }
           },
           "parameters": {
@@ -954,8 +993,7 @@
               }
             },
             "customActions": {
-              "type": "array",
-              "nullable": true,
+              "$ref": "#/definitions/customActionType",
               "metadata": {
                 "description": "Optional. A list of custom actions that can be performed with all of the Gallery Application Versions within this Gallery Application."
               }

--- a/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
@@ -64,7 +64,7 @@ module testDeployment '../../../main.bicep' = [
         publisherContact: 'avmtest@contoso.com'
         publisherUri: 'https://aka.ms/avm'
       }
-      softDeletePolicy: false
+      softDeletePolicy: true
       applications: [
         {
           name: '${namePrefix}-${serviceShort}-appd-001'

--- a/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
@@ -57,13 +57,6 @@ module testDeployment '../../../main.bicep' = [
         name: 'myCustomLockName'
       }
       description: 'This is a test deployment.'
-      sharingProfile: {
-        eula: 'test Eula'
-        permissions: 'Community'
-        publicNamePrefix: 'avmtest'
-        publisherContact: 'avmtest@contoso.com'
-        publisherUri: 'https://aka.ms/avm'
-      }
       applications: [
         {
           name: '${namePrefix}-${serviceShort}-appd-001'

--- a/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
@@ -56,6 +56,15 @@ module testDeployment '../../../main.bicep' = [
         kind: 'CanNotDelete'
         name: 'myCustomLockName'
       }
+      description: 'This is a test deployment.'
+      sharingProfile: {
+        eula: 'test Eula'
+        permissions: 'Private'
+        publicNamePrefix: 'avmtest'
+        publisherContact: 'avmtest@contoso.com'
+        publisherUri: 'https://aka.ms/avm'
+      }
+      softDeletePolicy: false
       applications: [
         {
           name: '${namePrefix}-${serviceShort}-appd-001'

--- a/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
@@ -64,7 +64,6 @@ module testDeployment '../../../main.bicep' = [
         publisherContact: 'avmtest@contoso.com'
         publisherUri: 'https://aka.ms/avm'
       }
-      softDeletePolicy: true
       applications: [
         {
           name: '${namePrefix}-${serviceShort}-appd-001'

--- a/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
@@ -59,7 +59,7 @@ module testDeployment '../../../main.bicep' = [
       description: 'This is a test deployment.'
       sharingProfile: {
         eula: 'test Eula'
-        permissions: 'Private'
+        permissions: 'Community'
         publicNamePrefix: 'avmtest'
         publisherContact: 'avmtest@contoso.com'
         publisherUri: 'https://aka.ms/avm'

--- a/avm/res/compute/gallery/version.json
+++ b/avm/res/compute/gallery/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.7",
+  "version": "0.8",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
## Description

This PR adds the `applicationsType` UDT and updates existing UDTs to follow AVM standards.

Tagging owner: @ReneHezser 

## Pipeline Reference


| Pipeline |
| -------- |
|    [![avm.res.compute.gallery](https://github.com/johnlokerse/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml/badge.svg?branch=johnlokerse%2Fudt-compute-gallery)](https://github.com/johnlokerse/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
