### PR TITLE
feat: RouteTable - Updated to latest AVM common types

### DIFF
--- a/avm/res/network/route-table/README.md
+++ b/avm/res/network/route-table/README.md
@@ -8,6 +8,7 @@ This module deploys a User Defined Route Table (UDR).
 - [Usage examples](#Usage-examples)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
 - [Data Collection](#Data-Collection)
 
 ## Resource Types
@@ -43,10 +44,7 @@ This instance deploys the module with the minimum set of required parameters.
 module routeTable 'br/public:avm/res/network/route-table:<version>' = {
   name: 'routeTableDeployment'
   params: {
-    // Required parameters
     name: 'nrtmin001'
-    // Non-required parameters
-    location: '<location>'
   }
 }
 ```
@@ -63,13 +61,8 @@ module routeTable 'br/public:avm/res/network/route-table:<version>' = {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    // Required parameters
     "name": {
       "value": "nrtmin001"
-    },
-    // Non-required parameters
-    "location": {
-      "value": "<location>"
     }
   }
 }
@@ -85,10 +78,7 @@ module routeTable 'br/public:avm/res/network/route-table:<version>' = {
 ```bicep-params
 using 'br/public:avm/res/network/route-table:<version>'
 
-// Required parameters
 param name = 'nrtmin001'
-// Non-required parameters
-param location = '<location>'
 ```
 
 </details>
@@ -296,11 +286,6 @@ module routeTable 'br/public:avm/res/network/route-table:<version>' = {
     // Required parameters
     name: 'nrtwaf001'
     // Non-required parameters
-    location: '<location>'
-    lock: {
-      kind: 'CanNotDelete'
-      name: 'myCustomLockName'
-    }
     routes: [
       {
         name: 'default'
@@ -337,15 +322,6 @@ module routeTable 'br/public:avm/res/network/route-table:<version>' = {
       "value": "nrtwaf001"
     },
     // Non-required parameters
-    "location": {
-      "value": "<location>"
-    },
-    "lock": {
-      "value": {
-        "kind": "CanNotDelete",
-        "name": "myCustomLockName"
-      }
-    },
     "routes": {
       "value": [
         {
@@ -382,11 +358,6 @@ using 'br/public:avm/res/network/route-table:<version>'
 // Required parameters
 param name = 'nrtwaf001'
 // Non-required parameters
-param location = '<location>'
-param lock = {
-  kind: 'CanNotDelete'
-  name: 'myCustomLockName'
-}
 param routes = [
   {
     name: 'default'
@@ -637,7 +608,6 @@ Properties of the route.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`addressPrefix`](#parameter-routespropertiesaddressprefix) | string | The destination CIDR to which the route applies. |
-| [`hasBgpOverride`](#parameter-routespropertieshasbgpoverride) | bool | A value indicating whether this route overrides overlapping BGP routes regardless of LPM. |
 | [`nextHopIpAddress`](#parameter-routespropertiesnexthopipaddress) | string | The IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance. |
 
 ### Parameter: `routes.properties.nextHopType`
@@ -664,13 +634,6 @@ The destination CIDR to which the route applies.
 - Required: No
 - Type: string
 
-### Parameter: `routes.properties.hasBgpOverride`
-
-A value indicating whether this route overrides overlapping BGP routes regardless of LPM.
-
-- Required: No
-- Type: bool
-
 ### Parameter: `routes.properties.nextHopIpAddress`
 
 The IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance.
@@ -693,6 +656,14 @@ Tags of the resource.
 | `name` | string | The name of the route table. |
 | `resourceGroupName` | string | The resource group the route table was deployed into. |
 | `resourceId` | string | The resource ID of the route table. |
+
+## Cross-referenced modules
+
+This section gives you an overview of all local-referenced module files (i.e., other modules that are referenced in this module) and all remote-referenced files (i.e., Bicep modules that are referenced from a Bicep Registry or Template Specs).
+
+| Reference | Type |
+| :-- | :-- |
+| `br/public:avm/utl/types/avm-common-types:0.5.1` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/network/route-table/main.bicep
+++ b/avm/res/network/route-table/main.bicep
@@ -8,16 +8,18 @@ param name string
 param location string = resourceGroup().location
 
 @description('Optional. An array of routes to be established within the hub route table.')
-param routes routeType
+param routes routeType[]?
 
 @description('Optional. Switch to disable BGP route propagation.')
 param disableBgpRoutePropagation bool = false
 
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
 @description('Optional. The lock settings of the service.')
-param lock lockType
+param lock lockType?
 
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
 @description('Optional. Array of role assignments to create.')
-param roleAssignments roleAssignmentType
+param roleAssignments roleAssignmentType[]?
 
 @description('Optional. Tags of the resource.')
 param tags object?
@@ -129,40 +131,8 @@ output location string = routeTable.location
 //   Definitions   //
 // =============== //
 
-type lockType = {
-  @description('Optional. Specify the name of lock.')
-  name: string?
-
-  @description('Optional. Specify the type of lock.')
-  kind: ('CanNotDelete' | 'ReadOnly' | 'None')?
-}?
-
-type roleAssignmentType = {
-  @description('Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated.')
-  name: string?
-
-  @description('Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.')
-  roleDefinitionIdOrName: string
-
-  @description('Required. The principal ID of the principal (user/group/identity) to assign the role to.')
-  principalId: string
-
-  @description('Optional. The principal type of the assigned principal ID.')
-  principalType: ('ServicePrincipal' | 'Group' | 'User' | 'ForeignGroup' | 'Device')?
-
-  @description('Optional. The description of the role assignment.')
-  description: string?
-
-  @description('Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container".')
-  condition: string?
-
-  @description('Optional. Version of the condition.')
-  conditionVersion: '2.0'?
-
-  @description('Optional. The Resource Id of the delegated managed identity resource.')
-  delegatedManagedIdentityResourceId: string?
-}[]?
-
+@export()
+@description('The type for a route.')
 type routeType = {
   @description('Required. Name of the route.')
   name: string
@@ -175,10 +145,7 @@ type routeType = {
     @description('Optional. The destination CIDR to which the route applies.')
     addressPrefix: string?
 
-    @description('Optional. A value indicating whether this route overrides overlapping BGP routes regardless of LPM.')
-    hasBgpOverride: bool?
-
     @description('Optional. The IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance.')
     nextHopIpAddress: string?
   }
-}[]?
+}

--- a/avm/res/network/route-table/main.json
+++ b/avm/res/network/route-table/main.json
@@ -5,13 +5,63 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "142872509148371547"
+      "version": "0.33.13.18514",
+      "templateHash": "4470171655507346598"
     },
     "name": "Route Tables",
     "description": "This module deploys a User Defined Route Table (UDR)."
   },
   "definitions": {
+    "routeType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. Name of the route."
+          }
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "nextHopType": {
+              "type": "string",
+              "allowedValues": [
+                "Internet",
+                "None",
+                "VirtualAppliance",
+                "VirtualNetworkGateway",
+                "VnetLocal"
+              ],
+              "metadata": {
+                "description": "Required. The type of Azure hop the packet should be sent to."
+              }
+            },
+            "addressPrefix": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The destination CIDR to which the route applies."
+              }
+            },
+            "nextHopIpAddress": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance."
+              }
+            }
+          },
+          "metadata": {
+            "description": "Required. Properties of the route."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The type for a route."
+      }
+    },
     "lockType": {
       "type": "object",
       "properties": {
@@ -35,137 +85,87 @@
           }
         }
       },
-      "nullable": true
+      "metadata": {
+        "description": "An AVM-aligned type for a lock.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+        }
+      }
     },
     "roleAssignmentType": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
-            }
-          },
-          "roleDefinitionIdOrName": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-            }
-          },
-          "principalId": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-            }
-          },
-          "principalType": {
-            "type": "string",
-            "allowedValues": [
-              "Device",
-              "ForeignGroup",
-              "Group",
-              "ServicePrincipal",
-              "User"
-            ],
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The principal type of the assigned principal ID."
-            }
-          },
-          "description": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The description of the role assignment."
-            }
-          },
-          "condition": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-            }
-          },
-          "conditionVersion": {
-            "type": "string",
-            "allowedValues": [
-              "2.0"
-            ],
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Version of the condition."
-            }
-          },
-          "delegatedManagedIdentityResourceId": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The Resource Id of the delegated managed identity resource."
-            }
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+          }
+        },
+        "roleDefinitionIdOrName": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+          }
+        },
+        "principalId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+          }
+        },
+        "principalType": {
+          "type": "string",
+          "allowedValues": [
+            "Device",
+            "ForeignGroup",
+            "Group",
+            "ServicePrincipal",
+            "User"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The principal type of the assigned principal ID."
+          }
+        },
+        "description": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The description of the role assignment."
+          }
+        },
+        "condition": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+          }
+        },
+        "conditionVersion": {
+          "type": "string",
+          "allowedValues": [
+            "2.0"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Version of the condition."
+          }
+        },
+        "delegatedManagedIdentityResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The Resource Id of the delegated managed identity resource."
           }
         }
       },
-      "nullable": true
-    },
-    "routeType": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. Name of the route."
-            }
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "nextHopType": {
-                "type": "string",
-                "allowedValues": [
-                  "Internet",
-                  "None",
-                  "VirtualAppliance",
-                  "VirtualNetworkGateway",
-                  "VnetLocal"
-                ],
-                "metadata": {
-                  "description": "Required. The type of Azure hop the packet should be sent to."
-                }
-              },
-              "addressPrefix": {
-                "type": "string",
-                "nullable": true,
-                "metadata": {
-                  "description": "Optional. The destination CIDR to which the route applies."
-                }
-              },
-              "hasBgpOverride": {
-                "type": "bool",
-                "nullable": true,
-                "metadata": {
-                  "description": "Optional. A value indicating whether this route overrides overlapping BGP routes regardless of LPM."
-                }
-              },
-              "nextHopIpAddress": {
-                "type": "string",
-                "nullable": true,
-                "metadata": {
-                  "description": "Optional. The IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance."
-                }
-              }
-            },
-            "metadata": {
-              "description": "Required. Properties of the route."
-            }
-          }
+      "metadata": {
+        "description": "An AVM-aligned type for a role assignment.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
         }
-      },
-      "nullable": true
+      }
     }
   },
   "parameters": {
@@ -183,7 +183,11 @@
       }
     },
     "routes": {
-      "$ref": "#/definitions/routeType",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/routeType"
+      },
+      "nullable": true,
       "metadata": {
         "description": "Optional. An array of routes to be established within the hub route table."
       }
@@ -197,12 +201,17 @@
     },
     "lock": {
       "$ref": "#/definitions/lockType",
+      "nullable": true,
       "metadata": {
         "description": "Optional. The lock settings of the service."
       }
     },
     "roleAssignments": {
-      "$ref": "#/definitions/roleAssignmentType",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/roleAssignmentType"
+      },
+      "nullable": true,
       "metadata": {
         "description": "Optional. Array of role assignments to create."
       }

--- a/avm/res/network/route-table/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/network/route-table/tests/e2e/defaults/main.test.bicep
@@ -40,6 +40,5 @@ module testDeployment '../../../main.bicep' = {
   name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}'
   params: {
     name: '${namePrefix}${serviceShort}001'
-    location: resourceLocation
   }
 }

--- a/avm/res/network/route-table/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/route-table/tests/e2e/waf-aligned/main.test.bicep
@@ -40,11 +40,6 @@ module testDeployment '../../../main.bicep' = {
   name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}'
   params: {
     name: '${namePrefix}${serviceShort}001'
-    location: resourceLocation
-    lock: {
-      kind: 'CanNotDelete'
-      name: 'myCustomLockName'
-    }
     routes: [
       {
         name: 'default'


### PR DESCRIPTION
## Description

- Updated to latest AVM common types
- Removed read-only property from routes type

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.network.route-table](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.route-table.yml/badge.svg?branch=users%2Falsehr%2FrouteTable_udt&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.route-table.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
