### PR TITLE
fix: allow any string for powershell and python module versions not just latest in automation-account

### DIFF
--- a/avm/res/automation/automation-account/README.md
+++ b/avm/res/automation/automation-account/README.md
@@ -2217,12 +2217,6 @@ Module version or specify latest to get the latest version.
 
 - Required: No
 - Type: string
-- Allowed:
-  ```Bicep
-  [
-    'latest'
-  ]
-  ```
 
 ### Parameter: `privateEndpoints`
 
@@ -2699,12 +2693,6 @@ Module version or specify latest to get the latest version.
 
 - Required: No
 - Type: string
-- Allowed:
-  ```Bicep
-  [
-    'latest'
-  ]
-  ```
 
 ### Parameter: `python3Packages`
 
@@ -2754,12 +2742,6 @@ Module version or specify latest to get the latest version.
 
 - Required: No
 - Type: string
-- Allowed:
-  ```Bicep
-  [
-    'latest'
-  ]
-  ```
 
 ### Parameter: `roleAssignments`
 

--- a/avm/res/automation/automation-account/main.bicep
+++ b/avm/res/automation/automation-account/main.bicep
@@ -656,7 +656,7 @@ type pwsh72ModuleType = {
   uri: string
 
   @description('Optional. Module version or specify latest to get the latest version.')
-  version: 'latest'?
+  version: string?
 }
 
 @export()
@@ -672,5 +672,5 @@ type python23PackageType = {
   uri: string
 
   @description('Optional. Module version or specify latest to get the latest version.')
-  version: 'latest'?
+  version: string?
 }

--- a/avm/res/automation/automation-account/main.json
+++ b/avm/res/automation/automation-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.13.18514",
-      "templateHash": "17517868551569081276"
+      "templateHash": "15152556071592649783"
     },
     "name": "Automation Accounts",
     "description": "This module deploys an Azure Automation Account."
@@ -159,9 +159,6 @@
         },
         "version": {
           "type": "string",
-          "allowedValues": [
-            "latest"
-          ],
           "nullable": true,
           "metadata": {
             "description": "Optional. Module version or specify latest to get the latest version."
@@ -197,9 +194,6 @@
         },
         "version": {
           "type": "string",
-          "allowedValues": [
-            "latest"
-          ],
           "nullable": true,
           "metadata": {
             "description": "Optional. Module version or specify latest to get the latest version."

--- a/avm/res/automation/automation-account/version.json
+++ b/avm/res/automation/automation-account/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.13",
+  "version": "0.13.1",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
## Description

This was missed as part of the original PR (#4352) to add support for powershell 7.2 and python 2/3 modules. The type for both was hard coded to only allow 'latest' or nothing as the value for the version of a module, but the bicep child module for those has a default value of 'latest' as well.

This change swaps to using string as the allowed type of the version property for both module types because the default value for the child module will handle not providing one and allows users to specify other versions for the modules they want to install.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.automation.automation-account](https://github.com/chrislgardner/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml/badge.svg?branch=autaccount-issue2485)](https://github.com/chrislgardner/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
