### PR TITLE
fix: revert Defender updates to `avm/res/storage/storage-account`

### DIFF
--- a/avm/res/storage/storage-account/README.md
+++ b/avm/res/storage/storage-account/README.md
@@ -22,7 +22,6 @@ This module deploys a Storage Account.
 | `Microsoft.KeyVault/vaults/secrets` | [2023-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2023-07-01/vaults/secrets) |
 | `Microsoft.Network/privateEndpoints` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-11-01/privateEndpoints) |
 | `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-11-01/privateEndpoints/privateDnsZoneGroups) |
-| `Microsoft.Security/advancedThreatProtectionSettings` | [2019-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Security/2019-01-01/advancedThreatProtectionSettings) |
 | `Microsoft.Storage/storageAccounts` | [2023-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2023-05-01/storageAccounts) |
 | `Microsoft.Storage/storageAccounts/blobServices` | [2022-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2022-09-01/storageAccounts/blobServices) |
 | `Microsoft.Storage/storageAccounts/blobServices/containers` | [2022-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Storage/2022-09-01/storageAccounts/blobServices/containers) |
@@ -3429,7 +3428,6 @@ param tags = {
 | [`defaultToOAuthAuthentication`](#parameter-defaulttooauthauthentication) | bool | A boolean flag which indicates whether the default authentication is OAuth or not. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
 | [`dnsEndpointType`](#parameter-dnsendpointtype) | string | Allows you to specify the type of endpoint. Set this to AzureDNSZone to create a large number of accounts in a single subscription, which creates accounts in an Azure DNS Zone and the endpoint URL will have an alphanumeric DNS Zone identifier. |
-| [`enableAdvancedThreatProtection`](#parameter-enableadvancedthreatprotection) | bool | Enables Advanced Threat Protection on the storage account. |
 | [`enableNfsV3`](#parameter-enablenfsv3) | bool | If true, enables NFS 3.0 support for the storage account. Requires enableHierarchicalNamespace to be true. |
 | [`enableSftp`](#parameter-enablesftp) | bool | If true, enables Secure File Transfer Protocol for the storage account. Requires enableHierarchicalNamespace to be true. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
@@ -3787,14 +3785,6 @@ Allows you to specify the type of endpoint. Set this to AzureDNSZone to create a
     'Standard'
   ]
   ```
-
-### Parameter: `enableAdvancedThreatProtection`
-
-Enables Advanced Threat Protection on the storage account.
-
-- Required: No
-- Type: bool
-- Default: `True`
 
 ### Parameter: `enableNfsV3`
 

--- a/avm/res/storage/storage-account/blob-service/container/immutability-policy/main.json
+++ b/avm/res/storage/storage-account/blob-service/container/immutability-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "8061556339565534458"
+      "version": "0.32.4.45862",
+      "templateHash": "12930903258566593173"
     },
     "name": "Storage Account Blob Container Immutability Policies",
     "description": "This module deploys a Storage Account Blob Container Immutability Policy."

--- a/avm/res/storage/storage-account/blob-service/container/main.json
+++ b/avm/res/storage/storage-account/blob-service/container/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "2991444340097371621"
+      "version": "0.32.4.45862",
+      "templateHash": "7180309977212880563"
     },
     "name": "Storage Account Blob Containers",
     "description": "This module deploys a Storage Account Blob Container."
@@ -294,8 +294,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "8061556339565534458"
+              "version": "0.32.4.45862",
+              "templateHash": "12930903258566593173"
             },
             "name": "Storage Account Blob Container Immutability Policies",
             "description": "This module deploys a Storage Account Blob Container Immutability Policy."

--- a/avm/res/storage/storage-account/blob-service/main.json
+++ b/avm/res/storage/storage-account/blob-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "7588078546699808778"
+      "version": "0.32.4.45862",
+      "templateHash": "7416701536235015086"
     },
     "name": "Storage Account blob Services",
     "description": "This module deploys a Storage Account Blob Service."
@@ -472,8 +472,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2991444340097371621"
+              "version": "0.32.4.45862",
+              "templateHash": "7180309977212880563"
             },
             "name": "Storage Account Blob Containers",
             "description": "This module deploys a Storage Account Blob Container."
@@ -761,8 +761,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "8061556339565534458"
+                      "version": "0.32.4.45862",
+                      "templateHash": "12930903258566593173"
                     },
                     "name": "Storage Account Blob Container Immutability Policies",
                     "description": "This module deploys a Storage Account Blob Container Immutability Policy."

--- a/avm/res/storage/storage-account/file-service/main.json
+++ b/avm/res/storage/storage-account/file-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "3168394810831105529"
+      "version": "0.32.4.45862",
+      "templateHash": "16196407713115246323"
     },
     "name": "Storage Account File Share Services",
     "description": "This module deploys a Storage Account File Share Service."
