### PR TITLE
fix: enhancements to hub-spoke module

### DIFF
--- a/avm/ptn/network/hub-networking/README.md
+++ b/avm/ptn/network/hub-networking/README.md
@@ -18,7 +18,7 @@ This module is designed to simplify the creation of multi-region hub networks in
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
-| `Microsoft.Network/azureFirewalls` | [2024-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/azureFirewalls) |
+| `Microsoft.Network/azureFirewalls` | [2024-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-01-01/azureFirewalls) |
 | `Microsoft.Network/bastionHosts` | [2022-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-11-01/bastionHosts) |
 | `Microsoft.Network/publicIPAddresses` | [2023-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-09-01/publicIPAddresses) |
 | `Microsoft.Network/routeTables` | [2023-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-04-01/routeTables) |

--- a/avm/ptn/network/hub-networking/README.md
+++ b/avm/ptn/network/hub-networking/README.md
@@ -193,7 +193,6 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
           'hidden-title': 'This is visible in the resource name'
           Role: 'DeploymentValidation'
         }
-        virtualNetworkName: 'vnet-hub1'
         vnetEncryption: false
         vnetEncryptionEnforcement: 'AllowUnencrypted'
       }
@@ -236,7 +235,7 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
             allowForwardedTraffic: true
             allowGatewayTransit: false
             allowVirtualNetworkAccess: true
-            remoteVirtualNetworkName: 'vnet-hub1'
+            remoteVirtualNetworkName: 'hub1'
             useRemoteGateways: false
           }
         ]
@@ -376,7 +375,6 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
             "hidden-title": "This is visible in the resource name",
             "Role": "DeploymentValidation"
           },
-          "virtualNetworkName": "vnet-hub1",
           "vnetEncryption": false,
           "vnetEncryptionEnforcement": "AllowUnencrypted"
         },
@@ -419,7 +417,7 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
               "allowForwardedTraffic": true,
               "allowGatewayTransit": false,
               "allowVirtualNetworkAccess": true,
-              "remoteVirtualNetworkName": "vnet-hub1",
+              "remoteVirtualNetworkName": "hub1",
               "useRemoteGateways": false
             }
           ],
@@ -559,7 +557,6 @@ param hubVirtualNetworks = {
       'hidden-title': 'This is visible in the resource name'
       Role: 'DeploymentValidation'
     }
-    virtualNetworkName: 'vnet-hub1'
     vnetEncryption: false
     vnetEncryptionEnforcement: 'AllowUnencrypted'
   }
@@ -602,7 +599,7 @@ param hubVirtualNetworks = {
         allowForwardedTraffic: true
         allowGatewayTransit: false
         allowVirtualNetworkAccess: true
-        remoteVirtualNetworkName: 'vnet-hub1'
+        remoteVirtualNetworkName: 'hub1'
         useRemoteGateways: false
       }
     ]
