### PR TITLE
fix: Make AvailabilityZone optional and protocolTypes required in the `avm/res/net-app/net-app-account` module

### DIFF
--- a/avm/res/net-app/net-app-account/README.md
+++ b/avm/res/net-app/net-app-account/README.md
@@ -1585,7 +1585,6 @@ List of volumes to create in the capacity pool.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-capacitypoolsvolumesname) | string | The name of the pool volume. |
-| [`protocolTypes`](#parameter-capacitypoolsvolumesprotocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`. |
 | [`subnetResourceId`](#parameter-capacitypoolsvolumessubnetresourceid) | string | The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes. |
 | [`usageThreshold`](#parameter-capacitypoolsvolumesusagethreshold) | int | Maximum storage quota allowed for a file system in bytes. |
 
@@ -1605,6 +1604,7 @@ List of volumes to create in the capacity pool.
 | [`keyVaultPrivateEndpointResourceId`](#parameter-capacitypoolsvolumeskeyvaultprivateendpointresourceid) | string | The resource ID of the key vault private endpoint. |
 | [`location`](#parameter-capacitypoolsvolumeslocation) | string | Location of the pool volume. |
 | [`networkFeatures`](#parameter-capacitypoolsvolumesnetworkfeatures) | string | Network feature for the volume. |
+| [`protocolTypes`](#parameter-capacitypoolsvolumesprotocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`. |
 | [`roleAssignments`](#parameter-capacitypoolsvolumesroleassignments) | array | Array of role assignments to create. |
 | [`serviceLevel`](#parameter-capacitypoolsvolumesservicelevel) | string | The pool service level. Must match the one of the parent capacity pool. |
 | [`smbContinuouslyAvailable`](#parameter-capacitypoolsvolumessmbcontinuouslyavailable) | bool | Enables continuously available share property for SMB volume. Only applicable for SMB volume. |
@@ -1618,21 +1618,6 @@ The name of the pool volume.
 
 - Required: Yes
 - Type: string
-
-### Parameter: `capacityPools.volumes.protocolTypes`
-
-Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`.
-
-- Required: Yes
-- Type: array
-- Allowed:
-  ```Bicep
-  [
-    'CIFS'
-    'NFSv3'
-    'NFSv4.1'
-  ]
-  ```
 
 ### Parameter: `capacityPools.volumes.subnetResourceId`
 
@@ -2061,6 +2046,21 @@ Network feature for the volume.
     'Basic_Standard'
     'Standard'
     'Standard_Basic'
+  ]
+  ```
+
+### Parameter: `capacityPools.volumes.protocolTypes`
+
+Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`.
+
+- Required: No
+- Type: array
+- Allowed:
+  ```Bicep
+  [
+    'CIFS'
+    'NFSv3'
+    'NFSv4.1'
   ]
   ```
 

--- a/avm/res/net-app/net-app-account/README.md
+++ b/avm/res/net-app/net-app-account/README.md
@@ -148,6 +148,7 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
         size: 4398046511104
         volumes: [
           {
+            availabilityZone: '1'
             dataProtection: {
               backup: {
                 backupPolicyName: 'myBackupPolicy'
@@ -191,11 +192,9 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
             ]
             subnetResourceId: '<subnetResourceId>'
             usageThreshold: 107374182400
-            zones: [
-              1
-            ]
           }
           {
+            availabilityZone: '1'
             encryptionKeySource: '<encryptionKeySource>'
             exportPolicy: {
               rules: [
@@ -226,9 +225,6 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
             smbNonBrowsable: 'Disabled'
             subnetResourceId: '<subnetResourceId>'
             usageThreshold: 107374182400
-            zones: [
-              1
-            ]
           }
         ]
       }
@@ -346,6 +342,7 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
           "size": 4398046511104,
           "volumes": [
             {
+              "availabilityZone": "1",
               "dataProtection": {
                 "backup": {
                   "backupPolicyName": "myBackupPolicy",
@@ -388,12 +385,10 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
                 }
               ],
               "subnetResourceId": "<subnetResourceId>",
-              "usageThreshold": 107374182400,
-              "zones": [
-                1
-              ]
+              "usageThreshold": 107374182400
             },
             {
+              "availabilityZone": "1",
               "encryptionKeySource": "<encryptionKeySource>",
               "exportPolicy": {
                 "rules": [
@@ -423,10 +418,7 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
               "smbEncryption": false,
               "smbNonBrowsable": "Disabled",
               "subnetResourceId": "<subnetResourceId>",
-              "usageThreshold": 107374182400,
-              "zones": [
-                1
-              ]
+              "usageThreshold": 107374182400
             }
           ]
         },
@@ -546,6 +538,7 @@ param capacityPools = [
     size: 4398046511104
     volumes: [
       {
+        availabilityZone: '1'
         dataProtection: {
           backup: {
             backupPolicyName: 'myBackupPolicy'
@@ -589,11 +582,9 @@ param capacityPools = [
         ]
         subnetResourceId: '<subnetResourceId>'
         usageThreshold: 107374182400
-        zones: [
-          1
-        ]
       }
       {
+        availabilityZone: '1'
         encryptionKeySource: '<encryptionKeySource>'
         exportPolicy: {
           rules: [
@@ -624,9 +615,6 @@ param capacityPools = [
         smbNonBrowsable: 'Disabled'
         subnetResourceId: '<subnetResourceId>'
         usageThreshold: 107374182400
-        zones: [
-          1
-        ]
       }
     ]
   }
@@ -723,6 +711,7 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
         size: 4398046511104
         volumes: [
           {
+            availabilityZone: '1'
             encryptionKeySource: '<encryptionKeySource>'
             exportPolicy: {
               rules: [
@@ -756,11 +745,9 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
             ]
             subnetResourceId: '<subnetResourceId>'
             usageThreshold: 107374182400
-            zones: [
-              1
-            ]
           }
           {
+            availabilityZone: '1'
             encryptionKeySource: '<encryptionKeySource>'
             name: 'nanaanfs3-vol-002'
             networkFeatures: 'Standard'
@@ -769,9 +756,6 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
             ]
             subnetResourceId: '<subnetResourceId>'
             usageThreshold: 107374182400
-            zones: [
-              1
-            ]
           }
         ]
       }
@@ -856,6 +840,7 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
           "size": 4398046511104,
           "volumes": [
             {
+              "availabilityZone": "1",
               "encryptionKeySource": "<encryptionKeySource>",
               "exportPolicy": {
                 "rules": [
@@ -888,12 +873,10 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
                 }
               ],
               "subnetResourceId": "<subnetResourceId>",
-              "usageThreshold": 107374182400,
-              "zones": [
-                1
-              ]
+              "usageThreshold": 107374182400
             },
             {
+              "availabilityZone": "1",
               "encryptionKeySource": "<encryptionKeySource>",
               "name": "nanaanfs3-vol-002",
               "networkFeatures": "Standard",
@@ -901,10 +884,7 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
                 "NFSv3"
               ],
               "subnetResourceId": "<subnetResourceId>",
-              "usageThreshold": 107374182400,
-              "zones": [
-                1
-              ]
+              "usageThreshold": 107374182400
             }
           ]
         },
@@ -993,6 +973,7 @@ param capacityPools = [
     size: 4398046511104
     volumes: [
       {
+        availabilityZone: '1'
         encryptionKeySource: '<encryptionKeySource>'
         exportPolicy: {
           rules: [
@@ -1026,11 +1007,9 @@ param capacityPools = [
         ]
         subnetResourceId: '<subnetResourceId>'
         usageThreshold: 107374182400
-        zones: [
-          1
-        ]
       }
       {
+        availabilityZone: '1'
         encryptionKeySource: '<encryptionKeySource>'
         name: 'nanaanfs3-vol-002'
         networkFeatures: 'Standard'
@@ -1039,9 +1018,6 @@ param capacityPools = [
         ]
         subnetResourceId: '<subnetResourceId>'
         usageThreshold: 107374182400
-        zones: [
-          1
-        ]
       }
     ]
   }
@@ -1609,6 +1585,7 @@ List of volumes to create in the capacity pool.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-capacitypoolsvolumesname) | string | The name of the pool volume. |
+| [`protocolTypes`](#parameter-capacitypoolsvolumesprotocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']` |
 | [`subnetResourceId`](#parameter-capacitypoolsvolumessubnetresourceid) | string | The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes. |
 | [`usageThreshold`](#parameter-capacitypoolsvolumesusagethreshold) | int | Maximum storage quota allowed for a file system in bytes. |
 
@@ -1616,6 +1593,7 @@ List of volumes to create in the capacity pool.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`availabilityZone`](#parameter-capacitypoolsvolumesavailabilityzone) | string | Zone where the volume will be placed. |
 | [`coolAccess`](#parameter-capacitypoolsvolumescoolaccess) | bool | If enabled (true) the pool can contain cool Access enabled volumes. |
 | [`coolAccessRetrievalPolicy`](#parameter-capacitypoolsvolumescoolaccessretrievalpolicy) | string | Determines the data retrieval behavior from the cool tier to standard storage based on the read pattern for cool access enabled volumes (Default/Never/Read). |
 | [`coolnessPeriod`](#parameter-capacitypoolsvolumescoolnessperiod) | int | Specifies the number of days after which data that is not accessed by clients will be tiered. |
@@ -1627,14 +1605,12 @@ List of volumes to create in the capacity pool.
 | [`keyVaultPrivateEndpointResourceId`](#parameter-capacitypoolsvolumeskeyvaultprivateendpointresourceid) | string | The resource ID of the key vault private endpoint. |
 | [`location`](#parameter-capacitypoolsvolumeslocation) | string | Location of the pool volume. |
 | [`networkFeatures`](#parameter-capacitypoolsvolumesnetworkfeatures) | string | Network feature for the volume. |
-| [`protocolTypes`](#parameter-capacitypoolsvolumesprotocoltypes) | array | Set of protocol types. |
 | [`roleAssignments`](#parameter-capacitypoolsvolumesroleassignments) | array | Array of role assignments to create. |
 | [`serviceLevel`](#parameter-capacitypoolsvolumesservicelevel) | string | The pool service level. Must match the one of the parent capacity pool. |
 | [`smbContinuouslyAvailable`](#parameter-capacitypoolsvolumessmbcontinuouslyavailable) | bool | Enables continuously available share property for SMB volume. Only applicable for SMB volume. |
 | [`smbEncryption`](#parameter-capacitypoolsvolumessmbencryption) | bool | Enables SMB encryption. Only applicable for SMB/DualProtocol volume. |
 | [`smbNonBrowsable`](#parameter-capacitypoolsvolumessmbnonbrowsable) | string | Enables non-browsable property for SMB Shares. Only applicable for SMB/DualProtocol volume. |
 | [`volumeType`](#parameter-capacitypoolsvolumesvolumetype) | string | The type of the volume. DataProtection volumes are used for replication. |
-| [`zones`](#parameter-capacitypoolsvolumeszones) | array | Zone where the volume will be placed. |
 
 ### Parameter: `capacityPools.volumes.name`
 
@@ -1642,6 +1618,21 @@ The name of the pool volume.
 
 - Required: Yes
 - Type: string
+
+### Parameter: `capacityPools.volumes.protocolTypes`
+
+Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`
+
+- Required: Yes
+- Type: array
+- Allowed:
+  ```Bicep
+  [
+    'CIFS'
+    'NFSv3'
+    'NFSv4.1'
+  ]
+  ```
 
 ### Parameter: `capacityPools.volumes.subnetResourceId`
 
@@ -1656,6 +1647,21 @@ Maximum storage quota allowed for a file system in bytes.
 
 - Required: Yes
 - Type: int
+
+### Parameter: `capacityPools.volumes.availabilityZone`
+
+Zone where the volume will be placed.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    '1'
+    '2'
+    '3'
+  ]
+  ```
 
 ### Parameter: `capacityPools.volumes.coolAccess`
 
@@ -2058,13 +2064,6 @@ Network feature for the volume.
   ]
   ```
 
-### Parameter: `capacityPools.volumes.protocolTypes`
-
-Set of protocol types.
-
-- Required: No
-- Type: array
-
 ### Parameter: `capacityPools.volumes.roleAssignments`
 
 Array of role assignments to create.
@@ -2218,13 +2217,6 @@ The type of the volume. DataProtection volumes are used for replication.
 
 - Required: No
 - Type: string
-
-### Parameter: `capacityPools.volumes.zones`
-
-Zone where the volume will be placed.
-
-- Required: No
-- Type: array
 
 ### Parameter: `customerManagedKey`
 

--- a/avm/res/net-app/net-app-account/README.md
+++ b/avm/res/net-app/net-app-account/README.md
@@ -1585,7 +1585,7 @@ List of volumes to create in the capacity pool.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-capacitypoolsvolumesname) | string | The name of the pool volume. |
-| [`protocolTypes`](#parameter-capacitypoolsvolumesprotocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']` |
+| [`protocolTypes`](#parameter-capacitypoolsvolumesprotocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`. |
 | [`subnetResourceId`](#parameter-capacitypoolsvolumessubnetresourceid) | string | The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes. |
 | [`usageThreshold`](#parameter-capacitypoolsvolumesusagethreshold) | int | Maximum storage quota allowed for a file system in bytes. |
 
@@ -1621,7 +1621,7 @@ The name of the pool volume.
 
 ### Parameter: `capacityPools.volumes.protocolTypes`
 
-Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`
+Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`.
 
 - Required: Yes
 - Type: array

--- a/avm/res/net-app/net-app-account/backup-policies/main.json
+++ b/avm/res/net-app/net-app-account/backup-policies/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "7141176618644423280"
+      "version": "0.33.93.31351",
+      "templateHash": "2748634922557584170"
     },
     "name": "Azure NetApp Files Backup Policy",
     "description": "This module deploys a Backup Policy for Azure NetApp File."

--- a/avm/res/net-app/net-app-account/backup-vault/backup/main.json
+++ b/avm/res/net-app/net-app-account/backup-vault/backup/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "3948084235912412629"
+      "version": "0.33.93.31351",
+      "templateHash": "17452697444375969559"
     },
     "name": "Azure NetApp Files Volume Backup",
     "description": "This module deploys a backup of a NetApp Files Volume."

--- a/avm/res/net-app/net-app-account/backup-vault/main.json
+++ b/avm/res/net-app/net-app-account/backup-vault/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "9738469557677047438"
+      "version": "0.33.93.31351",
+      "templateHash": "6704781490326075849"
     },
     "name": "Azure NetApp Files Volume Backup Vault",
     "description": "This module deploys a NetApp Files Backup Vault."
@@ -144,8 +144,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "3948084235912412629"
+              "version": "0.33.93.31351",
+              "templateHash": "17452697444375969559"
             },
             "name": "Azure NetApp Files Volume Backup",
             "description": "This module deploys a backup of a NetApp Files Volume."

--- a/avm/res/net-app/net-app-account/capacity-pool/README.md
+++ b/avm/res/net-app/net-app-account/capacity-pool/README.md
@@ -251,7 +251,6 @@ List of volumes to create in the capacity pool.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-volumesname) | string | The name of the pool volume. |
-| [`protocolTypes`](#parameter-volumesprotocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`. |
 | [`subnetResourceId`](#parameter-volumessubnetresourceid) | string | The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes. |
 | [`usageThreshold`](#parameter-volumesusagethreshold) | int | Maximum storage quota allowed for a file system in bytes. |
 
@@ -271,6 +270,7 @@ List of volumes to create in the capacity pool.
 | [`keyVaultPrivateEndpointResourceId`](#parameter-volumeskeyvaultprivateendpointresourceid) | string | The resource ID of the key vault private endpoint. |
 | [`location`](#parameter-volumeslocation) | string | Location of the pool volume. |
 | [`networkFeatures`](#parameter-volumesnetworkfeatures) | string | Network feature for the volume. |
+| [`protocolTypes`](#parameter-volumesprotocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`. |
 | [`roleAssignments`](#parameter-volumesroleassignments) | array | Array of role assignments to create. |
 | [`serviceLevel`](#parameter-volumesservicelevel) | string | The pool service level. Must match the one of the parent capacity pool. |
 | [`smbContinuouslyAvailable`](#parameter-volumessmbcontinuouslyavailable) | bool | Enables continuously available share property for SMB volume. Only applicable for SMB volume. |
@@ -284,21 +284,6 @@ The name of the pool volume.
 
 - Required: Yes
 - Type: string
-
-### Parameter: `volumes.protocolTypes`
-
-Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`.
-
-- Required: Yes
-- Type: array
-- Allowed:
-  ```Bicep
-  [
-    'CIFS'
-    'NFSv3'
-    'NFSv4.1'
-  ]
-  ```
 
 ### Parameter: `volumes.subnetResourceId`
 
@@ -727,6 +712,21 @@ Network feature for the volume.
     'Basic_Standard'
     'Standard'
     'Standard_Basic'
+  ]
+  ```
+
+### Parameter: `volumes.protocolTypes`
+
+Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`.
+
+- Required: No
+- Type: array
+- Allowed:
+  ```Bicep
+  [
+    'CIFS'
+    'NFSv3'
+    'NFSv4.1'
   ]
   ```
 

--- a/avm/res/net-app/net-app-account/capacity-pool/README.md
+++ b/avm/res/net-app/net-app-account/capacity-pool/README.md
@@ -251,6 +251,7 @@ List of volumes to create in the capacity pool.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-volumesname) | string | The name of the pool volume. |
+| [`protocolTypes`](#parameter-volumesprotocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']` |
 | [`subnetResourceId`](#parameter-volumessubnetresourceid) | string | The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes. |
 | [`usageThreshold`](#parameter-volumesusagethreshold) | int | Maximum storage quota allowed for a file system in bytes. |
 
@@ -258,6 +259,7 @@ List of volumes to create in the capacity pool.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`availabilityZone`](#parameter-volumesavailabilityzone) | string | Zone where the volume will be placed. |
 | [`coolAccess`](#parameter-volumescoolaccess) | bool | If enabled (true) the pool can contain cool Access enabled volumes. |
 | [`coolAccessRetrievalPolicy`](#parameter-volumescoolaccessretrievalpolicy) | string | Determines the data retrieval behavior from the cool tier to standard storage based on the read pattern for cool access enabled volumes (Default/Never/Read). |
 | [`coolnessPeriod`](#parameter-volumescoolnessperiod) | int | Specifies the number of days after which data that is not accessed by clients will be tiered. |
@@ -269,14 +271,12 @@ List of volumes to create in the capacity pool.
 | [`keyVaultPrivateEndpointResourceId`](#parameter-volumeskeyvaultprivateendpointresourceid) | string | The resource ID of the key vault private endpoint. |
 | [`location`](#parameter-volumeslocation) | string | Location of the pool volume. |
 | [`networkFeatures`](#parameter-volumesnetworkfeatures) | string | Network feature for the volume. |
-| [`protocolTypes`](#parameter-volumesprotocoltypes) | array | Set of protocol types. |
 | [`roleAssignments`](#parameter-volumesroleassignments) | array | Array of role assignments to create. |
 | [`serviceLevel`](#parameter-volumesservicelevel) | string | The pool service level. Must match the one of the parent capacity pool. |
 | [`smbContinuouslyAvailable`](#parameter-volumessmbcontinuouslyavailable) | bool | Enables continuously available share property for SMB volume. Only applicable for SMB volume. |
 | [`smbEncryption`](#parameter-volumessmbencryption) | bool | Enables SMB encryption. Only applicable for SMB/DualProtocol volume. |
 | [`smbNonBrowsable`](#parameter-volumessmbnonbrowsable) | string | Enables non-browsable property for SMB Shares. Only applicable for SMB/DualProtocol volume. |
 | [`volumeType`](#parameter-volumesvolumetype) | string | The type of the volume. DataProtection volumes are used for replication. |
-| [`zones`](#parameter-volumeszones) | array | Zone where the volume will be placed. |
 
 ### Parameter: `volumes.name`
 
@@ -284,6 +284,21 @@ The name of the pool volume.
 
 - Required: Yes
 - Type: string
+
+### Parameter: `volumes.protocolTypes`
+
+Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`
+
+- Required: Yes
+- Type: array
+- Allowed:
+  ```Bicep
+  [
+    'CIFS'
+    'NFSv3'
+    'NFSv4.1'
+  ]
+  ```
 
 ### Parameter: `volumes.subnetResourceId`
 
@@ -298,6 +313,21 @@ Maximum storage quota allowed for a file system in bytes.
 
 - Required: Yes
 - Type: int
+
+### Parameter: `volumes.availabilityZone`
+
+Zone where the volume will be placed.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    '1'
+    '2'
+    '3'
+  ]
+  ```
 
 ### Parameter: `volumes.coolAccess`
 
@@ -700,13 +730,6 @@ Network feature for the volume.
   ]
   ```
 
-### Parameter: `volumes.protocolTypes`
-
-Set of protocol types.
-
-- Required: No
-- Type: array
-
 ### Parameter: `volumes.roleAssignments`
 
 Array of role assignments to create.
@@ -860,13 +883,6 @@ The type of the volume. DataProtection volumes are used for replication.
 
 - Required: No
 - Type: string
-
-### Parameter: `volumes.zones`
-
-Zone where the volume will be placed.
-
-- Required: No
-- Type: array
 
 ## Outputs
 

--- a/avm/res/net-app/net-app-account/capacity-pool/README.md
+++ b/avm/res/net-app/net-app-account/capacity-pool/README.md
@@ -251,7 +251,7 @@ List of volumes to create in the capacity pool.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-volumesname) | string | The name of the pool volume. |
-| [`protocolTypes`](#parameter-volumesprotocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']` |
+| [`protocolTypes`](#parameter-volumesprotocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`. |
 | [`subnetResourceId`](#parameter-volumessubnetresourceid) | string | The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes. |
 | [`usageThreshold`](#parameter-volumesusagethreshold) | int | Maximum storage quota allowed for a file system in bytes. |
 
@@ -287,7 +287,7 @@ The name of the pool volume.
 
 ### Parameter: `volumes.protocolTypes`
 
-Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`
+Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`.
 
 - Required: Yes
 - Type: array

--- a/avm/res/net-app/net-app-account/capacity-pool/main.bicep
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.bicep
@@ -104,7 +104,7 @@ module capacityPool_volumes 'volume/main.bicep' = [
       serviceLevel: serviceLevel
       creationToken: volume.?creationToken ?? volume.name
       usageThreshold: volume.usageThreshold
-      protocolTypes: volume.?protocolTypes
+      protocolTypes: volume.protocolTypes
       subnetResourceId: volume.subnetResourceId
       exportPolicy: volume.?exportPolicy
       roleAssignments: volume.?roleAssignments
@@ -205,8 +205,8 @@ type volumeType = {
   @description('Required. Maximum storage quota allowed for a file system in bytes.')
   usageThreshold: int
 
-  @description('Required. Set of protocol types. Default value is `[\'NFSv3\']`. If you are creating a dual-stack volume, set either `[\'NFSv3\',\'CIFS\']` or `[\'NFSv4.1\',\'CIFS\']`.')
-  protocolTypes: ('NFSv3' | 'NFSv4.1' | 'CIFS')[]
+  @description('Optional. Set of protocol types. Default value is `[\'NFSv3\']`. If you are creating a dual-stack volume, set either `[\'NFSv3\',\'CIFS\']` or `[\'NFSv4.1\',\'CIFS\']`.')
+  protocolTypes: ('NFSv3' | 'NFSv4.1' | 'CIFS')[]?
 
   @description('Required. The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes.')
   subnetResourceId: string

--- a/avm/res/net-app/net-app-account/capacity-pool/main.bicep
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.bicep
@@ -109,7 +109,7 @@ module capacityPool_volumes 'volume/main.bicep' = [
       exportPolicy: volume.?exportPolicy
       roleAssignments: volume.?roleAssignments
       networkFeatures: volume.?networkFeatures
-      zones: volume.?zones
+      availabilityZone: volume.?availabilityZone ?? null
       coolAccess: volume.?coolAccess ?? false
       coolAccessRetrievalPolicy: volume.?coolAccessRetrievalPolicy
       coolnessPeriod: volume.?coolnessPeriod ?? 0
@@ -191,7 +191,7 @@ type volumeType = {
   location: string?
 
   @description('Optional. Zone where the volume will be placed.')
-  zones: int[]?
+  availabilityZone: ('1' | '2' | '3')?
 
   @description('Optional. The pool service level. Must match the one of the parent capacity pool.')
   serviceLevel: ('Premium' | 'Standard' | 'StandardZRS' | 'Ultra')?
@@ -205,8 +205,8 @@ type volumeType = {
   @description('Required. Maximum storage quota allowed for a file system in bytes.')
   usageThreshold: int
 
-  @description('Optional. Set of protocol types.')
-  protocolTypes: string[]?
+  @description('Required. Set of protocol types. Default value is `[\'NFSv3\']`. If you are creating a dual-stack volume, set either `[\'NFSv3\',\'CIFS\']` or `[\'NFSv4.1\',\'CIFS\']`')
+  protocolTypes: ('NFSv3' | 'NFSv4.1' | 'CIFS')[]
 
   @description('Required. The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes.')
   subnetResourceId: string

--- a/avm/res/net-app/net-app-account/capacity-pool/main.bicep
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.bicep
@@ -205,7 +205,7 @@ type volumeType = {
   @description('Required. Maximum storage quota allowed for a file system in bytes.')
   usageThreshold: int
 
-  @description('Required. Set of protocol types. Default value is `[\'NFSv3\']`. If you are creating a dual-stack volume, set either `[\'NFSv3\',\'CIFS\']` or `[\'NFSv4.1\',\'CIFS\']`')
+  @description('Required. Set of protocol types. Default value is `[\'NFSv3\']`. If you are creating a dual-stack volume, set either `[\'NFSv3\',\'CIFS\']` or `[\'NFSv4.1\',\'CIFS\']`.')
   protocolTypes: ('NFSv3' | 'NFSv4.1' | 'CIFS')[]
 
   @description('Required. The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes.')

--- a/avm/res/net-app/net-app-account/capacity-pool/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "5556488311735932716"
+      "templateHash": "1699498615964352100"
     },
     "name": "Azure NetApp Files Capacity Pools",
     "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -798,7 +798,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "10596779270536520264"
+              "templateHash": "6121105606836808879"
             },
             "name": "Azure NetApp Files Capacity Pool Volumes",
             "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -1266,7 +1266,7 @@
                 "CIFS"
               ],
               "metadata": {
-                "description": "Optional. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
+                "description": "Optional. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`."
               }
             },
             "subnetResourceId": {

--- a/avm/res/net-app/net-app-account/capacity-pool/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "3787822331723478801"
+      "templateHash": "4945428304943597123"
     },
     "name": "Azure NetApp Files Capacity Pools",
     "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -129,7 +129,7 @@
             "NFSv4.1"
           ],
           "metadata": {
-            "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
+            "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`."
           }
         },
         "subnetResourceId": {

--- a/avm/res/net-app/net-app-account/capacity-pool/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "4945428304943597123"
+      "templateHash": "5556488311735932716"
     },
     "name": "Azure NetApp Files Capacity Pools",
     "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -128,8 +128,9 @@
             "NFSv3",
             "NFSv4.1"
           ],
+          "nullable": true,
           "metadata": {
-            "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`."
+            "description": "Optional. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`."
           }
         },
         "subnetResourceId": {
@@ -738,7 +739,7 @@
             "value": "[coalesce(parameters('volumes'), createArray())[copyIndex()].usageThreshold]"
           },
           "protocolTypes": {
-            "value": "[tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'protocolTypes')]"
+            "value": "[coalesce(parameters('volumes'), createArray())[copyIndex()].protocolTypes]"
           },
           "subnetResourceId": {
             "value": "[coalesce(parameters('volumes'), createArray())[copyIndex()].subnetResourceId]"
@@ -797,7 +798,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "4356508059610520411"
+              "templateHash": "10596779270536520264"
             },
             "name": "Azure NetApp Files Capacity Pool Volumes",
             "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -1265,7 +1266,7 @@
                 "CIFS"
               ],
               "metadata": {
-                "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
+                "description": "Optional. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
               }
             },
             "subnetResourceId": {

--- a/avm/res/net-app/net-app-account/capacity-pool/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "10620001426687567729"
+      "version": "0.33.93.31351",
+      "templateHash": "3787822331723478801"
     },
     "name": "Azure NetApp Files Capacity Pools",
     "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -70,11 +70,13 @@
             "description": "Optional. Location of the pool volume."
           }
         },
-        "zones": {
-          "type": "array",
-          "items": {
-            "type": "int"
-          },
+        "availabilityZone": {
+          "type": "string",
+          "allowedValues": [
+            "1",
+            "2",
+            "3"
+          ],
           "nullable": true,
           "metadata": {
             "description": "Optional. Zone where the volume will be placed."
@@ -121,12 +123,13 @@
         },
         "protocolTypes": {
           "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "nullable": true,
+          "allowedValues": [
+            "CIFS",
+            "NFSv3",
+            "NFSv4.1"
+          ],
           "metadata": {
-            "description": "Optional. Set of protocol types."
+            "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
           }
         },
         "subnetResourceId": {
@@ -749,8 +752,8 @@
           "networkFeatures": {
             "value": "[tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'networkFeatures')]"
           },
-          "zones": {
-            "value": "[tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'zones')]"
+          "availabilityZone": {
+            "value": "[coalesce(tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'availabilityZone'), null())]"
           },
           "coolAccess": {
             "value": "[coalesce(tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'coolAccess'), false())]"
@@ -793,8 +796,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "14921990871750776609"
+              "version": "0.33.93.31351",
+              "templateHash": "4356508059610520411"
             },
             "name": "Azure NetApp Files Capacity Pool Volumes",
             "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -1197,15 +1200,13 @@
                 "description": "Optional. The type of the volume. DataProtection volumes are used for replication."
               }
             },
-            "zones": {
-              "type": "array",
-              "items": {
-                "type": "int"
-              },
-              "defaultValue": [
-                1,
-                2,
-                3
+            "availabilityZone": {
+              "type": "string",
+              "nullable": true,
+              "allowedValues": [
+                "1",
+                "2",
+                "3"
               ],
               "metadata": {
                 "description": "Optional. Zone where the volume will be placed."
@@ -1252,9 +1253,19 @@
             },
             "protocolTypes": {
               "type": "array",
-              "defaultValue": [],
+              "items": {
+                "type": "string"
+              },
+              "defaultValue": [
+                "NFSv3"
+              ],
+              "allowedValues": [
+                "NFSv3",
+                "NFSv4.1",
+                "CIFS"
+              ],
               "metadata": {
-                "description": "Optional. Set of protocol types."
+                "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
               }
             },
             "subnetResourceId": {
@@ -1428,7 +1439,7 @@
               "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "properties": "[shallowMerge(createArray(createObject('coolAccess', parameters('coolAccess'), 'coolAccessRetrievalPolicy', parameters('coolAccessRetrievalPolicy'), 'coolnessPeriod', parameters('coolnessPeriod'), 'encryptionKeySource', parameters('encryptionKeySource')), if(not(equals(parameters('encryptionKeySource'), 'Microsoft.NetApp')), createObject('keyVaultPrivateEndpointResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('keyVaultPrivateEndpointResourceId'), '//'), '/')[2], split(coalesce(parameters('keyVaultPrivateEndpointResourceId'), '////'), '/')[4]), 'Microsoft.Network/privateEndpoints', last(split(coalesce(parameters('keyVaultPrivateEndpointResourceId'), 'dummyVault'), '/')))), createObject()), if(not(empty(parameters('volumeType'))), createObject('volumeType', parameters('volumeType')), createObject()), createObject('dataProtection', if(not(empty(parameters('dataProtection'))), createObject('replication', if(not(empty(tryGet(parameters('dataProtection'), 'replication'))), createObject('endpointType', tryGet(parameters('dataProtection'), 'replication', 'endpointType'), 'remoteVolumeRegion', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '//'), '/')[2], split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '////'), '/')[4]), 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes', split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '//'), '/')[8], split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '//'), '/')[10], last(split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), 'dummyvolume'), '/'))), 'remoteVolumeResourceId', tryGet(parameters('dataProtection'), 'replication', 'remoteVolumeResourceId'), 'replicationSchedule', tryGet(parameters('dataProtection'), 'replication', 'replicationSchedule'), 'remotePath', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remotePath')), createObject()), 'backup', if(not(empty(tryGet(parameters('dataProtection'), 'backup'))), createObject('backupPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/backupPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName')), 'policyEnforced', coalesce(tryGet(parameters('dataProtection'), 'backup', 'policyEnforced'), false()), 'backupVaultId', resourceId('Microsoft.NetApp/netAppAccounts/backupVaults', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))), createObject()), 'snapshot', if(not(empty(tryGet(parameters('dataProtection'), 'snapshot'))), createObject('snapshotPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/snapshotPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))), createObject())), null()), 'networkFeatures', parameters('networkFeatures'), 'serviceLevel', parameters('serviceLevel'), 'creationToken', parameters('creationToken'), 'usageThreshold', parameters('usageThreshold'), 'protocolTypes', parameters('protocolTypes'), 'subnetId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('subnetResourceId'), '/')[2], split(parameters('subnetResourceId'), '/')[4]), 'Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/'))), 'exportPolicy', parameters('exportPolicy'), 'smbContinuouslyAvailable', parameters('smbContinuouslyAvailable'), 'smbEncryption', parameters('smbEncryption'), 'smbNonBrowsable', parameters('smbNonBrowsable'), 'kerberosEnabled', parameters('kerberosEnabled'))))]",
-              "zones": "[map(parameters('zones'), lambda('zone', format('{0}', lambdaVariables('zone'))))]"
+              "zones": "[if(not(empty(parameters('availabilityZone'))), createArray(parameters('availabilityZone')), null())]"
             },
             "volume_roleAssignments": {
               "copy": {

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/README.md
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/README.md
@@ -49,7 +49,7 @@ This module deploys an Azure NetApp Files Capacity Pool Volume.
 | [`keyVaultPrivateEndpointResourceId`](#parameter-keyvaultprivateendpointresourceid) | string | The resource ID of the key vault private endpoint. |
 | [`location`](#parameter-location) | string | Location of the pool volume. |
 | [`networkFeatures`](#parameter-networkfeatures) | string | Network feature for the volume. |
-| [`protocolTypes`](#parameter-protocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']` |
+| [`protocolTypes`](#parameter-protocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`serviceLevel`](#parameter-servicelevel) | string | The pool service level. Must match the one of the parent capacity pool. |
 | [`smbContinuouslyAvailable`](#parameter-smbcontinuouslyavailable) | bool | Enables continuously available share property for SMB volume. Only applicable for SMB volume. |
@@ -515,7 +515,7 @@ Network feature for the volume.
 
 ### Parameter: `protocolTypes`
 
-Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`
+Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`.
 
 - Required: No
 - Type: array

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/README.md
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/README.md
@@ -26,7 +26,6 @@ This module deploys an Azure NetApp Files Capacity Pool Volume.
 | [`coolnessPeriod`](#parameter-coolnessperiod) | int | Specifies the number of days after which data that is not accessed by clients will be tiered. |
 | [`encryptionKeySource`](#parameter-encryptionkeysource) | string | The source of the encryption key. |
 | [`name`](#parameter-name) | string | The name of the pool volume. |
-| [`protocolTypes`](#parameter-protocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']` |
 | [`subnetResourceId`](#parameter-subnetresourceid) | string | The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes. |
 | [`usageThreshold`](#parameter-usagethreshold) | int | Maximum storage quota allowed for a file system in bytes. |
 
@@ -50,6 +49,7 @@ This module deploys an Azure NetApp Files Capacity Pool Volume.
 | [`keyVaultPrivateEndpointResourceId`](#parameter-keyvaultprivateendpointresourceid) | string | The resource ID of the key vault private endpoint. |
 | [`location`](#parameter-location) | string | Location of the pool volume. |
 | [`networkFeatures`](#parameter-networkfeatures) | string | Network feature for the volume. |
+| [`protocolTypes`](#parameter-protocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']` |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`serviceLevel`](#parameter-servicelevel) | string | The pool service level. Must match the one of the parent capacity pool. |
 | [`smbContinuouslyAvailable`](#parameter-smbcontinuouslyavailable) | bool | Enables continuously available share property for SMB volume. Only applicable for SMB volume. |
@@ -84,27 +84,6 @@ The name of the pool volume.
 
 - Required: Yes
 - Type: string
-
-### Parameter: `protocolTypes`
-
-Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`
-
-- Required: No
-- Type: array
-- Default:
-  ```Bicep
-  [
-    'NFSv3'
-  ]
-  ```
-- Allowed:
-  ```Bicep
-  [
-    'CIFS'
-    'NFSv3'
-    'NFSv4.1'
-  ]
-  ```
 
 ### Parameter: `subnetResourceId`
 
@@ -531,6 +510,27 @@ Network feature for the volume.
     'Basic_Standard'
     'Standard'
     'Standard_Basic'
+  ]
+  ```
+
+### Parameter: `protocolTypes`
+
+Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`
+
+- Required: No
+- Type: array
+- Default:
+  ```Bicep
+  [
+    'NFSv3'
+  ]
+  ```
+- Allowed:
+  ```Bicep
+  [
+    'CIFS'
+    'NFSv3'
+    'NFSv4.1'
   ]
   ```
 

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/README.md
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/README.md
@@ -26,6 +26,7 @@ This module deploys an Azure NetApp Files Capacity Pool Volume.
 | [`coolnessPeriod`](#parameter-coolnessperiod) | int | Specifies the number of days after which data that is not accessed by clients will be tiered. |
 | [`encryptionKeySource`](#parameter-encryptionkeysource) | string | The source of the encryption key. |
 | [`name`](#parameter-name) | string | The name of the pool volume. |
+| [`protocolTypes`](#parameter-protocoltypes) | array | Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']` |
 | [`subnetResourceId`](#parameter-subnetresourceid) | string | The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes. |
 | [`usageThreshold`](#parameter-usagethreshold) | int | Maximum storage quota allowed for a file system in bytes. |
 
@@ -40,6 +41,7 @@ This module deploys an Azure NetApp Files Capacity Pool Volume.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`availabilityZone`](#parameter-availabilityzone) | string | Zone where the volume will be placed. |
 | [`coolAccessRetrievalPolicy`](#parameter-coolaccessretrievalpolicy) | string | Determines the data retrieval behavior from the cool tier to standard storage based on the read pattern for cool access enabled volumes (Default/Never/Read). |
 | [`creationToken`](#parameter-creationtoken) | string | A unique file path for the volume. This is the name of the volume export. A volume is mounted using the export path. File path must start with an alphabetical character and be unique within the subscription. |
 | [`dataProtection`](#parameter-dataprotection) | object | DataProtection type volumes include an object containing details of the replication. |
@@ -48,14 +50,12 @@ This module deploys an Azure NetApp Files Capacity Pool Volume.
 | [`keyVaultPrivateEndpointResourceId`](#parameter-keyvaultprivateendpointresourceid) | string | The resource ID of the key vault private endpoint. |
 | [`location`](#parameter-location) | string | Location of the pool volume. |
 | [`networkFeatures`](#parameter-networkfeatures) | string | Network feature for the volume. |
-| [`protocolTypes`](#parameter-protocoltypes) | array | Set of protocol types. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`serviceLevel`](#parameter-servicelevel) | string | The pool service level. Must match the one of the parent capacity pool. |
 | [`smbContinuouslyAvailable`](#parameter-smbcontinuouslyavailable) | bool | Enables continuously available share property for SMB volume. Only applicable for SMB volume. |
 | [`smbEncryption`](#parameter-smbencryption) | bool | Enables SMB encryption. Only applicable for SMB/DualProtocol volume. |
 | [`smbNonBrowsable`](#parameter-smbnonbrowsable) | string | Enables non-browsable property for SMB Shares. Only applicable for SMB/DualProtocol volume. |
 | [`volumeType`](#parameter-volumetype) | string | The type of the volume. DataProtection volumes are used for replication. |
-| [`zones`](#parameter-zones) | array | Zone where the volume will be placed. |
 
 ### Parameter: `coolAccess`
 
@@ -85,6 +85,27 @@ The name of the pool volume.
 - Required: Yes
 - Type: string
 
+### Parameter: `protocolTypes`
+
+Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`
+
+- Required: No
+- Type: array
+- Default:
+  ```Bicep
+  [
+    'NFSv3'
+  ]
+  ```
+- Allowed:
+  ```Bicep
+  [
+    'CIFS'
+    'NFSv3'
+    'NFSv4.1'
+  ]
+  ```
+
 ### Parameter: `subnetResourceId`
 
 The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes.
@@ -112,6 +133,21 @@ The name of the parent NetApp account. Required if the template is used in a sta
 
 - Required: Yes
 - Type: string
+
+### Parameter: `availabilityZone`
+
+Zone where the volume will be placed.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    '1'
+    '2'
+    '3'
+  ]
+  ```
 
 ### Parameter: `coolAccessRetrievalPolicy`
 
@@ -498,14 +534,6 @@ Network feature for the volume.
   ]
   ```
 
-### Parameter: `protocolTypes`
-
-Set of protocol types.
-
-- Required: No
-- Type: array
-- Default: `[]`
-
 ### Parameter: `roleAssignments`
 
 Array of role assignments to create.
@@ -663,21 +691,6 @@ The type of the volume. DataProtection volumes are used for replication.
 
 - Required: No
 - Type: string
-
-### Parameter: `zones`
-
-Zone where the volume will be placed.
-
-- Required: No
-- Type: array
-- Default:
-  ```Bicep
-  [
-    1
-    2
-    3
-  ]
-  ```
 
 ## Outputs
 

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/main.bicep
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/main.bicep
@@ -32,7 +32,12 @@ param keyVaultPrivateEndpointResourceId string?
 param volumeType string?
 
 @description('Optional. Zone where the volume will be placed.')
-param zones int[] = [1, 2, 3]
+@allowed([
+  '1'
+  '2'
+  '3'
+])
+param availabilityZone string?
 
 @description('Optional. The pool service level. Must match the one of the parent capacity pool.')
 @allowed([
@@ -58,8 +63,13 @@ param creationToken string = name
 @description('Required. Maximum storage quota allowed for a file system in bytes.')
 param usageThreshold int
 
-@description('Optional. Set of protocol types.')
-param protocolTypes array = []
+@description('Required. Set of protocol types. Default value is `[\'NFSv3\']`. If you are creating a dual-stack volume, set either `[\'NFSv3\',\'CIFS\']` or `[\'NFSv4.1\',\'CIFS\']`')
+@allowed([
+  'NFSv3'
+  'NFSv4.1'
+  'CIFS'
+])
+param protocolTypes string[] = ['NFSv3']
 
 @description('Required. The Azure Resource URI for a delegated subnet. Must have the delegation Microsoft.NetApp/volumes.')
 param subnetResourceId string
@@ -224,7 +234,7 @@ resource volume 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2024-07-0
     smbNonBrowsable: smbNonBrowsable
     kerberosEnabled: kerberosEnabled
   }
-  zones: map(zones, zone => '${zone}')
+  zones: !empty(availabilityZone) ? [availabilityZone!] : null
 }
 
 resource volume_roleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/main.bicep
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/main.bicep
@@ -63,7 +63,7 @@ param creationToken string = name
 @description('Required. Maximum storage quota allowed for a file system in bytes.')
 param usageThreshold int
 
-@description('Optional. Set of protocol types. Default value is `[\'NFSv3\']`. If you are creating a dual-stack volume, set either `[\'NFSv3\',\'CIFS\']` or `[\'NFSv4.1\',\'CIFS\']`')
+@description('Optional. Set of protocol types. Default value is `[\'NFSv3\']`. If you are creating a dual-stack volume, set either `[\'NFSv3\',\'CIFS\']` or `[\'NFSv4.1\',\'CIFS\']`.')
 @allowed([
   'NFSv3'
   'NFSv4.1'

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/main.bicep
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/main.bicep
@@ -63,7 +63,7 @@ param creationToken string = name
 @description('Required. Maximum storage quota allowed for a file system in bytes.')
 param usageThreshold int
 
-@description('Required. Set of protocol types. Default value is `[\'NFSv3\']`. If you are creating a dual-stack volume, set either `[\'NFSv3\',\'CIFS\']` or `[\'NFSv4.1\',\'CIFS\']`')
+@description('Optional. Set of protocol types. Default value is `[\'NFSv3\']`. If you are creating a dual-stack volume, set either `[\'NFSv3\',\'CIFS\']` or `[\'NFSv4.1\',\'CIFS\']`')
 @allowed([
   'NFSv3'
   'NFSv4.1'

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "4356508059610520411"
+      "templateHash": "10596779270536520264"
     },
     "name": "Azure NetApp Files Capacity Pool Volumes",
     "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -474,7 +474,7 @@
         "CIFS"
       ],
       "metadata": {
-        "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
+        "description": "Optional. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
       }
     },
     "subnetResourceId": {

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "14921990871750776609"
+      "version": "0.33.93.31351",
+      "templateHash": "4356508059610520411"
     },
     "name": "Azure NetApp Files Capacity Pool Volumes",
     "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -409,15 +409,13 @@
         "description": "Optional. The type of the volume. DataProtection volumes are used for replication."
       }
     },
-    "zones": {
-      "type": "array",
-      "items": {
-        "type": "int"
-      },
-      "defaultValue": [
-        1,
-        2,
-        3
+    "availabilityZone": {
+      "type": "string",
+      "nullable": true,
+      "allowedValues": [
+        "1",
+        "2",
+        "3"
       ],
       "metadata": {
         "description": "Optional. Zone where the volume will be placed."
@@ -464,9 +462,19 @@
     },
     "protocolTypes": {
       "type": "array",
-      "defaultValue": [],
+      "items": {
+        "type": "string"
+      },
+      "defaultValue": [
+        "NFSv3"
+      ],
+      "allowedValues": [
+        "NFSv3",
+        "NFSv4.1",
+        "CIFS"
+      ],
       "metadata": {
-        "description": "Optional. Set of protocol types."
+        "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
       }
     },
     "subnetResourceId": {
@@ -640,7 +648,7 @@
       "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "properties": "[shallowMerge(createArray(createObject('coolAccess', parameters('coolAccess'), 'coolAccessRetrievalPolicy', parameters('coolAccessRetrievalPolicy'), 'coolnessPeriod', parameters('coolnessPeriod'), 'encryptionKeySource', parameters('encryptionKeySource')), if(not(equals(parameters('encryptionKeySource'), 'Microsoft.NetApp')), createObject('keyVaultPrivateEndpointResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('keyVaultPrivateEndpointResourceId'), '//'), '/')[2], split(coalesce(parameters('keyVaultPrivateEndpointResourceId'), '////'), '/')[4]), 'Microsoft.Network/privateEndpoints', last(split(coalesce(parameters('keyVaultPrivateEndpointResourceId'), 'dummyVault'), '/')))), createObject()), if(not(empty(parameters('volumeType'))), createObject('volumeType', parameters('volumeType')), createObject()), createObject('dataProtection', if(not(empty(parameters('dataProtection'))), createObject('replication', if(not(empty(tryGet(parameters('dataProtection'), 'replication'))), createObject('endpointType', tryGet(parameters('dataProtection'), 'replication', 'endpointType'), 'remoteVolumeRegion', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '//'), '/')[2], split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '////'), '/')[4]), 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes', split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '//'), '/')[8], split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '//'), '/')[10], last(split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), 'dummyvolume'), '/'))), 'remoteVolumeResourceId', tryGet(parameters('dataProtection'), 'replication', 'remoteVolumeResourceId'), 'replicationSchedule', tryGet(parameters('dataProtection'), 'replication', 'replicationSchedule'), 'remotePath', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remotePath')), createObject()), 'backup', if(not(empty(tryGet(parameters('dataProtection'), 'backup'))), createObject('backupPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/backupPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName')), 'policyEnforced', coalesce(tryGet(parameters('dataProtection'), 'backup', 'policyEnforced'), false()), 'backupVaultId', resourceId('Microsoft.NetApp/netAppAccounts/backupVaults', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))), createObject()), 'snapshot', if(not(empty(tryGet(parameters('dataProtection'), 'snapshot'))), createObject('snapshotPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/snapshotPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))), createObject())), null()), 'networkFeatures', parameters('networkFeatures'), 'serviceLevel', parameters('serviceLevel'), 'creationToken', parameters('creationToken'), 'usageThreshold', parameters('usageThreshold'), 'protocolTypes', parameters('protocolTypes'), 'subnetId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('subnetResourceId'), '/')[2], split(parameters('subnetResourceId'), '/')[4]), 'Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/'))), 'exportPolicy', parameters('exportPolicy'), 'smbContinuouslyAvailable', parameters('smbContinuouslyAvailable'), 'smbEncryption', parameters('smbEncryption'), 'smbNonBrowsable', parameters('smbNonBrowsable'), 'kerberosEnabled', parameters('kerberosEnabled'))))]",
-      "zones": "[map(parameters('zones'), lambda('zone', format('{0}', lambdaVariables('zone'))))]"
+      "zones": "[if(not(empty(parameters('availabilityZone'))), createArray(parameters('availabilityZone')), null())]"
     },
     "volume_roleAssignments": {
       "copy": {

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "10596779270536520264"
+      "templateHash": "6121105606836808879"
     },
     "name": "Azure NetApp Files Capacity Pool Volumes",
     "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -474,7 +474,7 @@
         "CIFS"
       ],
       "metadata": {
-        "description": "Optional. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
+        "description": "Optional. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`."
       }
     },
     "subnetResourceId": {

--- a/avm/res/net-app/net-app-account/main.json
+++ b/avm/res/net-app/net-app-account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "15376852435816415720"
+      "version": "0.33.93.31351",
+      "templateHash": "13295235819889082560"
     },
     "name": "Azure NetApp Files",
     "description": "This module deploys an Azure NetApp File."
@@ -903,11 +903,13 @@
             "description": "Optional. Location of the pool volume."
           }
         },
-        "zones": {
-          "type": "array",
-          "items": {
-            "type": "int"
-          },
+        "availabilityZone": {
+          "type": "string",
+          "allowedValues": [
+            "1",
+            "2",
+            "3"
+          ],
           "nullable": true,
           "metadata": {
             "description": "Optional. Zone where the volume will be placed."
@@ -954,12 +956,13 @@
         },
         "protocolTypes": {
           "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "nullable": true,
+          "allowedValues": [
+            "CIFS",
+            "NFSv3",
+            "NFSv4.1"
+          ],
           "metadata": {
-            "description": "Optional. Set of protocol types."
+            "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
           }
         },
         "subnetResourceId": {
@@ -1454,8 +1457,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "7141176618644423280"
+              "version": "0.33.93.31351",
+              "templateHash": "2748634922557584170"
             },
             "name": "Azure NetApp Files Backup Policy",
             "description": "This module deploys a Backup Policy for Azure NetApp File."
@@ -1601,8 +1604,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "14119927784920096194"
+              "version": "0.33.93.31351",
+              "templateHash": "4819700356691399545"
             },
             "name": "Azure NetApp Files Snapshot Policy",
             "description": "This module deploys a Snapshot Policy for an Azure NetApp File."
@@ -1917,8 +1920,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "9738469557677047438"
+              "version": "0.33.93.31351",
+              "templateHash": "6704781490326075849"
             },
             "name": "Azure NetApp Files Volume Backup Vault",
             "description": "This module deploys a NetApp Files Backup Vault."
@@ -2056,8 +2059,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "3948084235912412629"
+                      "version": "0.33.93.31351",
+                      "templateHash": "17452697444375969559"
                     },
                     "name": "Azure NetApp Files Volume Backup",
                     "description": "This module deploys a backup of a NetApp Files Volume."
@@ -2266,8 +2269,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "10620001426687567729"
+              "version": "0.33.93.31351",
+              "templateHash": "3787822331723478801"
             },
             "name": "Azure NetApp Files Capacity Pools",
             "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -2331,11 +2334,13 @@
                     "description": "Optional. Location of the pool volume."
                   }
                 },
-                "zones": {
-                  "type": "array",
-                  "items": {
-                    "type": "int"
-                  },
+                "availabilityZone": {
+                  "type": "string",
+                  "allowedValues": [
+                    "1",
+                    "2",
+                    "3"
+                  ],
                   "nullable": true,
                   "metadata": {
                     "description": "Optional. Zone where the volume will be placed."
@@ -2382,12 +2387,13 @@
                 },
                 "protocolTypes": {
                   "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "nullable": true,
+                  "allowedValues": [
+                    "CIFS",
+                    "NFSv3",
+                    "NFSv4.1"
+                  ],
                   "metadata": {
-                    "description": "Optional. Set of protocol types."
+                    "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
                   }
                 },
                 "subnetResourceId": {
@@ -3010,8 +3016,8 @@
                   "networkFeatures": {
                     "value": "[tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'networkFeatures')]"
                   },
-                  "zones": {
-                    "value": "[tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'zones')]"
+                  "availabilityZone": {
+                    "value": "[coalesce(tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'availabilityZone'), null())]"
                   },
                   "coolAccess": {
                     "value": "[coalesce(tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'coolAccess'), false())]"
@@ -3054,8 +3060,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "14921990871750776609"
+                      "version": "0.33.93.31351",
+                      "templateHash": "4356508059610520411"
                     },
                     "name": "Azure NetApp Files Capacity Pool Volumes",
                     "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -3458,15 +3464,13 @@
                         "description": "Optional. The type of the volume. DataProtection volumes are used for replication."
                       }
                     },
-                    "zones": {
-                      "type": "array",
-                      "items": {
-                        "type": "int"
-                      },
-                      "defaultValue": [
-                        1,
-                        2,
-                        3
+                    "availabilityZone": {
+                      "type": "string",
+                      "nullable": true,
+                      "allowedValues": [
+                        "1",
+                        "2",
+                        "3"
                       ],
                       "metadata": {
                         "description": "Optional. Zone where the volume will be placed."
@@ -3513,9 +3517,19 @@
                     },
                     "protocolTypes": {
                       "type": "array",
-                      "defaultValue": [],
+                      "items": {
+                        "type": "string"
+                      },
+                      "defaultValue": [
+                        "NFSv3"
+                      ],
+                      "allowedValues": [
+                        "NFSv3",
+                        "NFSv4.1",
+                        "CIFS"
+                      ],
                       "metadata": {
-                        "description": "Optional. Set of protocol types."
+                        "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
                       }
                     },
                     "subnetResourceId": {
@@ -3689,7 +3703,7 @@
                       "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('name'))]",
                       "location": "[parameters('location')]",
                       "properties": "[shallowMerge(createArray(createObject('coolAccess', parameters('coolAccess'), 'coolAccessRetrievalPolicy', parameters('coolAccessRetrievalPolicy'), 'coolnessPeriod', parameters('coolnessPeriod'), 'encryptionKeySource', parameters('encryptionKeySource')), if(not(equals(parameters('encryptionKeySource'), 'Microsoft.NetApp')), createObject('keyVaultPrivateEndpointResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('keyVaultPrivateEndpointResourceId'), '//'), '/')[2], split(coalesce(parameters('keyVaultPrivateEndpointResourceId'), '////'), '/')[4]), 'Microsoft.Network/privateEndpoints', last(split(coalesce(parameters('keyVaultPrivateEndpointResourceId'), 'dummyVault'), '/')))), createObject()), if(not(empty(parameters('volumeType'))), createObject('volumeType', parameters('volumeType')), createObject()), createObject('dataProtection', if(not(empty(parameters('dataProtection'))), createObject('replication', if(not(empty(tryGet(parameters('dataProtection'), 'replication'))), createObject('endpointType', tryGet(parameters('dataProtection'), 'replication', 'endpointType'), 'remoteVolumeRegion', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '//'), '/')[2], split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '////'), '/')[4]), 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes', split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '//'), '/')[8], split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '//'), '/')[10], last(split(coalesce(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), 'dummyvolume'), '/'))), 'remoteVolumeResourceId', tryGet(parameters('dataProtection'), 'replication', 'remoteVolumeResourceId'), 'replicationSchedule', tryGet(parameters('dataProtection'), 'replication', 'replicationSchedule'), 'remotePath', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remotePath')), createObject()), 'backup', if(not(empty(tryGet(parameters('dataProtection'), 'backup'))), createObject('backupPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/backupPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName')), 'policyEnforced', coalesce(tryGet(parameters('dataProtection'), 'backup', 'policyEnforced'), false()), 'backupVaultId', resourceId('Microsoft.NetApp/netAppAccounts/backupVaults', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))), createObject()), 'snapshot', if(not(empty(tryGet(parameters('dataProtection'), 'snapshot'))), createObject('snapshotPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/snapshotPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))), createObject())), null()), 'networkFeatures', parameters('networkFeatures'), 'serviceLevel', parameters('serviceLevel'), 'creationToken', parameters('creationToken'), 'usageThreshold', parameters('usageThreshold'), 'protocolTypes', parameters('protocolTypes'), 'subnetId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('subnetResourceId'), '/')[2], split(parameters('subnetResourceId'), '/')[4]), 'Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/'))), 'exportPolicy', parameters('exportPolicy'), 'smbContinuouslyAvailable', parameters('smbContinuouslyAvailable'), 'smbEncryption', parameters('smbEncryption'), 'smbNonBrowsable', parameters('smbNonBrowsable'), 'kerberosEnabled', parameters('kerberosEnabled'))))]",
-                      "zones": "[map(parameters('zones'), lambda('zone', format('{0}', lambdaVariables('zone'))))]"
+                      "zones": "[if(not(empty(parameters('availabilityZone'))), createArray(parameters('availabilityZone')), null())]"
                     },
                     "volume_roleAssignments": {
                       "copy": {
@@ -3834,8 +3848,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "9738469557677047438"
+              "version": "0.33.93.31351",
+              "templateHash": "6704781490326075849"
             },
             "name": "Azure NetApp Files Volume Backup Vault",
             "description": "This module deploys a NetApp Files Backup Vault."
@@ -3973,8 +3987,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "3948084235912412629"
+                      "version": "0.33.93.31351",
+                      "templateHash": "17452697444375969559"
                     },
                     "name": "Azure NetApp Files Volume Backup",
                     "description": "This module deploys a backup of a NetApp Files Volume."

--- a/avm/res/net-app/net-app-account/main.json
+++ b/avm/res/net-app/net-app-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "4277145266997648582"
+      "templateHash": "10108769802479446069"
     },
     "name": "Azure NetApp Files",
     "description": "This module deploys an Azure NetApp File."
@@ -961,8 +961,9 @@
             "NFSv3",
             "NFSv4.1"
           ],
+          "nullable": true,
           "metadata": {
-            "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`."
+            "description": "Optional. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`."
           }
         },
         "subnetResourceId": {
@@ -2270,7 +2271,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "4945428304943597123"
+              "templateHash": "5556488311735932716"
             },
             "name": "Azure NetApp Files Capacity Pools",
             "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -2392,8 +2393,9 @@
                     "NFSv3",
                     "NFSv4.1"
                   ],
+                  "nullable": true,
                   "metadata": {
-                    "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`."
+                    "description": "Optional. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`."
                   }
                 },
                 "subnetResourceId": {
@@ -3002,7 +3004,7 @@
                     "value": "[coalesce(parameters('volumes'), createArray())[copyIndex()].usageThreshold]"
                   },
                   "protocolTypes": {
-                    "value": "[tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'protocolTypes')]"
+                    "value": "[coalesce(parameters('volumes'), createArray())[copyIndex()].protocolTypes]"
                   },
                   "subnetResourceId": {
                     "value": "[coalesce(parameters('volumes'), createArray())[copyIndex()].subnetResourceId]"
@@ -3061,7 +3063,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.33.93.31351",
-                      "templateHash": "4356508059610520411"
+                      "templateHash": "10596779270536520264"
                     },
                     "name": "Azure NetApp Files Capacity Pool Volumes",
                     "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -3529,7 +3531,7 @@
                         "CIFS"
                       ],
                       "metadata": {
-                        "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
+                        "description": "Optional. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
                       }
                     },
                     "subnetResourceId": {

--- a/avm/res/net-app/net-app-account/main.json
+++ b/avm/res/net-app/net-app-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "10108769802479446069"
+      "templateHash": "3903518118689042803"
     },
     "name": "Azure NetApp Files",
     "description": "This module deploys an Azure NetApp File."
@@ -2271,7 +2271,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "5556488311735932716"
+              "templateHash": "1699498615964352100"
             },
             "name": "Azure NetApp Files Capacity Pools",
             "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -3063,7 +3063,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.33.93.31351",
-                      "templateHash": "10596779270536520264"
+                      "templateHash": "6121105606836808879"
                     },
                     "name": "Azure NetApp Files Capacity Pool Volumes",
                     "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -3531,7 +3531,7 @@
                         "CIFS"
                       ],
                       "metadata": {
-                        "description": "Optional. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
+                        "description": "Optional. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`."
                       }
                     },
                     "subnetResourceId": {

--- a/avm/res/net-app/net-app-account/main.json
+++ b/avm/res/net-app/net-app-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "13295235819889082560"
+      "templateHash": "4277145266997648582"
     },
     "name": "Azure NetApp Files",
     "description": "This module deploys an Azure NetApp File."
@@ -962,7 +962,7 @@
             "NFSv4.1"
           ],
           "metadata": {
-            "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
+            "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`."
           }
         },
         "subnetResourceId": {
@@ -2270,7 +2270,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "3787822331723478801"
+              "templateHash": "4945428304943597123"
             },
             "name": "Azure NetApp Files Capacity Pools",
             "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -2393,7 +2393,7 @@
                     "NFSv4.1"
                   ],
                   "metadata": {
-                    "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`"
+                    "description": "Required. Set of protocol types. Default value is `['NFSv3']`. If you are creating a dual-stack volume, set either `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']`."
                   }
                 },
                 "subnetResourceId": {

--- a/avm/res/net-app/net-app-account/snapshot-policies/main.json
+++ b/avm/res/net-app/net-app-account/snapshot-policies/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "14119927784920096194"
+      "version": "0.33.93.31351",
+      "templateHash": "4819700356691399545"
     },
     "name": "Azure NetApp Files Snapshot Policy",
     "description": "This module deploys a Snapshot Policy for an Azure NetApp File."

--- a/avm/res/net-app/net-app-account/tests/e2e/max/main.test.bicep
+++ b/avm/res/net-app/net-app-account/tests/e2e/max/main.test.bicep
@@ -113,7 +113,7 @@ module testDeployment '../../../main.bicep' = {
                 }
               ]
             }
-            zones: [1]
+            availabilityZone: '1'
             networkFeatures: 'Standard'
             encryptionKeySource: encryptionKeySource
             protocolTypes: [
@@ -150,7 +150,7 @@ module testDeployment '../../../main.bicep' = {
               ]
             }
             name: 'vol-002'
-            zones: [1]
+            availabilityZone: '1'
             networkFeatures: 'Standard'
             encryptionKeySource: encryptionKeySource
             protocolTypes: [

--- a/avm/res/net-app/net-app-account/tests/e2e/nfs3/main.test.bicep
+++ b/avm/res/net-app/net-app-account/tests/e2e/nfs3/main.test.bicep
@@ -88,7 +88,7 @@ module testDeployment '../../../main.bicep' = {
               ]
             }
             name: '${namePrefix}-${serviceShort}-vol-001'
-            zones: [1]
+            availabilityZone: '1'
             networkFeatures: 'Standard'
             encryptionKeySource: encryptionKeySource
             protocolTypes: [
@@ -106,7 +106,17 @@ module testDeployment '../../../main.bicep' = {
           }
           {
             name: '${namePrefix}-${serviceShort}-vol-002'
-            zones: [1]
+            availabilityZone: '1'
+            networkFeatures: 'Standard'
+            encryptionKeySource: encryptionKeySource
+            protocolTypes: [
+              'NFSv3'
+            ]
+            subnetResourceId: nestedDependencies.outputs.subnetResourceId
+            usageThreshold: 107374182400
+          }
+          {
+            name: '${namePrefix}-${serviceShort}-vol-002'
             networkFeatures: 'Standard'
             encryptionKeySource: encryptionKeySource
             protocolTypes: [

--- a/avm/res/net-app/net-app-account/tests/e2e/nfs3/main.test.bicep
+++ b/avm/res/net-app/net-app-account/tests/e2e/nfs3/main.test.bicep
@@ -115,16 +115,6 @@ module testDeployment '../../../main.bicep' = {
             subnetResourceId: nestedDependencies.outputs.subnetResourceId
             usageThreshold: 107374182400
           }
-          {
-            name: '${namePrefix}-${serviceShort}-vol-002'
-            networkFeatures: 'Standard'
-            encryptionKeySource: encryptionKeySource
-            protocolTypes: [
-              'NFSv3'
-            ]
-            subnetResourceId: nestedDependencies.outputs.subnetResourceId
-            usageThreshold: 107374182400
-          }
         ]
       }
       {

--- a/avm/res/net-app/net-app-account/version.json
+++ b/avm/res/net-app/net-app-account/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.6",
+    "version": "0.7",
     "pathFilters": [
         "./main.json"
     ]


### PR DESCRIPTION
## Description
This PR resolves the following issues in the `avm/res/net-app/net-app-account` module
* On the NetApp Volume submodule, `zone` has been renamed to `availabilityZone`.  
* The type for `availabilityZone` has been changed to `string` from `int[]` and is now optional with null as the default. Previously the module would try and deploy in all three zones if no value is defined.
* Changed: `protocolTypes` is now an optional array of strings with three possible options `'NFSv3', 'NFSv4.1', and 'CIFS'`. If no value is provided, the default value of `['NFSv3']` is used.
* Added to the description for `protocolTypes` to specify `['NFSv3','CIFS']` or `['NFSv4.1','CIFS']` if creating dual-stack volumes.
* Added in additional submodule README.md and main.json files generated by Set-AVMModule.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.net-app.net-app-account](https://github.com/thecmdradama/bicep-registry-modules/actions/workflows/avm.res.net-app.net-app-account.yml/badge.svg)](https://github.com/thecmdradama/bicep-registry-modules/actions/workflows/avm.res.net-app.net-app-account.yml)     |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
