### PR TITLE
fix(net-app): fix availability zone parameter reference

### DIFF
--- a/avm/res/net-app/net-app-account/capacity-pool/main.bicep
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.bicep
@@ -111,7 +111,7 @@ module capacityPool_volumes 'volume/main.bicep' = [
       exportPolicy: volume.?exportPolicy
       roleAssignments: volume.?roleAssignments
       networkFeatures: volume.?networkFeatures
-      zone: volume.?availabilityZone
+      zone: volume.?zone
       coolAccess: volume.?coolAccess ?? false
       coolAccessRetrievalPolicy: volume.?coolAccessRetrievalPolicy
       coolnessPeriod: volume.?coolnessPeriod

--- a/avm/res/net-app/net-app-account/capacity-pool/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "567288787230162458"
+      "templateHash": "18256505389133665653"
     },
     "name": "Azure NetApp Files Capacity Pools",
     "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -774,7 +774,7 @@
             "value": "[tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'networkFeatures')]"
           },
           "zone": {
-            "value": "[tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'availabilityZone')]"
+            "value": "[tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'zone')]"
           },
           "coolAccess": {
             "value": "[coalesce(tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'coolAccess'), false())]"

--- a/avm/res/net-app/net-app-account/main.json
+++ b/avm/res/net-app/net-app-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "17807010386700434469"
+      "templateHash": "7313510258873685995"
     },
     "name": "Azure NetApp Files",
     "description": "This module deploys an Azure NetApp File."
@@ -2269,7 +2269,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "567288787230162458"
+              "templateHash": "18256505389133665653"
             },
             "name": "Azure NetApp Files Capacity Pools",
             "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -3037,7 +3037,7 @@
                     "value": "[tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'networkFeatures')]"
                   },
                   "zone": {
-                    "value": "[tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'availabilityZone')]"
+                    "value": "[tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'zone')]"
                   },
                   "coolAccess": {
                     "value": "[coalesce(tryGet(coalesce(parameters('volumes'), createArray())[copyIndex()], 'coolAccess'), false())]"


### PR DESCRIPTION
## Description
Fixes an issue created with the #4469 PR with the referenced parameter for `zone` on the net-app capacity pool. I had not changed this from `availabilityZone`.
<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
