### PR TITLE
fix: Shortened test resource name for HCI cluster

### DIFF
--- a/avm/res/azure-stack-hci/cluster/README.md
+++ b/avm/res/azure-stack-hci/cluster/README.md
@@ -49,7 +49,7 @@ module cluster 'br/public:avm/res/azure-stack-hci/cluster:<version>' = {
     deploymentSettings: {
       clusterNodeNames: '<clusterNodeNames>'
       clusterWitnessStorageAccountName: '<clusterWitnessStorageAccountName>'
-      customLocationName: 'ashc2nmin-location'
+      customLocationName: 'ashcmin-location'
       defaultGateway: '172.20.0.1'
       deploymentPrefix: '<deploymentPrefix>'
       dnsServers: [
@@ -181,7 +181,7 @@ module cluster 'br/public:avm/res/azure-stack-hci/cluster:<version>' = {
       "value": {
         "clusterNodeNames": "<clusterNodeNames>",
         "clusterWitnessStorageAccountName": "<clusterWitnessStorageAccountName>",
-        "customLocationName": "ashc2nmin-location",
+        "customLocationName": "ashcmin-location",
         "defaultGateway": "172.20.0.1",
         "deploymentPrefix": "<deploymentPrefix>",
         "dnsServers": [
@@ -309,7 +309,7 @@ param name = '<name>'
 param deploymentSettings = {
   clusterNodeNames: '<clusterNodeNames>'
   clusterWitnessStorageAccountName: '<clusterWitnessStorageAccountName>'
-  customLocationName: 'ashc2nmin-location'
+  customLocationName: 'ashcmin-location'
   defaultGateway: '172.20.0.1'
   deploymentPrefix: '<deploymentPrefix>'
   dnsServers: [
@@ -442,7 +442,7 @@ module cluster 'br/public:avm/res/azure-stack-hci/cluster:<version>' = {
       bitlockerDataVolumes: true
       clusterNodeNames: '<clusterNodeNames>'
       clusterWitnessStorageAccountName: '<clusterWitnessStorageAccountName>'
-      customLocationName: 'ashc2nwaf-location'
+      customLocationName: 'ashcwaf-location'
       defaultGateway: '172.20.0.1'
       deploymentPrefix: '<deploymentPrefix>'
       dnsServers: [
@@ -585,7 +585,7 @@ module cluster 'br/public:avm/res/azure-stack-hci/cluster:<version>' = {
         "bitlockerDataVolumes": true,
         "clusterNodeNames": "<clusterNodeNames>",
         "clusterWitnessStorageAccountName": "<clusterWitnessStorageAccountName>",
-        "customLocationName": "ashc2nwaf-location",
+        "customLocationName": "ashcwaf-location",
         "defaultGateway": "172.20.0.1",
         "deploymentPrefix": "<deploymentPrefix>",
         "dnsServers": [
@@ -726,7 +726,7 @@ param deploymentSettings = {
   bitlockerDataVolumes: true
   clusterNodeNames: '<clusterNodeNames>'
   clusterWitnessStorageAccountName: '<clusterWitnessStorageAccountName>'
-  customLocationName: 'ashc2nwaf-location'
+  customLocationName: 'ashcwaf-location'
   defaultGateway: '172.20.0.1'
   deploymentPrefix: '<deploymentPrefix>'
   dnsServers: [

--- a/avm/res/azure-stack-hci/cluster/deployment-setting/main.json
+++ b/avm/res/azure-stack-hci/cluster/deployment-setting/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "7982158538530558379"
+      "version": "0.33.13.18514",
+      "templateHash": "10232132824907554113"
     },
     "name": "Azure Stack HCI Cluster Deployment Settings",
     "description": "This module deploys an Azure Stack HCI Cluster Deployment Settings resource."

--- a/avm/res/azure-stack-hci/cluster/main.json
+++ b/avm/res/azure-stack-hci/cluster/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "2661952410917464461"
+      "version": "0.33.13.18514",
+      "templateHash": "2800706656796817324"
     },
     "name": "Azure Stack HCI Cluster",
     "description": "This module deploys an Azure Stack HCI Cluster on the provided Arc Machines."
@@ -837,8 +837,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "7982158538530558379"
+              "version": "0.33.13.18514",
+              "templateHash": "10232132824907554113"
             },
             "name": "Azure Stack HCI Cluster Deployment Settings",
             "description": "This module deploys an Azure Stack HCI Cluster Deployment Settings resource."

--- a/avm/res/azure-stack-hci/cluster/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/azure-stack-hci/cluster/tests/e2e/defaults/main.test.bicep
@@ -8,7 +8,7 @@ metadata description = 'This test deploys an Azure VM to host a 2 node switched 
 param resourceGroupName string = 'dep-${namePrefix}-azure-stack-hci.cluster-${serviceShort}-rg'
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
-param serviceShort string = 'ashc2nmin'
+param serviceShort string = 'ashcmin'
 
 @description('Optional. A token to inject into the name of each resource.')
 param namePrefix string = '#_namePrefix_#'
@@ -49,7 +49,7 @@ module nestedDependencies 'dependencies.bicep' = {
   name: '${uniqueString(deployment().name, enforcedLocation)}-test-nestedDependencies-${serviceShort}'
   scope: resourceGroup
   params: {
-    clusterName: '${namePrefix}${serviceShort}001'
+    clusterName: '${namePrefix}${serviceShort}1'
     clusterWitnessStorageAccountName: 'dep${namePrefix}wst${serviceShort}'
     keyVaultDiagnosticStorageAccountName: 'dep${namePrefix}st${serviceShort}'
     keyVaultName: 'dep-${namePrefix}-kv-${serviceShort}'

--- a/avm/res/azure-stack-hci/cluster/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/azure-stack-hci/cluster/tests/e2e/waf-aligned/main.test.bicep
@@ -8,7 +8,7 @@ metadata description = 'This test deploys an Azure VM to host a 2 node switched 
 param resourceGroupName string = 'dep-${namePrefix}-azure-stack-hci.cluster-${serviceShort}-rg'
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
-param serviceShort string = 'ashc2nwaf'
+param serviceShort string = 'ashcwaf'
 
 @description('Optional. A token to inject into the name of each resource.')
 param namePrefix string = '#_namePrefix_#'
@@ -49,7 +49,7 @@ module nestedDependencies 'dependencies.bicep' = {
   name: '${uniqueString(deployment().name, enforcedLocation)}-test-nestedDependencies-${serviceShort}'
   scope: resourceGroup
   params: {
-    clusterName: '${namePrefix}${serviceShort}001'
+    clusterName: '${namePrefix}${serviceShort}1'
     clusterWitnessStorageAccountName: 'dep${namePrefix}wst${serviceShort}'
     keyVaultDiagnosticStorageAccountName: 'dep${namePrefix}st${serviceShort}'
     keyVaultName: 'dep-${namePrefix}-kv-${serviceShort}'


### PR DESCRIPTION
## Description

Shortened test resource name for HCI cluster as it runs into a length issue (16 chars vs max of 15 chars) during test deployment
No version update required as it only afffects test resources.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
