### PR TITLE
fix: Accelerated Network `res/compute/gallery`

### DIFF
--- a/avm/res/compute/gallery/README.md
+++ b/avm/res/compute/gallery/README.md
@@ -19,7 +19,7 @@ This module deploys an Azure Compute Gallery (formerly known as Shared Image Gal
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 | `Microsoft.Compute/galleries` | [2023-07-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2023-07-03/galleries) |
 | `Microsoft.Compute/galleries/applications` | [2022-03-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2022-03-03/galleries/applications) |
-| `Microsoft.Compute/galleries/images` | [2023-07-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2023-07-03/galleries/images) |
+| `Microsoft.Compute/galleries/images` | [2024-03-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2024-03-03/galleries/images) |
 
 ## Usage examples
 
@@ -144,6 +144,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
     description: 'This is a test deployment.'
     images: [
       {
+        allowUpdateImage: true
         architecture: 'x64'
         description: 'testDescription'
         endOfLife: '2033-01-01'
@@ -169,6 +170,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
         releaseNoteUri: 'https://testReleaseNoteUri.com'
       }
       {
+        allowUpdateImage: false
         hyperVGeneration: 'V2'
         identifier: {
           offer: 'WindowsServer'
@@ -377,6 +379,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
     "images": {
       "value": [
         {
+          "allowUpdateImage": true,
           "architecture": "x64",
           "description": "testDescription",
           "endOfLife": "2033-01-01",
@@ -402,6 +405,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
           "releaseNoteUri": "https://testReleaseNoteUri.com"
         },
         {
+          "allowUpdateImage": false,
           "hyperVGeneration": "V2",
           "identifier": {
             "offer": "WindowsServer",
@@ -610,6 +614,7 @@ param applications = [
 param description = 'This is a test deployment.'
 param images = [
   {
+    allowUpdateImage: true
     architecture: 'x64'
     description: 'testDescription'
     endOfLife: '2033-01-01'
@@ -635,6 +640,7 @@ param images = [
     releaseNoteUri: 'https://testReleaseNoteUri.com'
   }
   {
+    allowUpdateImage: false
     hyperVGeneration: 'V2'
     identifier: {
       offer: 'WindowsServer'
@@ -1296,6 +1302,7 @@ Images to create.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`allowUpdateImage`](#parameter-imagesallowupdateimage) | bool | Must be set to true if the gallery image features are being updated. |
 | [`architecture`](#parameter-imagesarchitecture) | string | The architecture of the image. Applicable to OS disks only. |
 | [`description`](#parameter-imagesdescription) | string | The description of this gallery image definition resource. This property is updatable. |
 | [`endOfLife`](#parameter-imagesendoflife) | string | The end of life date of the gallery image definition. This property can be used for decommissioning purposes. This property is updatable. |
@@ -1381,6 +1388,13 @@ This property allows you to specify the type of the OS that is included in the d
     'Windows'
   ]
   ```
+
+### Parameter: `images.allowUpdateImage`
+
+Must be set to true if the gallery image features are being updated.
+
+- Required: No
+- Type: bool
 
 ### Parameter: `images.architecture`
 

--- a/avm/res/compute/gallery/README.md
+++ b/avm/res/compute/gallery/README.md
@@ -9,6 +9,7 @@ This module deploys an Azure Compute Gallery (formerly known as Shared Image Gal
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
 - [Cross-referenced modules](#Cross-referenced-modules)
+- [Notes](#Notes)
 - [Data Collection](#Data-Collection)
 
 ## Resource Types
@@ -17,8 +18,8 @@ This module deploys an Azure Compute Gallery (formerly known as Shared Image Gal
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Compute/galleries` | [2023-07-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2023-07-03/galleries) |
-| `Microsoft.Compute/galleries/applications` | [2022-03-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2022-03-03/galleries/applications) |
+| `Microsoft.Compute/galleries` | [2024-03-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2024-03-03/galleries) |
+| `Microsoft.Compute/galleries/applications` | [2024-03-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2024-03-03/galleries/applications) |
 | `Microsoft.Compute/galleries/images` | [2024-03-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2024-03-03/galleries/images) |
 
 ## Usage examples
@@ -217,6 +218,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
         }
       }
       {
+        diskControllerType: 'SCSI'
         hyperVGeneration: 'V2'
         identifier: {
           offer: '0001-com-ubuntu-minimal-focal'
@@ -237,6 +239,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
         }
       }
       {
+        diskControllerType: 'SCSI, NVMe'
         hyperVGeneration: 'V2'
         identifier: {
           offer: '0001-com-ubuntu-minimal-focal'
@@ -452,6 +455,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
           }
         },
         {
+          "diskControllerType": "SCSI",
           "hyperVGeneration": "V2",
           "identifier": {
             "offer": "0001-com-ubuntu-minimal-focal",
@@ -472,6 +476,7 @@ module gallery 'br/public:avm/res/compute/gallery:<version>' = {
           }
         },
         {
+          "diskControllerType": "SCSI, NVMe",
           "hyperVGeneration": "V2",
           "identifier": {
             "offer": "0001-com-ubuntu-minimal-focal",
@@ -687,6 +692,7 @@ param images = [
     }
   }
   {
+    diskControllerType: 'SCSI'
     hyperVGeneration: 'V2'
     identifier: {
       offer: '0001-com-ubuntu-minimal-focal'
@@ -707,6 +713,7 @@ param images = [
     }
   }
   {
+    diskControllerType: 'SCSI, NVMe'
     hyperVGeneration: 'V2'
     identifier: {
       offer: '0001-com-ubuntu-minimal-focal'
@@ -1305,6 +1312,7 @@ Images to create.
 | [`allowUpdateImage`](#parameter-imagesallowupdateimage) | bool | Must be set to true if the gallery image features are being updated. |
 | [`architecture`](#parameter-imagesarchitecture) | string | The architecture of the image. Applicable to OS disks only. |
 | [`description`](#parameter-imagesdescription) | string | The description of this gallery image definition resource. This property is updatable. |
+| [`diskControllerType`](#parameter-imagesdiskcontrollertype) | string | The disk controllers that an OS disk supports. |
 | [`endOfLife`](#parameter-imagesendoflife) | string | The end of life date of the gallery image definition. This property can be used for decommissioning purposes. This property is updatable. |
 | [`eula`](#parameter-imageseula) | string | The Eula agreement for the gallery image definition. |
 | [`excludedDiskTypes`](#parameter-imagesexcludeddisktypes) | array | Describes the disallowed disk types. |
@@ -1416,6 +1424,21 @@ The description of this gallery image definition resource. This property is upda
 
 - Required: No
 - Type: string
+
+### Parameter: `images.diskControllerType`
+
+The disk controllers that an OS disk supports.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'NVMe, SCSI'
+    'SCSI'
+    'SCSI, NVMe'
+  ]
+  ```
 
 ### Parameter: `images.endOfLife`
 
@@ -1785,6 +1808,22 @@ This section gives you an overview of all local-referenced module files (i.e., o
 | Reference | Type |
 | :-- | :-- |
 | `br/public:avm/utl/types/avm-common-types:0.3.0` | Remote reference |
+
+## Notes
+
+Currently it is not possible to redeploy the `image.diskControllerType` property with a value of `NVMe, SCSI`. The initial deployment is working, but other deployments will result in an error.
+
+```json
+"details": [
+    {
+      "code": "PropertyChangeNotAllowed",
+      "target": "DiskControllerTypes",
+      "message": "Changing property 'DiskControllerTypes' is not allowed."
+    }
+  ]
+```
+
+Once this bug has been resolved, the max test will be updated to deploy an image with the property value.
 
 ## Data Collection
 

--- a/avm/res/compute/gallery/application/README.md
+++ b/avm/res/compute/gallery/application/README.md
@@ -15,7 +15,7 @@ This module deploys an Azure Compute Gallery Application.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Compute/galleries/applications` | [2022-03-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2022-03-03/galleries/applications) |
+| `Microsoft.Compute/galleries/applications` | [2024-03-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2024-03-03/galleries/applications) |
 
 ## Parameters
 

--- a/avm/res/compute/gallery/application/main.bicep
+++ b/avm/res/compute/gallery/application/main.bicep
@@ -72,11 +72,11 @@ var formattedRoleAssignments = [
   })
 ]
 
-resource gallery 'Microsoft.Compute/galleries@2022-03-03' existing = {
+resource gallery 'Microsoft.Compute/galleries@2024-03-03' existing = {
   name: galleryName
 }
 
-resource application 'Microsoft.Compute/galleries/applications@2022-03-03' = {
+resource application 'Microsoft.Compute/galleries/applications@2024-03-03' = {
   name: name
   parent: gallery
   location: location

--- a/avm/res/compute/gallery/application/main.json
+++ b/avm/res/compute/gallery/application/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "15930204168902038752"
+      "templateHash": "8421640590183520512"
     },
     "name": "Compute Galleries Applications",
     "description": "This module deploys an Azure Compute Gallery Application."
@@ -281,12 +281,12 @@
     "gallery": {
       "existing": true,
       "type": "Microsoft.Compute/galleries",
-      "apiVersion": "2022-03-03",
+      "apiVersion": "2024-03-03",
       "name": "[parameters('galleryName')]"
     },
     "application": {
       "type": "Microsoft.Compute/galleries/applications",
-      "apiVersion": "2022-03-03",
+      "apiVersion": "2024-03-03",
       "name": "[format('{0}/{1}', parameters('galleryName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -350,7 +350,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('application', '2022-03-03', 'full').location]"
+      "value": "[reference('application', '2024-03-03', 'full').location]"
     }
   }
 }

--- a/avm/res/compute/gallery/application/main.json
+++ b/avm/res/compute/gallery/application/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "7761447372947910331"
+      "version": "0.33.93.31351",
+      "templateHash": "15930204168902038752"
     },
     "name": "Compute Galleries Applications",
     "description": "This module deploys an Azure Compute Gallery Application."

--- a/avm/res/compute/gallery/image/README.md
+++ b/avm/res/compute/gallery/image/README.md
@@ -40,6 +40,7 @@ This module deploys an Azure Compute Gallery Image Definition.
 | [`architecture`](#parameter-architecture) | string | The architecture of the image. Applicable to OS disks only. |
 | [`description`](#parameter-description) | string | The description of this gallery image definition resource. This property is updatable. |
 | [`disallowed`](#parameter-disallowed) | object | Describes the disallowed disk types. |
+| [`diskControllerType`](#parameter-diskcontrollertype) | string | The disk controllers that an OS disk supports. |
 | [`endOfLifeDate`](#parameter-endoflifedate) | string | The end of life date of the gallery image definition. This property can be used for decommissioning purposes. This property is updatable. |
 | [`eula`](#parameter-eula) | string | The Eula agreement for the gallery image definition. |
 | [`hyperVGeneration`](#parameter-hypervgeneration) | string | The hypervisor generation of the Virtual Machine. If this value is not specified, then it is determined by the securityType parameter. If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1. |
@@ -184,6 +185,21 @@ A list of disk types.
   ```Bicep
   [
     'Standard_LRS'
+  ]
+  ```
+
+### Parameter: `diskControllerType`
+
+The disk controllers that an OS disk supports.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'NVMe, SCSI'
+    'SCSI'
+    'SCSI, NVMe'
   ]
   ```
 

--- a/avm/res/compute/gallery/image/README.md
+++ b/avm/res/compute/gallery/image/README.md
@@ -13,7 +13,7 @@ This module deploys an Azure Compute Gallery Image Definition.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Compute/galleries/images` | [2023-07-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2023-07-03/galleries/images) |
+| `Microsoft.Compute/galleries/images` | [2024-03-03](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2024-03-03/galleries/images) |
 
 ## Parameters
 
@@ -36,6 +36,7 @@ This module deploys an Azure Compute Gallery Image Definition.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`allowUpdateImage`](#parameter-allowupdateimage) | bool | Must be set to true if the gallery image features are being updated. |
 | [`architecture`](#parameter-architecture) | string | The architecture of the image. Applicable to OS disks only. |
 | [`description`](#parameter-description) | string | The description of this gallery image definition resource. This property is updatable. |
 | [`disallowed`](#parameter-disallowed) | object | Describes the disallowed disk types. |
@@ -131,6 +132,13 @@ The name of the parent Azure Shared Image Gallery. Required if the template is u
 
 - Required: Yes
 - Type: string
+
+### Parameter: `allowUpdateImage`
+
+Must be set to true if the gallery image features are being updated.
+
+- Required: No
+- Type: bool
 
 ### Parameter: `architecture`
 

--- a/avm/res/compute/gallery/image/README.md
+++ b/avm/res/compute/gallery/image/README.md
@@ -213,7 +213,6 @@ Specify if the image supports accelerated networking.
 
 - Required: No
 - Type: bool
-- Default: `True`
 
 ### Parameter: `isHibernateSupported`
 

--- a/avm/res/compute/gallery/image/main.bicep
+++ b/avm/res/compute/gallery/image/main.bicep
@@ -135,7 +135,7 @@ resource image 'Microsoft.Compute/galleries/images@2023-07-03' = {
         ? [
             {
               name: 'AcceleratedNetworking'
-              value: isAcceleratedNetworkSupported
+              value: '${isAcceleratedNetworkSupported}'
             }
           ]
         : []),

--- a/avm/res/compute/gallery/image/main.bicep
+++ b/avm/res/compute/gallery/image/main.bicep
@@ -52,6 +52,9 @@ param isAcceleratedNetworkSupported bool?
 @sys.description('Optional. Specifiy if the image supports hibernation.')
 param isHibernateSupported bool?
 
+@sys.description('Optional. Must be set to true if the gallery image features are being updated.')
+param allowUpdateImage bool?
+
 @sys.description('Optional. The architecture of the image. Applicable to OS disks only.')
 param architecture ('x64' | 'Arm64')?
 
@@ -117,12 +120,13 @@ resource gallery 'Microsoft.Compute/galleries@2023-07-03' existing = {
   name: galleryName
 }
 
-resource image 'Microsoft.Compute/galleries/images@2023-07-03' = {
+resource image 'Microsoft.Compute/galleries/images@2024-03-03' = {
   name: name
   parent: gallery
   location: location
   tags: tags
   properties: {
+    allowUpdateImage: allowUpdateImage != null ? allowUpdateImage : null
     architecture: architecture
     description: description
     disallowed: {
@@ -134,7 +138,7 @@ resource image 'Microsoft.Compute/galleries/images@2023-07-03' = {
       (isAcceleratedNetworkSupported != null // Accelerated network is not set by default and must not be set for unsupported skus
         ? [
             {
-              name: 'AcceleratedNetworking'
+              name: 'IsAcceleratedNetworkSupported'
               value: '${isAcceleratedNetworkSupported}'
             }
           ]

--- a/avm/res/compute/gallery/image/main.bicep
+++ b/avm/res/compute/gallery/image/main.bicep
@@ -47,7 +47,7 @@ param securityType (
   | 'ConfidentialVMSupported')?
 
 @sys.description('Optional. Specify if the image supports accelerated networking.')
-param isAcceleratedNetworkSupported bool = true
+param isAcceleratedNetworkSupported bool?
 
 @sys.description('Optional. Specifiy if the image supports hibernation.')
 param isHibernateSupported bool?
@@ -131,12 +131,14 @@ resource image 'Microsoft.Compute/galleries/images@2023-07-03' = {
     endOfLifeDate: endOfLifeDate
     eula: eula
     features: union(
-      [
-        {
-          name: 'IsAcceleratedNetworkSupported'
-          value: '${isAcceleratedNetworkSupported}'
-        }
-      ],
+      (isAcceleratedNetworkSupported != null // Accelerated network is not set by default and must not be set for unsupported skus
+        ? [
+            {
+              name: 'AcceleratedNetworking'
+              value: isAcceleratedNetworkSupported
+            }
+          ]
+        : []),
       (securityType != null && securityType != 'Standard' // Standard is the default and is not set
         ? [
             {

--- a/avm/res/compute/gallery/image/main.bicep
+++ b/avm/res/compute/gallery/image/main.bicep
@@ -73,6 +73,9 @@ param eula string?
 @sys.description('Optional. The hypervisor generation of the Virtual Machine. If this value is not specified, then it is determined by the securityType parameter. If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1.')
 param hyperVGeneration ('V1' | 'V2')?
 
+@sys.description('Optional. The disk controllers that an OS disk supports.')
+param diskControllerType ('SCSI' | 'SCSI, NVMe' | 'NVMe, SCSI')?
+
 @sys.description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType
 
@@ -116,7 +119,7 @@ var formattedRoleAssignments = [
   })
 ]
 
-resource gallery 'Microsoft.Compute/galleries@2023-07-03' existing = {
+resource gallery 'Microsoft.Compute/galleries@2024-03-03' existing = {
   name: galleryName
 }
 
@@ -156,6 +159,14 @@ resource image 'Microsoft.Compute/galleries/images@2024-03-03' = {
             {
               name: 'IsHibernateSupported'
               value: '${isHibernateSupported}'
+            }
+          ]
+        : []),
+      (diskControllerType != null
+        ? [
+            {
+              name: 'DiskControllerTypes'
+              value: '${diskControllerType}'
             }
           ]
         : [])

--- a/avm/res/compute/gallery/image/main.json
+++ b/avm/res/compute/gallery/image/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "17936066559310819755"
+      "templateHash": "5191633407919649272"
     },
     "name": "Compute Galleries Image Definitions",
     "description": "This module deploys an Azure Compute Gallery Image Definition."
@@ -117,7 +117,7 @@
             "type": "string"
           },
           "metadata": {
-            "example": "  [\r\n    'Standard_LRS'\r\n  ]",
+            "example": "  [\n    'Standard_LRS'\n  ]",
             "description": "Required. A list of disk types."
           }
         }
@@ -376,7 +376,7 @@
       "type": "object",
       "nullable": true,
       "metadata": {
-        "example": "{\r\n    key1: 'value1'\r\n    key2: 'value2'\r\n}\r\n",
+        "example": "{\n    key1: 'value1'\n    key2: 'value2'\n}\n",
         "description": "Optional. Tags for all the image."
       }
     }

--- a/avm/res/compute/gallery/image/main.json
+++ b/avm/res/compute/gallery/image/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "5516871841308676858"
+      "templateHash": "11735716684616231078"
     },
     "name": "Compute Galleries Image Definitions",
     "description": "This module deploys an Azure Compute Gallery Image Definition."
@@ -400,7 +400,7 @@
         },
         "endOfLifeDate": "[parameters('endOfLifeDate')]",
         "eula": "[parameters('eula')]",
-        "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'AcceleratedNetworking', 'value', parameters('isAcceleratedNetworkSupported'))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
+        "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'AcceleratedNetworking', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
         "hyperVGeneration": "[coalesce(parameters('hyperVGeneration'), if(not(empty(coalesce(parameters('securityType'), ''))), 'V2', 'V1'))]",
         "identifier": {
           "publisher": "[parameters('identifier').publisher]",

--- a/avm/res/compute/gallery/image/main.json
+++ b/avm/res/compute/gallery/image/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "11735716684616231078"
+      "templateHash": "5501596607567835785"
     },
     "name": "Compute Galleries Image Definitions",
     "description": "This module deploys an Azure Compute Gallery Image Definition."
@@ -297,6 +297,13 @@
         "description": "Optional. Specifiy if the image supports hibernation."
       }
     },
+    "allowUpdateImage": {
+      "type": "bool",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Must be set to true if the gallery image features are being updated."
+      }
+    },
     "architecture": {
       "type": "string",
       "allowedValues": [
@@ -388,11 +395,12 @@
     },
     "image": {
       "type": "Microsoft.Compute/galleries/images",
-      "apiVersion": "2023-07-03",
+      "apiVersion": "2024-03-03",
       "name": "[format('{0}/{1}', parameters('galleryName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
       "properties": {
+        "allowUpdateImage": "[if(not(equals(parameters('allowUpdateImage'), null())), parameters('allowUpdateImage'), null())]",
         "architecture": "[parameters('architecture')]",
         "description": "[parameters('description')]",
         "disallowed": {
@@ -400,7 +408,7 @@
         },
         "endOfLifeDate": "[parameters('endOfLifeDate')]",
         "eula": "[parameters('eula')]",
-        "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'AcceleratedNetworking', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
+        "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'IsAcceleratedNetworkSupported', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
         "hyperVGeneration": "[coalesce(parameters('hyperVGeneration'), if(not(empty(coalesce(parameters('securityType'), ''))), 'V2', 'V1'))]",
         "identifier": {
           "publisher": "[parameters('identifier').publisher]",
@@ -468,7 +476,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('image', '2023-07-03', 'full').location]"
+      "value": "[reference('image', '2024-03-03', 'full').location]"
     }
   }
 }

--- a/avm/res/compute/gallery/image/main.json
+++ b/avm/res/compute/gallery/image/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "13858460997059168010"
+      "version": "0.33.93.31351",
+      "templateHash": "5516871841308676858"
     },
     "name": "Compute Galleries Image Definitions",
     "description": "This module deploys an Azure Compute Gallery Image Definition."
@@ -285,7 +285,7 @@
     },
     "isAcceleratedNetworkSupported": {
       "type": "bool",
-      "defaultValue": true,
+      "nullable": true,
       "metadata": {
         "description": "Optional. Specify if the image supports accelerated networking."
       }
@@ -400,7 +400,7 @@
         },
         "endOfLifeDate": "[parameters('endOfLifeDate')]",
         "eula": "[parameters('eula')]",
-        "features": "[union(createArray(createObject('name', 'IsAcceleratedNetworkSupported', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
+        "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'AcceleratedNetworking', 'value', parameters('isAcceleratedNetworkSupported'))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
         "hyperVGeneration": "[coalesce(parameters('hyperVGeneration'), if(not(empty(coalesce(parameters('securityType'), ''))), 'V2', 'V1'))]",
         "identifier": {
           "publisher": "[parameters('identifier').publisher]",

--- a/avm/res/compute/gallery/image/main.json
+++ b/avm/res/compute/gallery/image/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "5501596607567835785"
+      "templateHash": "17936066559310819755"
     },
     "name": "Compute Galleries Image Definitions",
     "description": "This module deploys an Azure Compute Gallery Image Definition."
@@ -117,7 +117,7 @@
             "type": "string"
           },
           "metadata": {
-            "example": "  [\n    'Standard_LRS'\n  ]",
+            "example": "  [\r\n    'Standard_LRS'\r\n  ]",
             "description": "Required. A list of disk types."
           }
         }
@@ -354,6 +354,18 @@
         "description": "Optional. The hypervisor generation of the Virtual Machine. If this value is not specified, then it is determined by the securityType parameter. If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1."
       }
     },
+    "diskControllerType": {
+      "type": "string",
+      "allowedValues": [
+        "NVMe, SCSI",
+        "SCSI",
+        "SCSI, NVMe"
+      ],
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The disk controllers that an OS disk supports."
+      }
+    },
     "roleAssignments": {
       "$ref": "#/definitions/roleAssignmentType",
       "metadata": {
@@ -364,7 +376,7 @@
       "type": "object",
       "nullable": true,
       "metadata": {
-        "example": "{\n    key1: 'value1'\n    key2: 'value2'\n}\n",
+        "example": "{\r\n    key1: 'value1'\r\n    key2: 'value2'\r\n}\r\n",
         "description": "Optional. Tags for all the image."
       }
     }
@@ -390,7 +402,7 @@
     "gallery": {
       "existing": true,
       "type": "Microsoft.Compute/galleries",
-      "apiVersion": "2023-07-03",
+      "apiVersion": "2024-03-03",
       "name": "[parameters('galleryName')]"
     },
     "image": {
@@ -408,7 +420,7 @@
         },
         "endOfLifeDate": "[parameters('endOfLifeDate')]",
         "eula": "[parameters('eula')]",
-        "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'IsAcceleratedNetworkSupported', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
+        "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'IsAcceleratedNetworkSupported', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()), if(not(equals(parameters('diskControllerType'), null())), createArray(createObject('name', 'DiskControllerTypes', 'value', format('{0}', parameters('diskControllerType')))), createArray()))]",
         "hyperVGeneration": "[coalesce(parameters('hyperVGeneration'), if(not(empty(coalesce(parameters('securityType'), ''))), 'V2', 'V1'))]",
         "identifier": {
           "publisher": "[parameters('identifier').publisher]",

--- a/avm/res/compute/gallery/main.bicep
+++ b/avm/res/compute/gallery/main.bicep
@@ -168,6 +168,7 @@ module galleries_images 'image/main.bicep' = [
       location: image.?location ?? location
       galleryName: gallery.name
       description: image.?description
+      allowUpdateImage: image.?allowUpdateImage
       osType: image.osType
       osState: image.osState
       identifier: image.identifier
@@ -225,6 +226,9 @@ type imageType = {
 
   @sys.description('Optional. The description of this gallery image definition resource. This property is updatable.')
   description: string?
+
+  @sys.description('Optional. Must be set to true if the gallery image features are being updated.')
+  allowUpdateImage: bool?
 
   @sys.description('Required. This property allows you to specify the type of the OS that is included in the disk when creating a VM from a managed image.')
   osType: ('Linux' | 'Windows')

--- a/avm/res/compute/gallery/main.bicep
+++ b/avm/res/compute/gallery/main.bicep
@@ -101,7 +101,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource gallery 'Microsoft.Compute/galleries@2023-07-03' = {
+resource gallery 'Microsoft.Compute/galleries@2024-03-03' = {
   name: name
   location: location
   tags: tags
@@ -178,6 +178,7 @@ module galleries_images 'image/main.bicep' = [
       securityType: image.?securityType
       isAcceleratedNetworkSupported: image.?isAcceleratedNetworkSupported
       isHibernateSupported: image.?isHibernateSupported
+      diskControllerType: image.?diskControllerType
       architecture: image.?architecture
       eula: image.?eula
       privacyStatementUri: image.?privacyStatementUri
@@ -262,6 +263,9 @@ type imageType = {
 
   @sys.description('Optional. Specify if the image supports hibernation.')
   isHibernateSupported: bool?
+
+  @sys.description('Optional. The disk controllers that an OS disk supports.')
+  diskControllerType: ('SCSI' | 'SCSI, NVMe' | 'NVMe, SCSI')?
 
   @sys.description('Optional. The architecture of the image. Applicable to OS disks only.')
   architecture: ('x64' | 'Arm64')?

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "10262602523402140606"
+      "templateHash": "16733314595117009110"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery)."
@@ -1202,7 +1202,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "5516871841308676858"
+              "templateHash": "11735716684616231078"
             },
             "name": "Compute Galleries Image Definitions",
             "description": "This module deploys an Azure Compute Gallery Image Definition."
@@ -1596,7 +1596,7 @@
                 },
                 "endOfLifeDate": "[parameters('endOfLifeDate')]",
                 "eula": "[parameters('eula')]",
-                "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'AcceleratedNetworking', 'value', parameters('isAcceleratedNetworkSupported'))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
+                "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'AcceleratedNetworking', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
                 "hyperVGeneration": "[coalesce(parameters('hyperVGeneration'), if(not(empty(coalesce(parameters('securityType'), ''))), 'V2', 'V1'))]",
                 "identifier": {
                   "publisher": "[parameters('identifier').publisher]",

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "16937453533732128662"
+      "templateHash": "13224678661119042476"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery)."
@@ -115,6 +115,18 @@
           "nullable": true,
           "metadata": {
             "description": "Optional. Specify if the image supports hibernation."
+          }
+        },
+        "diskControllerType": {
+          "type": "string",
+          "allowedValues": [
+            "NVMe, SCSI",
+            "SCSI",
+            "SCSI, NVMe"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The disk controllers that an OS disk supports."
           }
         },
         "architecture": {
@@ -601,7 +613,7 @@
       "type": "object",
       "nullable": true,
       "metadata": {
-        "example": "  {\n      key1: 'value1'\n      key2: 'value2'\n  }\n  ",
+        "example": "  {\r\n      key1: 'value1'\r\n      key2: 'value2'\r\n  }\r\n  ",
         "description": "Optional. Tags for all resources."
       }
     },
@@ -660,7 +672,7 @@
     },
     "gallery": {
       "type": "Microsoft.Compute/galleries",
-      "apiVersion": "2023-07-03",
+      "apiVersion": "2024-03-03",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -765,7 +777,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "15930204168902038752"
+              "templateHash": "8421640590183520512"
             },
             "name": "Compute Galleries Applications",
             "description": "This module deploys an Azure Compute Gallery Application."
@@ -1040,12 +1052,12 @@
             "gallery": {
               "existing": true,
               "type": "Microsoft.Compute/galleries",
-              "apiVersion": "2022-03-03",
+              "apiVersion": "2024-03-03",
               "name": "[parameters('galleryName')]"
             },
             "application": {
               "type": "Microsoft.Compute/galleries/applications",
-              "apiVersion": "2022-03-03",
+              "apiVersion": "2024-03-03",
               "name": "[format('{0}/{1}', parameters('galleryName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
@@ -1109,7 +1121,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('application', '2022-03-03', 'full').location]"
+              "value": "[reference('application', '2024-03-03', 'full').location]"
             }
           }
         }
@@ -1174,6 +1186,9 @@
           "isHibernateSupported": {
             "value": "[tryGet(coalesce(parameters('images'), createArray())[copyIndex()], 'isHibernateSupported')]"
           },
+          "diskControllerType": {
+            "value": "[tryGet(coalesce(parameters('images'), createArray())[copyIndex()], 'diskControllerType')]"
+          },
           "architecture": {
             "value": "[tryGet(coalesce(parameters('images'), createArray())[copyIndex()], 'architecture')]"
           },
@@ -1212,7 +1227,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "5501596607567835785"
+              "templateHash": "17936066559310819755"
             },
             "name": "Compute Galleries Image Definitions",
             "description": "This module deploys an Azure Compute Gallery Image Definition."
@@ -1323,7 +1338,7 @@
                     "type": "string"
                   },
                   "metadata": {
-                    "example": "  [\n    'Standard_LRS'\n  ]",
+                    "example": "  [\r\n    'Standard_LRS'\r\n  ]",
                     "description": "Required. A list of disk types."
                   }
                 }
@@ -1560,6 +1575,18 @@
                 "description": "Optional. The hypervisor generation of the Virtual Machine. If this value is not specified, then it is determined by the securityType parameter. If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1."
               }
             },
+            "diskControllerType": {
+              "type": "string",
+              "allowedValues": [
+                "NVMe, SCSI",
+                "SCSI",
+                "SCSI, NVMe"
+              ],
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The disk controllers that an OS disk supports."
+              }
+            },
             "roleAssignments": {
               "$ref": "#/definitions/roleAssignmentType",
               "metadata": {
@@ -1570,7 +1597,7 @@
               "type": "object",
               "nullable": true,
               "metadata": {
-                "example": "{\n    key1: 'value1'\n    key2: 'value2'\n}\n",
+                "example": "{\r\n    key1: 'value1'\r\n    key2: 'value2'\r\n}\r\n",
                 "description": "Optional. Tags for all the image."
               }
             }
@@ -1596,7 +1623,7 @@
             "gallery": {
               "existing": true,
               "type": "Microsoft.Compute/galleries",
-              "apiVersion": "2023-07-03",
+              "apiVersion": "2024-03-03",
               "name": "[parameters('galleryName')]"
             },
             "image": {
@@ -1614,7 +1641,7 @@
                 },
                 "endOfLifeDate": "[parameters('endOfLifeDate')]",
                 "eula": "[parameters('eula')]",
-                "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'IsAcceleratedNetworkSupported', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
+                "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'IsAcceleratedNetworkSupported', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()), if(not(equals(parameters('diskControllerType'), null())), createArray(createObject('name', 'DiskControllerTypes', 'value', format('{0}', parameters('diskControllerType')))), createArray()))]",
                 "hyperVGeneration": "[coalesce(parameters('hyperVGeneration'), if(not(empty(coalesce(parameters('securityType'), ''))), 'V2', 'V1'))]",
                 "identifier": {
                   "publisher": "[parameters('identifier').publisher]",
@@ -1719,7 +1746,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('gallery', '2023-07-03', 'full').location]"
+      "value": "[reference('gallery', '2024-03-03', 'full').location]"
     },
     "imageResourceIds": {
       "type": "array",

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "13224678661119042476"
+      "templateHash": "2873286844914975103"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery)."
@@ -1227,7 +1227,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "17936066559310819755"
+              "templateHash": "5191633407919649272"
             },
             "name": "Compute Galleries Image Definitions",
             "description": "This module deploys an Azure Compute Gallery Image Definition."
@@ -1338,7 +1338,7 @@
                     "type": "string"
                   },
                   "metadata": {
-                    "example": "  [\r\n    'Standard_LRS'\r\n  ]",
+                    "example": "  [\n    'Standard_LRS'\n  ]",
                     "description": "Required. A list of disk types."
                   }
                 }
@@ -1597,7 +1597,7 @@
               "type": "object",
               "nullable": true,
               "metadata": {
-                "example": "{\r\n    key1: 'value1'\r\n    key2: 'value2'\r\n}\r\n",
+                "example": "{\n    key1: 'value1'\n    key2: 'value2'\n}\n",
                 "description": "Optional. Tags for all the image."
               }
             }

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "16733314595117009110"
+      "templateHash": "16937453533732128662"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery)."
@@ -28,6 +28,13 @@
           "nullable": true,
           "metadata": {
             "description": "Optional. The description of this gallery image definition resource. This property is updatable."
+          }
+        },
+        "allowUpdateImage": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Must be set to true if the gallery image features are being updated."
           }
         },
         "osType": {
@@ -1137,6 +1144,9 @@
           "description": {
             "value": "[tryGet(coalesce(parameters('images'), createArray())[copyIndex()], 'description')]"
           },
+          "allowUpdateImage": {
+            "value": "[tryGet(coalesce(parameters('images'), createArray())[copyIndex()], 'allowUpdateImage')]"
+          },
           "osType": {
             "value": "[coalesce(parameters('images'), createArray())[copyIndex()].osType]"
           },
@@ -1202,7 +1212,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "11735716684616231078"
+              "templateHash": "5501596607567835785"
             },
             "name": "Compute Galleries Image Definitions",
             "description": "This module deploys an Azure Compute Gallery Image Definition."
@@ -1493,6 +1503,13 @@
                 "description": "Optional. Specifiy if the image supports hibernation."
               }
             },
+            "allowUpdateImage": {
+              "type": "bool",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Must be set to true if the gallery image features are being updated."
+              }
+            },
             "architecture": {
               "type": "string",
               "allowedValues": [
@@ -1584,11 +1601,12 @@
             },
             "image": {
               "type": "Microsoft.Compute/galleries/images",
-              "apiVersion": "2023-07-03",
+              "apiVersion": "2024-03-03",
               "name": "[format('{0}/{1}', parameters('galleryName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
               "properties": {
+                "allowUpdateImage": "[if(not(equals(parameters('allowUpdateImage'), null())), parameters('allowUpdateImage'), null())]",
                 "architecture": "[parameters('architecture')]",
                 "description": "[parameters('description')]",
                 "disallowed": {
@@ -1596,7 +1614,7 @@
                 },
                 "endOfLifeDate": "[parameters('endOfLifeDate')]",
                 "eula": "[parameters('eula')]",
-                "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'AcceleratedNetworking', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
+                "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'IsAcceleratedNetworkSupported', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
                 "hyperVGeneration": "[coalesce(parameters('hyperVGeneration'), if(not(empty(coalesce(parameters('securityType'), ''))), 'V2', 'V1'))]",
                 "identifier": {
                   "publisher": "[parameters('identifier').publisher]",
@@ -1664,7 +1682,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('image', '2023-07-03', 'full').location]"
+              "value": "[reference('image', '2024-03-03', 'full').location]"
             }
           }
         }

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "2873286844914975103"
+      "templateHash": "13276352345178978927"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery)."
@@ -613,7 +613,7 @@
       "type": "object",
       "nullable": true,
       "metadata": {
-        "example": "  {\r\n      key1: 'value1'\r\n      key2: 'value2'\r\n  }\r\n  ",
+        "example": "  {\n      key1: 'value1'\n      key2: 'value2'\n  }\n  ",
         "description": "Optional. Tags for all resources."
       }
     },

--- a/avm/res/compute/gallery/main.json
+++ b/avm/res/compute/gallery/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "8716597573060065028"
+      "version": "0.33.93.31351",
+      "templateHash": "10262602523402140606"
     },
     "name": "Azure Compute Galleries",
     "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery)."
@@ -757,8 +757,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "7761447372947910331"
+              "version": "0.33.93.31351",
+              "templateHash": "15930204168902038752"
             },
             "name": "Compute Galleries Applications",
             "description": "This module deploys an Azure Compute Gallery Application."
@@ -1201,8 +1201,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "13858460997059168010"
+              "version": "0.33.93.31351",
+              "templateHash": "5516871841308676858"
             },
             "name": "Compute Galleries Image Definitions",
             "description": "This module deploys an Azure Compute Gallery Image Definition."
@@ -1481,7 +1481,7 @@
             },
             "isAcceleratedNetworkSupported": {
               "type": "bool",
-              "defaultValue": true,
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Specify if the image supports accelerated networking."
               }
