### PR TITLE
fix: Change parameter from iscontentTypeToCompressAll to isCompressionEnabled Issue #4734

### DIFF
--- a/avm/res/cdn/profile/README.md
+++ b/avm/res/cdn/profile/README.md
@@ -1670,7 +1670,7 @@ Compression settings.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`iscontentTypeToCompressAll`](#parameter-afdendpointsroutescacheconfigurationcompressionsettingsiscontenttypetocompressall) | bool | Indicates whether content compression is enabled on AzureFrontDoor. Default value is false. If compression is enabled, content will be served as compressed if user requests for a compressed version. Content won't be compressed on AzureFrontDoor when requested content is smaller than 1 byte or larger than 1 MB. |
+| [`isCompressionEnabled`](#parameter-afdendpointsroutescacheconfigurationcompressionsettings) | bool | Indicates whether content compression is enabled on AzureFrontDoor. Default value is false. If compression is enabled, content will be served as compressed if user requests for a compressed version. Content won't be compressed on AzureFrontDoor when requested content is smaller than 1 byte or larger than 1 MB. |
 
 ### Parameter: `afdEndpoints.routes.cacheConfiguration.compressionSettings.contentTypesToCompress`
 
@@ -1679,7 +1679,7 @@ List of content types on which compression applies. The value should be a valid 
 - Required: Yes
 - Type: array
 
-### Parameter: `afdEndpoints.routes.cacheConfiguration.compressionSettings.iscontentTypeToCompressAll`
+### Parameter: `afdEndpoints.routes.cacheConfiguration.compressionSettings.isCompressionEnabled`
 
 Indicates whether content compression is enabled on AzureFrontDoor. Default value is false. If compression is enabled, content will be served as compressed if user requests for a compressed version. Content won't be compressed on AzureFrontDoor when requested content is smaller than 1 byte or larger than 1 MB.
 

--- a/avm/res/cdn/profile/afdEndpoint/README.md
+++ b/avm/res/cdn/profile/afdEndpoint/README.md
@@ -168,7 +168,7 @@ Compression settings.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`iscontentTypeToCompressAll`](#parameter-routescacheconfigurationcompressionsettingsiscontenttypetocompressall) | bool | Indicates whether content compression is enabled on AzureFrontDoor. Default value is false. If compression is enabled, content will be served as compressed if user requests for a compressed version. Content won't be compressed on AzureFrontDoor when requested content is smaller than 1 byte or larger than 1 MB. |
+| [`isCompressionEnabled`](#parameter-iscompressionenabled) | bool | Indicates whether content compression is enabled on AzureFrontDoor. Default value is false. If compression is enabled, content will be served as compressed if user requests for a compressed version. Content won't be compressed on AzureFrontDoor when requested content is smaller than 1 byte or larger than 1 MB. |
 
 ### Parameter: `routes.cacheConfiguration.compressionSettings.contentTypesToCompress`
 
@@ -177,7 +177,7 @@ List of content types on which compression applies. The value should be a valid 
 - Required: Yes
 - Type: array
 
-### Parameter: `routes.cacheConfiguration.compressionSettings.iscontentTypeToCompressAll`
+### Parameter: `routes.cacheConfiguration.compressionSettings.isCompressionEnabled`
 
 Indicates whether content compression is enabled on AzureFrontDoor. Default value is false. If compression is enabled, content will be served as compressed if user requests for a compressed version. Content won't be compressed on AzureFrontDoor when requested content is smaller than 1 byte or larger than 1 MB.
 

--- a/avm/res/cdn/profile/afdEndpoint/main.json
+++ b/avm/res/cdn/profile/afdEndpoint/main.json
@@ -82,7 +82,7 @@
                 "description": "Required. List of content types on which compression applies. The value should be a valid MIME type."
               }
             },
-            "iscontentTypeToCompressAll": {
+            "isCompressionEnabled": {
               "type": "bool",
               "nullable": true,
               "metadata": {
@@ -514,7 +514,7 @@
                         "description": "Required. List of content types on which compression applies. The value should be a valid MIME type."
                       }
                     },
-                    "iscontentTypeToCompressAll": {
+                    "isCompressionEnabled": {
                       "type": "bool",
                       "nullable": true,
                       "metadata": {

--- a/avm/res/cdn/profile/afdEndpoint/route/main.bicep
+++ b/avm/res/cdn/profile/afdEndpoint/route/main.bicep
@@ -172,7 +172,7 @@ type afdRoutecacheConfigurationType = {
     contentTypesToCompress: string[]
 
     @description('Optional. Indicates whether content compression is enabled on AzureFrontDoor. Default value is false. If compression is enabled, content will be served as compressed if user requests for a compressed version. Content won\'t be compressed on AzureFrontDoor when requested content is smaller than 1 byte or larger than 1 MB.')
-    iscontentTypeToCompressAll: bool?
+    isCompressionEnabled: bool?
   }
   @description('Required. Query parameters to include or exclude (comma separated).')
   queryParameters: string

--- a/avm/res/cdn/profile/afdEndpoint/route/main.json
+++ b/avm/res/cdn/profile/afdEndpoint/route/main.json
@@ -140,7 +140,7 @@
                 "description": "Required. List of content types on which compression applies. The value should be a valid MIME type."
               }
             },
-            "iscontentTypeToCompressAll": {
+            "isCompressionEnabled": {
               "type": "bool",
               "nullable": true,
               "metadata": {

--- a/avm/res/cdn/profile/main.json
+++ b/avm/res/cdn/profile/main.json
@@ -177,7 +177,7 @@
                 "description": "Required. List of content types on which compression applies. The value should be a valid MIME type."
               }
             },
-            "iscontentTypeToCompressAll": {
+            "isCompressionEnabled": {
               "type": "bool",
               "nullable": true,
               "metadata": {
@@ -3237,7 +3237,7 @@
                         "description": "Required. List of content types on which compression applies. The value should be a valid MIME type."
                       }
                     },
-                    "iscontentTypeToCompressAll": {
+                    "isCompressionEnabled": {
                       "type": "bool",
                       "nullable": true,
                       "metadata": {
@@ -3669,7 +3669,7 @@
                                 "description": "Required. List of content types on which compression applies. The value should be a valid MIME type."
                               }
                             },
-                            "iscontentTypeToCompressAll": {
+                            "isCompressionEnabled": {
                               "type": "bool",
                               "nullable": true,
                               "metadata": {


### PR DESCRIPTION
## Description

Changed to the parameter iscontentTypeToCompressAll to isCompressionEnabled as this is the correct parameter name.
See https://learn.microsoft.com/en-us/azure/templates/microsoft.cdn/profiles/endpoints?pivots=deployment-language-arm-template

I just created a fix for this we I found there is an open issue https://github.com/Azure/bicep-registry-modules/issues/4734
This should solve that

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ x] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [x ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
