### PR TITLE
fix: Fixed Compute-Disk Import Test RBAC assignment

### DIFF
--- a/avm/res/compute/disk/tests/e2e/import/dependencies.bicep
+++ b/avm/res/compute/disk/tests/e2e/import/dependencies.bicep
@@ -50,7 +50,6 @@ module roleAssignment 'dependencies_rbac.bicep' = {
   scope: subscription()
   params: {
     managedIdentityPrincipalId: managedIdentity.properties.principalId
-    managedIdentityResourceId: managedIdentity.id
   }
 }
 

--- a/avm/res/compute/disk/tests/e2e/import/dependencies_rbac.bicep
+++ b/avm/res/compute/disk/tests/e2e/import/dependencies_rbac.bicep
@@ -1,13 +1,10 @@
 targetScope = 'subscription'
 
-@description('Required. The resource ID of the created Managed Identity.')
-param managedIdentityResourceId string
-
 @description('Required. The principal ID of the created Managed Identity.')
 param managedIdentityPrincipalId string
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(subscription().subscriptionId, 'Contributor', managedIdentityResourceId)
+  name: guid(subscription().subscriptionId, managedIdentityPrincipalId, 'Contributor')
   properties: {
     roleDefinitionId: subscriptionResourceId(
       'Microsoft.Authorization/roleDefinitions',


### PR DESCRIPTION
## Description

Changed RBAC assignment name to use principalId instead of resourceId to avoid issues like ` Tenant ID, application ID, principal ID, and scope are not allowed to be updated. (Code:RoleAssignmentUpdateNotPermitted)`

The change is in alignment with how we perform role assignments in resource modules.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.res.compute.disk](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk.yml/badge.svg?branch=users%2Falsehr%2FdiskRBACName&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk.yml)       |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