@@ -1264,7 +1261,6 @@ The hub virtual networks to create.
 | [`routeTableName`](#parameter-hubvirtualnetworks>any_other_property<routetablename) | string | The name of the route table. |
 | [`subnets`](#parameter-hubvirtualnetworks>any_other_property<subnets) | array | The subnets of the virtual network. |
 | [`tags`](#parameter-hubvirtualnetworks>any_other_property<tags) | object | The tags of the virtual network. |
-| [`virtualNetworkName`](#parameter-hubvirtualnetworks>any_other_property<virtualnetworkname) | string | The name of the hub virtual network. |
 | [`vnetEncryption`](#parameter-hubvirtualnetworks>any_other_property<vnetencryption) | bool | Enable/Disable VNet encryption. |
 | [`vnetEncryptionEnforcement`](#parameter-hubvirtualnetworks>any_other_property<vnetencryptionenforcement) | string | The VNet encryption enforcement settings of the virtual network. |
 
@@ -2220,13 +2216,6 @@ The tags of the virtual network.
 
 - Required: No
 - Type: object
-
-### Parameter: `hubVirtualNetworks.>Any_other_property<.virtualNetworkName`
-
-The name of the hub virtual network.
-
-- Required: No
-- Type: string
 
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.vnetEncryption`
 

--- a/avm/ptn/network/hub-networking/README.md
+++ b/avm/ptn/network/hub-networking/README.md
@@ -236,7 +236,7 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
             allowForwardedTraffic: true
             allowGatewayTransit: false
             allowVirtualNetworkAccess: true
-            remoteVirtualNetworkName: 'hub1'
+            remoteVirtualNetworkName: 'vnet-hub1'
             useRemoteGateways: false
           }
         ]
@@ -419,7 +419,7 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
               "allowForwardedTraffic": true,
               "allowGatewayTransit": false,
               "allowVirtualNetworkAccess": true,
-              "remoteVirtualNetworkName": "hub1",
+              "remoteVirtualNetworkName": "vnet-hub1",
               "useRemoteGateways": false
             }
           ],
@@ -602,7 +602,7 @@ param hubVirtualNetworks = {
         allowForwardedTraffic: true
         allowGatewayTransit: false
         allowVirtualNetworkAccess: true
-        remoteVirtualNetworkName: 'hub1'
+        remoteVirtualNetworkName: 'vnet-hub1'
         useRemoteGateways: false
       }
     ]

--- a/avm/ptn/network/hub-networking/README.md
+++ b/avm/ptn/network/hub-networking/README.md
@@ -1255,8 +1255,10 @@ The hub virtual networks to create.
 | [`peeringSettings`](#parameter-hubvirtualnetworks>any_other_property<peeringsettings) | array | The peerings of the virtual network. |
 | [`roleAssignments`](#parameter-hubvirtualnetworks>any_other_property<roleassignments) | array | The role assignments to create. |
 | [`routes`](#parameter-hubvirtualnetworks>any_other_property<routes) | array | Routes to add to the virtual network route table. |
+| [`routeTableName`](#parameter-hubvirtualnetworks>any_other_property<routetablename) | string | The name of the route table. |
 | [`subnets`](#parameter-hubvirtualnetworks>any_other_property<subnets) | array | The subnets of the virtual network. |
 | [`tags`](#parameter-hubvirtualnetworks>any_other_property<tags) | object | The tags of the virtual network. |
+| [`virtualNetworkName`](#parameter-hubvirtualnetworks>any_other_property<virtualnetworkname) | string | The name of the hub virtual network. |
 | [`vnetEncryption`](#parameter-hubvirtualnetworks>any_other_property<vnetencryption) | bool | Enable/Disable VNet encryption. |
 | [`vnetEncryptionEnforcement`](#parameter-hubvirtualnetworks>any_other_property<vnetencryptionenforcement) | string | The VNet encryption enforcement settings of the virtual network. |
 
@@ -1280,6 +1282,7 @@ The Azure Firewall config.
 | :-- | :-- | :-- |
 | [`additionalPublicIpConfigurations`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsadditionalpublicipconfigurations) | array | Additional public IP configurations. |
 | [`applicationRuleCollections`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsapplicationrulecollections) | array | Application rule collections. |
+| [`azureFirewallName`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsazurefirewallname) | string | The name of the Azure Firewall. |
 | [`azureSkuTier`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsazureskutier) | string | Azure Firewall SKU. |
 | [`diagnosticSettings`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsdiagnosticsettings) | array | Diagnostic settings. |
 | [`enableTelemetry`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsenabletelemetry) | bool | Enable/Disable usage telemetry for module. |
@@ -1313,12 +1316,27 @@ Application rule collections.
 - Required: No
 - Type: array
 
+### Parameter: `hubVirtualNetworks.>Any_other_property<.azureFirewallSettings.azureFirewallName`
+
+The name of the Azure Firewall.
+
+- Required: No
+- Type: string
+
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.azureFirewallSettings.azureSkuTier`
 
 Azure Firewall SKU.
 
 - Required: No
 - Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Basic'
+    'Premium'
+    'Standard'
+  ]
+  ```
 
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.azureFirewallSettings.diagnosticSettings`
 
@@ -1708,12 +1726,21 @@ The Azure Bastion config.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`bastionHostName`](#parameter-hubvirtualnetworks>any_other_property<bastionhostbastionhostname) | string | The name of the bastion host. |
 | [`disableCopyPaste`](#parameter-hubvirtualnetworks>any_other_property<bastionhostdisablecopypaste) | bool | Enable/Disable copy/paste functionality. |
 | [`enableFileCopy`](#parameter-hubvirtualnetworks>any_other_property<bastionhostenablefilecopy) | bool | Enable/Disable file copy functionality. |
 | [`enableIpConnect`](#parameter-hubvirtualnetworks>any_other_property<bastionhostenableipconnect) | bool | Enable/Disable IP connect functionality. |
+| [`enableKerberos`](#parameter-hubvirtualnetworks>any_other_property<bastionhostenablekerberos) | bool | Enable/Disable Kerberos authentication. |
 | [`enableShareableLink`](#parameter-hubvirtualnetworks>any_other_property<bastionhostenableshareablelink) | bool | Enable/Disable shareable link functionality. |
 | [`scaleUnits`](#parameter-hubvirtualnetworks>any_other_property<bastionhostscaleunits) | int | The number of scale units for the Bastion host. Defaults to 4. |
 | [`skuName`](#parameter-hubvirtualnetworks>any_other_property<bastionhostskuname) | string | The SKU name of the Bastion host. Defaults to Standard. |
+
+### Parameter: `hubVirtualNetworks.>Any_other_property<.bastionHost.bastionHostName`
+
+The name of the bastion host.
+
+- Required: No
+- Type: string
 
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.bastionHost.disableCopyPaste`
 
@@ -1732,6 +1759,13 @@ Enable/Disable file copy functionality.
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.bastionHost.enableIpConnect`
 
 Enable/Disable IP connect functionality.
+
+- Required: No
+- Type: bool
+
+### Parameter: `hubVirtualNetworks.>Any_other_property<.bastionHost.enableKerberos`
+
+Enable/Disable Kerberos authentication.
 
 - Required: No
 - Type: bool
@@ -1756,6 +1790,15 @@ The SKU name of the Bastion host. Defaults to Standard.
 
 - Required: No
 - Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Basic'
+    'Developer'
+    'Premium'
+    'Standard'
+  ]
+  ```
 
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.ddosProtectionPlanResourceId`
 
@@ -2151,6 +2194,13 @@ Routes to add to the virtual network route table.
 - Required: No
 - Type: array
 
+### Parameter: `hubVirtualNetworks.>Any_other_property<.routeTableName`
+
+The name of the route table.
+
+- Required: No
+- Type: string
+
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.subnets`
 
 The subnets of the virtual network.
@@ -2164,6 +2214,13 @@ The tags of the virtual network.
 
 - Required: No
 - Type: object
+
+### Parameter: `hubVirtualNetworks.>Any_other_property<.virtualNetworkName`
+
+The name of the hub virtual network.
+
+- Required: No
+- Type: string
 
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.vnetEncryption`
 

--- a/avm/ptn/network/hub-networking/README.md
+++ b/avm/ptn/network/hub-networking/README.md
@@ -18,7 +18,7 @@ This module is designed to simplify the creation of multi-region hub networks in
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
-| `Microsoft.Network/azureFirewalls` | [2024-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-01-01/azureFirewalls) |
+| `Microsoft.Network/azureFirewalls` | [2024-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/azureFirewalls) |
 | `Microsoft.Network/bastionHosts` | [2022-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2022-11-01/bastionHosts) |
 | `Microsoft.Network/publicIPAddresses` | [2023-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-09-01/publicIPAddresses) |
 | `Microsoft.Network/routeTables` | [2023-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-04-01/routeTables) |
@@ -118,6 +118,11 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
             name: 'hub1-waf-pip'
           }
           threatIntelMode: 'Alert'
+          zones: [
+            1
+            2
+            3
+          ]
         }
         bastionHost: {
           bastionHostName: 'bastion-hub1'
@@ -299,7 +304,12 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
             "publicIPAddressObject": {
               "name": "hub1-waf-pip"
             },
-            "threatIntelMode": "Alert"
+            "threatIntelMode": "Alert",
+            "zones": [
+              1,
+              2,
+              3
+            ]
           },
           "bastionHost": {
             "bastionHostName": "bastion-hub1",
@@ -482,6 +492,11 @@ param hubVirtualNetworks = {
         name: 'hub1-waf-pip'
       }
       threatIntelMode: 'Alert'
+      zones: [
+        1
+        2
+        3
+      ]
     }
     bastionHost: {
       bastionHostName: 'bastion-hub1'

--- a/avm/ptn/network/hub-networking/README.md
+++ b/avm/ptn/network/hub-networking/README.md
@@ -120,6 +120,7 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
           threatIntelMode: 'Alert'
         }
         bastionHost: {
+          bastionHostName: 'bastion-hub1'
           disableCopyPaste: true
           enableFileCopy: false
           enableIpConnect: false
@@ -192,6 +193,7 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
           'hidden-title': 'This is visible in the resource name'
           Role: 'DeploymentValidation'
         }
+        virtualNetworkName: 'vnet-hub1'
         vnetEncryption: false
         vnetEncryptionEnforcement: 'AllowUnencrypted'
       }
@@ -301,6 +303,7 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
             "threatIntelMode": "Alert"
           },
           "bastionHost": {
+            "bastionHostName": "bastion-hub1",
             "disableCopyPaste": true,
             "enableFileCopy": false,
             "enableIpConnect": false,
@@ -373,6 +376,7 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
             "hidden-title": "This is visible in the resource name",
             "Role": "DeploymentValidation"
           },
+          "virtualNetworkName": "vnet-hub1",
           "vnetEncryption": false,
           "vnetEncryptionEnforcement": "AllowUnencrypted"
         },
@@ -482,6 +486,7 @@ param hubVirtualNetworks = {
       threatIntelMode: 'Alert'
     }
     bastionHost: {
+      bastionHostName: 'bastion-hub1'
       disableCopyPaste: true
       enableFileCopy: false
       enableIpConnect: false
@@ -554,6 +559,7 @@ param hubVirtualNetworks = {
       'hidden-title': 'This is visible in the resource name'
       Role: 'DeploymentValidation'
     }
+    virtualNetworkName: 'vnet-hub1'
     vnetEncryption: false
     vnetEncryptionEnforcement: 'AllowUnencrypted'
   }

--- a/avm/ptn/network/hub-networking/main.bicep
+++ b/avm/ptn/network/hub-networking/main.bicep
@@ -86,7 +86,7 @@ module hubVirtualNetworkPeer_remote 'modules/vnets.bicep' = [
 
 resource hubVirtualNetworkPeer_local 'Microsoft.Network/virtualNetworks@2024-01-01' existing = [
   for (hub, index) in items(hubVirtualNetworks ?? {}): if (hub.value.enablePeering) {
-    name: hub.key
+    name: hub.value.?virtualNetworkName ?? hub.key
   }
 ]
 

--- a/avm/ptn/network/hub-networking/main.bicep
+++ b/avm/ptn/network/hub-networking/main.bicep
@@ -44,10 +44,10 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2023-07-01' = if (enableT
 // Create hub virtual networks
 module hubVirtualNetwork 'br/public:avm/res/network/virtual-network:0.5.0' = [
   for (hub, index) in items(hubVirtualNetworks ?? {}): {
-    name: '${uniqueString(deployment().name, location)}-${hub.value.?virtualNetworkName ?? hub.key}-nvn'
+    name: '${uniqueString(deployment().name, location)}-${hub.key}-nvn'
     params: {
       // Required parameters
-      name: hub.value.?virtualNetworkName ?? hub.key
+      name: hub.key
       addressPrefixes: hub.value.addressPrefixes
       // Non-required parameters
       ddosProtectionPlanResourceId: hub.value.?ddosProtectionPlanResourceId ?? ''
@@ -86,7 +86,7 @@ module hubVirtualNetworkPeer_remote 'modules/vnets.bicep' = [
 
 resource hubVirtualNetworkPeer_local 'Microsoft.Network/virtualNetworks@2024-01-01' existing = [
   for (hub, index) in items(hubVirtualNetworks ?? {}): if (hub.value.enablePeering) {
-    name: hub.value.?virtualNetworkName ?? hub.key
+    name: hub.key
   }
 ]
 
@@ -109,7 +109,7 @@ resource hubVirtualNetworkPeering 'Microsoft.Network/virtualNetworks/virtualNetw
 // Create hub virtual network route tables
 module hubRouteTable 'br/public:avm/res/network/route-table:0.4.0' = [
   for (hub, index) in items(hubVirtualNetworks ?? {}): {
-    name: '${uniqueString(deployment().name, location)}-${hub.value.?virtualNetworkName ?? hub.key}-nrt'
+    name: '${uniqueString(deployment().name, location)}-${hub.key}-nrt'
     params: {
       name: hub.value.?routeTableName ?? hub.key
       location: hub.value.?location ?? location
@@ -142,7 +142,7 @@ resource hubRoute 'Microsoft.Network/routeTables/routes@2024-01-01' = [
 // There is a minimum subnet requirement of /27 prefix.
 module hubBastion 'br/public:avm/res/network/bastion-host:0.4.0' = [
   for (hub, index) in items(hubVirtualNetworks ?? {}): if (hub.value.enableBastion) {
-    name: '${uniqueString(deployment().name, location)}-${hub.value.?virtualNetworkName ?? hub.key}-nbh'
+    name: '${uniqueString(deployment().name, location)}-${hub.key}-nbh'
     params: {
       // Required parameters
       name: hub.value.?bastionHost.?bastionHostName ?? hub.key
@@ -170,7 +170,7 @@ module hubBastion 'br/public:avm/res/network/bastion-host:0.4.0' = [
 // AzureFirewallSubnet is required to deploy Azure Firewall service. This subnet must exist in the subnets array if you enable Azure Firewall.
 module hubAzureFirewall 'br/public:avm/res/network/azure-firewall:0.5.1' = [
   for (hub, index) in items(hubVirtualNetworks ?? {}): if (hub.value.enableAzureFirewall) {
-    name: '${uniqueString(deployment().name, location)}-${hub.value.?virtualNetworkName ?? hub.key}-naf'
+    name: '${uniqueString(deployment().name, location)}-${hub.key}-naf'
     params: {
       // Required parameters
       name: hub.value.?azureFirewallSettings.?azureFirewallName ?? hub.key
@@ -204,10 +204,10 @@ module hubAzureFirewall 'br/public:avm/res/network/azure-firewall:0.5.1' = [
 
 module hubAzureFirewallSubnet 'modules/getSubnet.bicep' = [
   for (hub, index) in items(hubVirtualNetworks ?? {}): if (hub.value.enableAzureFirewall) {
-    name: '${uniqueString(deployment().name, location)}-${hub.value.?virtualNetworkName ?? hub.key}-nafs'
+    name: '${uniqueString(deployment().name, location)}-${hub.key}-nafs'
     params: {
       subnetName: 'AzureFirewallSubnet'
-      virtualNetworkName: hub.value.?virtualNetworkName ?? hub.key
+      virtualNetworkName: hub.key
     }
     dependsOn: [hubVirtualNetwork]
   }
@@ -216,10 +216,10 @@ module hubAzureFirewallSubnet 'modules/getSubnet.bicep' = [
 @batchSize(1)
 module hubAzureFirewallSubnetAssociation 'modules/subnets.bicep' = [
   for (hub, index) in items(hubVirtualNetworks ?? {}): if (hub.value.enableAzureFirewall) {
-    name: '${uniqueString(deployment().name, location)}-${hub.value.?virtualNetworkName ?? hub.key}-nafsa'
+    name: '${uniqueString(deployment().name, location)}-${hub.key}-nafsa'
     params: {
       name: 'AzureFirewallSubnet'
-      virtualNetworkName: hub.value.?virtualNetworkName ?? hub.key
+      virtualNetworkName: hub.key
       addressPrefix: hubAzureFirewallSubnet[index].outputs.addressPrefix
       routeTableResourceId: hubRouteTable[index].outputs.resourceId
     }
@@ -366,9 +366,6 @@ type diagnosticSettingType = {
 type hubVirtualNetworkType = {
   @description('Required. The hub virtual networks to create.')
   *: {
-    @description('Optional. The name of the hub virtual network.')
-    virtualNetworkName: string?
-
     @description('Required. The address prefixes for the virtual network.')
     addressPrefixes: array
 

--- a/avm/ptn/network/hub-networking/main.bicep
+++ b/avm/ptn/network/hub-networking/main.bicep
@@ -207,7 +207,7 @@ module hubAzureFirewallSubnet 'modules/getSubnet.bicep' = [
     name: '${uniqueString(deployment().name, location)}-${hub.key}-nafs'
     params: {
       subnetName: 'AzureFirewallSubnet'
-      virtualNetworkName: hub.key
+      virtualNetworkName: hub.value.?virtualNetworkName
     }
     dependsOn: [hubVirtualNetwork]
   }
@@ -219,7 +219,7 @@ module hubAzureFirewallSubnetAssociation 'modules/subnets.bicep' = [
     name: '${uniqueString(deployment().name, location)}-${hub.key}-nafsa'
     params: {
       name: 'AzureFirewallSubnet'
-      virtualNetworkName: hub.key
+      virtualNetworkName: hub.value.?virtualNetworkName
       addressPrefix: hubAzureFirewallSubnet[index].outputs.addressPrefix
       routeTableResourceId: hubRouteTable[index].outputs.resourceId
     }

--- a/avm/ptn/network/hub-networking/main.bicep
+++ b/avm/ptn/network/hub-networking/main.bicep
@@ -207,7 +207,7 @@ module hubAzureFirewallSubnet 'modules/getSubnet.bicep' = [
     name: '${uniqueString(deployment().name, location)}-${hub.key}-nafs'
     params: {
       subnetName: 'AzureFirewallSubnet'
-      virtualNetworkName: hub.value.?virtualNetworkName
+      virtualNetworkName: hub.value.?virtualNetworkName ?? hub.key
     }
     dependsOn: [hubVirtualNetwork]
   }
@@ -219,7 +219,7 @@ module hubAzureFirewallSubnetAssociation 'modules/subnets.bicep' = [
     name: '${uniqueString(deployment().name, location)}-${hub.key}-nafsa'
     params: {
       name: 'AzureFirewallSubnet'
-      virtualNetworkName: hub.value.?virtualNetworkName
+      virtualNetworkName: hub.value.?virtualNetworkName ?? hub.key
       addressPrefix: hubAzureFirewallSubnet[index].outputs.addressPrefix
       routeTableResourceId: hubRouteTable[index].outputs.resourceId
     }

--- a/avm/ptn/network/hub-networking/main.json
+++ b/avm/ptn/network/hub-networking/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "10213449664992313640"
+      "templateHash": "7215123939021069638"
     },
     "name": "Hub Networking",
     "description": "This module is designed to simplify the creation of multi-region hub networks in Azure. It will create a number of virtual networks and subnets, and optionally peer them together in a mesh topology with routing."
@@ -727,7 +727,7 @@
       "existing": true,
       "type": "Microsoft.Network/virtualNetworks",
       "apiVersion": "2024-01-01",
-      "name": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
+      "name": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
     },
     "hubVirtualNetworkPeering": {
       "copy": {
@@ -736,7 +736,7 @@
       },
       "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
       "apiVersion": "2024-01-01",
-      "name": "[format('{0}/{1}-to-{2}-peering', items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key, items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key, coalesce(flatten(variables('hubVirtualNetworkPeerings')), createArray())[copyIndex()].remoteVirtualNetworkName)]",
+      "name": "[format('{0}/{1}-to-{2}-peering', coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key), coalesce(flatten(variables('hubVirtualNetworkPeerings')), createArray())[copyIndex()].remoteVirtualNetworkName)]",
       "properties": {
         "allowForwardedTraffic": "[coalesce(coalesce(flatten(variables('hubVirtualNetworkPeerings')), createArray())[copyIndex()].allowForwardedTraffic, false())]",
         "allowGatewayTransit": "[coalesce(coalesce(flatten(variables('hubVirtualNetworkPeerings')), createArray())[copyIndex()].allowGatewayTransit, false())]",
@@ -758,7 +758,7 @@
       },
       "type": "Microsoft.Network/routeTables/routes",
       "apiVersion": "2024-01-01",
-      "name": "[format('{0}/{1}-to-{2}-route', items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key, items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key, coalesce(flatten(variables('hubVirtualNetworkPeerings')), createArray())[copyIndex()].remoteVirtualNetworkName)]",
+      "name": "[format('{0}/{1}-to-{2}-route', coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key), coalesce(flatten(variables('hubVirtualNetworkPeerings')), createArray())[copyIndex()].remoteVirtualNetworkName)]",
       "properties": {
         "addressPrefix": "[reference(format('hubVirtualNetworkPeer_remote[{0}]', copyIndex())).outputs.addressPrefix.value]",
         "nextHopType": "VirtualAppliance",

--- a/avm/ptn/network/hub-networking/main.json
+++ b/avm/ptn/network/hub-networking/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "13136672128961850379"
+      "templateHash": "10213449664992313640"
     },
     "name": "Hub Networking",
     "description": "This module is designed to simplify the creation of multi-region hub networks in Azure. It will create a number of virtual networks and subnets, and optionally peer them together in a mesh topology with routing."
@@ -6513,7 +6513,7 @@
             "value": "AzureFirewallSubnet"
           },
           "virtualNetworkName": {
-            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName')]"
+            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
           }
         },
         "template": {
@@ -6588,7 +6588,7 @@
             "value": "AzureFirewallSubnet"
           },
           "virtualNetworkName": {
-            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName')]"
+            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
           },
           "addressPrefix": {
             "value": "[reference(format('hubAzureFirewallSubnet[{0}]', copyIndex())).outputs.addressPrefix.value]"

--- a/avm/ptn/network/hub-networking/main.json
+++ b/avm/ptn/network/hub-networking/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "17217074817683912688"
+      "templateHash": "13136672128961850379"
     },
     "name": "Hub Networking",
     "description": "This module is designed to simplify the creation of multi-region hub networks in Azure. It will create a number of virtual networks and subnets, and optionally peer them together in a mesh topology with routing."
@@ -6513,7 +6513,7 @@
             "value": "AzureFirewallSubnet"
           },
           "virtualNetworkName": {
-            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName')]"
           }
         },
         "template": {
@@ -6588,7 +6588,7 @@
             "value": "AzureFirewallSubnet"
           },
           "virtualNetworkName": {
-            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName')]"
           },
           "addressPrefix": {
             "value": "[reference(format('hubAzureFirewallSubnet[{0}]', copyIndex())).outputs.addressPrefix.value]"

--- a/avm/ptn/network/hub-networking/main.json
+++ b/avm/ptn/network/hub-networking/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "17389954898374222994"
+      "version": "0.33.93.31351",
+      "templateHash": "17217074817683912688"
     },
     "name": "Hub Networking",
     "description": "This module is designed to simplify the creation of multi-region hub networks in Azure. It will create a number of virtual networks and subnets, and optionally peer them together in a mesh topology with routing."
@@ -236,6 +236,13 @@
       "additionalProperties": {
         "type": "object",
         "properties": {
+          "virtualNetworkName": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The name of the hub virtual network."
+            }
+          },
           "addressPrefixes": {
             "type": "array",
             "metadata": {
@@ -280,6 +287,13 @@
                   "description": "Optional. Enable/Disable shareable link functionality."
                 }
               },
+              "enableKerberos": {
+                "type": "bool",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Enable/Disable Kerberos authentication."
+                }
+              },
               "scaleUnits": {
                 "type": "int",
                 "nullable": true,
@@ -289,9 +303,22 @@
               },
               "skuName": {
                 "type": "string",
+                "allowedValues": [
+                  "Basic",
+                  "Developer",
+                  "Premium",
+                  "Standard"
+                ],
                 "nullable": true,
                 "metadata": {
                   "description": "Optional. The SKU name of the Bastion host. Defaults to Standard."
+                }
+              },
+              "bastionHostName": {
+                "type": "string",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. The name of the bastion host."
                 }
               }
             },
@@ -391,6 +418,13 @@
               "description": "Optional. Routes to add to the virtual network route table."
             }
           },
+          "routeTableName": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The name of the route table."
+            }
+          },
           "subnets": {
             "type": "array",
             "nullable": true,
@@ -473,6 +507,13 @@
     "azureFirewallType": {
       "type": "object",
       "properties": {
+        "azureFirewallName": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The name of the Azure Firewall."
+          }
+        },
         "hubIpAddresses": {
           "type": "object",
           "nullable": true,
@@ -503,6 +544,11 @@
         },
         "azureSkuTier": {
           "type": "string",
+          "allowedValues": [
+            "Basic",
+            "Premium",
+            "Standard"
+          ],
           "nullable": true,
           "metadata": {
             "description": "Optional. Azure Firewall SKU."
@@ -739,7 +785,7 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
+            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
           },
           "addressPrefixes": {
             "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value.addressPrefixes]"
@@ -2340,8 +2386,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "13800865708253602673"
+              "version": "0.33.93.31351",
+              "templateHash": "6971888757750761810"
             },
             "name": "Virtual Networks",
             "description": "This module deploys a Virtual Network."
@@ -2406,7 +2452,7 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
+            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'routeTableName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
           },
           "location": {
             "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'location'), parameters('location'))]"
@@ -2425,6 +2471,9 @@
           },
           "tags": {
             "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags'), createObject())]"
+          },
+          "lock": {
+            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock'), createObject())]"
           }
         },
         "template": {
@@ -2790,7 +2839,7 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
+            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'bastionHostName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
           },
           "virtualNetworkResourceId": {
             "value": "[reference(format('hubVirtualNetwork[{0}]', copyIndex())).outputs.resourceId.value]"
@@ -2827,6 +2876,12 @@
           },
           "tags": {
             "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags'), createObject())]"
+          },
+          "lock": {
+            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock'), createObject())]"
+          },
+          "enableKerberos": {
+            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'enableKerberos'), false())]"
           }
         },
         "template": {
@@ -4010,7 +4065,7 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
+            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'azureFirewallName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
           },
           "hubIPAddresses": {
             "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'hubIpAddresses'), createObject())]"
@@ -6467,8 +6522,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "17332298613317998164"
+              "version": "0.33.93.31351",
+              "templateHash": "4695558034353162860"
             },
             "name": "Existing Virtual Network Subnets",
             "description": "This module retrieves an existing Virtual Network Subnet."
@@ -6549,8 +6604,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "13712864569972623739"
+              "version": "0.33.93.31351",
+              "templateHash": "3980815084200627301"
             },
             "name": "Virtual Network Subnets",
             "description": "This module deploys a Virtual Network Subnet."

--- a/avm/ptn/network/hub-networking/main.json
+++ b/avm/ptn/network/hub-networking/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "10309836000326275731"
+      "templateHash": "13578022486694565821"
     },
     "name": "Hub Networking",
     "description": "This module is designed to simplify the creation of multi-region hub networks in Azure. It will create a number of virtual networks and subnets, and optionally peer them together in a mesh topology with routing."
@@ -280,6 +280,13 @@
                   "description": "Optional. Enable/Disable shareable link functionality."
                 }
               },
+              "enableKerberos": {
+                "type": "bool",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Enable/Disable Kerberos authentication."
+                }
+              },
               "scaleUnits": {
                 "type": "int",
                 "nullable": true,
@@ -289,9 +296,22 @@
               },
               "skuName": {
                 "type": "string",
+                "allowedValues": [
+                  "Basic",
+                  "Developer",
+                  "Premium",
+                  "Standard"
+                ],
                 "nullable": true,
                 "metadata": {
                   "description": "Optional. The SKU name of the Bastion host. Defaults to Standard."
+                }
+              },
+              "bastionHostName": {
+                "type": "string",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. The name of the bastion host."
                 }
               }
             },
@@ -391,6 +411,13 @@
               "description": "Optional. Routes to add to the virtual network route table."
             }
           },
+          "routeTableName": {
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. The name of the route table."
+            }
+          },
           "subnets": {
             "type": "array",
             "nullable": true,
@@ -473,6 +500,13 @@
     "azureFirewallType": {
       "type": "object",
       "properties": {
+        "azureFirewallName": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The name of the Azure Firewall."
+          }
+        },
         "hubIpAddresses": {
           "type": "object",
           "nullable": true,
@@ -503,6 +537,11 @@
         },
         "azureSkuTier": {
           "type": "string",
+          "allowedValues": [
+            "Basic",
+            "Premium",
+            "Standard"
+          ],
           "nullable": true,
           "metadata": {
             "description": "Optional. Azure Firewall SKU."
@@ -2406,7 +2445,7 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
+            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'routeTableName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
           },
           "location": {
             "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'location'), parameters('location'))]"
@@ -2425,6 +2464,9 @@
           },
           "tags": {
             "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags'), createObject())]"
+          },
+          "lock": {
+            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock'), createObject())]"
           }
         },
         "template": {
@@ -2790,7 +2832,7 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
+            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'bastionHostName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
           },
           "virtualNetworkResourceId": {
             "value": "[reference(format('hubVirtualNetwork[{0}]', copyIndex())).outputs.resourceId.value]"
@@ -2827,6 +2869,12 @@
           },
           "tags": {
             "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags'), createObject())]"
+          },
+          "lock": {
+            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock'), createObject())]"
+          },
+          "enableKerberos": {
+            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'enableKerberos'), false())]"
           }
         },
         "template": {
@@ -4010,7 +4058,7 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
+            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'azureFirewallName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
           },
           "hubIPAddresses": {
             "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'hubIpAddresses'), createObject())]"

--- a/avm/ptn/network/hub-networking/main.json
+++ b/avm/ptn/network/hub-networking/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "14406697444955750551"
+      "templateHash": "13578022486694565821"
     },
     "name": "Hub Networking",
     "description": "This module is designed to simplify the creation of multi-region hub networks in Azure. It will create a number of virtual networks and subnets, and optionally peer them together in a mesh topology with routing."
@@ -236,13 +236,6 @@
       "additionalProperties": {
         "type": "object",
         "properties": {
-          "virtualNetworkName": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The name of the hub virtual network."
-            }
-          },
           "addressPrefixes": {
             "type": "array",
             "metadata": {
@@ -727,7 +720,7 @@
       "existing": true,
       "type": "Microsoft.Network/virtualNetworks",
       "apiVersion": "2024-01-01",
-      "name": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
+      "name": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
     },
     "hubVirtualNetworkPeering": {
       "copy": {
@@ -736,7 +729,7 @@
       },
       "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
       "apiVersion": "2024-01-01",
-      "name": "[format('{0}/{1}-to-{2}-peering', coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key), coalesce(flatten(variables('hubVirtualNetworkPeerings')), createArray())[copyIndex()].remoteVirtualNetworkName)]",
+      "name": "[format('{0}/{1}-to-{2}-peering', items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key, items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key, coalesce(flatten(variables('hubVirtualNetworkPeerings')), createArray())[copyIndex()].remoteVirtualNetworkName)]",
       "properties": {
         "allowForwardedTraffic": "[coalesce(coalesce(flatten(variables('hubVirtualNetworkPeerings')), createArray())[copyIndex()].allowForwardedTraffic, false())]",
         "allowGatewayTransit": "[coalesce(coalesce(flatten(variables('hubVirtualNetworkPeerings')), createArray())[copyIndex()].allowGatewayTransit, false())]",
@@ -758,7 +751,7 @@
       },
       "type": "Microsoft.Network/routeTables/routes",
       "apiVersion": "2024-01-01",
-      "name": "[format('{0}/{1}-to-{2}-route', coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key), coalesce(flatten(variables('hubVirtualNetworkPeerings')), createArray())[copyIndex()].remoteVirtualNetworkName)]",
+      "name": "[format('{0}/{1}-to-{2}-route', items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key, items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key, coalesce(flatten(variables('hubVirtualNetworkPeerings')), createArray())[copyIndex()].remoteVirtualNetworkName)]",
       "properties": {
         "addressPrefix": "[reference(format('hubVirtualNetworkPeer_remote[{0}]', copyIndex())).outputs.addressPrefix.value]",
         "nextHopType": "VirtualAppliance",
@@ -777,7 +770,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-nvn', uniqueString(deployment().name, parameters('location')), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key))]",
+      "name": "[format('{0}-{1}-nvn', uniqueString(deployment().name, parameters('location')), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -785,7 +778,7 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
+            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
           },
           "addressPrefixes": {
             "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value.addressPrefixes]"
@@ -2444,7 +2437,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-nrt', uniqueString(deployment().name, parameters('location')), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key))]",
+      "name": "[format('{0}-{1}-nrt', uniqueString(deployment().name, parameters('location')), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -2831,7 +2824,7 @@
       "condition": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value.enableBastion]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-nbh', uniqueString(deployment().name, parameters('location')), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key))]",
+      "name": "[format('{0}-{1}-nbh', uniqueString(deployment().name, parameters('location')), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -4057,7 +4050,7 @@
       "condition": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value.enableAzureFirewall]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-naf', uniqueString(deployment().name, parameters('location')), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key))]",
+      "name": "[format('{0}-{1}-naf', uniqueString(deployment().name, parameters('location')), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -6502,7 +6495,7 @@
       "condition": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value.enableAzureFirewall]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-nafs', uniqueString(deployment().name, parameters('location')), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key))]",
+      "name": "[format('{0}-{1}-nafs', uniqueString(deployment().name, parameters('location')), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -6513,7 +6506,7 @@
             "value": "AzureFirewallSubnet"
           },
           "virtualNetworkName": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
+            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
           }
         },
         "template": {
@@ -6577,7 +6570,7 @@
       "condition": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value.enableAzureFirewall]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-nafsa', uniqueString(deployment().name, parameters('location')), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key))]",
