### PR TITLE
Module Issue: Storage Account - Incorrect Handling of denyEncryptionScopeOverride Parameter

### DIFF
--- a/avm/res/storage/storage-account/blob-service/container/main.bicep
+++ b/avm/res/storage/storage-account/blob-service/container/main.bicep
@@ -15,7 +15,7 @@ param name string
 param defaultEncryptionScope string = ''
 
 @description('Optional. Block override of encryption scope from the container default.')
-param denyEncryptionScopeOverride bool = false
+param denyEncryptionScopeOverride bool?
 
 @description('Optional. Enable NFSv3 all squash on blob container.')
 param enableNfsV3AllSquash bool = false
@@ -117,7 +117,7 @@ resource container 'Microsoft.Storage/storageAccounts/blobServices/containers@20
   parent: storageAccount::blobServices
   properties: {
     defaultEncryptionScope: !empty(defaultEncryptionScope) ? defaultEncryptionScope : null
-    denyEncryptionScopeOverride: denyEncryptionScopeOverride == true ? denyEncryptionScopeOverride : null
+    denyEncryptionScopeOverride: denyEncryptionScopeOverride
     enableNfsV3AllSquash: enableNfsV3AllSquash == true ? enableNfsV3AllSquash : null
     enableNfsV3RootSquash: enableNfsV3RootSquash == true ? enableNfsV3RootSquash : null
     immutableStorageWithVersioning: immutableStorageWithVersioningEnabled == true


### PR DESCRIPTION
## Description

Ref: [#4258](https://github.com/Azure/bicep-registry-modules/issues/4258)

Issue Summary:
When deploying the Storage Account module with a Blob container, the denyEncryptionScopeOverride parameter in the container's main.bicep template is incorrectly being set to null instead of explicitly retaining the expected false value when configured as such.

This behavior causes potential misconfigurations when deployed on a existing storage account that already has this variable set to false, as you are not allowed to change this property after its creation.

Fixes ##4258
-->

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
