### PR TITLE
fix: PostgreSQL Flexible Server Pipeline repair

### DIFF
--- a/avm/res/db-for-postgre-sql/flexible-server/README.md
+++ b/avm/res/db-for-postgre-sql/flexible-server/README.md
@@ -1317,7 +1317,7 @@ param tags = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`administratorLogin`](#parameter-administratorlogin) | string | The administrator login name for the server. Can only be specified when the PostgreSQL server is being created. |
+| [`administratorLogin`](#parameter-administratorlogin) | string | The administrator login name to the server. Can only be specified when the PostgreSQL server is being created. |
 | [`administratorLoginPassword`](#parameter-administratorloginpassword) | securestring | The administrator login password. |
 | [`administrators`](#parameter-administrators) | array | The Azure AD administrators when AAD authentication enabled. |
 | [`availabilityZone`](#parameter-availabilityzone) | string | Availability zone information of the server. Default will have no preference set. |
@@ -1410,7 +1410,7 @@ Required if 'createMode' is set to 'PointInTimeRestore'.
 
 ### Parameter: `administratorLogin`
 
-The administrator login name for the server. Can only be specified when the PostgreSQL server is being created.
+The administrator login name to the server. Can only be specified when the PostgreSQL server is being created.
 
 - Required: No
 - Type: string

--- a/avm/res/db-for-postgre-sql/flexible-server/administrator/main.json
+++ b/avm/res/db-for-postgre-sql/flexible-server/administrator/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.34.60546",
-      "templateHash": "16481538210870485841"
+      "version": "0.31.92.45157",
+      "templateHash": "787734745917336225"
     },
     "name": "DBforPostgreSQL Flexible Server Administrators",
     "description": "This module deploys a DBforPostgreSQL Flexible Server Administrator.",

--- a/avm/res/db-for-postgre-sql/flexible-server/configuration/main.json
+++ b/avm/res/db-for-postgre-sql/flexible-server/configuration/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.34.60546",
-      "templateHash": "4744350024962623928"
+      "version": "0.31.92.45157",
+      "templateHash": "17983721131351446823"
     },
     "name": "DBforPostgreSQL Flexible Server Configurations",
     "description": "This module deploys a DBforPostgreSQL Flexible Server Configuration.",
@@ -54,7 +54,10 @@
       "properties": {
         "source": "[if(not(empty(parameters('source'))), parameters('source'), null())]",
         "value": "[if(not(empty(parameters('value'))), parameters('value'), null())]"
-      }
+      },
+      "dependsOn": [
+        "flexibleServer"
+      ]
     }
   },
   "outputs": {

--- a/avm/res/db-for-postgre-sql/flexible-server/database/main.json
+++ b/avm/res/db-for-postgre-sql/flexible-server/database/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.34.60546",
-      "templateHash": "5925943942284222024"
+      "version": "0.31.92.45157",
+      "templateHash": "12789563869551162858"
     },
     "name": "DBforPostgreSQL Flexible Server Databases",
     "description": "This module deploys a DBforPostgreSQL Flexible Server Database.",
@@ -54,7 +54,10 @@
       "properties": {
         "collation": "[if(not(empty(parameters('collation'))), parameters('collation'), null())]",
         "charset": "[if(not(empty(parameters('charset'))), parameters('charset'), null())]"
-      }
+      },
+      "dependsOn": [
+        "flexibleServer"
+      ]
     }
   },
   "outputs": {

--- a/avm/res/db-for-postgre-sql/flexible-server/firewall-rule/main.json
+++ b/avm/res/db-for-postgre-sql/flexible-server/firewall-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.34.60546",
-      "templateHash": "9983440066171652627"
+      "version": "0.31.92.45157",
+      "templateHash": "13990914411694160996"
     },
     "name": "DBforPostgreSQL Flexible Server Firewall Rules",
     "description": "This module deploys a DBforPostgreSQL Flexible Server Firewall Rule.",

--- a/avm/res/db-for-postgre-sql/flexible-server/main.bicep
+++ b/avm/res/db-for-postgre-sql/flexible-server/main.bicep
@@ -5,7 +5,7 @@ metadata owner = 'Azure/module-maintainers'
 @description('Required. The name of the PostgreSQL flexible server.')
 param name string
 
-@description('Optional. The administrator login name for the server. Can only be specified when the PostgreSQL server is being created.')
+@description('Optional. The administrator login name to the server. Can only be specified when the PostgreSQL server is being created.')
 param administratorLogin string?
 
 @description('Optional. The administrator login password.')

