### PR TITLE
feat: Add test to check if child module does not contain version.json file

### DIFF
--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -100,6 +100,17 @@ Describe 'File/folder tests' -Tag 'Modules' {
             $file.Name | Should -BeExactly 'README.md'
         }
 
+        # only avm/res/network/virtual-network/subnet is allowed to have a version.json file (PoC for child module publishing)
+        It '[<moduleFolderName>] Child module should not contain a [` version.json `] file.' -TestCases ($moduleFolderTestCases | Where-Object { (-Not $_.isTopLevelModule) -And ($_.moduleFolderName -ne 'network/virtual-network/subnet') }) {
+
+            param (
+                [string] $moduleFolderPath
+            )
+
+            $pathExisting = Test-Path (Join-Path -Path $moduleFolderPath 'version.json')
+            $pathExisting | Should -Be $false
+        }
+
         It '[<moduleFolderName>] Module should contain a [` ORPHANED.md `] file only if orphaned.' -TestCases ($moduleFolderTestCases | Where-Object { $_.isTopLevelModule }) {
 
             param(


### PR DESCRIPTION
## Description

Closes https://dev.azure.com/CSUSolEng/Azure%20Verified%20Modules/_workitems/edit/38535

Adds a test to check if child modules do not contain version.json files (so they get published), except for avm/res/network/virtual-network/subnet, which will be published in a PoC for child module publishing

## Pipeline Reference

test case 1: storage account children without version.json file
![image](https://github.com/user-attachments/assets/7290460b-27fa-4aa1-a8cd-cb4d277ca32f)

test case 2: blob-service (a storage account child) with version.json file
![image](https://github.com/user-attachments/assets/32d635f4-038f-432b-a27f-54ac410369de)

test case 3: subnet without version.json file
![image](https://github.com/user-attachments/assets/8b81e83a-750b-4e39-8357-ee5b6d636430)

test case 4: subnet with version.json file (no test is visible as expected)
![image](https://github.com/user-attachments/assets/25943276-3d6c-4e38-9ee5-e66b800c5d12)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
