### PR TITLE
fix: automation account - Regen json files to comply with bicep version change

### DIFF
--- a/avm/res/automation/automation-account/credential/main.json
+++ b/avm/res/automation/automation-account/credential/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.92.45157",
-      "templateHash": "3177693922733831864"
+      "version": "0.32.4.45862",
+      "templateHash": "14072663101928459073"
     },
     "name": "Automation Account Credential",
     "description": "This module deploys Azure Automation Account Credential.",
@@ -60,10 +60,7 @@
         "password": "[parameters('password')]",
         "userName": "[parameters('userName')]",
         "description": "[coalesce(parameters('description'), '')]"
-      },
-      "dependsOn": [
-        "automationAccount"
-      ]
+      }
     }
   },
   "outputs": {

--- a/avm/res/automation/automation-account/job-schedule/main.json
+++ b/avm/res/automation/automation-account/job-schedule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.92.45157",
-      "templateHash": "1973660029373842500"
+      "version": "0.32.4.45862",
+      "templateHash": "17724956402217558185"
     },
     "name": "Automation Account Job Schedules",
     "description": "This module deploys an Azure Automation Account Job Schedule.",

--- a/avm/res/automation/automation-account/main.json
+++ b/avm/res/automation/automation-account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.92.45157",
-      "templateHash": "7064248988534134732"
+      "version": "0.32.4.45862",
+      "templateHash": "7322194552342116892"
     },
     "name": "Automation Accounts",
     "description": "This module deploys an Azure Automation Account.",
@@ -848,10 +848,7 @@
       "apiVersion": "2023-02-01",
       "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '//'), '/')[2]]",
       "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '////'), '/')[4]]",
-      "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]",
-      "dependsOn": [
-        "cMKKeyVault"
-      ]
+      "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]"
     },
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
@@ -907,8 +904,8 @@
         "disableLocalAuth": "[parameters('disableLocalAuth')]"
       },
       "dependsOn": [
-        "cMKKeyVault",
-        "cMKUserAssignedIdentity"
+        "cMKKeyVault::cMKKey",
+        "cMKKeyVault"
       ]
     },
     "automationAccount_lock": {
@@ -1025,8 +1022,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.31.92.45157",
-              "templateHash": "3177693922733831864"
+              "version": "0.32.4.45862",
+              "templateHash": "14072663101928459073"
             },
             "name": "Automation Account Credential",
             "description": "This module deploys Azure Automation Account Credential.",
@@ -1080,10 +1077,7 @@
                 "password": "[parameters('password')]",
                 "userName": "[parameters('userName')]",
                 "description": "[coalesce(parameters('description'), '')]"
-              },
-              "dependsOn": [
-                "automationAccount"
-              ]
+              }
             }
           },
           "outputs": {
@@ -1155,8 +1149,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.31.92.45157",
-              "templateHash": "1826826272421943582"
+              "version": "0.32.4.45862",
+              "templateHash": "11043846710506937492"
             },
             "name": "Automation Account Modules",
             "description": "This module deploys an Azure Automation Account Module.",
@@ -1221,10 +1215,7 @@
                   "uri": "[if(not(equals(parameters('version'), 'latest')), format('{0}/{1}/{2}', parameters('uri'), parameters('name'), parameters('version')), format('{0}/{1}', parameters('uri'), parameters('name')))]",
                   "version": "[if(not(equals(parameters('version'), 'latest')), parameters('version'), null())]"
                 }
-              },
-              "dependsOn": [
-                "automationAccount"
-              ]
+              }
             }
           },
           "outputs": {
@@ -1311,8 +1302,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.31.92.45157",
-              "templateHash": "9390427400811966884"
+              "version": "0.32.4.45862",
+              "templateHash": "2769963466163535886"
             },
             "name": "Automation Account Schedules",
             "description": "This module deploys an Azure Automation Account Schedule.",
@@ -1496,8 +1487,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.31.92.45157",
-              "templateHash": "17488627496732697335"
+              "version": "0.32.4.45862",
+              "templateHash": "10628373878524632674"
             },
             "name": "Automation Account Runbooks",
             "description": "This module deploys an Azure Automation Account Runbook.",
@@ -1625,11 +1616,7 @@
                 "runbookType": "[parameters('type')]",
                 "description": "[parameters('description')]",
                 "publishContentLink": "[if(not(empty(parameters('uri'))), if(empty(parameters('uri')), null(), createObject('uri', if(not(empty(parameters('uri'))), if(empty(parameters('scriptStorageAccountResourceId')), parameters('uri'), format('{0}?{1}', parameters('uri'), listAccountSas(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('scriptStorageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('scriptStorageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('scriptStorageAccountResourceId'), 'dummyVault'), '/'))), '2021-04-01', variables('accountSasProperties')).accountSasToken)), null()), 'version', if(not(empty(parameters('version'))), parameters('version'), null()))), null())]"
-              },
-              "dependsOn": [
-                "automationAccount",
-                "storageAccount"
-              ]
+              }
             }
           },
           "outputs": {
@@ -1704,8 +1691,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.31.92.45157",
-              "templateHash": "1973660029373842500"
+              "version": "0.32.4.45862",
+              "templateHash": "17724956402217558185"
             },
             "name": "Automation Account Job Schedules",
             "description": "This module deploys an Azure Automation Account Job Schedule.",
