### PR TITLE
feat: API versions update of `avm/res/network/public-ip-adress`

### DIFF
--- a/avm/res/network/public-ip-address/README.md
+++ b/avm/res/network/public-ip-address/README.md
@@ -18,7 +18,7 @@ This module deploys a Public IP Address.
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
-| `Microsoft.Network/publicIPAddresses` | [2023-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-09-01/publicIPAddresses) |
+| `Microsoft.Network/publicIPAddresses` | [2024-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/publicIPAddresses) |
 
 ## Usage examples
 
@@ -846,12 +846,11 @@ The domain name label. The concatenation of the domain name label and the region
 
 The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN.
 
-- Required: Yes
+- Required: No
 - Type: string
 - Allowed:
   ```Bicep
   [
-    ''
     'NoReuse'
     'ResourceGroupReuse'
     'SubscriptionReuse'

--- a/avm/res/network/public-ip-address/README.md
+++ b/avm/res/network/public-ip-address/README.md
@@ -826,12 +826,12 @@ The DNS settings of the public IP address.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`domainNameLabel`](#parameter-dnssettingsdomainnamelabel) | string | The domain name label. The concatenation of the domain name label and the regionalized DNS zone make up the fully qualified domain name associated with the public IP address. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system. |
-| [`domainNameLabelScope`](#parameter-dnssettingsdomainnamelabelscope) | string | The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN. |
 
 **Optional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`domainNameLabelScope`](#parameter-dnssettingsdomainnamelabelscope) | string | The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN. |
 | [`fqdn`](#parameter-dnssettingsfqdn) | string | The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone. |
 | [`reverseFqdn`](#parameter-dnssettingsreversefqdn) | string | The reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN. |
 

--- a/avm/res/network/public-ip-address/main.bicep
+++ b/avm/res/network/public-ip-address/main.bicep
@@ -144,7 +144,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource publicIpAddress 'Microsoft.Network/publicIPAddresses@2023-09-01' = {
+resource publicIpAddress 'Microsoft.Network/publicIPAddresses@2024-05-01' = {
   name: name
   location: location
   tags: tags
@@ -249,7 +249,7 @@ type dnsSettingsType = {
   domainNameLabel: string
 
   @description('Required. The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN.')
-  domainNameLabelScope: ('' | 'NoReuse' | 'ResourceGroupReuse' | 'SubscriptionReuse' | 'TenantReuse')
+  domainNameLabelScope: ('NoReuse' | 'ResourceGroupReuse' | 'SubscriptionReuse' | 'TenantReuse')?
 
   @description('Optional. The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone.')
   fqdn: string?

--- a/avm/res/network/public-ip-address/main.bicep
+++ b/avm/res/network/public-ip-address/main.bicep
@@ -248,7 +248,7 @@ type dnsSettingsType = {
   @description('Required. The domain name label. The concatenation of the domain name label and the regionalized DNS zone make up the fully qualified domain name associated with the public IP address. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system.')
   domainNameLabel: string
 
-  @description('Required. The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN.')
+  @description('Optional. The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN.')
   domainNameLabelScope: ('NoReuse' | 'ResourceGroupReuse' | 'SubscriptionReuse' | 'TenantReuse')?
 
   @description('Optional. The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone.')

--- a/avm/res/network/public-ip-address/main.json
+++ b/avm/res/network/public-ip-address/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "3357602174596763976"
+      "version": "0.33.93.31351",
+      "templateHash": "7493361708090920602"
     },
     "name": "Public IP Addresses",
     "description": "This module deploys a Public IP Address."
@@ -24,12 +24,12 @@
         "domainNameLabelScope": {
           "type": "string",
           "allowedValues": [
-            "",
             "NoReuse",
             "ResourceGroupReuse",
             "SubscriptionReuse",
             "TenantReuse"
           ],
+          "nullable": true,
           "metadata": {
             "description": "Required. The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN."
           }
@@ -534,7 +534,7 @@
     },
     "publicIpAddress": {
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "2023-09-01",
+      "apiVersion": "2024-05-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -665,7 +665,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('publicIpAddress', '2023-09-01', 'full').location]"
+      "value": "[reference('publicIpAddress', '2024-05-01', 'full').location]"
     }
   }
 }

--- a/avm/res/network/public-ip-address/main.json
+++ b/avm/res/network/public-ip-address/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "7493361708090920602"
+      "templateHash": "11118459859179868367"
     },
     "name": "Public IP Addresses",
     "description": "This module deploys a Public IP Address."
@@ -31,7 +31,7 @@
           ],
           "nullable": true,
           "metadata": {
-            "description": "Required. The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN."
+            "description": "Optional. The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN."
           }
         },
         "fqdn": {

--- a/avm/res/network/public-ip-address/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/network/public-ip-address/tests/e2e/defaults/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-11-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/network/public-ip-address/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/public-ip-address/tests/e2e/max/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-11-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/network/public-ip-address/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/public-ip-address/tests/e2e/waf-aligned/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-11-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/network/public-ip-address/version.json
+++ b/avm/res/network/public-ip-address/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.7",
+  "version": "0.8",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
## Description

- updated API version, which addresses a static validation warning `API version tests / In [res/network/public-ip-address] used resource type [publicIPAddresses] should use one of the recent API version(s). Currently using [2023-09-01].`
- updated the `domainNameLabelScope` UDT to address a Bicep warning complaining about the expected value type. 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.network.public-ip-address](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml/badge.svg?branch=users%2Fkrbar%2FpipUpdate)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
