### PR TITLE
[fix] `res/elastic-san/elastic-san` fixes json

### DIFF
--- a/avm/res/elastic-san/elastic-san/README.md
+++ b/avm/res/elastic-san/elastic-san/README.md
@@ -2251,6 +2251,7 @@ The name of the Elastic SAN Volume Snapshot. The name can only contain lowercase
 | `name` | string | The name of the deployed Elastic SAN. |
 | `resourceGroupName` | string | The resource group of the deployed Elastic SAN. |
 | `resourceId` | string | The resource ID of the deployed Elastic SAN. |
+| `systemAssignedMIPrincipalId` | string | The principal ID of the system assigned identity. |
 | `volumeGroups` | array | Details on the deployed Elastic SAN Volume Groups. |
 
 ## Cross-referenced modules

--- a/avm/res/elastic-san/elastic-san/main.bicep
+++ b/avm/res/elastic-san/elastic-san/main.bicep
@@ -66,8 +66,6 @@ param roleAssignments roleAssignmentType[]?
 // Variables      //
 // ============== //
 
-var enableReferencedModulesTelemetry = false
-
 // Default to Premium_ZRS unless the user specifically chooses Premium_LRS and specifies an availability zone number.
 var calculatedSku = sku == 'Premium_LRS' ? (availabilityZone != null ? 'Premium_LRS' : 'Premium_ZRS') : 'Premium_ZRS'
 
@@ -271,11 +269,15 @@ output volumeGroups volumeGroupOutputType[] = [
     name: elasticSan_volumeGroups[i].outputs.name
     location: elasticSan_volumeGroups[i].outputs.location
     resourceGroupName: elasticSan_volumeGroups[i].outputs.resourceGroupName
-    systemAssignedMIPrincipalId: elasticSan_volumeGroups[i].outputs.systemAssignedMIPrincipalId
+    systemAssignedMIPrincipalId: elasticSan_volumeGroups[i].outputs.?systemAssignedMIPrincipalId!
     volumes: elasticSan_volumeGroups[i].outputs.volumes
     privateEndpoints: elasticSan_volumeGroups[i].outputs.privateEndpoints
   }
 ]
+
+// temporary solution to the static test "If a UDT definition [managedIdentitiesType] exists and supports system-assigned-identities, the template should have an output for its principal ID."
+@description('The principal ID of the system assigned identity.')
+output systemAssignedMIPrincipalId string? = null
 
 // ================ //
 // Definitions      //

--- a/avm/res/elastic-san/elastic-san/main.bicep
+++ b/avm/res/elastic-san/elastic-san/main.bicep
@@ -269,7 +269,7 @@ output volumeGroups volumeGroupOutputType[] = [
     name: elasticSan_volumeGroups[i].outputs.name
     location: elasticSan_volumeGroups[i].outputs.location
     resourceGroupName: elasticSan_volumeGroups[i].outputs.resourceGroupName
-    systemAssignedMIPrincipalId: elasticSan_volumeGroups[i].outputs.?systemAssignedMIPrincipalId!
+    systemAssignedMIPrincipalId: elasticSan_volumeGroups[i].outputs.systemAssignedMIPrincipalId
     volumes: elasticSan_volumeGroups[i].outputs.volumes
     privateEndpoints: elasticSan_volumeGroups[i].outputs.privateEndpoints
   }
@@ -277,7 +277,7 @@ output volumeGroups volumeGroupOutputType[] = [
 
 // temporary solution to the static test "If a UDT definition [managedIdentitiesType] exists and supports system-assigned-identities, the template should have an output for its principal ID."
 @description('The principal ID of the system assigned identity.')
-output systemAssignedMIPrincipalId string? = ''
+output systemAssignedMIPrincipalId string? = null
 
 // ================ //
 // Definitions      //

--- a/avm/res/elastic-san/elastic-san/main.bicep
+++ b/avm/res/elastic-san/elastic-san/main.bicep
@@ -277,7 +277,7 @@ output volumeGroups volumeGroupOutputType[] = [
 
 // temporary solution to the static test "If a UDT definition [managedIdentitiesType] exists and supports system-assigned-identities, the template should have an output for its principal ID."
 @description('The principal ID of the system assigned identity.')
-output systemAssignedMIPrincipalId string? = null
+output systemAssignedMIPrincipalId string? = ''
 
 // ================ //
 // Definitions      //

--- a/avm/res/elastic-san/elastic-san/main.json
+++ b/avm/res/elastic-san/elastic-san/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "15467174942437862431"
+      "templateHash": "10260423698998007856"
     },
     "name": "Elastic SANs",
     "description": "This module deploys an Elastic SAN."
@@ -3161,7 +3161,7 @@
           "name": "[reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs.name.value]",
           "location": "[reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs.location.value]",
           "resourceGroupName": "[reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs.resourceGroupName.value]",
-          "systemAssignedMIPrincipalId": "[tryGet(tryGet(reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs, 'systemAssignedMIPrincipalId'), 'value')]",
+          "systemAssignedMIPrincipalId": "[reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs.systemAssignedMIPrincipalId.value]",
           "volumes": "[reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs.volumes.value]",
           "privateEndpoints": "[reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs.privateEndpoints.value]"
         }