@@ -359,8 +359,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "12044655551245282190"
+              "version": "0.32.4.45862",
+              "templateHash": "5204319087439022536"
             },
             "name": "Storage Account File Shares",
             "description": "This module deploys a Storage Account File Share."

--- a/avm/res/storage/storage-account/file-service/share/main.json
+++ b/avm/res/storage/storage-account/file-service/share/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "12044655551245282190"
+      "version": "0.32.4.45862",
+      "templateHash": "5204319087439022536"
     },
     "name": "Storage Account File Shares",
     "description": "This module deploys a Storage Account File Share."

--- a/avm/res/storage/storage-account/local-user/main.json
+++ b/avm/res/storage/storage-account/local-user/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "5655292159520921149"
+      "version": "0.32.4.45862",
+      "templateHash": "16427795222629898111"
     },
     "name": "Storage Account Local Users",
     "description": "This module deploys a Storage Account Local User, which is used for SFTP authentication."

--- a/avm/res/storage/storage-account/main.bicep
+++ b/avm/res/storage/storage-account/main.bicep
@@ -188,9 +188,6 @@ param keyType string?
 @description('Optional. Key vault reference and secret settings for the module\'s secrets export.')
 param secretsExportConfiguration secretsExportConfigurationType?
 
-@description('Optional. Enables Advanced Threat Protection on the storage account.')
-param enableAdvancedThreatProtection bool = true
-
 var supportsBlobService = kind == 'BlockBlobStorage' || kind == 'BlobStorage' || kind == 'StorageV2' || kind == 'Storage'
 var supportsFileService = kind == 'FileStorage' || kind == 'StorageV2' || kind == 'Storage'
 
@@ -694,15 +691,6 @@ module secretsExport 'modules/keyVaultExport.bicep' = if (secretsExportConfigura
           ]
         : []
     )
-  }
-}
-
-// Microsoft Defender plan
-resource storageAccount_atp 'Microsoft.Security/advancedThreatProtectionSettings@2019-01-01' = if (enableAdvancedThreatProtection) {
-  name: 'current'
-  scope: storageAccount
-  properties: {
-    isEnabled: true
   }
 }
 

--- a/avm/res/storage/storage-account/main.json
+++ b/avm/res/storage/storage-account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "9582256320776207177"
+      "version": "0.32.4.45862",
+      "templateHash": "9739064632358098891"
     },
     "name": "Storage Accounts",
     "description": "This module deploys a Storage Account."
@@ -1245,13 +1245,6 @@
       "metadata": {
         "description": "Optional. Key vault reference and secret settings for the module's secrets export."
       }
-    },
-    "enableAdvancedThreatProtection": {
-      "type": "bool",
-      "defaultValue": true,
-      "metadata": {
-        "description": "Optional. Enables Advanced Threat Protection on the storage account."
-      }
     }
   },
   "variables": {
@@ -1445,19 +1438,6 @@
         "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
         "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
         "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
-      },
-      "dependsOn": [
-        "storageAccount"
-      ]
-    },
-    "storageAccount_atp": {
-      "condition": "[parameters('enableAdvancedThreatProtection')]",
-      "type": "Microsoft.Security/advancedThreatProtectionSettings",
-      "apiVersion": "2019-01-01",
-      "scope": "[format('Microsoft.Storage/storageAccounts/{0}', parameters('name'))]",
-      "name": "current",
-      "properties": {
-        "isEnabled": true
       },
       "dependsOn": [
         "storageAccount"
@@ -2242,8 +2222,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "10504956743360699891"
+              "version": "0.32.4.45862",
+              "templateHash": "4014848332192190169"
             },
             "name": "Storage Account Management Policies",
             "description": "This module deploys a Storage Account Management Policy."
@@ -2351,8 +2331,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "5655292159520921149"
+              "version": "0.32.4.45862",
+              "templateHash": "16427795222629898111"
             },
             "name": "Storage Account Local Users",
             "description": "This module deploys a Storage Account Local User, which is used for SFTP authentication."
@@ -2589,8 +2569,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "7588078546699808778"
+              "version": "0.32.4.45862",
+              "templateHash": "7416701536235015086"
             },
             "name": "Storage Account blob Services",
             "description": "This module deploys a Storage Account Blob Service."
@@ -3056,8 +3036,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "2991444340097371621"
+                      "version": "0.32.4.45862",
+                      "templateHash": "7180309977212880563"
                     },
                     "name": "Storage Account Blob Containers",
                     "description": "This module deploys a Storage Account Blob Container."
@@ -3345,8 +3325,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "8061556339565534458"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12930903258566593173"
                             },
                             "name": "Storage Account Blob Container Immutability Policies",
                             "description": "This module deploys a Storage Account Blob Container Immutability Policy."
