### PR TITLE
fix: sub-vending, adding CI secret

### DIFF
--- a/avm/ptn/lz/sub-vending/main.json
+++ b/avm/ptn/lz/sub-vending/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "16856855794906870670"
+      "version": "0.33.93.31351",
+      "templateHash": "14919277706976174104"
     },
     "name": "Sub-vending",
     "description": "This module deploys a subscription to accelerate deployment of landing zones. For more information on how to use it, please visit this [Wiki](https://github.com/Azure/bicep-lz-vending/wiki).",
@@ -669,8 +669,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "2801471703151139948"
+              "version": "0.33.93.31351",
+              "templateHash": "8425865084067531624"
             }
           },
           "parameters": {
@@ -880,8 +880,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "250791371811352682"
+              "version": "0.33.93.31351",
+              "templateHash": "11018695082972643897"
             },
             "name": "`/subResourcesWrapper/deploy.bicep` Parameters",
             "description": "This module is used by the [`bicep-lz-vending`](https://aka.ms/sub-vending/bicep) module to help orchestrate the deployment",
@@ -1588,8 +1588,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "12834168093418139358"
+                      "version": "0.33.93.31351",
+                      "templateHash": "8452628568304993719"
                     }
                   },
                   "parameters": {
@@ -1649,8 +1649,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "15508893729756562690"
+                      "version": "0.33.93.31351",
+                      "templateHash": "11019372772177629958"
                     }
                   },
                   "parameters": {
@@ -1709,8 +1709,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.13.18514",
-                              "templateHash": "2541836993831686925"
+                              "version": "0.33.93.31351",
+                              "templateHash": "8397259050503224920"
                             }
                           },
                           "parameters": {
@@ -1765,8 +1765,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.13.18514",
-                                      "templateHash": "7264500549088500335"
+                                      "version": "0.33.93.31351",
+                                      "templateHash": "7623404265819505597"
                                     }
                                   },
                                   "parameters": {
@@ -1843,8 +1843,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.13.18514",
-                              "templateHash": "9459644647794329484"
+                              "version": "0.33.93.31351",
+                              "templateHash": "8957892045766331539"
                             }
                           },
                           "parameters": {
@@ -1898,8 +1898,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.13.18514",
-                                      "templateHash": "8593973730489733307"
+                                      "version": "0.33.93.31351",
+                                      "templateHash": "14513856367602857749"
                                     }
                                   },
                                   "parameters": {
@@ -2511,8 +2511,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "15508893729756562690"
+                      "version": "0.33.93.31351",
+                      "templateHash": "11019372772177629958"
                     }
                   },
                   "parameters": {
@@ -2571,8 +2571,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.13.18514",
-                              "templateHash": "2541836993831686925"
+                              "version": "0.33.93.31351",
+                              "templateHash": "8397259050503224920"
                             }
                           },
                           "parameters": {
@@ -2627,8 +2627,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.13.18514",
-                                      "templateHash": "7264500549088500335"
+                                      "version": "0.33.93.31351",
+                                      "templateHash": "7623404265819505597"
                                     }
                                   },
                                   "parameters": {
@@ -2705,8 +2705,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.13.18514",
-                              "templateHash": "9459644647794329484"
+                              "version": "0.33.93.31351",
+                              "templateHash": "8957892045766331539"
                             }
                           },
                           "parameters": {
@@ -2760,8 +2760,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.13.18514",
-                                      "templateHash": "8593973730489733307"
+                                      "version": "0.33.93.31351",
+                                      "templateHash": "14513856367602857749"
                                     }
                                   },
                                   "parameters": {
@@ -4454,8 +4454,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "4537798139153123030"
+                      "version": "0.33.93.31351",
+                      "templateHash": "12390675321128699904"
                     }
                   },
                   "parameters": {

--- a/avm/ptn/lz/sub-vending/tests/e2e/defaults/main.test.bicep
+++ b/avm/ptn/lz/sub-vending/tests/e2e/defaults/main.test.bicep
@@ -6,7 +6,6 @@ targetScope = 'managementGroup'
 @description('Optional. The location to deploy resources to.')
 param resourceLocation string = deployment().location
 
-// This parameter needs to be updated with the billing account and the enrollment account of your environment.
 @description('Required. The scope of the subscription billing. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-SubscriptionBillingScope\'.')
 @secure()
 param subscriptionBillingScope string = ''

--- a/avm/ptn/lz/sub-vending/tests/e2e/defaults/main.test.bicep
+++ b/avm/ptn/lz/sub-vending/tests/e2e/defaults/main.test.bicep
@@ -6,9 +6,10 @@ targetScope = 'managementGroup'
 @description('Optional. The location to deploy resources to.')
 param resourceLocation string = deployment().location
 
-// This parameter needs to be updated with the billing account and the enrollment account of your enviornment.
-@description('Optional. The subscription billing scope.')
-param subscriptionBillingScope string = 'providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/350580'
+// This parameter needs to be updated with the billing account and the enrollment account of your environment.
+@description('Required. The scope of the subscription billing. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-SubscriptionBillingScope\'.')
+@secure()
+param subscriptionBillingScope string = ''
 
 @description('Optional. A token to inject into the name of each resource.')
 param namePrefix string = '#_namePrefix_#'

--- a/avm/ptn/lz/sub-vending/tests/e2e/hub-spoke/main.test.bicep
+++ b/avm/ptn/lz/sub-vending/tests/e2e/hub-spoke/main.test.bicep
@@ -6,7 +6,6 @@ targetScope = 'managementGroup'
 @description('Optional. The location to deploy resources to.')
 param resourceLocation string = deployment().location
 
-// This parameter needs to be updated with the billing account and the enrollment account of your environment.
 @description('Required. The scope of the subscription billing. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-SubscriptionBillingScope\'.')
 @secure()
 param subscriptionBillingScope string = ''

--- a/avm/ptn/lz/sub-vending/tests/e2e/hub-spoke/main.test.bicep
+++ b/avm/ptn/lz/sub-vending/tests/e2e/hub-spoke/main.test.bicep
@@ -6,9 +6,10 @@ targetScope = 'managementGroup'
 @description('Optional. The location to deploy resources to.')
 param resourceLocation string = deployment().location
 
-// This parameter needs to be updated with the billing account and the enrollment account of your enviornment.
-@description('Optional. The subscription billing scope.')
-param subscriptionBillingScope string = 'providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/350580'
+// This parameter needs to be updated with the billing account and the enrollment account of your environment.
+@description('Required. The scope of the subscription billing. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-SubscriptionBillingScope\'.')
+@secure()
+param subscriptionBillingScope string = ''
 
 @description('Optional. A token to inject into the name of each resource.')
 param namePrefix string = '#_namePrefix_#'

--- a/avm/ptn/lz/sub-vending/tests/e2e/rbac-condition/main.test.bicep
+++ b/avm/ptn/lz/sub-vending/tests/e2e/rbac-condition/main.test.bicep
@@ -6,7 +6,6 @@ targetScope = 'managementGroup'
 @description('Optional. The location to deploy resources to.')
 param resourceLocation string = deployment().location
 
-// This parameter needs to be updated with the billing account and the enrollment account of your environment.
 @description('Required. The scope of the subscription billing. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-SubscriptionBillingScope\'.')
 @secure()
 param subscriptionBillingScope string = ''

--- a/avm/ptn/lz/sub-vending/tests/e2e/rbac-condition/main.test.bicep
+++ b/avm/ptn/lz/sub-vending/tests/e2e/rbac-condition/main.test.bicep
@@ -6,9 +6,10 @@ targetScope = 'managementGroup'
 @description('Optional. The location to deploy resources to.')
 param resourceLocation string = deployment().location
 
-// This parameter needs to be updated with the billing account and the enrollment account of your enviornment.
-@description('Optional. The subscription billing scope.')
-param subscriptionBillingScope string = 'providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/350580'
+// This parameter needs to be updated with the billing account and the enrollment account of your environment.
+@description('Required. The scope of the subscription billing. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-SubscriptionBillingScope\'.')
+@secure()
+param subscriptionBillingScope string = ''
 
 @description('Optional. A token to inject into the name of each resource.')
 param namePrefix string = '#_namePrefix_#'

--- a/avm/ptn/lz/sub-vending/tests/e2e/vwan-spoke/main.test.bicep
+++ b/avm/ptn/lz/sub-vending/tests/e2e/vwan-spoke/main.test.bicep
@@ -6,7 +6,6 @@ targetScope = 'managementGroup'
 @description('Optional. The location to deploy resources to.')
 param resourceLocation string = deployment().location
 
-// This parameter needs to be updated with the billing account and the enrollment account of your environment.
 @description('Required. The scope of the subscription billing. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-SubscriptionBillingScope\'.')
 @secure()
 param subscriptionBillingScope string = ''

--- a/avm/ptn/lz/sub-vending/tests/e2e/vwan-spoke/main.test.bicep
+++ b/avm/ptn/lz/sub-vending/tests/e2e/vwan-spoke/main.test.bicep
@@ -6,9 +6,10 @@ targetScope = 'managementGroup'
 @description('Optional. The location to deploy resources to.')
 param resourceLocation string = deployment().location
 
-// This parameter needs to be updated with the billing account and the enrollment account of your enviornment.
-@description('Optional. The subscription billing scope.')
-param subscriptionBillingScope string = 'providers/Microsoft.Billing/billingAccounts/7690848/enrollmentAccounts/350580'
+// This parameter needs to be updated with the billing account and the enrollment account of your environment.
+@description('Required. The scope of the subscription billing. This value is tenant-specific and must be stored in the CI Key Vault in a secret named \'CI-SubscriptionBillingScope\'.')
+@secure()
+param subscriptionBillingScope string = ''
 
 @description('Optional. A token to inject into the name of each resource.')
 param namePrefix string = '#_namePrefix_#'

--- a/avm/ptn/network/hub-networking/main.json
+++ b/avm/ptn/network/hub-networking/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "17389954898374222994"
+      "version": "0.33.93.31351",
+      "templateHash": "10309836000326275731"
     },
     "name": "Hub Networking",
     "description": "This module is designed to simplify the creation of multi-region hub networks in Azure. It will create a number of virtual networks and subnets, and optionally peer them together in a mesh topology with routing."
@@ -2340,8 +2340,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "13800865708253602673"
+              "version": "0.33.93.31351",
+              "templateHash": "6971888757750761810"
             },
             "name": "Virtual Networks",
             "description": "This module deploys a Virtual Network."
@@ -6467,8 +6467,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "17332298613317998164"
+              "version": "0.33.93.31351",
+              "templateHash": "4695558034353162860"
             },
             "name": "Existing Virtual Network Subnets",
             "description": "This module retrieves an existing Virtual Network Subnet."
@@ -6549,8 +6549,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "13712864569972623739"
+              "version": "0.33.93.31351",
+              "templateHash": "3980815084200627301"
             },
             "name": "Virtual Network Subnets",
             "description": "This module deploys a Virtual Network Subnet."


### PR DESCRIPTION
## Description

Adding a custom CI secret to the sub-vending module

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|  [![avm.ptn.lz.sub-vending](https://github.com/sebassem/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml/badge.svg?branch=avm-ptn-vending-add-secret)](https://github.com/sebassem/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml)        |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ X] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [X] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
