### PR TITLE
fix: Storage Account - Storage Account - Incorrect Handling of denyEncryptionScopeOverride Parameter

### DIFF
--- a/avm/res/storage/storage-account/blob-service/container/README.md
+++ b/avm/res/storage/storage-account/blob-service/container/README.md
@@ -83,7 +83,6 @@ Block override of encryption scope from the container default.
 
 - Required: No
 - Type: bool
-- Default: `False`
 
 ### Parameter: `enableNfsV3AllSquash`
 

--- a/avm/res/storage/storage-account/blob-service/container/immutability-policy/main.json
+++ b/avm/res/storage/storage-account/blob-service/container/immutability-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "8061556339565534458"
+      "version": "0.33.13.18514",
+      "templateHash": "2769922037435749045"
     },
     "name": "Storage Account Blob Container Immutability Policies",
     "description": "This module deploys a Storage Account Blob Container Immutability Policy."

--- a/avm/res/storage/storage-account/blob-service/container/main.bicep
+++ b/avm/res/storage/storage-account/blob-service/container/main.bicep
@@ -15,7 +15,7 @@ param name string
 param defaultEncryptionScope string = ''
 
 @description('Optional. Block override of encryption scope from the container default.')
-param denyEncryptionScopeOverride bool = false
+param denyEncryptionScopeOverride bool?
 
 @description('Optional. Enable NFSv3 all squash on blob container.')
 param enableNfsV3AllSquash bool = false
@@ -117,7 +117,7 @@ resource container 'Microsoft.Storage/storageAccounts/blobServices/containers@20
   parent: storageAccount::blobServices
   properties: {
     defaultEncryptionScope: !empty(defaultEncryptionScope) ? defaultEncryptionScope : null
-    denyEncryptionScopeOverride: denyEncryptionScopeOverride == true ? denyEncryptionScopeOverride : null
+    denyEncryptionScopeOverride: denyEncryptionScopeOverride
     enableNfsV3AllSquash: enableNfsV3AllSquash == true ? enableNfsV3AllSquash : null
     enableNfsV3RootSquash: enableNfsV3RootSquash == true ? enableNfsV3RootSquash : null
     immutableStorageWithVersioning: immutableStorageWithVersioningEnabled == true

--- a/avm/res/storage/storage-account/blob-service/container/main.json
+++ b/avm/res/storage/storage-account/blob-service/container/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "2991444340097371621"
+      "version": "0.33.13.18514",
+      "templateHash": "15727824641798999553"
     },
     "name": "Storage Account Blob Containers",
     "description": "This module deploys a Storage Account Blob Container."
@@ -118,7 +118,7 @@
     },
     "denyEncryptionScopeOverride": {
       "type": "bool",
-      "defaultValue": false,
+      "nullable": true,
       "metadata": {
         "description": "Optional. Block override of encryption scope from the container default."
       }
@@ -231,7 +231,7 @@
       "name": "[format('{0}/{1}/{2}', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name'))]",
       "properties": {
         "defaultEncryptionScope": "[if(not(empty(parameters('defaultEncryptionScope'))), parameters('defaultEncryptionScope'), null())]",
-        "denyEncryptionScopeOverride": "[if(equals(parameters('denyEncryptionScopeOverride'), true()), parameters('denyEncryptionScopeOverride'), null())]",
+        "denyEncryptionScopeOverride": "[parameters('denyEncryptionScopeOverride')]",
         "enableNfsV3AllSquash": "[if(equals(parameters('enableNfsV3AllSquash'), true()), parameters('enableNfsV3AllSquash'), null())]",
         "enableNfsV3RootSquash": "[if(equals(parameters('enableNfsV3RootSquash'), true()), parameters('enableNfsV3RootSquash'), null())]",
         "immutableStorageWithVersioning": "[if(equals(parameters('immutableStorageWithVersioningEnabled'), true()), createObject('enabled', parameters('immutableStorageWithVersioningEnabled')), null())]",
@@ -294,8 +294,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "8061556339565534458"
+              "version": "0.33.13.18514",
+              "templateHash": "2769922037435749045"
             },
             "name": "Storage Account Blob Container Immutability Policies",
             "description": "This module deploys a Storage Account Blob Container Immutability Policy."

--- a/avm/res/storage/storage-account/blob-service/main.json
+++ b/avm/res/storage/storage-account/blob-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "2058460323623594433"
+      "version": "0.33.13.18514",
+      "templateHash": "13802891409950802048"
     },
     "name": "Storage Account blob Services",
     "description": "This module deploys a Storage Account Blob Service."
