### PR TITLE
fix: Adding missing MongoDB server versions to Azure Cosmos DB

### DIFF
--- a/avm/res/document-db/database-account/README.md
+++ b/avm/res/document-db/database-account/README.md
@@ -4627,6 +4627,9 @@ Default to 4.2. Specifies the MongoDB server version to use.
     '3.6'
     '4.0'
     '4.2'
+    '5.0'
+    '6.0'
+    '7.0'
   ]
   ```
 

--- a/avm/res/document-db/database-account/main.bicep
+++ b/avm/res/document-db/database-account/main.bicep
@@ -67,6 +67,9 @@ param maxIntervalInSeconds int = 300
   '3.6'
   '4.0'
   '4.2'
+  '5.0'
+  '6.0'
+  '7.0'
 ])
 param serverVersion string = '4.2'
 

--- a/avm/res/document-db/database-account/main.json
+++ b/avm/res/document-db/database-account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.30.23.60470",
-      "templateHash": "13300542630733457081"
+      "version": "0.31.92.45157",
+      "templateHash": "1272677222480156701"
     },
     "name": "DocumentDB Database Accounts",
     "description": "This module deploys a DocumentDB Database Account.",
@@ -986,7 +986,10 @@
         "3.2",
         "3.6",
         "4.0",
-        "4.2"
+        "4.2",
+        "5.0",
+        "6.0",
+        "7.0"
       ],
       "metadata": {
         "description": "Optional. Default to 4.2. Specifies the MongoDB server version to use."
@@ -1396,8 +1399,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "10274585444287252550"
+              "version": "0.31.92.45157",
+              "templateHash": "14039021912249335209"
             },
             "name": "DocumentDB Database Account SQL Databases",
             "description": "This module deploys a SQL Database in a CosmosDB Account.",
@@ -1529,8 +1532,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "165408036680070575"
+                      "version": "0.31.92.45157",
+                      "templateHash": "1471754747460263407"
                     },
                     "name": "DocumentDB Database Account SQL Database Containers",
                     "description": "This module deploys a SQL Database Container in a CosmosDB Account.",
@@ -1786,8 +1789,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "13088569006752107887"
+              "version": "0.31.92.45157",
+              "templateHash": "3860121931480041680"
             },
             "name": "DocumentDB Database Account SQL Role.",
             "description": "This module deploys SQL Role Definision and Assignment in a CosmosDB Account.",
@@ -1873,8 +1876,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "5054354703268051893"
+                      "version": "0.31.92.45157",
+                      "templateHash": "2222650596260487600"
                     },
                     "name": "DocumentDB Database Account SQL Role Definitions.",
                     "description": "This module deploys a SQL Role Definision in a CosmosDB Account.",
@@ -1994,8 +1997,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "4561927123418147924"
+                      "version": "0.31.92.45157",
+                      "templateHash": "12993275952067538651"
                     },
                     "name": "DocumentDB Database Account SQL Role Assignments.",
                     "description": "This module deploys a SQL Role Assignment in a CosmosDB Account.",
@@ -2108,8 +2111,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "1169635175830874795"
+              "version": "0.31.92.45157",
+              "templateHash": "18295016247574474595"
             },
             "name": "DocumentDB Database Account MongoDB Databases",
             "description": "This module deploys a MongoDB Database within a CosmosDB Account.",
@@ -2211,8 +2214,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1358778299011674509"
+                      "version": "0.31.92.45157",
+                      "templateHash": "9799909568020880663"
                     },
                     "name": "DocumentDB Database Account MongoDB Database Collections",
                     "description": "This module deploys a MongoDB Database Collection.",
@@ -2371,8 +2374,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "14612267479855031826"
+              "version": "0.31.92.45157",
+              "templateHash": "6528096364275148764"
             },
             "name": "DocumentDB Database Account Gremlin Databases",
             "description": "This module deploys a Gremlin Database within a CosmosDB Account.",
@@ -2477,8 +2480,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "5396990720772518636"
+                      "version": "0.31.92.45157",
+                      "templateHash": "16994331830326213766"
                     },
                     "name": "DocumentDB Database Accounts Gremlin Databases Graphs",
                     "description": "This module deploys a DocumentDB Database Accounts Gremlin Database Graph.",
@@ -2656,8 +2659,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "15712676324433329983"
+              "version": "0.31.92.45157",
+              "templateHash": "6722170581524078621"
             },
             "name": "Azure Cosmos DB account tables",
             "description": "This module deploys a table within an Azure Cosmos DB Account.",
@@ -3543,8 +3546,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "12263717469683062316"
+              "version": "0.31.92.45157",
+              "templateHash": "7954388693868310378"
             }
           },
           "definitions": {


### PR DESCRIPTION
## Description

Adds support for the following server versions to MongoDB (RU-based) in Azure Cosmos DB:

- `5.0`
- `6.0`
- `7.0`

Closes #3709

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|  [![avm.res.document-db.database-account](https://github.com/seesharprun/bicep-registry-modules/actions/workflows/avm.res.document-db.database-account.yml/badge.svg)](https://github.com/seesharprun/bicep-registry-modules/actions/workflows/avm.res.document-db.database-account.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
