### PR TITLE
fix: Small update to the `Type`-suffix check for UDTs

### DIFF
--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -1248,7 +1248,7 @@ Describe 'Module tests' -Tag 'Module' {
 
                 $incorrectTypes = [System.Collections.ArrayList]@()
                 foreach ($typeName in $templateFileContent.definitions.Keys) {
-                    if ($typeName -cnotmatch '^[a-z].*Type$') {
+                    if ($typeName -cnotmatch '^.*Type$') {
                         $incorrectTypes += $typeName
                     }
                 }

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -1248,7 +1248,13 @@ Describe 'Module tests' -Tag 'Module' {
 
                 $incorrectTypes = [System.Collections.ArrayList]@()
                 foreach ($typeName in $templateFileContent.definitions.Keys) {
-                    if ($typeName -cnotmatch '^.*Type$') {
+                    if ($typeName -cnotmatch '^(.+\.)?[a-z].*Type$') {
+                        # Passes
+                        # - testType
+                        # - _1.testType
+                        # NOT passes
+                        # - test
+                        # - _1.TestType
                         $incorrectTypes += $typeName
                     }
                 }


### PR DESCRIPTION
## Description

Changed the regex to also cover cases like `_1.privateEndpointCustomDnsConfigType` 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.res.web.static-site](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.static-site.yml/badge.svg?branch=users%2Falsehr%2FudtRegexFix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.static-site.yml) (should not show warning) |
| [![avm.res.network.dns-forwarding-ruleset](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-forwarding-ruleset.yml/badge.svg?branch=users%2Falsehr%2FudtRegexFix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-forwarding-ruleset.yml) (should show warning) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
