### PR TITLE
feat: Update `avm/res/event-hub/namespace` - Add connection string output to Event Hub namespace module

### DIFF
--- a/avm/res/event-hub/namespace/README.md
+++ b/avm/res/event-hub/namespace/README.md
@@ -2310,6 +2310,7 @@ Switch to make the Event Hub Namespace zone redundant.
 | `resourceGroupName` | string | The resource group where the namespace is deployed. |
 | `resourceId` | string | The resource ID of the eventspace. |
 | `systemAssignedMIPrincipalId` | string | The principal ID of the system assigned identity. |
+| `connectionString` | string | The connection string of the Event Hub namespace. |
 
 ## Cross-referenced modules
 

--- a/avm/res/event-hub/namespace/main.bicep
+++ b/avm/res/event-hub/namespace/main.bicep
@@ -492,6 +492,9 @@ output privateEndpoints array = [
   }
 ]
 
+@description('The connection string of the Event Hub namespace using the Root Managed Shared Access Key.')
+output connectionString string = listKeys(concat(resourceId('Microsoft.EventHub/namespaces', name), '/AuthorizationRules/RootManageSharedAccessKey'), '2024-01-01').primaryConnectionString
+
 // =============== //
 //   Definitions   //
 // =============== //


### PR DESCRIPTION
Fixes #3638

Add output for Event Hub namespace connection string

* Add output for connection string using `listKeys` function in `avm/res/event-hub/namespace/main.bicep`
* Update `outputs` section in `avm/res/event-hub/namespace/main.bicep` to include connection string
* Document new output for connection string in `avm/res/event-hub/namespace/README.md`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Azure/bicep-registry-modules/pull/3906?shareId=07afe390-88ac-4688-89f9-6038b6188816).