### PR TITLE
feat: Added test to ensure `version.json` file only has the `major.minor` versions specified

### DIFF
--- a/avm/res/automation/automation-account/version.json
+++ b/avm/res/automation/automation-account/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.13.1",
+  "version": "0.14",
   "pathFilters": [
     "./main.json"
   ]

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -104,6 +104,16 @@ Describe 'File/folder tests' -Tag 'Modules' {
             $file.Name | Should -BeExactly 'README.md'
         }
 
+        It '[<moduleFolderName>] A [` version.json `] file must only have a major & minor version.' -TestCases ($moduleFolderTestCases | Where-Object { Test-Path (Join-Path $_.moduleFolderPath 'version.json') }) {
+
+            param (
+                [string] $moduleFolderPath
+            )
+
+            $versionFileContent = Get-Content (Join-Path -Path $moduleFolderPath 'version.json') | ConvertFrom-Json -AsHashtable
+            $versionFileContent.Version | Should -Match '^\d+\.\d+$'
+        }
+
         # only avm/res/network/virtual-network/subnet is allowed to have a version.json file (PoC for child module publishing)
         It '[<moduleFolderName>] Child module should not contain a [` version.json `] file.' -TestCases ($moduleFolderTestCases | Where-Object { (-Not $_.isTopLevelModule) -And ($_.moduleFolderName -ne 'network/virtual-network/subnet') }) {
 

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -111,7 +111,7 @@ Describe 'File/folder tests' -Tag 'Modules' {
             )
 
             $versionFileContent = Get-Content (Join-Path -Path $moduleFolderPath 'version.json') | ConvertFrom-Json -AsHashtable
-            $versionFileContent.Version | Should -Match '^\d+\.\d+$'
+            $versionFileContent.version | Should -Match '^[0-9]+\.[0-9]+$' -Because 'only the <major>.<minor> version may be specified in the version.json file.'
         }
 
         # only avm/res/network/virtual-network/subnet is allowed to have a version.json file (PoC for child module publishing)

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -111,7 +111,7 @@ Describe 'File/folder tests' -Tag 'Modules' {
             )
 
             $versionFileContent = Get-Content (Join-Path -Path $moduleFolderPath 'version.json') | ConvertFrom-Json -AsHashtable
-            $versionFileContent.version | Should -Match '^[0-9]+\.[0-9]+$' -Because 'only the <major>.<minor> version may be specified in the version.json file.'
+            $versionFileContent.version | Should -Match '^[0-9]+\.[0-9]+$' -Because 'only the major.minor version may be specified in the version.json file.'
         }
 
         # only avm/res/network/virtual-network/subnet is allowed to have a version.json file (PoC for child module publishing)


### PR DESCRIPTION
## Description

- Added test to ensure `version.json` file only has the `major.minor` versions specified
- Fixed automation account

Run before automation account was fixed
![image](https://github.com/user-attachments/assets/14134290-7de6-4581-8d93-bb2ede1dd27f)

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.automation.automation-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml/badge.svg?branch=users%2Falsehr%2FversionFileTest&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml)      |
| [![avm.res.key-vault.vault](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml/badge.svg?branch=users%2Falsehr%2FversionFileTest&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
