### PR TITLE
feat: Add tags to failover group module in  'avm/res/sql/server'

### DIFF
--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -3405,6 +3405,7 @@ The failover groups configuration.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`readOnlyEndpoint`](#parameter-failovergroupsreadonlyendpoint) | object | Read-only endpoint of the failover group instance. |
+| [`tags`](#parameter-failovergroupstags) | object | Tags of the resource. |
 
 ### Parameter: `failoverGroups.databases`
 
@@ -3515,6 +3516,13 @@ The target partner server where the read-only endpoint points to.
 
 - Required: Yes
 - Type: string
+
+### Parameter: `failoverGroups.tags`
+
+Tags of the resource.
+
+- Required: No
+- Type: object
 
 ### Parameter: `federatedClientId`
 

--- a/avm/res/sql/server/failover-group/README.md
+++ b/avm/res/sql/server/failover-group/README.md
@@ -37,6 +37,7 @@ This module deploys Azure SQL Server failover group.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`readOnlyEndpoint`](#parameter-readonlyendpoint) | object | Read-only endpoint of the failover group instance. |
+| [`tags`](#parameter-tags) | object | Tags of the resource. |
 
 ### Parameter: `databases`
 
@@ -154,6 +155,13 @@ The target partner server where the read-only endpoint points to.
 
 - Required: Yes
 - Type: string
+
+### Parameter: `tags`
+
+Tags of the resource.
+
+- Required: No
+- Type: object
 
 ## Outputs
 

--- a/avm/res/sql/server/failover-group/main.bicep
+++ b/avm/res/sql/server/failover-group/main.bicep
@@ -26,12 +26,16 @@ resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
   name: serverName
 }
 
+@description('Optional. Tags of the resource.')
+param tags object?
+
 // https://stackoverflow.com/questions/78337117/azure-sql-failover-group-fails-on-second-run
 // https://github.com/Azure/bicep-types-az/issues/2153
 
 resource failoverGroup 'Microsoft.Sql/servers/failoverGroups@2024-05-01-preview' = {
   name: name
   parent: server
+  tags: tags
   properties: {
     databases: [for db in databases: resourceId('Microsoft.Sql/servers/databases', serverName, db)]
     partnerServers: [

--- a/avm/res/sql/server/failover-group/main.json
+++ b/avm/res/sql/server/failover-group/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "13275639318827144855"
+      "templateHash": "16832516411852699458"
     },
     "name": "Azure SQL Server failover group",
     "description": "This module deploys Azure SQL Server failover group."
@@ -115,6 +115,13 @@
       "metadata": {
         "description": "Required. Databases secondary type on partner server."
       }
+    },
+    "tags": {
+      "type": "object",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Tags of the resource."
+      }
     }
   },
   "resources": {
@@ -128,6 +135,7 @@
       "type": "Microsoft.Sql/servers/failoverGroups",
       "apiVersion": "2024-05-01-preview",
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
+      "tags": "[parameters('tags')]",
       "properties": {
         "copy": [
           {

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -530,6 +530,7 @@ module failover_groups 'failover-group/main.bicep' = [
     name: '${uniqueString(deployment().name, location)}-Sql-FailoverGroup-${index}'
     params: {
       name: failoverGroup.name
+      tags: failoverGroup.?tags ?? tags
       serverName: server.name
       databases: failoverGroup.databases
       partnerServers: failoverGroup.partnerServers
@@ -958,6 +959,9 @@ type securityAlerPolicyType = {
 type failoverGroupType = {
   @description('Required. The name of the failover group.')
   name: string
+
+  @description('Optional. Tags of the resource.')
+  tags: object?
 
   @description('Required. List of databases in the failover group.')
   databases: string[]

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "3462169398572643878"
+      "version": "0.33.93.31351",
+      "templateHash": "15781736031753199939"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -931,6 +931,13 @@
           "type": "string",
           "metadata": {
             "description": "Required. The name of the failover group."
+          }
+        },
+        "tags": {
+          "type": "object",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Tags of the resource."
           }
         },
         "databases": {
@@ -5712,6 +5719,9 @@
           "name": {
             "value": "[parameters('failoverGroups')[copyIndex()].name]"
           },
+          "tags": {
+            "value": "[coalesce(tryGet(parameters('failoverGroups')[copyIndex()], 'tags'), parameters('tags'))]"
+          },
           "serverName": {
             "value": "[parameters('name')]"
           },
@@ -5738,8 +5748,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "12788896097070917561"
+              "version": "0.33.93.31351",
+              "templateHash": "16832516411852699458"
             },
             "name": "Azure SQL Server failover group",
             "description": "This module deploys Azure SQL Server failover group."
@@ -5848,6 +5858,13 @@
               "metadata": {
                 "description": "Required. Databases secondary type on partner server."
               }
+            },
+            "tags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the resource."
+              }
             }
           },
           "resources": {
@@ -5861,6 +5878,7 @@
               "type": "Microsoft.Sql/servers/failoverGroups",
               "apiVersion": "2024-05-01-preview",
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
+              "tags": "[parameters('tags')]",
               "properties": {
                 "copy": [
                   {

--- a/avm/res/sql/server/version.json
+++ b/avm/res/sql/server/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.13",
+  "version": "0.14",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
## Description

Adding / passing down tags property to the failover group module in `avm/res/sql/server`.

## Pipeline Reference

| Pipeline |
| -------- |
|     [![avm.res.sql.server](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg?branch=4655)](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml)   |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