@@ -3525,8 +3505,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "3168394810831105529"
+              "version": "0.32.4.45862",
+              "templateHash": "16196407713115246323"
             },
             "name": "Storage Account File Share Services",
             "description": "This module deploys a Storage Account File Share Service."
@@ -3879,8 +3859,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "12044655551245282190"
+                      "version": "0.32.4.45862",
+                      "templateHash": "5204319087439022536"
                     },
                     "name": "Storage Account File Shares",
                     "description": "This module deploys a Storage Account File Share."
@@ -4314,8 +4294,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "1736438454543575457"
+              "version": "0.32.4.45862",
+              "templateHash": "14497929042813606497"
             },
             "name": "Storage Account Queue Services",
             "description": "This module deploys a Storage Account Queue Service."
@@ -4633,8 +4613,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "6383154227554431205"
+                      "version": "0.32.4.45862",
+                      "templateHash": "9969689246600110741"
                     },
                     "name": "Storage Account Queues",
                     "description": "This module deploys a Storage Account Queue."
@@ -4903,8 +4883,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "12583903411447171294"
+              "version": "0.32.4.45862",
+              "templateHash": "4194630585059896468"
             },
             "name": "Storage Account Table Services",
             "description": "This module deploys a Storage Account Table Service."
@@ -5219,8 +5199,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "1369356397929898951"
+                      "version": "0.32.4.45862",
+                      "templateHash": "4457939127962832961"
                     },
                     "name": "Storage Account Table",
                     "description": "This module deploys a Storage Account Table."
@@ -5473,8 +5453,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2275047425860597278"
+              "version": "0.32.4.45862",
+              "templateHash": "9771994149501143078"
             }
           },
           "definitions": {

--- a/avm/res/storage/storage-account/management-policy/main.json
+++ b/avm/res/storage/storage-account/management-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "10504956743360699891"
+      "version": "0.32.4.45862",
+      "templateHash": "4014848332192190169"
     },
     "name": "Storage Account Management Policies",
     "description": "This module deploys a Storage Account Management Policy."

--- a/avm/res/storage/storage-account/queue-service/main.json
+++ b/avm/res/storage/storage-account/queue-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "1736438454543575457"
+      "version": "0.32.4.45862",
+      "templateHash": "14497929042813606497"
     },
     "name": "Storage Account Queue Services",
     "description": "This module deploys a Storage Account Queue Service."
@@ -324,8 +324,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "6383154227554431205"
+              "version": "0.32.4.45862",
+              "templateHash": "9969689246600110741"
             },
             "name": "Storage Account Queues",
             "description": "This module deploys a Storage Account Queue."

--- a/avm/res/storage/storage-account/queue-service/queue/main.json
+++ b/avm/res/storage/storage-account/queue-service/queue/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "6383154227554431205"
+      "version": "0.32.4.45862",
+      "templateHash": "9969689246600110741"
     },
     "name": "Storage Account Queues",
     "description": "This module deploys a Storage Account Queue."

--- a/avm/res/storage/storage-account/table-service/main.json
+++ b/avm/res/storage/storage-account/table-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "12583903411447171294"
+      "version": "0.32.4.45862",
+      "templateHash": "4194630585059896468"
     },
     "name": "Storage Account Table Services",
     "description": "This module deploys a Storage Account Table Service."
@@ -321,8 +321,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "1369356397929898951"
+              "version": "0.32.4.45862",
+              "templateHash": "4457939127962832961"
             },
             "name": "Storage Account Table",
             "description": "This module deploys a Storage Account Table."

--- a/avm/res/storage/storage-account/table-service/table/main.json
+++ b/avm/res/storage/storage-account/table-service/table/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "1369356397929898951"
+      "version": "0.32.4.45862",
+      "templateHash": "4457939127962832961"
     },
     "name": "Storage Account Table",
     "description": "This module deploys a Storage Account Table."

--- a/avm/res/storage/storage-account/version.json
+++ b/avm/res/storage/storage-account/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.18",
+  "version": "0.17",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
This reverts PR #4379  due to deploy tests failing,

> Failed to enable the Defender for Storage (classic) plan on the storage account '***ssablob001' - This plan is no longer available for new subscriptions and storage accounts, subscriptions already using the new or classic per storage account plans, or re-enabling. Please use the latest API to protect your storage account. If you have enabled the new plan, disable any policies attempting to re-enable the classic plan.

Thanks to @AlexanderSehr for bringing it out.

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.


-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.storage.storage-account](https://github.com/thecsw/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml/badge.svg?branch=sandy%2Frevert-storage-atp)](https://github.com/thecsw/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml)     |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [X] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
