### PR TITLE
fix: `Set-ModuleReadme` fixed issue with too vague regex check

### DIFF
--- a/avm/res/api-management/service/tests/e2e/max/main.test.bicep
+++ b/avm/res/api-management/service/tests/e2e/max/main.test.bicep
@@ -82,7 +82,7 @@ module testDeployment '../../../main.bicep' = [
       publisherName: '${namePrefix}-az-amorg-x-001'
       additionalLocations: [
         {
-          location: '${locationRegion2}'
+          location: locationRegion2
           sku: {
             name: 'Premium'
             capacity: 1

--- a/avm/res/network/trafficmanagerprofile/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/trafficmanagerprofile/tests/e2e/waf-aligned/main.test.bicep
@@ -110,7 +110,7 @@ module testDeployment '../../../main.bicep' = [
             targetResourceId: nestedDependencies.outputs.webApp01ResourceId
             weight: 1
             priority: 1
-            endpointLocation: '${enforcedLocation01}'
+            endpointLocation: enforcedLocation01
             endpointStatus: 'Enabled'
           }
         }
@@ -121,7 +121,7 @@ module testDeployment '../../../main.bicep' = [
             targetResourceId: nestedDependencies.outputs.webApp02ResourceId
             weight: 1
             priority: 2
-            endpointLocation: '${enforcedLocation02}'
+            endpointLocation: enforcedLocation02
             endpointStatus: 'Enabled'
           }
         }

--- a/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
+++ b/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
@@ -1165,7 +1165,7 @@ function ConvertTo-FormattedJSONParameterObject {
             $isLineWithStringValue = $lineValue -match '^".+"$' # e.g. "value"
             $isLineWithFunction = $lineValue -match '^[a-zA-Z0-9]+\(.+' # e.g., split(something) or loadFileAsBase64("./test.pfx")
             $isLineWithPlainValue = $lineValue -match '^\w+$' # e.g. adminPassword: password
-            $isLineWithPrimitiveValue = $lineValue -match '^\s*true|false|[0-9]+$' # e.g., isSecure: true
+            $isLineWithPrimitiveValue = $lineValue -match '^\s*(true|false|[0-9])+$' # e.g., isSecure: true
             $isLineContainingCondition = $lineValue -match '^\w+ [=!?|&]{2} .+\?.+\:.+$' # e.g., iteration == "init" ? "A" : "B"
 
             # Special case: Multi-line function


### PR DESCRIPTION
## Description

- The updated regex incorrectly considered a value like `abc1` as a primitive value. The updated format ensures, that no characters may preceed a number value - avoiding this error.
- Updated module test file that implemented a workaround to cope with this issue
- Re-ran readme generation across all modules with (as expected) not changes nor errors

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.batch.batch-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.batch.batch-account.yml/badge.svg?branch=users%2Falsehr%2FreadmePrimitiveRegexFix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.batch.batch-account.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
