### PR TITLE
feat: NAT-GW - Updated to latest common types & zonal spec

### DIFF
--- a/avm/res/network/nat-gateway/README.md
+++ b/avm/res/network/nat-gateway/README.md
@@ -52,8 +52,6 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
     // Required parameters
     name: 'nngmin001'
     zone: 1
-    // Non-required parameters
-    location: '<location>'
   }
 }
 ```
@@ -76,10 +74,6 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
     },
     "zone": {
       "value": 1
-    },
-    // Non-required parameters
-    "location": {
-      "value": "<location>"
     }
   }
 }
@@ -98,8 +92,6 @@ using 'br/public:avm/res/network/nat-gateway:<version>'
 // Required parameters
 param name = 'nngmin001'
 param zone = 1
-// Non-required parameters
-param location = '<location>'
 ```
 
 </details>
@@ -120,9 +112,8 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
   params: {
     // Required parameters
     name: 'nngepip001'
-    zone: 1
+    zone: -1
     // Non-required parameters
-    location: '<location>'
     publicIpResourceIds: '<publicIpResourceIds>'
   }
 }
@@ -145,12 +136,9 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
       "value": "nngepip001"
     },
     "zone": {
-      "value": 1
+      "value": -1
     },
     // Non-required parameters
-    "location": {
-      "value": "<location>"
-    },
     "publicIpResourceIds": {
       "value": "<publicIpResourceIds>"
     }
@@ -170,9 +158,8 @@ using 'br/public:avm/res/network/nat-gateway:<version>'
 
 // Required parameters
 param name = 'nngepip001'
-param zone = 1
+param zone = -1
 // Non-required parameters
-param location = '<location>'
 param publicIpResourceIds = '<publicIpResourceIds>'
 ```
 
@@ -481,9 +468,8 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
   params: {
     // Required parameters
     name: 'nngcprx001'
-    zone: 0
+    zone: -1
     // Non-required parameters
-    location: '<location>'
     publicIPPrefixObjects: [
       {
         name: 'nngcprx001-pippre'
@@ -514,12 +500,9 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
       "value": "nngcprx001"
     },
     "zone": {
-      "value": 0
+      "value": -1
     },
     // Non-required parameters
-    "location": {
-      "value": "<location>"
-    },
     "publicIPPrefixObjects": {
       "value": [
         {
@@ -547,9 +530,8 @@ using 'br/public:avm/res/network/nat-gateway:<version>'
 
 // Required parameters
 param name = 'nngcprx001'
-param zone = 0
+param zone = -1
 // Non-required parameters
-param location = '<location>'
 param publicIPPrefixObjects = [
   {
     name: 'nngcprx001-pippre'
@@ -581,11 +563,6 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
     name: 'nngwaf001'
     zone: 1
     // Non-required parameters
-    location: '<location>'
-    lock: {
-      kind: 'CanNotDelete'
-      name: 'myCustomLockName'
-    }
     publicIPAddressObjects: [
       {
         diagnosticSettings: [
@@ -640,15 +617,6 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
       "value": 1
     },
     // Non-required parameters
-    "location": {
-      "value": "<location>"
-    },
-    "lock": {
-      "value": {
-        "kind": "CanNotDelete",
-        "name": "myCustomLockName"
-      }
-    },
     "publicIPAddressObjects": {
       "value": [
         {
@@ -701,11 +669,6 @@ using 'br/public:avm/res/network/nat-gateway:<version>'
 param name = 'nngwaf001'
 param zone = 1
 // Non-required parameters
-param location = '<location>'
-param lock = {
-  kind: 'CanNotDelete'
-  name: 'myCustomLockName'
-}
 param publicIPAddressObjects = [
   {
     diagnosticSettings: [
@@ -748,7 +711,6 @@ param tags = {
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-name) | string | Name of the Azure Bastion resource. |
-| [`zone`](#parameter-zone) | int | A list of availability zones denoting the zone in which Nat Gateway should be deployed. |
 
 **Optional parameters**
 
@@ -764,6 +726,7 @@ param tags = {
 | [`publicIpResourceIds`](#parameter-publicipresourceids) | array | Existing Public IP Address resource IDs to use for the NAT Gateway. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Tags for the resource. |
+| [`zone`](#parameter-zone) | int | If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones). |
 
 ### Parameter: `name`
 
@@ -771,22 +734,6 @@ Name of the Azure Bastion resource.
 
 - Required: Yes
 - Type: string
-
-### Parameter: `zone`
-
-A list of availability zones denoting the zone in which Nat Gateway should be deployed.
-
-- Required: Yes
-- Type: int
-- Allowed:
-  ```Bicep
-  [
-    0
-    1
-    2
-    3
-  ]
-  ```
 
 ### Parameter: `enableTelemetry`
 
@@ -989,6 +936,22 @@ Tags for the resource.
 - Required: No
 - Type: object
 
+### Parameter: `zone`
+
+If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).
+
+- Required: Yes
+- Type: int
+- Allowed:
+  ```Bicep
+  [
+    -1
+    1
+    2
+    3
+  ]
+  ```
+
 ## Outputs
 
 | Output | Type | Description |
@@ -1006,6 +969,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 | :-- | :-- |
 | `br/public:avm/res/network/public-ip-address:0.5.1` | Remote reference |
 | `br/public:avm/res/network/public-ip-prefix:0.4.1` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.5.1` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/network/nat-gateway/README.md