@@ -3173,7 +3173,7 @@
       "metadata": {
         "description": "The principal ID of the system assigned identity."
       },
-      "value": ""
+      "value": null
     }
   }
 }

--- a/avm/res/elastic-san/elastic-san/main.json
+++ b/avm/res/elastic-san/elastic-san/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "17181272843392709683"
+      "templateHash": "15467174942437862431"
     },
     "name": "Elastic SANs",
     "description": "This module deploys an Elastic SAN."
@@ -3173,7 +3173,7 @@
       "metadata": {
         "description": "The principal ID of the system assigned identity."
       },
-      "value": null
+      "value": ""
     }
   }
 }

--- a/avm/res/elastic-san/elastic-san/main.json
+++ b/avm/res/elastic-san/elastic-san/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "17730994242644626467"
+      "templateHash": "17181272843392709683"
     },
     "name": "Elastic SANs",
     "description": "This module deploys an Elastic SAN."
@@ -937,7 +937,6 @@
         "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
       }
     ],
-    "enableReferencedModulesTelemetry": false,
     "calculatedSku": "[if(equals(parameters('sku'), 'Premium_LRS'), if(not(equals(parameters('availabilityZone'), null())), 'Premium_LRS', 'Premium_ZRS'), 'Premium_ZRS')]",
     "calculatedZone": "[if(equals(parameters('sku'), 'Premium_LRS'), if(not(equals(parameters('availabilityZone'), null())), createArray(format('{0}', parameters('availabilityZone'))), null()), null())]",
     "totalVirtualNetworkRules": "[reduce(map(coalesce(parameters('volumeGroups'), createArray()), lambda('volumeGroup', length(coalesce(tryGet(lambdaVariables('volumeGroup'), 'virtualNetworkRules'), createArray())))), 0, lambda('cur', 'next', add(lambdaVariables('cur'), lambdaVariables('next'))))]",
@@ -1100,7 +1099,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "10002384107919856685"
+              "templateHash": "1900871994989460547"
             },
             "name": "Elastic SAN Volume Groups",
             "description": "This module deploys an Elastic SAN Volume Group."
@@ -1834,7 +1833,7 @@
               "identity": "[variables('identity')]",
               "properties": {
                 "encryption": "[if(not(empty(parameters('customerManagedKey'))), 'EncryptionAtRestWithCustomerManagedKey', 'EncryptionAtRestWithPlatformKey')]",
-                "encryptionProperties": "[if(not(empty(parameters('customerManagedKey'))), createObject('identity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), createObject('userAssignedIdentity', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2], split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/')))), null()), 'keyVaultProperties', if(not(empty(parameters('customerManagedKey'))), createObject('keyName', parameters('customerManagedKey').keyName, 'keyVaultUri', reference('cMKKeyVault').vaultUri, 'keyVersion', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'keyVersion'), ''))), parameters('customerManagedKey').keyVersion, last(split(reference('cMKKeyVault::cMKKey').keyUriWithVersion, '/')))), null())), null())]",
+                "encryptionProperties": "[if(not(empty(parameters('customerManagedKey'))), createObject('identity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), createObject('userAssignedIdentity', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2], split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/')))), null()), 'keyVaultProperties', if(not(empty(parameters('customerManagedKey'))), createObject('keyName', parameters('customerManagedKey').keyName, 'keyVaultUri', reference('cMKKeyVault').vaultUri, 'keyVersion', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'keyVersion'), ''))), tryGet(parameters('customerManagedKey'), 'keyVersion'), last(split(reference('cMKKeyVault::cMKKey').keyUriWithVersion, '/')))), null())), null())]",
                 "networkAcls": "[if(not(empty(variables('networkRules'))), createObject('virtualNetworkRules', variables('networkRules')), null())]",
                 "protocolType": "Iscsi"
               },
@@ -3104,7 +3103,7 @@
                   "name": "[reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs.name.value]",
                   "location": "[reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs.location.value]",
                   "resourceId": "[reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs.resourceId.value]",
-                  "groupId": "[reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs.groupId.value]",
+                  "groupId": "[tryGet(tryGet(reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs, 'groupId'), 'value')]",
                   "customDnsConfig": "[reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfig.value]",
                   "networkInterfaceResourceIds": "[reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceResourceIds.value]"
                 }
@@ -3162,11 +3161,19 @@
           "name": "[reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs.name.value]",
           "location": "[reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs.location.value]",
           "resourceGroupName": "[reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs.resourceGroupName.value]",