+      "name": "[format('{0}-{1}-nafsa', uniqueString(deployment().name, parameters('location')), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -6588,7 +6581,7 @@
             "value": "AzureFirewallSubnet"
           },
           "virtualNetworkName": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
+            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
           },
           "addressPrefix": {
             "value": "[reference(format('hubAzureFirewallSubnet[{0}]', copyIndex())).outputs.addressPrefix.value]"

--- a/avm/ptn/network/hub-networking/main.json
+++ b/avm/ptn/network/hub-networking/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "13578022486694565821"
+      "templateHash": "10309836000326275731"
     },
     "name": "Hub Networking",
     "description": "This module is designed to simplify the creation of multi-region hub networks in Azure. It will create a number of virtual networks and subnets, and optionally peer them together in a mesh topology with routing."
@@ -280,13 +280,6 @@
                   "description": "Optional. Enable/Disable shareable link functionality."
                 }
               },
-              "enableKerberos": {
-                "type": "bool",
-                "nullable": true,
-                "metadata": {
-                  "description": "Optional. Enable/Disable Kerberos authentication."
-                }
-              },
               "scaleUnits": {
                 "type": "int",
                 "nullable": true,
@@ -296,22 +289,9 @@
               },
               "skuName": {
                 "type": "string",
-                "allowedValues": [
-                  "Basic",
-                  "Developer",
-                  "Premium",
-                  "Standard"
-                ],
                 "nullable": true,
                 "metadata": {
                   "description": "Optional. The SKU name of the Bastion host. Defaults to Standard."
-                }
-              },
-              "bastionHostName": {
-                "type": "string",
-                "nullable": true,
-                "metadata": {
-                  "description": "Optional. The name of the bastion host."
                 }
               }
             },
