### PR TITLE
fix: CDN Profile - Updated JSON templates to latest

### DIFF
--- a/avm/res/cdn/profile/afdEndpoint/main.json
+++ b/avm/res/cdn/profile/afdEndpoint/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "13135731354374453249"
+      "version": "0.33.13.18514",
+      "templateHash": "8177824551774407436"
     },
     "name": "CDN Profiles AFD Endpoints",
     "description": "This module deploys a CDN Profile AFD Endpoint."
@@ -379,8 +379,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "14731142764965944373"
+              "version": "0.33.13.18514",
+              "templateHash": "5263422487313973220"
             },
             "name": "CDN Profiles AFD Endpoint Route",
             "description": "This module deploys a CDN Profile AFD Endpoint route."
@@ -676,7 +676,7 @@
             },
             "profile::customDomains": {
               "copy": {
-                "name": "customDomains",
+                "name": "profile::customDomains",
                 "count": "[length(coalesce(parameters('customDomainNames'), createArray()))]"
               },
               "existing": true,
@@ -692,7 +692,7 @@
             },
             "profile::ruleSet": {
               "copy": {
-                "name": "ruleSet",
+                "name": "profile::ruleSet",
                 "count": "[length(parameters('ruleSets'))]"
               },
               "existing": true,

--- a/avm/res/cdn/profile/afdEndpoint/route/main.json
+++ b/avm/res/cdn/profile/afdEndpoint/route/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "14731142764965944373"
+      "version": "0.33.13.18514",
+      "templateHash": "5263422487313973220"
     },
     "name": "CDN Profiles AFD Endpoint Route",
     "description": "This module deploys a CDN Profile AFD Endpoint route."
@@ -302,7 +302,7 @@
     },
     "profile::customDomains": {
       "copy": {
-        "name": "customDomains",
+        "name": "profile::customDomains",
         "count": "[length(coalesce(parameters('customDomainNames'), createArray()))]"
       },
       "existing": true,
@@ -318,7 +318,7 @@
     },
     "profile::ruleSet": {
       "copy": {
-        "name": "ruleSet",
+        "name": "profile::ruleSet",
         "count": "[length(parameters('ruleSets'))]"
       },
       "existing": true,

--- a/avm/res/cdn/profile/customdomain/main.json
+++ b/avm/res/cdn/profile/customdomain/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "10872254821030072983"
+      "version": "0.33.13.18514",
+      "templateHash": "13058047826352389276"
     },
     "name": "CDN Profiles Custom Domains",
     "description": "This module deploys a CDN Profile Custom Domains."

--- a/avm/res/cdn/profile/endpoint/main.json
+++ b/avm/res/cdn/profile/endpoint/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "9549854961484064285"
+      "version": "0.33.13.18514",
+      "templateHash": "9667828946590224838"
     },
     "name": "CDN Profiles Endpoints",
     "description": "This module deploys a CDN Profile Endpoint."
@@ -121,8 +121,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "13720707069401173773"
+              "version": "0.33.13.18514",
+              "templateHash": "14207274905612158052"
             },
             "name": "CDN Profiles Endpoints Origins",
             "description": "This module deploys a CDN Profile Endpoint Origin."

--- a/avm/res/cdn/profile/endpoint/origin/main.json
+++ b/avm/res/cdn/profile/endpoint/origin/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "13720707069401173773"
+      "version": "0.33.13.18514",
+      "templateHash": "14207274905612158052"
     },
     "name": "CDN Profiles Endpoints Origins",
     "description": "This module deploys a CDN Profile Endpoint Origin."

--- a/avm/res/cdn/profile/origingroup/main.json
+++ b/avm/res/cdn/profile/origingroup/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "2255246560564651285"
+      "version": "0.33.13.18514",
+      "templateHash": "2309166106272805364"
     },
     "name": "CDN Profiles Origin Group",
     "description": "This module deploys a CDN Profile Origin Group."
@@ -348,8 +348,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "12548128435491978362"
+              "version": "0.33.13.18514",
+              "templateHash": "4615820934914726240"
             },
             "name": "CDN Profiles Origin",
             "description": "This module deploys a CDN Profile Origin."

--- a/avm/res/cdn/profile/origingroup/origin/main.json
+++ b/avm/res/cdn/profile/origingroup/origin/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "12548128435491978362"
+      "version": "0.33.13.18514",
+      "templateHash": "4615820934914726240"
     },
     "name": "CDN Profiles Origin",
     "description": "This module deploys a CDN Profile Origin."

--- a/avm/res/cdn/profile/ruleset/main.json
+++ b/avm/res/cdn/profile/ruleset/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "16187656524256202445"
+      "version": "0.33.13.18514",
+      "templateHash": "832720268679200418"
     },
     "name": "CDN Profiles Rule Sets",
     "description": "This module deploys a CDN Profile rule set."
@@ -163,8 +163,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "5126669469544382460"
+              "version": "0.33.13.18514",
+              "templateHash": "4778641008462766741"
             },
             "name": "CDN Profiles Rules",
             "description": "This module deploys a CDN Profile rule."

--- a/avm/res/cdn/profile/ruleset/rule/main.json
+++ b/avm/res/cdn/profile/ruleset/rule/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "5126669469544382460"
+      "version": "0.33.13.18514",
+      "templateHash": "4778641008462766741"
     },
     "name": "CDN Profiles Rules",
     "description": "This module deploys a CDN Profile rule."

--- a/avm/res/cdn/profile/secret/main.json
+++ b/avm/res/cdn/profile/secret/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "8122410068056305563"
+      "version": "0.33.13.18514",
+      "templateHash": "6185880578813937844"
     },
     "name": "CDN Profiles Secret",
     "description": "This module deploys a CDN Profile Secret."

--- a/avm/res/cdn/profile/securityPolicies/main.json
+++ b/avm/res/cdn/profile/securityPolicies/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "11785514765749998247"
+      "version": "0.33.13.18514",
+      "templateHash": "9521724516599685420"
     },
     "name": "CDN Profiles Security Policy",
     "description": "This module deploys a CDN Profile Security Policy."


### PR DESCRIPTION
## Description

Regenerated JSON files to latest

Closes #4310

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.cdn.profile](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml/badge.svg?branch=users%2Falsehr%2FcdnStaticFix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
