### PR TITLE
fix: Removed duplicated resource from PE type

### DIFF
--- a/avm/utl/types/avm-common-types/README.md
+++ b/avm/utl/types/avm-common-types/README.md
@@ -266,7 +266,6 @@ param privateEndpointMultiService privateEndpointMultiServiceType[] = [
       ]
     }
     privateLinkServiceConnectionName: 'myConnection'
-    resourceGroupName: 'myResourceGroup'
     tags: {
       Environment: 'Non-Prod'
       Role: 'DeploymentValidation'

--- a/avm/utl/types/avm-common-types/main.bicep
+++ b/avm/utl/types/avm-common-types/main.bicep
@@ -299,9 +299,6 @@ type privateEndpointSingleServiceType = {
 
   @description('Optional. Enable/Disable usage telemetry for module.')
   enableTelemetry: bool?
-
-  @description('Optional. Specify if you want to deploy the Private Endpoint into a different Resource Group than the main resource.')
-  resourceGroupName: string?
 }
 
 @export()
@@ -358,9 +355,6 @@ type privateEndpointMultiServiceType = {
 
   @description('Optional. Enable/Disable usage telemetry for module.')
   enableTelemetry: bool?
-
-  @description('Optional. Specify if you want to deploy the Private Endpoint into a different resource group than the main resource.')
-  resourceGroupName: string?
 }
 
 // ======================== //

--- a/avm/utl/types/avm-common-types/main.json
+++ b/avm/utl/types/avm-common-types/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.32.4.45862",
-      "templateHash": "14999467792384745276"
+      "templateHash": "9152524058851826986"
     },
     "name": "Default interface types for AVM modules",
     "description": "This module provides you with all common variants for AVM interfaces to be used in AVM modules.\n\nDetails for how to implement these interfaces can be found in the AVM documentation [here](https://azure.github.io/Azure-Verified-Modules/specs/bcp/res/interfaces/).\n",
@@ -704,13 +704,6 @@
           "metadata": {
             "description": "Optional. Enable/Disable usage telemetry for module."
           }
-        },
-        "resourceGroupName": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Specify if you want to deploy the Private Endpoint into a different Resource Group than the main resource."
-          }
         }
       },
       "metadata": {
@@ -849,13 +842,6 @@
           "nullable": true,
           "metadata": {
             "description": "Optional. Enable/Disable usage telemetry for module."
-          }
-        },
-        "resourceGroupName": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Specify if you want to deploy the Private Endpoint into a different resource group than the main resource."
           }
         }
       },

--- a/avm/utl/types/avm-common-types/tests/e2e/import/main.test.bicep
+++ b/avm/utl/types/avm-common-types/tests/e2e/import/main.test.bicep
@@ -225,7 +225,6 @@ param privateEndpointMultiService privateEndpointMultiServiceType[] = [
       ]
     }
     privateLinkServiceConnectionName: 'myConnection'
-    resourceGroupName: 'myResourceGroup'
     tags: {
       Environment: 'Non-Prod'
       Role: 'DeploymentValidation'


### PR DESCRIPTION
## Description

When introducing the `resourceGroupResourceId` property, the `resourceGroupName` property was not removed from the `privateEndpointMultiServiceType` and `privateEndpointSingleServiceType` types.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|      [![avm.utl.types.avm-common-types](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml/badge.svg?branch=users%2Falsehr%2FavmPESpecRGDuplicationFix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml)    |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
