### PR TITLE
fix: use storageNetworkType and networkIntentType for azlocal

### DIFF
--- a/avm/res/azure-stack-hci/cluster/README.md
+++ b/avm/res/azure-stack-hci/cluster/README.md
@@ -1174,6 +1174,199 @@ An array of Network ATC Network Intent objects that define the Compute, Manageme
 - Required: Yes
 - Type: array
 
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`adapter`](#parameter-deploymentsettingsnetworkintentsadapter) | array | The names of the network adapters to include in the intent. |
+| [`adapterPropertyOverrides`](#parameter-deploymentsettingsnetworkintentsadapterpropertyoverrides) | object | The adapter property overrides for the network intent. |
+| [`name`](#parameter-deploymentsettingsnetworkintentsname) | string | The name of the network intent. |
+| [`overrideAdapterProperty`](#parameter-deploymentsettingsnetworkintentsoverrideadapterproperty) | bool | Specify whether to override the adapter property. Use false by default. |
+| [`overrideQosPolicy`](#parameter-deploymentsettingsnetworkintentsoverrideqospolicy) | bool | Specify whether to override the qosPolicy property. Use false by default. |
+| [`overrideVirtualSwitchConfiguration`](#parameter-deploymentsettingsnetworkintentsoverridevirtualswitchconfiguration) | bool | Specify whether to override the virtualSwitchConfiguration property. Use false by default. |
+| [`qosPolicyOverrides`](#parameter-deploymentsettingsnetworkintentsqospolicyoverrides) | object | The qosPolicy overrides for the network intent. |
+| [`trafficType`](#parameter-deploymentsettingsnetworkintentstraffictype) | array | The traffic types for the network intent. |
+| [`virtualSwitchConfigurationOverrides`](#parameter-deploymentsettingsnetworkintentsvirtualswitchconfigurationoverrides) | object | The virtualSwitchConfiguration overrides for the network intent. |
+
+### Parameter: `deploymentSettings.networkIntents.adapter`
+
+The names of the network adapters to include in the intent.
+
+- Required: Yes
+- Type: array
+
+### Parameter: `deploymentSettings.networkIntents.adapterPropertyOverrides`
+
+The adapter property overrides for the network intent.
+
+- Required: Yes
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`jumboPacket`](#parameter-deploymentsettingsnetworkintentsadapterpropertyoverridesjumbopacket) | string | The jumboPacket configuration for the network adapters. |
+| [`networkDirect`](#parameter-deploymentsettingsnetworkintentsadapterpropertyoverridesnetworkdirect) | string | The networkDirect configuration for the network adapters. |
+| [`networkDirectTechnology`](#parameter-deploymentsettingsnetworkintentsadapterpropertyoverridesnetworkdirecttechnology) | string | The networkDirectTechnology configuration for the network adapters. |
+
+### Parameter: `deploymentSettings.networkIntents.adapterPropertyOverrides.jumboPacket`
+
+The jumboPacket configuration for the network adapters.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `deploymentSettings.networkIntents.adapterPropertyOverrides.networkDirect`
+
+The networkDirect configuration for the network adapters.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Disabled'
+    'Enabled'
+  ]
+  ```
+
+### Parameter: `deploymentSettings.networkIntents.adapterPropertyOverrides.networkDirectTechnology`
+
+The networkDirectTechnology configuration for the network adapters.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'iWARP'
+    'RoCEv2'
+  ]
+  ```
+
+### Parameter: `deploymentSettings.networkIntents.name`
+
+The name of the network intent.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `deploymentSettings.networkIntents.overrideAdapterProperty`
+
+Specify whether to override the adapter property. Use false by default.
+
+- Required: Yes
+- Type: bool
+
+### Parameter: `deploymentSettings.networkIntents.overrideQosPolicy`
+
+Specify whether to override the qosPolicy property. Use false by default.
+
+- Required: Yes
+- Type: bool
+
+### Parameter: `deploymentSettings.networkIntents.overrideVirtualSwitchConfiguration`
+
+Specify whether to override the virtualSwitchConfiguration property. Use false by default.
+
+- Required: Yes
+- Type: bool
+
+### Parameter: `deploymentSettings.networkIntents.qosPolicyOverrides`
+
+The qosPolicy overrides for the network intent.
+
+- Required: Yes
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`bandwidthPercentage_SMB`](#parameter-deploymentsettingsnetworkintentsqospolicyoverridesbandwidthpercentage_smb) | string | The bandwidthPercentage for the network intent. Recommend 50. |
+| [`priorityValue8021Action_Cluster`](#parameter-deploymentsettingsnetworkintentsqospolicyoverridespriorityvalue8021action_cluster) | string | Recommend 7. |
+| [`priorityValue8021Action_SMB`](#parameter-deploymentsettingsnetworkintentsqospolicyoverridespriorityvalue8021action_smb) | string | Recommend 3. |
+
+### Parameter: `deploymentSettings.networkIntents.qosPolicyOverrides.bandwidthPercentage_SMB`
+
+The bandwidthPercentage for the network intent. Recommend 50.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `deploymentSettings.networkIntents.qosPolicyOverrides.priorityValue8021Action_Cluster`
+
+Recommend 7.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `deploymentSettings.networkIntents.qosPolicyOverrides.priorityValue8021Action_SMB`
+
+Recommend 3.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `deploymentSettings.networkIntents.trafficType`
+
+The traffic types for the network intent.
+
+- Required: Yes
+- Type: array
+- Allowed:
+  ```Bicep
+  [
+    'Compute'
+    'Management'
+    'Storage'
+  ]
+  ```
+
+### Parameter: `deploymentSettings.networkIntents.virtualSwitchConfigurationOverrides`
+
+The virtualSwitchConfiguration overrides for the network intent.
+
+- Required: Yes
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`enableIov`](#parameter-deploymentsettingsnetworkintentsvirtualswitchconfigurationoverridesenableiov) | string | The enableIov configuration for the network intent. |
+| [`loadBalancingAlgorithm`](#parameter-deploymentsettingsnetworkintentsvirtualswitchconfigurationoverridesloadbalancingalgorithm) | string | The loadBalancingAlgorithm configuration for the network intent. |
+
+### Parameter: `deploymentSettings.networkIntents.virtualSwitchConfigurationOverrides.enableIov`
+
+The enableIov configuration for the network intent.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'false'
+    'true'
+  ]
+  ```
+
+### Parameter: `deploymentSettings.networkIntents.virtualSwitchConfigurationOverrides.loadBalancingAlgorithm`
+
+The loadBalancingAlgorithm configuration for the network intent.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Dynamic'
+    'HyperVPort'
+    'IPHash'
+  ]
+  ```
+
 ### Parameter: `deploymentSettings.startingIPAddress`
 
 The starting IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs.
@@ -1194,6 +1387,77 @@ An array of JSON objects that define the storage network configuration for the c
 
 - Required: Yes
 - Type: array
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`adapterName`](#parameter-deploymentsettingsstoragenetworksadaptername) | string | The name of the storage adapter. |
+| [`vlan`](#parameter-deploymentsettingsstoragenetworksvlan) | string | The VLAN for the storage adapter. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-deploymentsettingsstoragenetworksname) | string | The name of the storage network. |
+| [`storageAdapterIPInfo`](#parameter-deploymentsettingsstoragenetworksstorageadapteripinfo) | array | The storage adapter IP information for 3-node switchless or manual config deployments. |
+
+### Parameter: `deploymentSettings.storageNetworks.adapterName`
+
+The name of the storage adapter.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `deploymentSettings.storageNetworks.vlan`
+
+The VLAN for the storage adapter.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `deploymentSettings.storageNetworks.name`
+
+The name of the storage network.
+
+- Required: No
+- Type: string
+
+### Parameter: `deploymentSettings.storageNetworks.storageAdapterIPInfo`
+
+The storage adapter IP information for 3-node switchless or manual config deployments.
+
+- Required: No
+- Type: array
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`ipv4Address`](#parameter-deploymentsettingsstoragenetworksstorageadapteripinfoipv4address) | string | The IPv4 address for the storage adapter. |
+| [`physicalNode`](#parameter-deploymentsettingsstoragenetworksstorageadapteripinfophysicalnode) | string | The HCI node name. |
+| [`subnetMask`](#parameter-deploymentsettingsstoragenetworksstorageadapteripinfosubnetmask) | string | The subnet mask for the storage adapter. |
+
+### Parameter: `deploymentSettings.storageNetworks.storageAdapterIPInfo.ipv4Address`
+
+The IPv4 address for the storage adapter.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `deploymentSettings.storageNetworks.storageAdapterIPInfo.physicalNode`
+
+The HCI node name.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `deploymentSettings.storageNetworks.storageAdapterIPInfo.subnetMask`
+
+The subnet mask for the storage adapter.
+
+- Required: Yes
+- Type: string
 
 ### Parameter: `deploymentSettings.subnetMask`
 

--- a/avm/res/azure-stack-hci/cluster/deployment-setting/main.bicep
+++ b/avm/res/azure-stack-hci/cluster/deployment-setting/main.bicep
@@ -202,7 +202,7 @@ resource deploymentSettings 'Microsoft.AzureStackHCI/clusters/deploymentSettings
               storageConnectivitySwitchless: storageConnectivitySwitchless
               storageNetworks: [
                 for (storageAdapter, index) in storageNetworks: {
-                  name: 'StorageNetwork${index + 1}'
+                  name: storageAdapter.name ?? 'StorageNetwork${index + 1}'
                   networkAdapterName: storageAdapter.adapterName
                   vlanId: storageAdapter.vlan
                   storageAdapterIPInfo: storageAdapter.?storageAdapterIPInfo

--- a/avm/res/azure-stack-hci/cluster/deployment-setting/main.json
+++ b/avm/res/azure-stack-hci/cluster/deployment-setting/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "9536857013030923630"
+      "templateHash": "8375880528238701715"
     },
     "name": "Azure Stack HCI Cluster Deployment Settings",
     "description": "This module deploys an Azure Stack HCI Cluster Deployment Settings resource."
@@ -348,7 +348,7 @@
                       "name": "storageNetworks",
                       "count": "[length(parameters('storageNetworks'))]",
                       "input": {
-                        "name": "[format('StorageNetwork{0}', add(copyIndex('storageNetworks'), 1))]",
+                        "name": "[coalesce(parameters('storageNetworks')[copyIndex('storageNetworks')].name, format('StorageNetwork{0}', add(copyIndex('storageNetworks'), 1)))]",
                         "networkAdapterName": "[parameters('storageNetworks')[copyIndex('storageNetworks')].adapterName]",
                         "vlanId": "[parameters('storageNetworks')[copyIndex('storageNetworks')].vlan]",
                         "storageAdapterIPInfo": "[tryGet(parameters('storageNetworks')[copyIndex('storageNetworks')], 'storageAdapterIPInfo')]"

--- a/avm/res/azure-stack-hci/cluster/main.bicep
+++ b/avm/res/azure-stack-hci/cluster/main.bicep
@@ -347,6 +347,9 @@ type storageAdapterIPInfoType = {
 // define custom type for storage network objects
 @export()
 type storageNetworksType = {
+  @description('Optional. The name of the storage network.')
+  name: string?
+
   @description('Required. The name of the storage adapter.')
   adapterName: string
 
@@ -467,7 +470,7 @@ type deploymentSettingsType = {
   dnsServers: string[]
 
   @description('Required. An array of Network ATC Network Intent objects that define the Compute, Management, and Storage network configuration for the cluster.')
-  networkIntents: array
+  networkIntents: networkIntentType[]
 
   @description('Required. Specify whether the Storage Network connectivity is switched or switchless.')
   storageConnectivitySwitchless: bool
@@ -476,7 +479,7 @@ type deploymentSettingsType = {
   enableStorageAutoIp: bool?
 
   @description('Required. An array of JSON objects that define the storage network configuration for the cluster. Each object should contain the adapterName, VLAN properties, and (optionally) IP configurations.')
-  storageNetworks: array
+  storageNetworks: storageNetworksType[]
 
   // other cluster configuration parameters
   @description('Required. The name of the Custom Location associated with the Arc Resource Bridge for this cluster. This value should reflect the physical location and identifier of the HCI cluster. Example: cl-hci-den-clu01.')

--- a/avm/res/azure-stack-hci/cluster/main.json
+++ b/avm/res/azure-stack-hci/cluster/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "3963124488380176930"
+      "templateHash": "16430185328734041481"
     },
     "name": "Azure Stack HCI Cluster",
     "description": "This module deploys an Azure Stack HCI Cluster on the provided Arc Machines."
@@ -182,6 +182,13 @@
     "storageNetworksType": {
       "type": "object",
       "properties": {
+        "name": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The name of the storage network."
+          }
+        },
         "adapterName": {
           "type": "string",
           "metadata": {
@@ -444,6 +451,9 @@
         },
         "networkIntents": {
           "type": "array",
+          "items": {
+            "$ref": "#/definitions/networkIntentType"
+          },
           "metadata": {
             "description": "Required. An array of Network ATC Network Intent objects that define the Compute, Management, and Storage network configuration for the cluster."
           }
@@ -463,6 +473,9 @@
         },
         "storageNetworks": {
           "type": "array",
+          "items": {
+            "$ref": "#/definitions/storageNetworksType"
+          },
           "metadata": {
             "description": "Required. An array of JSON objects that define the storage network configuration for the cluster. Each object should contain the adapterName, VLAN properties, and (optionally) IP configurations."
           }
@@ -1279,7 +1292,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "9536857013030923630"
+              "templateHash": "8375880528238701715"
             },
             "name": "Azure Stack HCI Cluster Deployment Settings",
             "description": "This module deploys an Azure Stack HCI Cluster Deployment Settings resource."
@@ -1621,7 +1634,7 @@
                               "name": "storageNetworks",
                               "count": "[length(parameters('storageNetworks'))]",
                               "input": {
-                                "name": "[format('StorageNetwork{0}', add(copyIndex('storageNetworks'), 1))]",
+                                "name": "[coalesce(parameters('storageNetworks')[copyIndex('storageNetworks')].name, format('StorageNetwork{0}', add(copyIndex('storageNetworks'), 1)))]",
                                 "networkAdapterName": "[parameters('storageNetworks')[copyIndex('storageNetworks')].adapterName]",
                                 "vlanId": "[parameters('storageNetworks')[copyIndex('storageNetworks')].vlan]",
                                 "storageAdapterIPInfo": "[tryGet(parameters('storageNetworks')[copyIndex('storageNetworks')], 'storageAdapterIPInfo')]"


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
