### PR TITLE
feat: add support for removing PIM role assignments in resource removal script

### DIFF
--- a/utilities/pipelines/e2eValidation/resourceRemoval/helper/Invoke-ResourceRemoval.ps1
+++ b/utilities/pipelines/e2eValidation/resourceRemoval/helper/Invoke-ResourceRemoval.ps1
@@ -105,6 +105,55 @@ function Invoke-ResourceRemoval {
             $null = $roleAssignmentsOnScope | Where-Object { $_.RoleAssignmentId -eq $ResourceId } | Remove-AzRoleAssignment
             break
         }
+        'Microsoft.Authorization/roleEligibilityScheduleRequests' {
+            $idElem = $ResourceId.Split('/')
+            $scope = $idElem[0..($idElem.Count - 5)] -join '/'
+            $pimRequestName = $idElem[-1]
+            $pimRoleAssignment = Get-AzRoleEligibilityScheduleRequest -Scope $scope -Name $pimRequestName
+            if ($pimRoleAssignment) {
+                $pimRoleAssignmentPrinicpalId = $pimRoleAssignment.PrincipalId
+                $pimRoleAssignmentRoleDefinitionId = $pimRoleAssignment.RoleDefinitionId
+                $guid = New-Guid
+                # PIM role assignments cannot be removed before 5 minutes from being created. Waiting for 5 minutes
+                Write-Verbose 'Waiting for 5 minutes before removing PIM role assignment' -Verbose
+                Start-Sleep -Seconds 300
+                # The PIM ARM API doesn't support DELETE requests so the only way to delete an assignment is by creating a new assignment with `AdminRemove` type using a new GUID
+                $removalInputObject = @{
+                    Name             = $guid
+                    Scope            = $scope
+                    PrincipalId      = $pimRoleAssignmentPrinicpalId
+                    RequestType      = 'AdminRemove'
+                    RoleDefinitionId = $pimRoleAssignmentRoleDefinitionId
+                }
+                $null = New-AzRoleEligibilityScheduleRequest @removalInputObject
+
+            }
+            break
+        }
+        'Microsoft.Authorization/roleAssignmentScheduleRequests' {
+            $idElem = $ResourceId.Split('/')
+            $scope = $idElem[0..($idElem.Count - 5)] -join '/'
+            $pimRequestName = $idElem[-1]
+            $pimRoleAssignment = Get-AzRoleAssignmentScheduleRequest -Scope $scope -Name $pimRequestName
+            if ($pimRoleAssignment) {
+                $pimRoleAssignmentPrinicpalId = $pimRoleAssignment.PrincipalId
+                $pimRoleAssignmentRoleDefinitionId = $pimRoleAssignment.RoleDefinitionId
+                $guid = New-Guid
+                # PIM role assignments cannot be removed before 5 minutes from being created. Waiting for 5 minutes
+                Write-Verbose 'Waiting for 5 minutes before removing PIM role assignment' -Verbose
+                Start-Sleep -Seconds 300
+                # The PIM ARM API doesn't support DELETE requests so the only way to delete an assignment is by creating a new assignment with `AdminRemove` type using a new GUID
+                $removalInputObject = @{
+                    Name             = $guid
+                    Scope            = $scope
+                    PrincipalId      = $pimRoleAssignmentPrinicpalId
+                    RequestType      = 'AdminRemove'
+                    RoleDefinitionId = $pimRoleAssignmentRoleDefinitionId
+                }
+                $null = New-AzRoleAssignmentScheduleRequest @removalInputObject
+            }
+            break
+        }
         'Microsoft.RecoveryServices/vaults' {
             # Pre-Removal
             # -----------


### PR DESCRIPTION
## Description

Adding resource removal logic for PIM role assignments

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