+++ b/avm/res/network/nat-gateway/README.md
@@ -711,6 +711,7 @@ param tags = {
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`name`](#parameter-name) | string | Name of the Azure Bastion resource. |
+| [`zone`](#parameter-zone) | int | If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones). |
 
 **Optional parameters**
 
@@ -726,7 +727,6 @@ param tags = {
 | [`publicIpResourceIds`](#parameter-publicipresourceids) | array | Existing Public IP Address resource IDs to use for the NAT Gateway. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Tags for the resource. |
-| [`zone`](#parameter-zone) | int | If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones). |
 
 ### Parameter: `name`
 
@@ -734,6 +734,22 @@ Name of the Azure Bastion resource.
 
 - Required: Yes
 - Type: string
+
+### Parameter: `zone`
+
+If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).
+
+- Required: Yes
+- Type: int
+- Allowed:
+  ```Bicep
+  [
+    -1
+    1
+    2
+    3
+  ]
+  ```
 
 ### Parameter: `enableTelemetry`
 
@@ -935,22 +951,6 @@ Tags for the resource.
 
 - Required: No
 - Type: object
-
-### Parameter: `zone`
-
-If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).
-
-- Required: Yes
-- Type: int
-- Allowed:
-  ```Bicep
-  [
-    -1
-    1
-    2
-    3
-  ]
-  ```
 
 ## Outputs
 

--- a/avm/res/network/nat-gateway/README.md
+++ b/avm/res/network/nat-gateway/README.md
@@ -710,7 +710,7 @@ param tags = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`availabilityZone`](#parameter-availabilityzone) | int | If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones). |
+| [`availabilityZone`](#parameter-availabilityzone) | int | If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones). |
 | [`name`](#parameter-name) | string | Name of the Azure Bastion resource. |
 
 **Optional parameters**
@@ -730,7 +730,7 @@ param tags = {
 
 ### Parameter: `availabilityZone`
 
-If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).
+If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones).
 
 - Required: Yes
 - Type: int

--- a/avm/res/network/nat-gateway/README.md
+++ b/avm/res/network/nat-gateway/README.md
@@ -50,8 +50,8 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
   name: 'natGatewayDeployment'
   params: {
     // Required parameters
+    availabilityZone: 1
     name: 'nngmin001'
-    zone: 1
   }
 }
 ```
@@ -69,11 +69,11 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "availabilityZone": {
+      "value": 1
+    },
     "name": {
       "value": "nngmin001"
-    },
-    "zone": {
-      "value": 1
     }
   }
 }
@@ -90,8 +90,8 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
 using 'br/public:avm/res/network/nat-gateway:<version>'
 
 // Required parameters
+param availabilityZone = 1
 param name = 'nngmin001'
-param zone = 1
 ```
 
 </details>
@@ -111,8 +111,8 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
   name: 'natGatewayDeployment'
   params: {
     // Required parameters
+    availabilityZone: -1
     name: 'nngepip001'
-    zone: -1
     // Non-required parameters
     publicIpResourceIds: '<publicIpResourceIds>'
   }
@@ -132,11 +132,11 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "availabilityZone": {
+      "value": -1
+    },
     "name": {
       "value": "nngepip001"
-    },
-    "zone": {
-      "value": -1
     },
     // Non-required parameters
     "publicIpResourceIds": {
@@ -157,8 +157,8 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
 using 'br/public:avm/res/network/nat-gateway:<version>'
 
 // Required parameters
+param availabilityZone = -1
 param name = 'nngepip001'
-param zone = -1
 // Non-required parameters
 param publicIpResourceIds = '<publicIpResourceIds>'
 ```
@@ -180,8 +180,8 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
   name: 'natGatewayDeployment'
   params: {
     // Required parameters
+    availabilityZone: 1
     name: 'nngmax001'
-    zone: 1
     // Non-required parameters
     location: '<location>'
     lock: {
@@ -271,11 +271,11 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "availabilityZone": {
+      "value": 1
+    },
     "name": {
       "value": "nngmax001"
-    },
-    "zone": {
-      "value": 1
     },
     // Non-required parameters
     "location": {
@@ -374,8 +374,8 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
 using 'br/public:avm/res/network/nat-gateway:<version>'
 
 // Required parameters
+param availabilityZone = 1
 param name = 'nngmax001'
-param zone = 1
 // Non-required parameters
 param location = '<location>'
 param lock = {
@@ -467,8 +467,8 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
   name: 'natGatewayDeployment'
   params: {
     // Required parameters
+    availabilityZone: -1
     name: 'nngcprx001'
-    zone: -1
     // Non-required parameters
     publicIPPrefixObjects: [
       {
@@ -496,11 +496,11 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "availabilityZone": {
+      "value": -1
+    },
     "name": {
       "value": "nngcprx001"
-    },
-    "zone": {
-      "value": -1
     },
     // Non-required parameters
     "publicIPPrefixObjects": {
@@ -529,8 +529,8 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
 using 'br/public:avm/res/network/nat-gateway:<version>'
 
 // Required parameters
+param availabilityZone = -1
 param name = 'nngcprx001'
-param zone = -1
 // Non-required parameters
 param publicIPPrefixObjects = [
   {
@@ -560,8 +560,8 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
   name: 'natGatewayDeployment'
   params: {
     // Required parameters
+    availabilityZone: 1
     name: 'nngwaf001'
-    zone: 1
     // Non-required parameters
     publicIPAddressObjects: [
       {
@@ -610,11 +610,11 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "availabilityZone": {
+      "value": 1
+    },
     "name": {
       "value": "nngwaf001"
-    },
-    "zone": {
-      "value": 1
     },
     // Non-required parameters
     "publicIPAddressObjects": {
@@ -666,8 +666,8 @@ module natGateway 'br/public:avm/res/network/nat-gateway:<version>' = {
 using 'br/public:avm/res/network/nat-gateway:<version>'
 
 // Required parameters
+param availabilityZone = 1
 param name = 'nngwaf001'
-param zone = 1
 // Non-required parameters
 param publicIPAddressObjects = [
   {
@@ -710,8 +710,8 @@ param tags = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`availabilityZone`](#parameter-availabilityzone) | int | If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones). |
 | [`name`](#parameter-name) | string | Name of the Azure Bastion resource. |
-| [`zone`](#parameter-zone) | int | If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones). |
 
 **Optional parameters**
 
@@ -728,16 +728,9 @@ param tags = {
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Tags for the resource. |
 
-### Parameter: `name`
+### Parameter: `availabilityZone`
 
-Name of the Azure Bastion resource.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `zone`
-
-If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).
+If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).
 
 - Required: Yes
 - Type: int
@@ -750,6 +743,13 @@ If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to
     3
   ]
   ```
+
+### Parameter: `name`
+
+Name of the Azure Bastion resource.
+
+- Required: Yes
+- Type: string
 
 ### Parameter: `enableTelemetry`
 

--- a/avm/res/network/nat-gateway/main.bicep
+++ b/avm/res/network/nat-gateway/main.bicep
@@ -4,7 +4,7 @@ metadata description = 'This module deploys a NAT Gateway.'
 @description('Required. Name of the Azure Bastion resource.')
 param name string
 
-@description('Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).')
+@description('Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).')
 @allowed([
   -1
   1

--- a/avm/res/network/nat-gateway/main.bicep
+++ b/avm/res/network/nat-gateway/main.bicep
@@ -4,9 +4,9 @@ metadata description = 'This module deploys a NAT Gateway.'
 @description('Required. Name of the Azure Bastion resource.')
 param name string
 
-@description('Required. A list of availability zones denoting the zone in which Nat Gateway should be deployed.')
+@description('Optional. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).')
 @allowed([
-  0
+  -1
   1
   2
   3
@@ -31,11 +31,13 @@ param publicIPPrefixObjects array?
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
 @description('Optional. The lock settings of the service.')
-param lock lockType
+param lock lockType?
 
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
 @description('Optional. Array of role assignments to create.')
-param roleAssignments roleAssignmentType
+param roleAssignments roleAssignmentType[]?
 
 @description('Optional. Tags for the resource.')
 param tags object?
@@ -111,7 +113,7 @@ module publicIPAddresses 'br/public:avm/res/network/public-ip-address:0.5.1' = [
       skuName: 'Standard' // Must be standard
       skuTier: publicIPAddressObject.?skuTier
       tags: publicIPAddressObject.?tags ?? tags
-      zones: publicIPAddressObject.?zones ?? (zone != 0 ? [zone] : null)
+      zones: publicIPAddressObject.?zones ?? (zone != -1 ? [zone] : null)
       enableTelemetry: enableReferencedModulesTelemetry
       ddosSettings: publicIPAddressObject.?ddosSettings
       dnsSettings: publicIPAddressObject.?dnsSettings
@@ -169,7 +171,7 @@ resource natGateway 'Microsoft.Network/natGateways@2023-04-01' = {
     publicIpPrefixes: formattedPublicIpPrefixResourceIds.outputs.formattedResourceIds
     publicIpAddresses: formattedPublicIpResourceIds.outputs.formattedResourceIds
   }
-  zones: zone != 0 ? [string(zone)] : null
+  zones: zone != -1 ? [string(zone)] : null
 }
 
 resource natGateway_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(lock ?? {}) && lock.?kind != 'None') {
@@ -210,41 +212,3 @@ output resourceGroupName string = resourceGroup().name
 
 @description('The location the resource was deployed into.')
 output location string = natGateway.location
-
-// =============== //
-//   Definitions   //
-// =============== //
-
-type lockType = {
-  @description('Optional. Specify the name of lock.')
-  name: string?
-
-  @description('Optional. Specify the type of lock.')
-  kind: ('CanNotDelete' | 'ReadOnly' | 'None')?
-}?
-
-type roleAssignmentType = {
-  @description('Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated.')
-  name: string?
-
-  @description('Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: \'/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11\'.')
-  roleDefinitionIdOrName: string
-
-  @description('Required. The principal ID of the principal (user/group/identity) to assign the role to.')
-  principalId: string
-
-  @description('Optional. The principal type of the assigned principal ID.')
-  principalType: ('ServicePrincipal' | 'Group' | 'User' | 'ForeignGroup' | 'Device')?
-
-  @description('Optional. The description of the role assignment.')
-  description: string?
-
-  @description('Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase "foo_storage_container".')
-  condition: string?
-
-  @description('Optional. Version of the condition.')
-  conditionVersion: '2.0'?
-
-  @description('Optional. The Resource Id of the delegated managed identity resource.')
-  delegatedManagedIdentityResourceId: string?
-}[]?

--- a/avm/res/network/nat-gateway/main.bicep
+++ b/avm/res/network/nat-gateway/main.bicep
@@ -4,7 +4,7 @@ metadata description = 'This module deploys a NAT Gateway.'
 @description('Required. Name of the Azure Bastion resource.')
 param name string
 
-@description('Optional. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).')
+@description('Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).')
 @allowed([
   -1
   1

--- a/avm/res/network/nat-gateway/main.bicep
+++ b/avm/res/network/nat-gateway/main.bicep
@@ -4,7 +4,7 @@ metadata description = 'This module deploys a NAT Gateway.'
 @description('Required. Name of the Azure Bastion resource.')
 param name string
 
-@description('Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).')
+@description('Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones).')
 @allowed([
   -1
   1

--- a/avm/res/network/nat-gateway/main.bicep
+++ b/avm/res/network/nat-gateway/main.bicep
@@ -11,7 +11,7 @@ param name string
   2
   3
 ])
-param zone int
+param availabilityZone int
 
 @description('Optional. The idle timeout of the NAT gateway.')
 param idleTimeoutInMinutes int = 5
@@ -113,7 +113,7 @@ module publicIPAddresses 'br/public:avm/res/network/public-ip-address:0.5.1' = [
       skuName: 'Standard' // Must be standard
       skuTier: publicIPAddressObject.?skuTier
       tags: publicIPAddressObject.?tags ?? tags
-      zones: publicIPAddressObject.?zones ?? (zone != -1 ? [zone] : null)
+      zones: publicIPAddressObject.?zones ?? (availabilityZone != -1 ? [availabilityZone] : null)
       enableTelemetry: enableReferencedModulesTelemetry
       ddosSettings: publicIPAddressObject.?ddosSettings
       dnsSettings: publicIPAddressObject.?dnsSettings
@@ -171,7 +171,7 @@ resource natGateway 'Microsoft.Network/natGateways@2023-04-01' = {
     publicIpPrefixes: formattedPublicIpPrefixResourceIds.outputs.formattedResourceIds
     publicIpAddresses: formattedPublicIpResourceIds.outputs.formattedResourceIds
   }
-  zones: zone != -1 ? [string(zone)] : null
+  zones: availabilityZone != -1 ? [string(availabilityZone)] : null
 }
 
 resource natGateway_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(lock ?? {}) && lock.?kind != 'None') {

--- a/avm/res/network/nat-gateway/main.json
+++ b/avm/res/network/nat-gateway/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "7390004441200914002"
+      "version": "0.34.44.8038",
+      "templateHash": "17580187960155953991"
     },
     "name": "NAT Gateways",
     "description": "This module deploys a NAT Gateway."
@@ -125,7 +125,7 @@
         "description": "Required. Name of the Azure Bastion resource."
       }
     },
-    "zone": {
+    "availabilityZone": {
       "type": "int",
       "allowedValues": [
         -1,
@@ -134,7 +134,7 @@
         3
       ],
       "metadata": {
-        "description": "Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones)."
+        "description": "Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones)."
       }
     },
     "idleTimeoutInMinutes": {
@@ -264,7 +264,7 @@
         "publicIpPrefixes": "[reference('formattedPublicIpPrefixResourceIds').outputs.formattedResourceIds.value]",
         "publicIpAddresses": "[reference('formattedPublicIpResourceIds').outputs.formattedResourceIds.value]"
       },
-      "zones": "[if(not(equals(parameters('zone'), -1)), createArray(string(parameters('zone'))), null())]",
+      "zones": "[if(not(equals(parameters('availabilityZone'), -1)), createArray(string(parameters('availabilityZone'))), null())]",
       "dependsOn": [
         "formattedPublicIpPrefixResourceIds",
         "formattedPublicIpResourceIds"
@@ -354,7 +354,7 @@
             "value": "[coalesce(tryGet(coalesce(parameters('publicIPAddressObjects'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
           },
           "zones": {
-            "value": "[coalesce(tryGet(coalesce(parameters('publicIPAddressObjects'), createArray())[copyIndex()], 'zones'), if(not(equals(parameters('zone'), -1)), createArray(parameters('zone')), null()))]"
+            "value": "[coalesce(tryGet(coalesce(parameters('publicIPAddressObjects'), createArray())[copyIndex()], 'zones'), if(not(equals(parameters('availabilityZone'), -1)), createArray(parameters('availabilityZone')), null()))]"
           },
           "enableTelemetry": {
             "value": "[variables('enableReferencedModulesTelemetry')]"
@@ -1018,8 +1018,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "235355553896786544"
+              "version": "0.34.44.8038",
+              "templateHash": "17170161255739585601"
             }
           },
           "parameters": {
@@ -1432,8 +1432,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "235355553896786544"
+              "version": "0.34.44.8038",
+              "templateHash": "17170161255739585601"
             }
           },
           "parameters": {

--- a/avm/res/network/nat-gateway/main.json
+++ b/avm/res/network/nat-gateway/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.13.18514",
-      "templateHash": "1746994181896269234"
+      "templateHash": "7390004441200914002"
     },
     "name": "NAT Gateways",
     "description": "This module deploys a NAT Gateway."
@@ -134,7 +134,7 @@
         3
       ],
       "metadata": {
-        "description": "Optional. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones)."
+        "description": "Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones)."
       }
     },
     "idleTimeoutInMinutes": {

--- a/avm/res/network/nat-gateway/main.json
+++ b/avm/res/network/nat-gateway/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "1228674487075439131"
+      "version": "0.33.13.18514",
+      "templateHash": "1746994181896269234"
     },
     "name": "NAT Gateways",
     "description": "This module deploys a NAT Gateway."
@@ -35,80 +35,87 @@
           }
         }
       },
-      "nullable": true
+      "metadata": {
+        "description": "An AVM-aligned type for a lock.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+        }
+      }
     },
     "roleAssignmentType": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