@@ -1836,8 +1823,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.31.92.45157",
-              "templateHash": "11138609945914911372"
+              "version": "0.32.4.45862",
+              "templateHash": "995071399213667449"
             },
             "name": "Automation Account Variables",
             "description": "This module deploys an Azure Automation Account Variable.",
@@ -1951,8 +1938,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.31.92.45157",
-              "templateHash": "127660536760800360"
+              "version": "0.32.4.45862",
+              "templateHash": "17097798234862446049"
             },
             "name": "Log Analytics Workspace Linked Services",
             "description": "This module deploys a Log Analytics Workspace Linked Service.",
@@ -2008,10 +1995,7 @@
               "properties": {
                 "resourceId": "[parameters('resourceId')]",
                 "writeAccessResourceId": "[if(empty(parameters('writeAccessResourceId')), null(), parameters('writeAccessResourceId'))]"
-              },
-              "dependsOn": [
-                "workspace"
-              ]
+              }
             }
           },
           "outputs": {
@@ -2354,8 +2338,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.31.92.45157",
-              "templateHash": "10379683657935183144"
+              "version": "0.32.4.45862",
+              "templateHash": "11568533167274650070"
             },
             "name": "Automation Account Software Update Configurations",
             "description": "This module deploys an Azure Automation Account Software Update Configuration.",
@@ -2738,10 +2722,7 @@
                   "nextRunOffsetMinutes": "[parameters('nextRunOffsetMinutes')]",
                   "description": "[parameters('scheduleDescription')]"
                 }
-              },
-              "dependsOn": [
-                "automationAccount"
-              ]
+              }
             }
           },
           "outputs": {

--- a/avm/res/automation/automation-account/module/main.json
+++ b/avm/res/automation/automation-account/module/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.92.45157",
-      "templateHash": "1826826272421943582"
+      "version": "0.32.4.45862",
+      "templateHash": "11043846710506937492"
     },
     "name": "Automation Account Modules",
     "description": "This module deploys an Azure Automation Account Module.",
@@ -71,10 +71,7 @@
           "uri": "[if(not(equals(parameters('version'), 'latest')), format('{0}/{1}/{2}', parameters('uri'), parameters('name'), parameters('version')), format('{0}/{1}', parameters('uri'), parameters('name')))]",
           "version": "[if(not(equals(parameters('version'), 'latest')), parameters('version'), null())]"
         }
-      },
-      "dependsOn": [
-        "automationAccount"
-      ]
+      }
     }
   },
   "outputs": {

--- a/avm/res/automation/automation-account/runbook/main.json
+++ b/avm/res/automation/automation-account/runbook/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.92.45157",
-      "templateHash": "17488627496732697335"
+      "version": "0.32.4.45862",
+      "templateHash": "10628373878524632674"
     },
     "name": "Automation Account Runbooks",
     "description": "This module deploys an Azure Automation Account Runbook.",
@@ -134,11 +134,7 @@
         "runbookType": "[parameters('type')]",
         "description": "[parameters('description')]",
         "publishContentLink": "[if(not(empty(parameters('uri'))), if(empty(parameters('uri')), null(), createObject('uri', if(not(empty(parameters('uri'))), if(empty(parameters('scriptStorageAccountResourceId')), parameters('uri'), format('{0}?{1}', parameters('uri'), listAccountSas(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('scriptStorageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('scriptStorageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('scriptStorageAccountResourceId'), 'dummyVault'), '/'))), '2021-04-01', variables('accountSasProperties')).accountSasToken)), null()), 'version', if(not(empty(parameters('version'))), parameters('version'), null()))), null())]"
-      },
-      "dependsOn": [
-        "automationAccount",
-        "storageAccount"
-      ]
+      }
     }
   },
   "outputs": {

--- a/avm/res/automation/automation-account/schedule/main.json
+++ b/avm/res/automation/automation-account/schedule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.92.45157",
-      "templateHash": "9390427400811966884"
+      "version": "0.32.4.45862",
+      "templateHash": "2769963466163535886"
     },
     "name": "Automation Account Schedules",
     "description": "This module deploys an Azure Automation Account Schedule.",

--- a/avm/res/automation/automation-account/software-update-configuration/main.json
+++ b/avm/res/automation/automation-account/software-update-configuration/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.92.45157",
-      "templateHash": "10379683657935183144"
+      "version": "0.32.4.45862",
+      "templateHash": "11568533167274650070"
     },
     "name": "Automation Account Software Update Configurations",
     "description": "This module deploys an Azure Automation Account Software Update Configuration.",
@@ -389,10 +389,7 @@
           "nextRunOffsetMinutes": "[parameters('nextRunOffsetMinutes')]",
           "description": "[parameters('scheduleDescription')]"
         }
-      },
-      "dependsOn": [
-        "automationAccount"
-      ]
+      }
     }
   },
   "outputs": {

--- a/avm/res/automation/automation-account/variable/main.json
+++ b/avm/res/automation/automation-account/variable/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.92.45157",
-      "templateHash": "11138609945914911372"
+      "version": "0.32.4.45862",
+      "templateHash": "995071399213667449"
     },
     "name": "Automation Account Variables",
     "description": "This module deploys an Azure Automation Account Variable.",


### PR DESCRIPTION
## Description

Recompile automation account json files using bicep latest version 0.32.4 to fix issue with static validation

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.automation.automation-account](https://github.com/eriqua/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml/badge.svg?branch=regen-autoacc&event=workflow_dispatch)](https://github.com/eriqua/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
