### PR TITLE
fix: Subscription-placement - Regenerated ARM JSON 

### DIFF
--- a/avm/ptn/mgmt-groups/subscription-placement/main.json
+++ b/avm/ptn/mgmt-groups/subscription-placement/main.json
@@ -6,11 +6,10 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.13.18514",
-      "templateHash": "2325138724313533895"
+      "templateHash": "1512617397431432841"
     },
     "name": "subscription-placement",
-    "description": "This module allows for placement of subscriptions to management groups ",
-    "owner": "Azure/module-maintainers"
+    "description": "This module allows for placement of subscriptions to management groups "
   },
   "definitions": {
     "subscriptionPlacementType": {
@@ -31,6 +30,10 @@
             "description": "Required. The list of subscription IDs to be placed underneath the management group."
           }
         }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The type for a subscription placement."
       }
     }
   },
@@ -105,12 +108,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.33.13.18514",
-              "templateHash": "10679020409212079790"
+              "templateHash": "6413058457168295861"
             }
           },
           "parameters": {
@@ -122,13 +126,16 @@
             },
             "subscriptionIds": {
               "type": "array",
+              "items": {
+                "type": "string"
+              },
               "metadata": {
                 "description": "The list of subscription IDs."
               }
             }
           },
-          "resources": [
-            {
+          "resources": {
+            "customSubscriptionPlacement": {
               "copy": {
                 "name": "customSubscriptionPlacement",
                 "count": "[length(parameters('subscriptionIds'))]"
@@ -137,7 +144,7 @@
               "apiVersion": "2023-04-01",
               "name": "[format('{0}/{1}', parameters('managementGroupId'), parameters('subscriptionIds')[copyIndex()])]"
             }
-          ],
+          },
           "outputs": {
             "subscriptionPlacements": {
               "type": "array",


### PR DESCRIPTION
## Description

When the previous PR was merged it turned out the ARM JSON file was not reflecting the 'latest' JSON.
This PR corrects this.

| Pipeline |
| - | 
| [![avm.ptn.mgmt-groups.subscription-placement](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.mgmt-groups.subscription-placement.yml/badge.svg?branch=users%2Falsehr%2Fmgmt-groups_subscription-placement_static&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.mgmt-groups.subscription-placement.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