-            }
-          },
-          "roleDefinitionIdOrName": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-            }
-          },
-          "principalId": {
-            "type": "string",
-            "metadata": {
-              "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-            }
-          },
-          "principalType": {
-            "type": "string",
-            "allowedValues": [
-              "Device",
-              "ForeignGroup",
-              "Group",
-              "ServicePrincipal",
-              "User"
-            ],
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The principal type of the assigned principal ID."
-            }
-          },
-          "description": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The description of the role assignment."
-            }
-          },
-          "condition": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-            }
-          },
-          "conditionVersion": {
-            "type": "string",
-            "allowedValues": [
-              "2.0"
-            ],
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. Version of the condition."
-            }
-          },
-          "delegatedManagedIdentityResourceId": {
-            "type": "string",
-            "nullable": true,
-            "metadata": {
-              "description": "Optional. The Resource Id of the delegated managed identity resource."
-            }
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+          }
+        },
+        "roleDefinitionIdOrName": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+          }
+        },
+        "principalId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+          }
+        },
+        "principalType": {
+          "type": "string",
+          "allowedValues": [
+            "Device",
+            "ForeignGroup",
+            "Group",
+            "ServicePrincipal",
+            "User"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The principal type of the assigned principal ID."
+          }
+        },
+        "description": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The description of the role assignment."
+          }
+        },
+        "condition": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+          }
+        },
+        "conditionVersion": {
+          "type": "string",
+          "allowedValues": [
+            "2.0"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Version of the condition."
+          }
+        },
+        "delegatedManagedIdentityResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The Resource Id of the delegated managed identity resource."
           }
         }
       },
