### PR TITLE
fix: Change in keyvault purge protection policy to allow for testing

### DIFF
--- a/avm/ptn/aca-lza/hosting-environment/main.json
+++ b/avm/ptn/aca-lza/hosting-environment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.32.4.45862",
-      "templateHash": "12311422039470730786"
+      "templateHash": "7424977067105298324"
     },
     "name": "Container Apps Landing Zone Accelerator",
     "description": "This Azure Container Apps pattern module represents an Azure Container Apps deployment aligned with the cloud adoption framework",
@@ -21560,7 +21560,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.32.4.45862",
-              "templateHash": "475523379519464096"
+              "templateHash": "3392565495195178374"
             }
           },
           "parameters": {
@@ -28072,7 +28072,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.32.4.45862",
-                      "templateHash": "871776826905490480"
+                      "templateHash": "10698940016173685847"
                     }
                   },
                   "parameters": {
@@ -31228,7 +31228,7 @@
                             "value": 7
                           },
                           "enablePurgeProtection": {
-                            "value": null
+                            "value": false
                           },
                           "publicNetworkAccess": {
                             "value": "Disabled"

--- a/avm/ptn/aca-lza/hosting-environment/modules/supporting-services/modules/key-vault.bicep
+++ b/avm/ptn/aca-lza/hosting-environment/modules/supporting-services/modules/key-vault.bicep
@@ -84,7 +84,7 @@ module keyvault 'br/public:avm/res/key-vault/vault:0.11.1' = {
     }
     enableSoftDelete: true
     softDeleteRetentionInDays: 7
-    enablePurgeProtection: null
+    enablePurgeProtection: false
     publicNetworkAccess: 'Disabled'
     enableRbacAuthorization: true
     enableVaultForDeployment: true

--- a/avm/ptn/aca-lza/hosting-environment/tests/e2e/defaults/main.test.bicep
+++ b/avm/ptn/aca-lza/hosting-environment/tests/e2e/defaults/main.test.bicep
@@ -11,7 +11,7 @@ targetScope = 'subscription'
 param resourceLocation string = deployment().location
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
-param serviceShort string = 'acamin'
+param serviceShort string = 'camin'
 
 @description('Optional. Test name prefix.')
 param namePrefix string = '#_namePrefix_#'

--- a/avm/ptn/aca-lza/hosting-environment/tests/e2e/hub-spoke/main.test.bicep
+++ b/avm/ptn/aca-lza/hosting-environment/tests/e2e/hub-spoke/main.test.bicep
@@ -11,7 +11,7 @@ targetScope = 'subscription'
 param resourceLocation string = deployment().location
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
-param serviceShort string = 'acahub'
+param serviceShort string = 'cahub'
 
 @description('Optional. Test name prefix.')
 param namePrefix string = '#_namePrefix_#'

--- a/avm/ptn/aca-lza/hosting-environment/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/ptn/aca-lza/hosting-environment/tests/e2e/waf-aligned/main.test.bicep
@@ -12,7 +12,7 @@ param resourceLocation string = deployment().location
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 // e.g., for a module 'network/private-endpoint' you could use 'npe' as a prefix and then 'waf' as a suffix for the waf-aligned test
-param serviceShort string = 'acawaf'
+param serviceShort string = 'cawaf'
 
 @description('Optional. Test name prefix.')
 param namePrefix string = '#_namePrefix_#'


### PR DESCRIPTION
## Description
Minor change to disable azure keyvault purge protection so that testing can re-deploy the keyvault after being deleted.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.ptn.aca-lza.hosting-environment](https://github.com/kpantos/bicep-registry-modules/actions/workflows/avm.ptn.aca-lza.hosting-environment.yml/badge.svg)](https://github.com/kpantos/bicep-registry-modules/actions/workflows/avm.ptn.aca-lza.hosting-environment.yml)     |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [X Azure Verified Module updates:
  - [X] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