-          "systemAssignedMIPrincipalId": "[reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs.systemAssignedMIPrincipalId.value]",
+          "systemAssignedMIPrincipalId": "[tryGet(tryGet(reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs, 'systemAssignedMIPrincipalId'), 'value')]",
           "volumes": "[reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs.volumes.value]",
           "privateEndpoints": "[reference(format('elasticSan_volumeGroups[{0}]', copyIndex())).outputs.privateEndpoints.value]"
         }
       }
+    },
+    "systemAssignedMIPrincipalId": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "The principal ID of the system assigned identity."
+      },
+      "value": null
     }
   }
 }

--- a/avm/res/elastic-san/elastic-san/volume-group/main.bicep
+++ b/avm/res/elastic-san/elastic-san/volume-group/main.bicep
@@ -120,7 +120,7 @@ resource volumeGroup 'Microsoft.ElasticSan/elasticSans/volumegroups@2023-01-01' 
                 keyName: customerManagedKey!.keyName
                 keyVaultUri: cMKKeyVault.properties.vaultUri
                 keyVersion: !empty(customerManagedKey.?keyVersion ?? '')
-                  ? customerManagedKey!.keyVersion
+                  ? customerManagedKey!.?keyVersion
                   : last(split(cMKKeyVault::cMKKey.properties.keyUriWithVersion, '/'))
               }
             : null
@@ -237,7 +237,7 @@ output privateEndpoints array = [
     name: volumeGroup_privateEndpoints[i].outputs.name
     location: volumeGroup_privateEndpoints[i].outputs.location
     resourceId: volumeGroup_privateEndpoints[i].outputs.resourceId
-    groupId: volumeGroup_privateEndpoints[i].outputs.groupId
+    groupId: volumeGroup_privateEndpoints[i].outputs.?groupId
     customDnsConfig: volumeGroup_privateEndpoints[i].outputs.customDnsConfig
     networkInterfaceResourceIds: volumeGroup_privateEndpoints[i].outputs.networkInterfaceResourceIds
   }

--- a/avm/res/elastic-san/elastic-san/volume-group/main.json
+++ b/avm/res/elastic-san/elastic-san/volume-group/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "10002384107919856685"
+      "templateHash": "1900871994989460547"
     },
     "name": "Elastic SAN Volume Groups",
     "description": "This module deploys an Elastic SAN Volume Group."
@@ -740,7 +740,7 @@
       "identity": "[variables('identity')]",
       "properties": {
         "encryption": "[if(not(empty(parameters('customerManagedKey'))), 'EncryptionAtRestWithCustomerManagedKey', 'EncryptionAtRestWithPlatformKey')]",
-        "encryptionProperties": "[if(not(empty(parameters('customerManagedKey'))), createObject('identity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), createObject('userAssignedIdentity', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2], split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/')))), null()), 'keyVaultProperties', if(not(empty(parameters('customerManagedKey'))), createObject('keyName', parameters('customerManagedKey').keyName, 'keyVaultUri', reference('cMKKeyVault').vaultUri, 'keyVersion', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'keyVersion'), ''))), parameters('customerManagedKey').keyVersion, last(split(reference('cMKKeyVault::cMKKey').keyUriWithVersion, '/')))), null())), null())]",
+        "encryptionProperties": "[if(not(empty(parameters('customerManagedKey'))), createObject('identity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), createObject('userAssignedIdentity', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2], split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/')))), null()), 'keyVaultProperties', if(not(empty(parameters('customerManagedKey'))), createObject('keyName', parameters('customerManagedKey').keyName, 'keyVaultUri', reference('cMKKeyVault').vaultUri, 'keyVersion', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'keyVersion'), ''))), tryGet(parameters('customerManagedKey'), 'keyVersion'), last(split(reference('cMKKeyVault::cMKKey').keyUriWithVersion, '/')))), null())), null())]",
         "networkAcls": "[if(not(empty(variables('networkRules'))), createObject('virtualNetworkRules', variables('networkRules')), null())]",
         "protocolType": "Iscsi"
       },
@@ -2010,7 +2010,7 @@
           "name": "[reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs.name.value]",
           "location": "[reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs.location.value]",
           "resourceId": "[reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs.resourceId.value]",
-          "groupId": "[reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs.groupId.value]",
+          "groupId": "[tryGet(tryGet(reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs, 'groupId'), 'value')]",
           "customDnsConfig": "[reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfig.value]",
           "networkInterfaceResourceIds": "[reference(format('volumeGroup_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceResourceIds.value]"
         }


### PR DESCRIPTION
## Description

Fixes the static test by regenerating the main.json and with a workaround for the systemAssignedMIPrincipalId output.

Closes  

## Pipeline Reference

| Pipeline |
| -------- |
|  [![avm.res.elastic-san.elastic-san](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.elastic-san.elastic-san.yml/badge.svg?branch=fix-elastic-san)](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.elastic-san.elastic-san.yml)        |

## Type of Change

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