-      "nullable": true
+      "metadata": {
+        "description": "An AVM-aligned type for a role assignment.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+        }
+      }
     }
   },
   "parameters": {
@@ -121,13 +128,13 @@
     "zone": {
       "type": "int",
       "allowedValues": [
-        0,
+        -1,
         1,
         2,
         3
       ],
       "metadata": {
-        "description": "Required. A list of availability zones denoting the zone in which Nat Gateway should be deployed."
+        "description": "Optional. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones)."
       }
     },
     "idleTimeoutInMinutes": {
@@ -174,12 +181,17 @@
     },
     "lock": {
       "$ref": "#/definitions/lockType",
+      "nullable": true,
       "metadata": {
         "description": "Optional. The lock settings of the service."
       }
     },
     "roleAssignments": {
-      "$ref": "#/definitions/roleAssignmentType",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/roleAssignmentType"
+      },
+      "nullable": true,
       "metadata": {
         "description": "Optional. Array of role assignments to create."
       }
@@ -252,7 +264,7 @@
         "publicIpPrefixes": "[reference('formattedPublicIpPrefixResourceIds').outputs.formattedResourceIds.value]",
         "publicIpAddresses": "[reference('formattedPublicIpResourceIds').outputs.formattedResourceIds.value]"
       },
-      "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]",
+      "zones": "[if(not(equals(parameters('zone'), -1)), createArray(string(parameters('zone'))), null())]",
       "dependsOn": [
         "formattedPublicIpPrefixResourceIds",
         "formattedPublicIpResourceIds"
@@ -342,7 +354,7 @@
             "value": "[coalesce(tryGet(coalesce(parameters('publicIPAddressObjects'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
           },
           "zones": {
-            "value": "[coalesce(tryGet(coalesce(parameters('publicIPAddressObjects'), createArray())[copyIndex()], 'zones'), if(not(equals(parameters('zone'), 0)), createArray(parameters('zone')), null()))]"
+            "value": "[coalesce(tryGet(coalesce(parameters('publicIPAddressObjects'), createArray())[copyIndex()], 'zones'), if(not(equals(parameters('zone'), -1)), createArray(parameters('zone')), null()))]"
           },
           "enableTelemetry": {
             "value": "[variables('enableReferencedModulesTelemetry')]"
@@ -1006,8 +1018,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "15600590522677918373"
+              "version": "0.33.13.18514",
+              "templateHash": "235355553896786544"
             }
           },
           "parameters": {
@@ -1420,8 +1432,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "15600590522677918373"
+              "version": "0.33.13.18514",
+              "templateHash": "235355553896786544"
             }
           },
           "parameters": {

--- a/avm/res/network/nat-gateway/main.json
+++ b/avm/res/network/nat-gateway/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "17580187960155953991"
+      "templateHash": "7426304486166209801"
     },
     "name": "NAT Gateways",
     "description": "This module deploys a NAT Gateway."