--- a/avm/res/db-for-postgre-sql/flexible-server/main.json
+++ b/avm/res/db-for-postgre-sql/flexible-server/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.34.60546",
-      "templateHash": "13236500116916645585"
+      "version": "0.31.92.45157",
+      "templateHash": "11631662675638152544"
     },
     "name": "DBforPostgreSQL Flexible Servers",
     "description": "This module deploys a DBforPostgreSQL Flexible Server.",
@@ -561,7 +561,7 @@
       "type": "string",
       "nullable": true,
       "metadata": {
-        "description": "Optional. The administrator login name for the server. Can only be specified when the PostgreSQL server is being created."
+        "description": "Optional. The administrator login name to the server. Can only be specified when the PostgreSQL server is being created."
       }
     },
     "administratorLoginPassword": {
@@ -856,7 +856,10 @@
       "apiVersion": "2023-07-01",
       "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '//'), '/')[2]]",
       "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '////'), '/')[4]]",
-      "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]"
+      "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]",
+      "dependsOn": [
+        "cMKKeyVault"
+      ]
     },
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
@@ -934,7 +937,11 @@
           "storageSizeGB": "[parameters('storageSizeGB')]"
         },
         "version": "[parameters('version')]"
-      }
+      },
+      "dependsOn": [
+        "cMKKeyVault",
+        "cMKUserAssignedIdentity"
+      ]
     },
     "flexibleServer_lock": {
       "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
@@ -1047,8 +1054,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.31.34.60546",
-              "templateHash": "5925943942284222024"
+              "version": "0.31.92.45157",
+              "templateHash": "12789563869551162858"
             },
             "name": "DBforPostgreSQL Flexible Server Databases",
             "description": "This module deploys a DBforPostgreSQL Flexible Server Database.",
@@ -1096,7 +1103,10 @@
               "properties": {
                 "collation": "[if(not(empty(parameters('collation'))), parameters('collation'), null())]",
                 "charset": "[if(not(empty(parameters('charset'))), parameters('charset'), null())]"
-              }
+              },
+              "dependsOn": [
+                "flexibleServer"
+              ]
             }
           },
           "outputs": {
@@ -1161,8 +1171,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.31.34.60546",
-              "templateHash": "9983440066171652627"
+              "version": "0.31.92.45157",
+              "templateHash": "13990914411694160996"
             },
             "name": "DBforPostgreSQL Flexible Server Firewall Rules",
             "description": "This module deploys a DBforPostgreSQL Flexible Server Firewall Rule.",
@@ -1271,8 +1281,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.31.34.60546",
-              "templateHash": "4744350024962623928"
+              "version": "0.31.92.45157",
+              "templateHash": "17983721131351446823"
             },
             "name": "DBforPostgreSQL Flexible Server Configurations",
             "description": "This module deploys a DBforPostgreSQL Flexible Server Configuration.",
@@ -1320,7 +1330,10 @@
               "properties": {
                 "source": "[if(not(empty(parameters('source'))), parameters('source'), null())]",
                 "value": "[if(not(empty(parameters('value'))), parameters('value'), null())]"
-              }
+              },
+              "dependsOn": [
+                "flexibleServer"
+              ]
             }
           },
           "outputs": {
@@ -1389,8 +1402,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.31.34.60546",
-              "templateHash": "16481538210870485841"
+              "version": "0.31.92.45157",
+              "templateHash": "787734745917336225"
             },
             "name": "DBforPostgreSQL Flexible Server Administrators",
             "description": "This module deploys a DBforPostgreSQL Flexible Server Administrator.",

--- a/avm/res/db-for-postgre-sql/flexible-server/version.json
+++ b/avm/res/db-for-postgre-sql/flexible-server/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.6",
+    "version": "0.7",
     "pathFilters": [
         "./main.json"
     ]


### PR DESCRIPTION
## Description
Fixes #3787 
Closes #3787

Updated main.json files.
<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->z

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.db-for-postgre-sql.flexible-server](https://github.com/arnoldna/bicep-registry-modules/actions/workflows/avm.res.db-for-postgre-sql.flexible-server.yml/badge.svg?branch=avm%2Fres%2Fdb-for-postgre-sql%2Fflexible-server)](https://github.com/arnoldna/bicep-registry-modules/actions/workflows/avm.res.db-for-postgre-sql.flexible-server.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [X] Update to documentation

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings