### PR TITLE
fix: bicep publish fix

### DIFF
--- a/utilities/pipelines/publish/Publish-ModuleFromPathToPBR.ps1
+++ b/utilities/pipelines/publish/Publish-ModuleFromPathToPBR.ps1
@@ -96,7 +96,7 @@ function Publish-ModuleFromPathToPBR {
     $publishInput = @(
         $moduleBicepFilePath
         '--target', ('br:{0}/public/bicep/{1}:{2}' -f $plainPublicRegistryServer, $publishedModuleName, $targetVersion)
-        '--documentationUri', $documentationUri
+        '--documentation-uri', $documentationUri
         '--with-source'
         '--force'
     )


### PR DESCRIPTION
## Description

Option `--documentationUri` has been deprecated and will be removed in a future release. Use `--documentation-uri` instead.
![image](https://github.com/user-attachments/assets/89087403-28ac-45bb-8ea7-1e6c334336d5)

Ref: https://learn.microsoft.com/en-us/cli/azure/bicep?view=azure-cli-latest#az-bicep-publish-optional-parameters

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
