### PR TITLE
fix: avm/res/storage/storage-account blob soft delete days to 7

### DIFF
--- a/avm/res/storage/storage-account/blob-service/README.md
+++ b/avm/res/storage/storage-account/blob-service/README.md
@@ -440,7 +440,7 @@ How long this blob can be restored. It should be less than DeleteRetentionPolicy
 
 - Required: No
 - Type: int
-- Default: `6`
+- Default: `7`
 - MinValue: 1
 - MaxValue: 365
 

--- a/avm/res/storage/storage-account/blob-service/container/immutability-policy/main.json
+++ b/avm/res/storage/storage-account/blob-service/container/immutability-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "12930903258566593173"
+      "version": "0.33.93.31351",
+      "templateHash": "8061556339565534458"
     },
     "name": "Storage Account Blob Container Immutability Policies",
     "description": "This module deploys a Storage Account Blob Container Immutability Policy."

--- a/avm/res/storage/storage-account/blob-service/container/main.json
+++ b/avm/res/storage/storage-account/blob-service/container/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "7180309977212880563"
+      "version": "0.33.93.31351",
+      "templateHash": "2991444340097371621"
     },
     "name": "Storage Account Blob Containers",
     "description": "This module deploys a Storage Account Blob Container."
@@ -294,8 +294,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "12930903258566593173"
+              "version": "0.33.93.31351",
+              "templateHash": "8061556339565534458"
             },
             "name": "Storage Account Blob Container Immutability Policies",
             "description": "This module deploys a Storage Account Blob Container Immutability Policy."

--- a/avm/res/storage/storage-account/blob-service/main.bicep
+++ b/avm/res/storage/storage-account/blob-service/main.bicep
@@ -55,7 +55,7 @@ param restorePolicyEnabled bool = false
 
 @minValue(1)
 @description('Optional. How long this blob can be restored. It should be less than DeleteRetentionPolicy days.')
-param restorePolicyDays int = 6
+param restorePolicyDays int = 7
 
 @description('Optional. Blob containers to create.')
 param containers array?

--- a/avm/res/storage/storage-account/blob-service/main.json
+++ b/avm/res/storage/storage-account/blob-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "7416701536235015086"
+      "version": "0.33.93.31351",
+      "templateHash": "2058460323623594433"
     },
     "name": "Storage Account blob Services",
     "description": "This module deploys a Storage Account Blob Service."
@@ -312,7 +312,7 @@
     },
     "restorePolicyDays": {
       "type": "int",
-      "defaultValue": 6,
+      "defaultValue": 7,
       "minValue": 1,
       "metadata": {
         "description": "Optional. How long this blob can be restored. It should be less than DeleteRetentionPolicy days."
@@ -472,8 +472,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "7180309977212880563"
+              "version": "0.33.93.31351",
+              "templateHash": "2991444340097371621"
             },
             "name": "Storage Account Blob Containers",
             "description": "This module deploys a Storage Account Blob Container."
@@ -761,8 +761,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.32.4.45862",
-                      "templateHash": "12930903258566593173"
+                      "version": "0.33.93.31351",
+                      "templateHash": "8061556339565534458"
                     },
                     "name": "Storage Account Blob Container Immutability Policies",
                     "description": "This module deploys a Storage Account Blob Container Immutability Policy."

--- a/avm/res/storage/storage-account/main.json
+++ b/avm/res/storage/storage-account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "9739064632358098891"
+      "version": "0.33.93.31351",
+      "templateHash": "17960260729884623690"
     },
     "name": "Storage Accounts",
     "description": "This module deploys a Storage Account."
@@ -2222,8 +2222,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "4014848332192190169"
+              "version": "0.33.93.31351",
+              "templateHash": "10504956743360699891"
             },
             "name": "Storage Account Management Policies",
             "description": "This module deploys a Storage Account Management Policy."
@@ -2331,8 +2331,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "16427795222629898111"
+              "version": "0.33.93.31351",
+              "templateHash": "5655292159520921149"
             },
             "name": "Storage Account Local Users",
             "description": "This module deploys a Storage Account Local User, which is used for SFTP authentication."
@@ -2569,8 +2569,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "7416701536235015086"
+              "version": "0.33.93.31351",
+              "templateHash": "2058460323623594433"
             },
             "name": "Storage Account blob Services",
             "description": "This module deploys a Storage Account Blob Service."
@@ -2876,7 +2876,7 @@
             },
             "restorePolicyDays": {
               "type": "int",
-              "defaultValue": 6,
+              "defaultValue": 7,
               "minValue": 1,
               "metadata": {
                 "description": "Optional. How long this blob can be restored. It should be less than DeleteRetentionPolicy days."
@@ -3036,8 +3036,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.32.4.45862",
-                      "templateHash": "7180309977212880563"
+                      "version": "0.33.93.31351",
+                      "templateHash": "2991444340097371621"
                     },
                     "name": "Storage Account Blob Containers",
                     "description": "This module deploys a Storage Account Blob Container."
@@ -3325,8 +3325,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.32.4.45862",
-                              "templateHash": "12930903258566593173"
+                              "version": "0.33.93.31351",
+                              "templateHash": "8061556339565534458"
                             },
                             "name": "Storage Account Blob Container Immutability Policies",
                             "description": "This module deploys a Storage Account Blob Container Immutability Policy."
@@ -3505,8 +3505,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "16196407713115246323"
+              "version": "0.33.93.31351",
+              "templateHash": "3168394810831105529"
             },
             "name": "Storage Account File Share Services",
             "description": "This module deploys a Storage Account File Share Service."
@@ -3859,8 +3859,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.32.4.45862",
-                      "templateHash": "5204319087439022536"
+                      "version": "0.33.93.31351",
+                      "templateHash": "12044655551245282190"
                     },
                     "name": "Storage Account File Shares",
                     "description": "This module deploys a Storage Account File Share."
@@ -4294,8 +4294,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "14497929042813606497"
+              "version": "0.33.93.31351",
+              "templateHash": "1736438454543575457"
             },
             "name": "Storage Account Queue Services",
             "description": "This module deploys a Storage Account Queue Service."
@@ -4613,8 +4613,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.32.4.45862",
-                      "templateHash": "9969689246600110741"
+                      "version": "0.33.93.31351",
+                      "templateHash": "6383154227554431205"
                     },
                     "name": "Storage Account Queues",
                     "description": "This module deploys a Storage Account Queue."
@@ -4883,8 +4883,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "4194630585059896468"
+              "version": "0.33.93.31351",
+              "templateHash": "12583903411447171294"
             },
             "name": "Storage Account Table Services",
             "description": "This module deploys a Storage Account Table Service."
@@ -5199,8 +5199,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.32.4.45862",
-                      "templateHash": "4457939127962832961"
+                      "version": "0.33.93.31351",
+                      "templateHash": "1369356397929898951"
                     },
                     "name": "Storage Account Table",
                     "description": "This module deploys a Storage Account Table."
@@ -5453,8 +5453,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "9771994149501143078"
+              "version": "0.33.93.31351",
+              "templateHash": "2275047425860597278"
             }
           },
           "definitions": {


### PR DESCRIPTION
## Description

I flagged last year that the blob soft delete days for blob was only 6, but for containers it was 7. The module owner agreed for consistency it should be 7 also. Therefore, this PR bumps this in line as per #2707. 

Closes #2707 to increase blob soft delete inline to 7 days with containers for consistency.

## Pipeline Reference

[![avm.res.storage.storage-account](https://github.com/riosengineer/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml/badge.svg)](https://github.com/riosengineer/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