@@ -411,13 +391,6 @@
               "description": "Optional. Routes to add to the virtual network route table."
             }
           },
-          "routeTableName": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The name of the route table."
-            }
-          },
           "subnets": {
             "type": "array",
             "nullable": true,
@@ -500,13 +473,6 @@
     "azureFirewallType": {
       "type": "object",
       "properties": {
-        "azureFirewallName": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The name of the Azure Firewall."
-          }
-        },
         "hubIpAddresses": {
           "type": "object",
           "nullable": true,
@@ -537,11 +503,6 @@
         },
         "azureSkuTier": {
           "type": "string",
-          "allowedValues": [
-            "Basic",
-            "Premium",
-            "Standard"
-          ],
           "nullable": true,
           "metadata": {
             "description": "Optional. Azure Firewall SKU."
@@ -2445,7 +2406,7 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'routeTableName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
+            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
           },
           "location": {
             "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'location'), parameters('location'))]"
@@ -2464,9 +2425,6 @@
           },
           "tags": {
             "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags'), createObject())]"
-          },
-          "lock": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock'), createObject())]"
           }
         },
         "template": {
@@ -2832,7 +2790,7 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'bastionHostName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
+            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
           },
           "virtualNetworkResourceId": {
             "value": "[reference(format('hubVirtualNetwork[{0}]', copyIndex())).outputs.resourceId.value]"
@@ -2869,12 +2827,6 @@
           },
           "tags": {
             "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags'), createObject())]"
-          },
-          "lock": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock'), createObject())]"
-          },
-          "enableKerberos": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'enableKerberos'), false())]"
           }
         },
         "template": {
@@ -4058,7 +4010,7 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'azureFirewallName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
+            "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key]"
           },
           "hubIPAddresses": {
             "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'hubIpAddresses'), createObject())]"

--- a/avm/ptn/network/hub-networking/main.json
+++ b/avm/ptn/network/hub-networking/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "7215123939021069638"
+      "templateHash": "14406697444955750551"
     },
     "name": "Hub Networking",
     "description": "This module is designed to simplify the creation of multi-region hub networks in Azure. It will create a number of virtual networks and subnets, and optionally peer them together in a mesh topology with routing."