@@ -472,8 +472,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2991444340097371621"
+              "version": "0.33.13.18514",
+              "templateHash": "15727824641798999553"
             },
             "name": "Storage Account Blob Containers",
             "description": "This module deploys a Storage Account Blob Container."
@@ -585,7 +585,7 @@
             },
             "denyEncryptionScopeOverride": {
               "type": "bool",
-              "defaultValue": false,
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Block override of encryption scope from the container default."
               }
@@ -698,7 +698,7 @@
               "name": "[format('{0}/{1}/{2}', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name'))]",
               "properties": {
                 "defaultEncryptionScope": "[if(not(empty(parameters('defaultEncryptionScope'))), parameters('defaultEncryptionScope'), null())]",
-                "denyEncryptionScopeOverride": "[if(equals(parameters('denyEncryptionScopeOverride'), true()), parameters('denyEncryptionScopeOverride'), null())]",
+                "denyEncryptionScopeOverride": "[parameters('denyEncryptionScopeOverride')]",
                 "enableNfsV3AllSquash": "[if(equals(parameters('enableNfsV3AllSquash'), true()), parameters('enableNfsV3AllSquash'), null())]",
                 "enableNfsV3RootSquash": "[if(equals(parameters('enableNfsV3RootSquash'), true()), parameters('enableNfsV3RootSquash'), null())]",
                 "immutableStorageWithVersioning": "[if(equals(parameters('immutableStorageWithVersioningEnabled'), true()), createObject('enabled', parameters('immutableStorageWithVersioningEnabled')), null())]",
@@ -761,8 +761,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "8061556339565534458"
+                      "version": "0.33.13.18514",
+                      "templateHash": "2769922037435749045"
                     },
                     "name": "Storage Account Blob Container Immutability Policies",
                     "description": "This module deploys a Storage Account Blob Container Immutability Policy."

--- a/avm/res/storage/storage-account/file-service/main.json
+++ b/avm/res/storage/storage-account/file-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "16196407713115246323"
+      "version": "0.33.13.18514",
+      "templateHash": "987643333058038389"
     },
     "name": "Storage Account File Share Services",
     "description": "This module deploys a Storage Account File Share Service."
@@ -359,8 +359,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "5204319087439022536"
+              "version": "0.33.13.18514",
+              "templateHash": "15193761941438215308"
             },
             "name": "Storage Account File Shares",
             "description": "This module deploys a Storage Account File Share."

--- a/avm/res/storage/storage-account/file-service/share/main.json
+++ b/avm/res/storage/storage-account/file-service/share/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "5204319087439022536"
+      "version": "0.33.13.18514",
+      "templateHash": "15193761941438215308"
     },
     "name": "Storage Account File Shares",
     "description": "This module deploys a Storage Account File Share."

--- a/avm/res/storage/storage-account/local-user/main.json
+++ b/avm/res/storage/storage-account/local-user/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "16427795222629898111"
+      "version": "0.33.13.18514",
+      "templateHash": "2528560857012083896"
     },
     "name": "Storage Account Local Users",
     "description": "This module deploys a Storage Account Local User, which is used for SFTP authentication."

--- a/avm/res/storage/storage-account/main.json
+++ b/avm/res/storage/storage-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.13.18514",
-      "templateHash": "3424685276444889234"
+      "templateHash": "7065290388008718363"
     },
     "name": "Storage Accounts",
     "description": "This module deploys a Storage Account."
@@ -2572,7 +2572,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.13.18514",
-              "templateHash": "14339432978450199921"
+              "templateHash": "13802891409950802048"
             },
             "name": "Storage Account blob Services",
             "description": "This module deploys a Storage Account Blob Service."
@@ -3039,7 +3039,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.33.13.18514",
-                      "templateHash": "10816586207828434096"
+                      "templateHash": "15727824641798999553"
                     },
                     "name": "Storage Account Blob Containers",
                     "description": "This module deploys a Storage Account Blob Container."