@@ -134,7 +134,7 @@
         3
       ],
       "metadata": {
-        "description": "Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones)."
+        "description": "Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones)."
       }
     },
     "idleTimeoutInMinutes": {

--- a/avm/res/network/nat-gateway/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/network/nat-gateway/tests/e2e/defaults/main.test.bicep
@@ -9,14 +9,12 @@ metadata description = 'This instance deploys the module with the minimum set of
 
 @description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
-// e.g., for a module 'network/private-endpoint' you could use 'dep-dev-network.privateendpoints-${serviceShort}-rg'
 param resourceGroupName string = 'dep-${namePrefix}-network.natgateway-${serviceShort}-rg'
 
 @description('Optional. The location to deploy resources to.')
 param resourceLocation string = deployment().location
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
-// e.g., for a module 'network/private-endpoint' you could use 'npe' as a prefix and then 'waf' as a suffix for the waf-aligned test
 param serviceShort string = 'nngmin'
 
 @description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
@@ -43,8 +41,6 @@ module testDeployment '../../../main.bicep' = [
     scope: resourceGroup
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
-      // You parameters go here
-      location: resourceLocation
       name: '${namePrefix}${serviceShort}001'
       zone: 1
     }

--- a/avm/res/network/nat-gateway/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/network/nat-gateway/tests/e2e/defaults/main.test.bicep
@@ -42,7 +42,7 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      zone: 1
+      availabilityZone: 1
     }
   }
 ]

