### PR TITLE
fix: Readme regen & dummy change to enable publishing

### DIFF
--- a/avm/ptn/azd/aks-automatic-cluster/README.md
+++ b/avm/ptn/azd/aks-automatic-cluster/README.md
@@ -126,7 +126,7 @@ param location = '<location>'
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`aadProfile`](#parameter-aadprofile) | object | Enable Azure Active Directory integration. |
+| [`aadProfile`](#parameter-aadprofile) | object | Settigs for the Azure Active Directory integration. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`location`](#parameter-location) | string | The Azure region/location for the AKS resources. |
 
@@ -136,13 +136,15 @@ The name for the AKS managed cluster.
 
 - Required: Yes
 - Type: string
+- Nullable: No
 
 ### Parameter: `aadProfile`
 
-Enable Azure Active Directory integration.
+Settigs for the Azure Active Directory integration.
 
 - Required: No
 - Type: object
+- Nullable: Yes
 
 **Required parameters**
 
@@ -167,6 +169,7 @@ Specifies whether to enable Azure RBAC for Kubernetes authorization.
 
 - Required: Yes
 - Type: bool
+- Nullable: No
 
 ### Parameter: `aadProfile.aadProfileManaged`
 
@@ -174,6 +177,7 @@ Specifies whether to enable managed AAD integration.
 
 - Required: Yes
 - Type: bool
+- Nullable: No
 
 ### Parameter: `aadProfile.aadProfileAdminGroupObjectIDs`
 
@@ -181,6 +185,7 @@ Specifies the AAD group object IDs that will have admin role of the cluster.
 
 - Required: No
 - Type: array
+- Nullable: Yes
 
 ### Parameter: `aadProfile.aadProfileClientAppID`
 
@@ -188,6 +193,7 @@ The client AAD application ID.
 
 - Required: No
 - Type: string
+- Nullable: Yes
 
 ### Parameter: `aadProfile.aadProfileServerAppID`
 
@@ -195,6 +201,7 @@ The server AAD application ID.
 
 - Required: No
 - Type: string
+- Nullable: Yes
 
 ### Parameter: `aadProfile.aadProfileServerAppSecret`
 
@@ -202,6 +209,7 @@ The server AAD application secret.
 
 - Required: No
 - Type: string
+- Nullable: Yes
 
 ### Parameter: `aadProfile.aadProfileTenantId`
 
@@ -209,6 +217,7 @@ Specifies the tenant ID of the Azure Active Directory used by the AKS cluster fo
 
 - Required: No
 - Type: string
+- Nullable: Yes
 
 ### Parameter: `enableTelemetry`
 
@@ -216,6 +225,7 @@ Enable/Disable usage telemetry for module.
 
 - Required: No
 - Type: bool
+- Nullable: No
 - Default: `True`
 
 ### Parameter: `location`
@@ -224,6 +234,7 @@ The Azure region/location for the AKS resources.
 
 - Required: No
 - Type: string
+- Nullable: No
 - Default: `[resourceGroup().location]`
 
 ## Outputs

--- a/avm/ptn/azd/aks-automatic-cluster/main.bicep
+++ b/avm/ptn/azd/aks-automatic-cluster/main.bicep
@@ -14,7 +14,7 @@ param location string = resourceGroup().location
 param enableTelemetry bool = true
 
 import { aadProfileType } from 'br/public:avm/res/container-service/managed-cluster:0.5.3'
-@description('Optional. Enable Azure Active Directory integration.')
+@description('Optional. Settigs for the Azure Active Directory integration.')
 param aadProfile aadProfileType?
 
 // ============== //

--- a/avm/ptn/azd/aks-automatic-cluster/main.json
+++ b/avm/ptn/azd/aks-automatic-cluster/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.32.4.45862",
-      "templateHash": "8684475244832615377"
+      "templateHash": "1131028867773380264"
     },
     "name": "Azd AKS Automatic Cluster",
     "description": "Creates an Azure Kubernetes Service (AKS) cluster with a system agent pool.\n\n**Note:** This module is not intended for broad, generic use, as it was designed to cater for the requirements of the AZD CLI product. Feature requests and bug fix requests are welcome if they support the development of the AZD CLI but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case",
@@ -100,7 +100,7 @@
       "$ref": "#/definitions/aadProfileType",
       "nullable": true,
       "metadata": {
-        "description": "Optional. Enable Azure Active Directory integration."
+        "description": "Optional. Settigs for the Azure Active Directory integration."
       }
     }
   },


### PR DESCRIPTION
## Description

- The previously merged PR had an outdated readme following another PR that was merged in the meantime that required an update of the same
- Updated the readme + added a dummy change to trigger a publish

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|      [![avm.ptn.azd.aks-automatic-cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks-automatic-cluster.yml/badge.svg?event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks-automatic-cluster.yml)    |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