@@ -3151,7 +3151,7 @@
                     },
                     "denyEncryptionScopeOverride": {
                       "type": "bool",
-                      "defaultValue": false,
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. Block override of encryption scope from the container default."
                       }
@@ -3264,7 +3264,7 @@
                       "name": "[format('{0}/{1}/{2}', parameters('storageAccountName'), parameters('blobServiceName'), parameters('name'))]",
                       "properties": {
                         "defaultEncryptionScope": "[if(not(empty(parameters('defaultEncryptionScope'))), parameters('defaultEncryptionScope'), null())]",
-                        "denyEncryptionScopeOverride": "[if(equals(parameters('denyEncryptionScopeOverride'), true()), parameters('denyEncryptionScopeOverride'), null())]",
+                        "denyEncryptionScopeOverride": "[parameters('denyEncryptionScopeOverride')]",
                         "enableNfsV3AllSquash": "[if(equals(parameters('enableNfsV3AllSquash'), true()), parameters('enableNfsV3AllSquash'), null())]",
                         "enableNfsV3RootSquash": "[if(equals(parameters('enableNfsV3RootSquash'), true()), parameters('enableNfsV3RootSquash'), null())]",
                         "immutableStorageWithVersioning": "[if(equals(parameters('immutableStorageWithVersioningEnabled'), true()), createObject('enabled', parameters('immutableStorageWithVersioningEnabled')), null())]",

--- a/avm/res/storage/storage-account/management-policy/main.json
+++ b/avm/res/storage/storage-account/management-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "4014848332192190169"
+      "version": "0.33.13.18514",
+      "templateHash": "4967204006599351003"
     },
     "name": "Storage Account Management Policies",
     "description": "This module deploys a Storage Account Management Policy."

--- a/avm/res/storage/storage-account/queue-service/main.json
+++ b/avm/res/storage/storage-account/queue-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "14497929042813606497"
+      "version": "0.33.13.18514",
+      "templateHash": "8158577333548255612"
     },
     "name": "Storage Account Queue Services",
     "description": "This module deploys a Storage Account Queue Service."
@@ -324,8 +324,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "9969689246600110741"
+              "version": "0.33.13.18514",
+              "templateHash": "9877120144610775153"
             },
             "name": "Storage Account Queues",
             "description": "This module deploys a Storage Account Queue."

--- a/avm/res/storage/storage-account/queue-service/queue/main.json
+++ b/avm/res/storage/storage-account/queue-service/queue/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "9969689246600110741"
+      "version": "0.33.13.18514",
+      "templateHash": "9877120144610775153"
     },
     "name": "Storage Account Queues",
     "description": "This module deploys a Storage Account Queue."

--- a/avm/res/storage/storage-account/table-service/main.json
+++ b/avm/res/storage/storage-account/table-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "4194630585059896468"
+      "version": "0.33.13.18514",
+      "templateHash": "541986423744885003"
     },
     "name": "Storage Account Table Services",
     "description": "This module deploys a Storage Account Table Service."
@@ -321,8 +321,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "4457939127962832961"
+              "version": "0.33.13.18514",
+              "templateHash": "11234204519679347949"
             },
             "name": "Storage Account Table",
             "description": "This module deploys a Storage Account Table."

--- a/avm/res/storage/storage-account/table-service/table/main.json
+++ b/avm/res/storage/storage-account/table-service/table/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "4457939127962832961"
+      "version": "0.33.13.18514",
+      "templateHash": "11234204519679347949"
     },
     "name": "Storage Account Table",
     "description": "This module deploys a Storage Account Table."


### PR DESCRIPTION
## Description

Rebased from https://github.com/Azure/bicep-registry-modules/pull/4435

### Original description:
Ref: https://github.com/Azure/bicep-registry-modules/issues/4258

Issue Summary:
When deploying the Storage Account module with a Blob container, the denyEncryptionScopeOverride parameter in the container's main.bicep template is incorrectly being set to null instead of explicitly retaining the expected false value when configured as such.

This behavior causes potential misconfigurations when deployed on a existing storage account that already has this variable set to false, as you are not allowed to change this property after its creation.

cc: @PetterHL 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|      [![avm.res.storage.storage-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml/badge.svg?branch=users%2Falsehr%2FPetterHL_main_rebase&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml)    |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