@@ -777,7 +777,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-nvn', uniqueString(deployment().name, parameters('location')), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]",
+      "name": "[format('{0}-{1}-nvn', uniqueString(deployment().name, parameters('location')), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -2444,7 +2444,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-nrt', uniqueString(deployment().name, parameters('location')), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]",
+      "name": "[format('{0}-{1}-nrt', uniqueString(deployment().name, parameters('location')), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -2831,7 +2831,7 @@
       "condition": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value.enableBastion]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-nbh', uniqueString(deployment().name, parameters('location')), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]",
+      "name": "[format('{0}-{1}-nbh', uniqueString(deployment().name, parameters('location')), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -4057,7 +4057,7 @@
       "condition": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value.enableAzureFirewall]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-naf', uniqueString(deployment().name, parameters('location')), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]",
+      "name": "[format('{0}-{1}-naf', uniqueString(deployment().name, parameters('location')), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -6502,7 +6502,7 @@
       "condition": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value.enableAzureFirewall]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-nafs', uniqueString(deployment().name, parameters('location')), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]",
+      "name": "[format('{0}-{1}-nafs', uniqueString(deployment().name, parameters('location')), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -6577,7 +6577,7 @@
       "condition": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value.enableAzureFirewall]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-nafsa', uniqueString(deployment().name, parameters('location')), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]",