--- a/avm/res/network/nat-gateway/tests/e2e/existingPip/main.test.bicep
+++ b/avm/res/network/nat-gateway/tests/e2e/existingPip/main.test.bicep
@@ -37,10 +37,8 @@ module nestedDependencies 'dependencies.bicep' = {
   params: {
     location: resourceLocation
     existingPipName: '${namePrefix}${serviceShort}001-existingpip1'
-    
   }
 }
-
 
 // ============== //
 // Test Execution //
@@ -52,9 +50,8 @@ module testDeployment '../../../main.bicep' = [
     scope: resourceGroup
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
-      location: resourceLocation
       name: '${namePrefix}${serviceShort}001'
-      zone: 1
+      zone: -1
       publicIpResourceIds: [nestedDependencies.outputs.existingPipResourceId]
     }
   }

--- a/avm/res/network/nat-gateway/tests/e2e/existingPip/main.test.bicep
+++ b/avm/res/network/nat-gateway/tests/e2e/existingPip/main.test.bicep
@@ -51,7 +51,7 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      zone: -1
+      availabilityZone: -1
       publicIpResourceIds: [nestedDependencies.outputs.existingPipResourceId]
     }
   }

--- a/avm/res/network/nat-gateway/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/nat-gateway/tests/e2e/max/main.test.bicep
@@ -66,7 +66,7 @@ module testDeployment '../../../main.bicep' = [
     params: {
       location: resourceLocation
       name: '${namePrefix}${serviceShort}001'
-      zone: 1
+      availabilityZone: 1
       lock: {
         kind: 'CanNotDelete'
         name: 'myCustomLockName'

--- a/avm/res/network/nat-gateway/tests/e2e/prefixCombined/main.test.bicep
+++ b/avm/res/network/nat-gateway/tests/e2e/prefixCombined/main.test.bicep
@@ -41,9 +41,8 @@ module testDeployment '../../../main.bicep' = [
     scope: resourceGroup
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
-      location: resourceLocation
       name: '${namePrefix}${serviceShort}001'
-      zone: 0
+      zone: -1
       publicIPPrefixObjects: [
         {
           name: '${namePrefix}${serviceShort}001-pippre'

--- a/avm/res/network/nat-gateway/tests/e2e/prefixCombined/main.test.bicep
+++ b/avm/res/network/nat-gateway/tests/e2e/prefixCombined/main.test.bicep
@@ -42,7 +42,7 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      zone: -1
+      availabilityZone: -1
       publicIPPrefixObjects: [
         {
           name: '${namePrefix}${serviceShort}001-pippre'

--- a/avm/res/network/nat-gateway/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/nat-gateway/tests/e2e/waf-aligned/main.test.bicep
@@ -56,7 +56,7 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      zone: 1
+      availabilityZone: 1
       publicIPAddressObjects: [
         {
           name: '${namePrefix}${serviceShort}001-pip'

--- a/avm/res/network/nat-gateway/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/nat-gateway/tests/e2e/waf-aligned/main.test.bicep
@@ -55,13 +55,8 @@ module testDeployment '../../../main.bicep' = [
     scope: resourceGroup
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
-      location: resourceLocation
       name: '${namePrefix}${serviceShort}001'
       zone: 1
-      lock: {
-        kind: 'CanNotDelete'
-        name: 'myCustomLockName'
-      }
       publicIPAddressObjects: [
         {
           name: '${namePrefix}${serviceShort}001-pip'

--- a/avm/res/network/nat-gateway/tests/unit/avm.core.team.tests.ps1
+++ b/avm/res/network/nat-gateway/tests/unit/avm.core.team.tests.ps1
@@ -6,10 +6,10 @@ If you wish to add your own Pester tests for you module create a new <something>
 #>
 
 param (
-    [Parameter(Mandatory = $false)]
+    [Parameter(Mandatory = $true)]
     [array] $moduleFolderPaths,
 
-    [Parameter(Mandatory = $false)]
+    [Parameter(Mandatory = $true)]
     [string] $repoRootPath
 )
 

--- a/avm/res/network/nat-gateway/tests/unit/avm.core.team.tests.ps1
+++ b/avm/res/network/nat-gateway/tests/unit/avm.core.team.tests.ps1
@@ -30,7 +30,7 @@ Describe 'AVM Core Team Module Specific Tests' {
     Context 'WAF - Reliability Pillar - Parameter Tests' {
 
         It 'NAT Gateway Module Availability Zone Parameter Should Not Have A Default Value Set' {
-            $isRequired = Get-IsParameterRequired -TemplateFileContent $moduleJsonContentHashtable -Parameter $moduleJsonContentHashtable.parameters.zone
+            $isRequired = Get-IsParameterRequired -TemplateFileContent $moduleJsonContentHashtable -Parameter $moduleJsonContentHashtable.parameters.availabilityZone
             $isRequired | Should -Be $true
         }
 

--- a/avm/res/network/nat-gateway/version.json
+++ b/avm/res/network/nat-gateway/version.json
@@ -1,7 +1,7 @@
 {
-    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "1.2",
-    "pathFilters": [
-        "./main.json"
-    ]
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "1.3",
+  "pathFilters": [
+    "./main.json"
+  ]
 }

--- a/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
+++ b/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
@@ -151,9 +151,9 @@ function Set-PesterGitHubOutput {
                 $testFile = $failedTest.ScriptBlock.File -replace ('{0}[\\|\/]*' -f [regex]::Escape($RepoRootPath))
             }
 
-            if ($failedTest.ErrorRecord) {
+            if (-not [String]::IsNullOrEmpty($failedTest.ErrorRecord)) {
                 $testLine = $failedTest.ErrorRecord.TargetObject.Line
-                $errorMessage = ($failedTest.ErrorRecord.TargetObject.Message.Trim() -replace '_', '\_') -replace '\n', '<br>' # Replace new lines with <br> to enable line breaks in markdown
+                $errorMessage = (($failedTest.ErrorRecord.TargetObject.Message ?? '').Trim() -replace '_', '\_') -replace '\n', '<br>' # Replace new lines with <br> to enable line breaks in markdown
 
                 $testReference = '{0}:{1}' -f (Split-Path $testFile -Leaf), $testLine
 

--- a/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
+++ b/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
@@ -151,8 +151,8 @@ function Set-PesterGitHubOutput {
                 $testFile = $failedTest.ScriptBlock.File -replace ('{0}[\\|\/]*' -f [regex]::Escape($RepoRootPath))
             }
 
-            if (-not [String]::IsNullOrEmpty($failedTest.ErrorRecord)) {
-                $testLine = $failedTest.ErrorRecord.TargetObject.Line
+            $testLine = $failedTest.ErrorRecord.TargetObject.Line
+            if (-not [String]::IsNullOrEmpty($testLine)) {
                 $errorMessage = (($failedTest.ErrorRecord.TargetObject.Message ?? '').Trim() -replace '_', '\_') -replace '\n', '<br>' # Replace new lines with <br> to enable line breaks in markdown
 
                 $testReference = '{0}:{1}' -f (Split-Path $testFile -Leaf), $testLine


### PR DESCRIPTION
## Description

- Updated to latest AVM common types
- Updated to latest zonal spec
- Added error handling for Pester output IF it throws an exception instead of failing 

<details><summary>Example run of workflow failing with exception</summary>

  ![image](https://github.com/user-attachments/assets/7c47a5a4-fb35-4a6d-86cc-2056ed4c5faa)

[ref](https://github.com/Azure/bicep-registry-modules/actions/runs/14179285769)
</details>

<details><summary>Example run of workflow failing with 'normal' error</summary>

![image](https://github.com/user-attachments/assets/a38f9ed7-2ba2-4ca4-ae7e-89ed9a4414e8)

[ref](https://github.com/Azure/bicep-registry-modules/actions/runs/14179498729)
</details>

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.network.nat-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml/badge.svg?branch=users%2Falsehr%2Fnatgw_udt&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