@@ -1596,7 +1596,7 @@
                 },
                 "endOfLifeDate": "[parameters('endOfLifeDate')]",
                 "eula": "[parameters('eula')]",
-                "features": "[union(createArray(createObject('name', 'IsAcceleratedNetworkSupported', 'value', format('{0}', parameters('isAcceleratedNetworkSupported')))), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
+                "features": "[union(if(not(equals(parameters('isAcceleratedNetworkSupported'), null())), createArray(createObject('name', 'AcceleratedNetworking', 'value', parameters('isAcceleratedNetworkSupported'))), createArray()), if(and(not(equals(parameters('securityType'), null())), not(equals(parameters('securityType'), 'Standard'))), createArray(createObject('name', 'SecurityType', 'value', format('{0}', parameters('securityType')))), createArray()), if(not(equals(parameters('isHibernateSupported'), null())), createArray(createObject('name', 'IsHibernateSupported', 'value', format('{0}', parameters('isHibernateSupported')))), createArray()))]",
                 "hyperVGeneration": "[coalesce(parameters('hyperVGeneration'), if(not(empty(coalesce(parameters('securityType'), ''))), 'V2', 'V1'))]",
                 "identifier": {
                   "publisher": "[parameters('identifier').publisher]",

--- a/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
@@ -91,6 +91,7 @@ module testDeployment '../../../main.bicep' = [
       images: [
         {
           name: '${namePrefix}-az-imgd-ws-001'
+          allowUpdateImage: true
           hyperVGeneration: 'V1'
           identifier: {
             publisher: 'MicrosoftWindowsServer'
@@ -114,6 +115,7 @@ module testDeployment '../../../main.bicep' = [
         }
         {
           name: '${namePrefix}-az-imgd-ws-002'
+          allowUpdateImage: false
           hyperVGeneration: 'V2'
           identifier: {
             publisher: 'MicrosoftWindowsServer'

--- a/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
@@ -180,6 +180,7 @@ module testDeployment '../../../main.bicep' = [
             max: 4
           }
           isAcceleratedNetworkSupported: false
+          diskControllerType: 'SCSI'
         }
         {
           name: '${namePrefix}-az-imgd-us-005'
@@ -200,6 +201,7 @@ module testDeployment '../../../main.bicep' = [
             max: 4
           }
           isAcceleratedNetworkSupported: true
+          diskControllerType: 'SCSI, NVMe'
         }
         {
           name: '${namePrefix}-az-imgd-us-006'
@@ -234,6 +236,7 @@ module testDeployment '../../../main.bicep' = [
           }
           releaseNoteUri: 'https://testReleaseNoteUri.com'
           isAcceleratedNetworkSupported: false
+          // diskControllerType: 'NVMe, SCSI' // --> needs to be uncommented, as there is a bug setting it again, which prevents the idem test to pass
         }
       ]
       roleAssignments: [

--- a/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
@@ -236,7 +236,7 @@ module testDeployment '../../../main.bicep' = [
           }
           releaseNoteUri: 'https://testReleaseNoteUri.com'
           isAcceleratedNetworkSupported: false
-          // diskControllerType: 'NVMe, SCSI' // --> needs to be uncommented, as there is a bug setting it again, which prevents the idem test to pass
+          // diskControllerType: 'NVMe, SCSI' // --> needs to remain commented, as there is a bug setting the value starting with 'NVMe' again, which prevents the idem test to pass
         }
       ]
       roleAssignments: [

--- a/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/gallery/tests/e2e/max/main.test.bicep
@@ -262,8 +262,5 @@ module testDeployment '../../../main.bicep' = [
         Role: 'DeploymentValidation'
       }
     }
-    dependsOn: [
-      nestedDependencies
-    ]
   }
 ]

--- a/avm/res/compute/gallery/version.json
+++ b/avm/res/compute/gallery/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.8",
+  "version": "0.9",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
## Description

Fixes accelerated networking property for `res/compute/gallery` module, updates RP references and adds the new property allowUpdateImage.

Closes #4374 
references #4349 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.compute.gallery](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml/badge.svg)](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml)     |

## Type of Change

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