+      "name": "[format('{0}-{1}-nafsa', uniqueString(deployment().name, parameters('location')), coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'virtualNetworkName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"

--- a/avm/ptn/network/hub-networking/tests/e2e/max/main.test.bicep
+++ b/avm/ptn/network/hub-networking/tests/e2e/max/main.test.bicep
@@ -62,7 +62,6 @@ module testDeployment '../../../main.bicep' = [
       location: resourceLocation
       hubVirtualNetworks: {
         hub1: {
-          virtualNetworkName: 'vnet-hub1'
           addressPrefixes: array(addressPrefix)
           azureFirewallSettings: {
             azureSkuTier: 'Standard'
@@ -187,7 +186,7 @@ module testDeployment '../../../main.bicep' = [
               allowGatewayTransit: false
               allowVirtualNetworkAccess: true
               useRemoteGateways: false
-              remoteVirtualNetworkName: 'vnet-hub1'
+              remoteVirtualNetworkName: 'hub1'
             }
           ]
           routes: [

--- a/avm/ptn/network/hub-networking/tests/e2e/max/main.test.bicep
+++ b/avm/ptn/network/hub-networking/tests/e2e/max/main.test.bicep
@@ -71,6 +71,11 @@ module testDeployment '../../../main.bicep' = [
               name: 'hub1-waf-pip'
             }
             threatIntelMode: 'Alert'
+            zones: [
+              1
+              2
+              3
+            ]
           }
           bastionHost: {
             bastionHostName: 'bastion-hub1'

--- a/avm/ptn/network/hub-networking/tests/e2e/max/main.test.bicep
+++ b/avm/ptn/network/hub-networking/tests/e2e/max/main.test.bicep
@@ -62,6 +62,7 @@ module testDeployment '../../../main.bicep' = [
       location: resourceLocation
       hubVirtualNetworks: {
         hub1: {
+          virtualNetworkName: 'vnet-hub1'
           addressPrefixes: array(addressPrefix)
           azureFirewallSettings: {
             azureSkuTier: 'Standard'
@@ -73,6 +74,7 @@ module testDeployment '../../../main.bicep' = [
             threatIntelMode: 'Alert'
           }
           bastionHost: {
+            bastionHostName: 'bastion-hub1'
             disableCopyPaste: true
             enableFileCopy: false
             enableIpConnect: false

--- a/avm/ptn/network/hub-networking/tests/e2e/max/main.test.bicep
+++ b/avm/ptn/network/hub-networking/tests/e2e/max/main.test.bicep
@@ -187,7 +187,7 @@ module testDeployment '../../../main.bicep' = [
               allowGatewayTransit: false
               allowVirtualNetworkAccess: true
               useRemoteGateways: false
-              remoteVirtualNetworkName: 'hub1'
+              remoteVirtualNetworkName: 'vnet-hub1'
             }
           ]
           routes: [


### PR DESCRIPTION
## Description

Closes #4433 

- Added options to specify bastion and route table names
- Added values for bastion and firewall Skus in UDT
- Added locks to route table
- Updated the necessary tests

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|  [![avm.ptn.network.hub-networking](https://github.com/sebassem/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml/badge.svg?branch=hub-spoke-enhancements)](https://github.com/sebassem/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml)        |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [X] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [X] Update to documentation

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
