### PR TITLE
fix: Small fix to module installation

### DIFF
--- a/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
+++ b/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
@@ -65,8 +65,10 @@ function Install-CustomModule {
                 # Get latest in case of multiple
                 $alreadyInstalled = ($alreadyInstalled | Sort-Object -Culture 'en-US' -Property 'Version' -Descending)[0]
             }
-            Write-Verbose ('Module [{0}] already installed with version [{1}]' -f $alreadyInstalled.Name, $alreadyInstalled.Version) -Verbose
-            continue
+            if ($alreadyInstalled) {
+                Write-Verbose ('Module [{0}] already installed with version [{1}]' -f $alreadyInstalled.Name, $alreadyInstalled.Version) -Verbose
+                continue
+            }
         }
 
         # Check if not to be excluded

--- a/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
+++ b/utilities/pipelines/sharedScripts/Set-EnvironmentOnAgent.ps1
@@ -81,7 +81,7 @@ function Install-CustomModule {
         if ($PSCmdlet.ShouldProcess('Module [{0}]' -f $foundModule.Name, 'Install')) {
             $foundModule | Install-Module -Force -SkipPublisherCheck -AllowClobber
             if ($installed = Get-Module -Name $foundModule.Name -ListAvailable) {
-                Write-Verbose ('Module [{0}] is installed with version [{1}]' -f $installed.Name, $installed.Version) -Verbose
+                Write-Verbose ('Module [{0}] is installed with version [{1}]' -f $installed[0].name, ($installed.Version -join ', ')) -Verbose
             } else {
                 Write-Error ('Installation of module [{0}] failed' -f $foundModule.Name)
             }


### PR DESCRIPTION
## Description

Up until now, if you specified a specific version for a module, the logic would ignore that in case any version of the module is installed. 
What it should do instead is to detect that the desired version is not installed and install it.

Tested with @sebassem [here](https://github.com/sebassem/bicep-registry-modules/actions/runs/12913147922)

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.analysis-services.server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml/badge.svg?branch=users%2Falsehr%2FmoduleInstallFix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml)     |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
