### PR TITLE
feat: Remove `'avm/ptn/lz/sub-vending` from OIDC exeption list

### DIFF
--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -70,9 +70,8 @@ runs:
           # Grouping task logs
           Write-Output '::group::Set OIDC exception'
 
-          # List of modules requiring more that 1 hour to deploy and delete resources
+          # List of modules requiring service principal + secret authentication
           $modulePath = "${{ inputs.modulePath }}"
-          # 'avm/ptn/lz/sub-vending'                             # Requires additional OIDC MSI permissions
           $exceptionModulePaths = @(
             'avm/res/compute/image'                              # Failing on resource deletion when trying to delete RBAC at subscription level
             'avm/res/compute/disk'                               # Failing on resource deletion when trying to delete RBAC at subscription level

--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -72,8 +72,8 @@ runs:
 
           # List of modules requiring more that 1 hour to deploy and delete resources
           $modulePath = "${{ inputs.modulePath }}"
+          # 'avm/ptn/lz/sub-vending'                             # Requires additional OIDC MSI permissions
           $exceptionModulePaths = @(
-            'avm/ptn/lz/sub-vending'                             # Requires additional OIDC MSI permissions
             'avm/res/compute/image'                              # Failing on resource deletion when trying to delete RBAC at subscription level
             'avm/res/compute/disk'                               # Failing on resource deletion when trying to delete RBAC at subscription level
             'avm/ptn/virtual-machine-images/azure-image-builder' # Failing on resource deletion when trying to delete RBAC at subscription level


### PR DESCRIPTION
## Description

Removing `'avm/ptn/lz/sub-vending` from the list of modules requiring service principal + secret authentication (OIDC exception)

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.ptn.lz.sub-vending](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml/badge.svg?branch=users%2Ferikag%2Foidc_sub&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
