### PR TITLE
feat: Added logic to find child modules when running `Test-ModuleLocally -PesterTest`

### DIFF
--- a/avm/utilities/tools/Test-ModuleLocally.ps1
+++ b/avm/utilities/tools/Test-ModuleLocally.ps1
@@ -139,6 +139,9 @@ function Test-ModuleLocally {
         [switch] $PesterTest,
 
         [Parameter(Mandatory = $false)]
+        [switch] $PesterTestRecurse,
+
+        [Parameter(Mandatory = $false)]
         [switch] $DeploymentTest,
 
         [Parameter(Mandatory = $false)]
@@ -177,8 +180,10 @@ function Test-ModuleLocally {
                 )
 
                 $moduleFolderPaths = @(Split-Path $TemplateFilePath -Parent)
-                $moduleFolderPaths += (Get-ChildItem -Path $moduleFolderPaths -Recurse -Directory -Force).FullName | Where-Object {
-                    (Get-ChildItem $_ -File -Depth 0 -Include @('main.json', 'main.bicep') -Force).Count -gt 0
+                if ($PesterTestRecurse) {
+                    $moduleFolderPaths += (Get-ChildItem -Path $moduleFolderPaths -Recurse -Directory -Force).FullName | Where-Object {
+                        (Get-ChildItem $_ -File -Depth 0 -Include @('main.json', 'main.bicep') -Force).Count -gt 0
+                    }
                 }
 
                 Invoke-Pester -Configuration @{

--- a/avm/utilities/tools/Test-ModuleLocally.ps1
+++ b/avm/utilities/tools/Test-ModuleLocally.ps1
@@ -170,7 +170,7 @@ function Test-ModuleLocally {
         ################
         # PESTER Tests #
         ################
-        if ($PesterTest) {
+        if ($PesterTest -or $PesterTestRecurse) {
             Write-Verbose "Pester Testing Module: $ModuleName"
 
             try {

--- a/avm/utilities/tools/Test-ModuleLocally.ps1
+++ b/avm/utilities/tools/Test-ModuleLocally.ps1
@@ -176,11 +176,16 @@ function Test-ModuleLocally {
                     (Join-Path $moduleRoot 'tests' 'unit')         # Module Unit Tests
                 )
 
+                $moduleFolderPaths = @(Split-Path $TemplateFilePath -Parent)
+                $moduleFolderPaths += (Get-ChildItem -Path $moduleFolderPaths -Recurse -Directory -Force).FullName | Where-Object {
+                    (Get-ChildItem $_ -File -Depth 0 -Include @('main.json', 'main.bicep') -Force).Count -gt 0
+                }
+
                 Invoke-Pester -Configuration @{
                     Run    = @{
                         Container = New-PesterContainer -Path $testFiles -Data @{
                             repoRootPath      = $repoRootPath
-                            moduleFolderPaths = Split-Path $TemplateFilePath -Parent
+                            moduleFolderPaths = $moduleFolderPaths
                         }
                     }
                     Output = @{


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

Changed logic in Test-ModuleLocally to detect child modules. Uses same code as in the GitHub Action at https://github.com/Azure/bicep-registry-modules/blob/main/.github/actions/templates/avm-validateModulePester/action.yml

Closes #3869 


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
