### PR TITLE
feat: Add CMK implementation to 'avm/res/sql/server'

### DIFF
--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -2286,6 +2286,7 @@ param vulnerabilityAssessmentsObj = {
 | [`federatedClientId`](#parameter-federatedclientid) | string | The Client id used for cross tenant CMK scenario. |
 | [`firewallRules`](#parameter-firewallrules) | array | The firewall rules to create in the server. |
 | [`isIPv6Enabled`](#parameter-isipv6enabled) | string | Whether or not to enable IPv6 support for this server. |
+| [`keys`](#parameter-keys) | array | The keys to configure. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. |
@@ -3700,6 +3701,50 @@ Whether or not to enable IPv6 support for this server.
     'Enabled'
   ]
   ```
+
+### Parameter: `keys`
+
+The keys to configure.
+
+- Required: No
+- Type: array
+- Default: `[]`
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-keysname) | string | The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern. |
+| [`serverKeyType`](#parameter-keysserverkeytype) | string | The server key type. |
+| [`uri`](#parameter-keysuri) | string | The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI is required to be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion'. |
+
+### Parameter: `keys.name`
+
+The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern.
+
+- Required: No
+- Type: string
+
+### Parameter: `keys.serverKeyType`
+
+The server key type.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'AzureKeyVault'
+    'ServiceManaged'
+  ]
+  ```
+
+### Parameter: `keys.uri`
+
+The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI is required to be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion'.
+
+- Required: No
+- Type: string
 
 ### Parameter: `location`
 

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -47,13 +47,14 @@ The following section provides usage examples for the module, which were used to
 - [With an administrator](#example-1-with-an-administrator)
 - [With audit settings](#example-2-with-audit-settings)
 - [Using only defaults](#example-3-using-only-defaults)
-- [Using elastic pool](#example-4-using-elastic-pool)
-- [Using failover groups](#example-5-using-failover-groups)
-- [Deploying with a key vault reference to save secrets](#example-6-deploying-with-a-key-vault-reference-to-save-secrets)
-- [Using large parameter set](#example-7-using-large-parameter-set)
-- [With a secondary database](#example-8-with-a-secondary-database)
-- [With vulnerability assessment](#example-9-with-vulnerability-assessment)
-- [WAF-aligned](#example-10-waf-aligned)
+- [Using only defaults](#example-4-using-only-defaults)
+- [Using elastic pool](#example-5-using-elastic-pool)
+- [Using failover groups](#example-6-using-failover-groups)
+- [Deploying with a key vault reference to save secrets](#example-7-deploying-with-a-key-vault-reference-to-save-secrets)
+- [Using large parameter set](#example-8-using-large-parameter-set)
+- [With a secondary database](#example-9-with-a-secondary-database)
+- [With vulnerability assessment](#example-10-with-vulnerability-assessment)
+- [WAF-aligned](#example-11-waf-aligned)
 
 ### Example 1: _With an administrator_
 
@@ -255,6 +256,138 @@ module server 'br/public:avm/res/sql/server:<version>' = {
   name: 'serverDeployment'
   params: {
     // Required parameters
+    name: 'sscmk001'
+    // Non-required parameters
+    administrators: {
+      azureADOnlyAuthentication: true
+      login: 'myspn'
+      principalType: 'Application'
+      sid: '<sid>'
+      tenantId: '<tenantId>'
+    }
+    customerManagedKey: {
+      autoRotationEnabled: true
+      keyName: '<keyName>'
+      keyVaultResourceId: '<keyVaultResourceId>'
+      keyVersion: '<keyVersion>'
+    }
+    location: '<location>'
+    managedIdentities: {
+      systemAssigned: false
+      userAssignedResourceIds: [
+        '<managedIdentityResourceId>'
+      ]
+    }
+    primaryUserAssignedIdentityId: '<primaryUserAssignedIdentityId>'
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON parameters file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "name": {
+      "value": "sscmk001"
+    },
+    // Non-required parameters
+    "administrators": {
+      "value": {
+        "azureADOnlyAuthentication": true,
+        "login": "myspn",
+        "principalType": "Application",
+        "sid": "<sid>",
+        "tenantId": "<tenantId>"
+      }
+    },
+    "customerManagedKey": {
+      "value": {
+        "autoRotationEnabled": true,
+        "keyName": "<keyName>",
+        "keyVaultResourceId": "<keyVaultResourceId>",
+        "keyVersion": "<keyVersion>"
+      }
+    },
+    "location": {
+      "value": "<location>"
+    },
+    "managedIdentities": {
+      "value": {
+        "systemAssigned": false,
+        "userAssignedResourceIds": [
+          "<managedIdentityResourceId>"
+        ]
+      }
+    },
+    "primaryUserAssignedIdentityId": {
+      "value": "<primaryUserAssignedIdentityId>"
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via Bicep parameters file</summary>
+
+```bicep-params
+using 'br/public:avm/res/sql/server:<version>'
+
+// Required parameters
+param name = 'sscmk001'
+// Non-required parameters
+param administrators = {
+  azureADOnlyAuthentication: true
+  login: 'myspn'
+  principalType: 'Application'
+  sid: '<sid>'
+  tenantId: '<tenantId>'
+}
+param customerManagedKey = {
+  autoRotationEnabled: true
+  keyName: '<keyName>'
+  keyVaultResourceId: '<keyVaultResourceId>'
+  keyVersion: '<keyVersion>'
+}
+param location = '<location>'
+param managedIdentities = {
+  systemAssigned: false
+  userAssignedResourceIds: [
+    '<managedIdentityResourceId>'
+  ]
+}
+param primaryUserAssignedIdentityId = '<primaryUserAssignedIdentityId>'
+```
+
+</details>
+<p>
+
+### Example 4: _Using only defaults_
+
+This instance deploys the module with the minimum set of required parameters.
+
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module server 'br/public:avm/res/sql/server:<version>' = {
+  name: 'serverDeployment'
+  params: {
+    // Required parameters
     name: 'ssmin001'
     // Non-required parameters
     administratorLogin: 'adminUserName'
@@ -315,7 +448,7 @@ param location = '<location>'
 </details>
 <p>
 
-### Example 4: _Using elastic pool_
+### Example 5: _Using elastic pool_
 
 This instance deploys the module with an elastic pool.
 
@@ -448,7 +581,7 @@ param location = '<location>'
 </details>
 <p>
 
-### Example 5: _Using failover groups_
+### Example 6: _Using failover groups_
 
 This instance deploys the module with failover groups.
 
@@ -754,7 +887,7 @@ param location = '<location>'
 </details>
 <p>
 
-### Example 6: _Deploying with a key vault reference to save secrets_
+### Example 7: _Deploying with a key vault reference to save secrets_
 
 This instance deploys the module saving all its secrets in a key vault.
 
@@ -865,7 +998,7 @@ param secretsExportConfiguration = {
 </details>
 <p>
 
-### Example 7: _Using large parameter set_
+### Example 8: _Using large parameter set_
 
 This instance deploys the module with most of its features enabled.
 
@@ -883,6 +1016,12 @@ module server 'br/public:avm/res/sql/server:<version>' = {
     // Non-required parameters
     administratorLogin: 'adminUserName'
     administratorLoginPassword: '<administratorLoginPassword>'
+    customerManagedKey: {
+      autoRotationEnabled: true
+      keyName: '<keyName>'
+      keyVaultResourceId: '<keyVaultResourceId>'
+      keyVersion: '<keyVersion>'
+    }
     databases: [
       {
         backupLongTermRetentionPolicy: {
@@ -922,22 +1061,11 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         }
       }
     ]
-    encryptionProtectorObj: {
-      serverKeyName: '<serverKeyName>'
-      serverKeyType: 'AzureKeyVault'
-    }
     firewallRules: [
       {
         endIpAddress: '0.0.0.0'
         name: 'AllowAllWindowsAzureIps'
         startIpAddress: '0.0.0.0'
-      }
-    ]
-    keys: [
-      {
-        name: '<name>'
-        serverKeyType: 'AzureKeyVault'
-        uri: '<uri>'
       }
     ]
     location: '<location>'
@@ -1046,14 +1174,24 @@ module server 'br/public:avm/res/sql/server:<version>' = {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    // Required parameters
     "name": {
       "value": "sqlsmax"
     },
+    // Non-required parameters
     "administratorLogin": {
       "value": "adminUserName"
     },
     "administratorLoginPassword": {
       "value": "<administratorLoginPassword>"
+    },
+    "customerManagedKey": {
+      "value": {
+        "autoRotationEnabled": true,
+        "keyName": "<keyName>",
+        "keyVaultResourceId": "<keyVaultResourceId>",
+        "keyVersion": "<keyVersion>"
+      }
     },
     "databases": {
       "value": [
@@ -1098,27 +1236,12 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         }
       ]
     },
-    "encryptionProtectorObj": {
-      "value": {
-        "serverKeyName": "<serverKeyName>",
-        "serverKeyType": "AzureKeyVault"
-      }
-    },
     "firewallRules": {
       "value": [
         {
           "endIpAddress": "0.0.0.0",
           "name": "AllowAllWindowsAzureIps",
           "startIpAddress": "0.0.0.0"
-        }
-      ]
-    },
-    "keys": {
-      "value": [
-        {
-          "name": "<name>",
-          "serverKeyType": "AzureKeyVault",
-          "uri": "<uri>"
         }
       ]
     },
@@ -1253,6 +1376,12 @@ param name = 'sqlsmax'
 // Non-required parameters
 param administratorLogin = 'adminUserName'
 param administratorLoginPassword = '<administratorLoginPassword>'
+param customerManagedKey = {
+  autoRotationEnabled: true
+  keyName: '<keyName>'
+  keyVaultResourceId: '<keyVaultResourceId>'
+  keyVersion: '<keyVersion>'
+}
 param databases = [
   {
     backupLongTermRetentionPolicy: {
@@ -1292,22 +1421,11 @@ param elasticPools = [
     }
   }
 ]
-param encryptionProtectorObj = {
-  serverKeyName: '<serverKeyName>'
-  serverKeyType: 'AzureKeyVault'
-}
 param firewallRules = [
   {
     endIpAddress: '0.0.0.0'
     name: 'AllowAllWindowsAzureIps'
     startIpAddress: '0.0.0.0'
-  }
-]
-param keys = [
-  {
-    name: '<name>'
-    serverKeyType: 'AzureKeyVault'
-    uri: '<uri>'
   }
 ]
 param location = '<location>'
@@ -1405,7 +1523,7 @@ param vulnerabilityAssessmentsObj = {
 </details>
 <p>
 
-### Example 8: _With a secondary database_
+### Example 9: _With a secondary database_
 
 This instance deploys the module with a secondary database.
 
@@ -1537,7 +1655,7 @@ param tags = {
 </details>
 <p>
 
-### Example 9: _With vulnerability assessment_
+### Example 10: _With vulnerability assessment_
 
 This instance deploys the module with a vulnerability assessment.
 
@@ -1720,7 +1838,7 @@ param vulnerabilityAssessmentsObj = {
 </details>
 <p>
 
-### Example 10: _WAF-aligned_
+### Example 11: _WAF-aligned_
 
 This instance deploys the module in alignment with the best-practices of the Azure Well-Architected Framework.
 
@@ -1742,6 +1860,12 @@ module server 'br/public:avm/res/sql/server:<version>' = {
       principalType: 'Application'
       sid: '<sid>'
       tenantId: '<tenantId>'
+    }
+    customerManagedKey: {
+      autoRotationEnabled: true
+      keyName: '<keyName>'
+      keyVaultResourceId: '<keyVaultResourceId>'
+      keyVersion: '<keyVersion>'
     }
     databases: [
       {
@@ -1781,16 +1905,6 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           name: 'GP_Gen5'
           tier: 'GeneralPurpose'
         }
-      }
-    ]
-    encryptionProtectorObj: {
-      serverKeyName: '<serverKeyName>'
-      serverKeyType: 'AzureKeyVault'
-    }
-    keys: [
-      {
-        serverKeyType: 'AzureKeyVault'
-        uri: '<uri>'
       }
     ]
     location: '<location>'
@@ -1867,9 +1981,11 @@ module server 'br/public:avm/res/sql/server:<version>' = {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    // Required parameters
     "name": {
       "value": "sqlswaf"
     },
+    // Non-required parameters
     "administrators": {
       "value": {
         "azureADOnlyAuthentication": true,
@@ -1877,6 +1993,14 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         "principalType": "Application",
         "sid": "<sid>",
         "tenantId": "<tenantId>"
+      }
+    },
+    "customerManagedKey": {
+      "value": {
+        "autoRotationEnabled": true,
+        "keyName": "<keyName>",
+        "keyVaultResourceId": "<keyVaultResourceId>",
+        "keyVersion": "<keyVersion>"
       }
     },
     "databases": {
@@ -1920,20 +2044,6 @@ module server 'br/public:avm/res/sql/server:<version>' = {
             "name": "GP_Gen5",
             "tier": "GeneralPurpose"
           }
-        }
-      ]
-    },
-    "encryptionProtectorObj": {
-      "value": {
-        "serverKeyName": "<serverKeyName>",
-        "serverKeyType": "AzureKeyVault"
-      }
-    },
-    "keys": {
-      "value": [
-        {
-          "serverKeyType": "AzureKeyVault",
-          "uri": "<uri>"
         }
       ]
     },
@@ -2037,6 +2147,12 @@ param administrators = {
   sid: '<sid>'
   tenantId: '<tenantId>'
 }
+param customerManagedKey = {
+  autoRotationEnabled: true
+  keyName: '<keyName>'
+  keyVaultResourceId: '<keyVaultResourceId>'
+  keyVersion: '<keyVersion>'
+}
 param databases = [
   {
     backupLongTermRetentionPolicy: {
@@ -2075,16 +2191,6 @@ param elasticPools = [
       name: 'GP_Gen5'
       tier: 'GeneralPurpose'
     }
-  }
-]
-param encryptionProtectorObj = {
-  serverKeyName: '<serverKeyName>'
-  serverKeyType: 'AzureKeyVault'
-}
-param keys = [
-  {
-    serverKeyType: 'AzureKeyVault'
-    uri: '<uri>'
   }
 ]
 param location = '<location>'
@@ -2172,16 +2278,14 @@ param vulnerabilityAssessmentsObj = {
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`auditSettings`](#parameter-auditsettings) | object | The audit settings configuration. If you want to disable auditing, set the parmaeter to an empty object. |
+| [`customerManagedKey`](#parameter-customermanagedkey) | object | The customer managed key definition for server TDE. |
 | [`databases`](#parameter-databases) | array | The databases to create in the server. |
 | [`elasticPools`](#parameter-elasticpools) | array | The Elastic Pools to create in the server. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
-| [`encryptionProtectorObj`](#parameter-encryptionprotectorobj) | object | The encryption protection configuration. |
 | [`failoverGroups`](#parameter-failovergroups) | array | The failover groups configuration. |
 | [`federatedClientId`](#parameter-federatedclientid) | string | The Client id used for cross tenant CMK scenario. |
 | [`firewallRules`](#parameter-firewallrules) | array | The firewall rules to create in the server. |
 | [`isIPv6Enabled`](#parameter-isipv6enabled) | string | Whether or not to enable IPv6 support for this server. |
-| [`keyId`](#parameter-keyid) | string | A CMK URI of the key to use for encryption. |
-| [`keys`](#parameter-keys) | array | The keys to configure. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. |
@@ -2407,6 +2511,63 @@ Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzur
 ### Parameter: `auditSettings.storageAccountResourceId`
 
 Specifies the identifier key of the auditing storage account.
+
+- Required: No
+- Type: string
+
+### Parameter: `customerManagedKey`
+
+The customer managed key definition for server TDE.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`keyName`](#parameter-customermanagedkeykeyname) | string | The name of the customer managed key to use for encryption. |
+| [`keyVaultResourceId`](#parameter-customermanagedkeykeyvaultresourceid) | string | The resource ID of a key vault to reference a customer managed key for encryption from. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`autoRotationEnabled`](#parameter-customermanagedkeyautorotationenabled) | bool | Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used. |
+| [`keyVersion`](#parameter-customermanagedkeykeyversion) | string | The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting. |
+| [`userAssignedIdentityResourceId`](#parameter-customermanagedkeyuserassignedidentityresourceid) | string | User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use. |
+
+### Parameter: `customerManagedKey.keyName`
+
+The name of the customer managed key to use for encryption.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `customerManagedKey.keyVaultResourceId`
+
+The resource ID of a key vault to reference a customer managed key for encryption from.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `customerManagedKey.autoRotationEnabled`
+
+Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used.
+
+- Required: No
+- Type: bool
+
+### Parameter: `customerManagedKey.keyVersion`
+
+The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting.
+
+- Required: No
+- Type: string
+
+### Parameter: `customerManagedKey.userAssignedIdentityResourceId`
+
+User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use.
 
 - Required: No
 - Type: string
@@ -3334,54 +3495,6 @@ Enable/Disable usage telemetry for module.
 - Type: bool
 - Default: `True`
 
-### Parameter: `encryptionProtectorObj`
-
-The encryption protection configuration.
-
-- Required: No
-- Type: object
-
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`serverKeyName`](#parameter-encryptionprotectorobjserverkeyname) | string | The name of the server key. |
-
-**Optional parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`autoRotationEnabled`](#parameter-encryptionprotectorobjautorotationenabled) | bool | Key auto rotation opt-in flag. |
-| [`serverKeyType`](#parameter-encryptionprotectorobjserverkeytype) | string | The encryption protector type. |
-
-### Parameter: `encryptionProtectorObj.serverKeyName`
-
-The name of the server key.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `encryptionProtectorObj.autoRotationEnabled`
-
-Key auto rotation opt-in flag.
-
-- Required: No
-- Type: bool
-
-### Parameter: `encryptionProtectorObj.serverKeyType`
-
-The encryption protector type.
-
-- Required: No
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'AzureKeyVault'
-    'ServiceManaged'
-  ]
-  ```
-
 ### Parameter: `failoverGroups`
 
 The failover groups configuration.
@@ -3587,57 +3700,6 @@ Whether or not to enable IPv6 support for this server.
     'Enabled'
   ]
   ```
-
-### Parameter: `keyId`
-
-A CMK URI of the key to use for encryption.
-
-- Required: No
-- Type: string
-
-### Parameter: `keys`
-
-The keys to configure.
-
-- Required: No
-- Type: array
-- Default: `[]`
-
-**Optional parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`name`](#parameter-keysname) | string | The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern. |
-| [`serverKeyType`](#parameter-keysserverkeytype) | string | The server key type. |
-| [`uri`](#parameter-keysuri) | string | The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI is required to be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion'. |
-
-### Parameter: `keys.name`
-
-The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern.
-
-- Required: No
-- Type: string
-
-### Parameter: `keys.serverKeyType`
-
-The server key type.
-
-- Required: No
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'AzureKeyVault'
-    'ServiceManaged'
-  ]
-  ```
-
-### Parameter: `keys.uri`
-
-The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI is required to be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion'.
-
-- Required: No
-- Type: string
 
 ### Parameter: `location`
 

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -46,7 +46,7 @@ The following section provides usage examples for the module, which were used to
 
 - [With an administrator](#example-1-with-an-administrator)
 - [With audit settings](#example-2-with-audit-settings)
-- [Using only defaults](#example-3-using-only-defaults)
+- [Using Customer-Managed-Keys with User-Assigned identity](#example-3-using-customer-managed-keys-with-user-assigned-identity)
 - [Using only defaults](#example-4-using-only-defaults)
 - [Using elastic pool](#example-5-using-elastic-pool)
 - [Using failover groups](#example-6-using-failover-groups)
@@ -242,9 +242,9 @@ param managedIdentities = {
 </details>
 <p>
 
-### Example 3: _Using only defaults_
+### Example 3: _Using Customer-Managed-Keys with User-Assigned identity_
 
-This instance deploys the module with the minimum set of required parameters.
+This instance deploys the module with Customer-Managed-Keys using a User-Assigned Identity to access the key.
 
 
 <details>
@@ -271,7 +271,6 @@ module server 'br/public:avm/res/sql/server:<version>' = {
       keyVaultResourceId: '<keyVaultResourceId>'
       keyVersion: '<keyVersion>'
     }
-    location: '<location>'
     managedIdentities: {
       systemAssigned: false
       userAssignedResourceIds: [
@@ -317,9 +316,6 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         "keyVersion": "<keyVersion>"
       }
     },
-    "location": {
-      "value": "<location>"
-    },
     "managedIdentities": {
       "value": {
         "systemAssigned": false,
@@ -361,7 +357,6 @@ param customerManagedKey = {
   keyVaultResourceId: '<keyVaultResourceId>'
   keyVersion: '<keyVersion>'
 }
-param location = '<location>'
 param managedIdentities = {
   systemAssigned: false
   userAssignedResourceIds: [

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -228,11 +228,13 @@ resource server 'Microsoft.Sql/servers@2023-08-01-preview' = {
     administrators: union({ administratorType: 'ActiveDirectory' }, administrators ?? {})
     federatedClientId: federatedClientId
     isIPv6Enabled: isIPv6Enabled
-    keyId: !empty(customerManagedKey.?keyVersion)
-      ? '${cMKKeyVault::cMKKey.properties.keyUri}/${customerManagedKey!.?keyVersion}'
-      : (customerManagedKey.?autoRotationEnabled ?? true)
-          ? cMKKeyVault::cMKKey.properties.keyUri
-          : cMKKeyVault::cMKKey.properties.keyUriWithVersion
+    keyId: customerManagedKey != null
+      ? !empty(customerManagedKey.?keyVersion)
+          ? '${cMKKeyVault::cMKKey.properties.keyUri}/${customerManagedKey!.?keyVersion}'
+          : (customerManagedKey.?autoRotationEnabled ?? true)
+              ? cMKKeyVault::cMKKey.properties.keyUri
+              : cMKKeyVault::cMKKey.properties.keyUriWithVersion
+      : null
     version: '12.0'
     minimalTlsVersion: minimalTlsVersion
     primaryUserAssignedIdentityId: !empty(primaryUserAssignedIdentityId) ? primaryUserAssignedIdentityId : null

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -50,8 +50,9 @@ param virtualNetworkRules virtualNetworkRuleType[] = []
 @description('Optional. The security alert policies to create in the server.')
 param securityAlertPolicies securityAlerPolicyType[] = []
 
-@description('Optional. The keys to configure.')
-param keys keyType[] = []
+import { customerManagedKeyWithAutoRotateType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+@description('Optional. The customer managed key definition for server TDE.')
+param customerManagedKey customerManagedKeyWithAutoRotateType?
 
 @description('Conditional. The Azure Active Directory (AAD) administrator authentication. Required if no `administratorLogin` & `administratorLoginPassword` is provided.')
 param administrators serverExternalAdministratorType?
@@ -60,9 +61,6 @@ param administrators serverExternalAdministratorType?
 @minLength(36)
 @maxLength(36)
 param federatedClientId string?
-
-@description('Optional. A CMK URI of the key to use for encryption.')
-param keyId string?
 
 @allowed([
   '1.0'
@@ -115,9 +113,6 @@ var identity = !empty(managedIdentities)
       userAssignedIdentities: !empty(formattedUserAssignedIdentities) ? formattedUserAssignedIdentities : null
     }
   : null
-
-@description('Optional. The encryption protection configuration.')
-param encryptionProtectorObj encryptionProtectorType?
 
 @description('Optional. The vulnerability assessment configuration.')
 param vulnerabilityAssessmentsObj vulnerabilityAssessmentType?
@@ -188,6 +183,18 @@ var formattedRoleAssignments = [
   })
 ]
 
+resource cMKKeyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId)) {
+  name: last(split(customerManagedKey.?keyVaultResourceId!, '/'))
+  scope: resourceGroup(
+    split(customerManagedKey.?keyVaultResourceId!, '/')[2],
+    split(customerManagedKey.?keyVaultResourceId!, '/')[4]
+  )
+
+  resource cMKKey 'keys@2023-07-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId) && !empty(customerManagedKey.?keyName)) {
+    name: customerManagedKey.?keyName!
+  }
+}
+
 #disable-next-line no-deployments-resources
 resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.sql-server.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
@@ -218,7 +225,11 @@ resource server 'Microsoft.Sql/servers@2023-08-01-preview' = {
     administrators: union({ administratorType: 'ActiveDirectory' }, administrators ?? {})
     federatedClientId: federatedClientId
     isIPv6Enabled: isIPv6Enabled
-    keyId: keyId
+    keyId: !empty(customerManagedKey.?keyVersion)
+      ? '${cMKKeyVault::cMKKey.properties.keyUri}/${customerManagedKey!.?keyVersion}'
+      : (customerManagedKey.?autoRotationEnabled ?? true)
+          ? cMKKeyVault::cMKKey.properties.keyUri
+          : cMKKeyVault::cMKKey.properties.keyUriWithVersion
     version: '12.0'
     minimalTlsVersion: minimalTlsVersion
     primaryUserAssignedIdentityId: !empty(primaryUserAssignedIdentityId) ? primaryUserAssignedIdentityId : null
@@ -453,29 +464,28 @@ module server_vulnerabilityAssessment 'vulnerability-assessment/main.bicep' = if
   ]
 }
 
-module server_keys 'key/main.bicep' = [
-  for (key, index) in keys: {
-    name: '${uniqueString(deployment().name, location)}-Sql-Key-${index}'
-    params: {
-      serverName: server.name
-      name: key.?name
-      serverKeyType: key.?serverKeyType
-      uri: key.?uri
-    }
+module server_key 'key/main.bicep' = if (customerManagedKey != null) {
+  name: '${uniqueString(deployment().name, location)}-Sql-Key'
+  params: {
+    serverName: server.name
+    name: '${cMKKeyVault.name}_${customerManagedKey.?keyName}_${customerManagedKey.?keyVersion}'
+    serverKeyType: 'AzureKeyVault'
+    uri: !empty(customerManagedKey.?keyVersion)
+      ? '${cMKKeyVault::cMKKey.properties.keyUri}/${customerManagedKey!.?keyVersion}'
+      : (customerManagedKey.?autoRotationEnabled ?? true)
+          ? cMKKeyVault::cMKKey.properties.keyUri
+          : cMKKeyVault::cMKKey.properties.keyUriWithVersion
   }
-]
+}
 
-module server_encryptionProtector 'encryption-protector/main.bicep' = if (encryptionProtectorObj != null) {
+module server_encryptionProtector 'encryption-protector/main.bicep' = if (customerManagedKey != null) {
   name: '${uniqueString(deployment().name, location)}-Sql-EncryProtector'
   params: {
     sqlServerName: server.name
-    serverKeyName: encryptionProtectorObj!.serverKeyName
-    serverKeyType: encryptionProtectorObj.?serverKeyType
-    autoRotationEnabled: encryptionProtectorObj.?autoRotationEnabled
+    serverKeyName: server_key.outputs.name
+    serverKeyType: 'AzureKeyVault'
+    autoRotationEnabled: customerManagedKey.?autoRotationEnabled
   }
-  dependsOn: [
-    server_keys
-  ]
 }
 
 module server_audit_settings 'audit-settings/main.bicep' = if (!empty(auditSettings)) {

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "380221310876456571"
+      "templateHash": "10864738477477872287"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -2005,6 +2005,16 @@
       "defaultValue": [],
       "metadata": {
         "description": "Optional. The security alert policies to create in the server."
+      }
+    },
+    "keys": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/keyType"
+      },
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional. The keys to configure."
       }
     },
     "customerManagedKey": {
@@ -5116,7 +5126,130 @@
         "server_securityAlertPolicies"
       ]
     },
-    "server_key": {
+    "server_keys": {
+      "copy": {
+        "name": "server_keys",
+        "count": "[length(parameters('keys'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('{0}-Sql-Key-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "serverName": {
+            "value": "[parameters('name')]"
+          },
+          "name": {
+            "value": "[tryGet(parameters('keys')[copyIndex()], 'name')]"
+          },
+          "serverKeyType": {
+            "value": "[tryGet(parameters('keys')[copyIndex()], 'serverKeyType')]"
+          },
+          "uri": {
+            "value": "[tryGet(parameters('keys')[copyIndex()], 'uri')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.33.93.31351",
+              "templateHash": "16484015504682658620"
+            },
+            "name": "Azure SQL Server Keys",
+            "description": "This module deploys an Azure SQL Server Key."
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern."
+              }
+            },
+            "serverName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the parent SQL server. Required if the template is used in a standalone deployment."
+              }
+            },
+            "serverKeyType": {
+              "type": "string",
+              "defaultValue": "ServiceManaged",
+              "allowedValues": [
+                "AzureKeyVault",
+                "ServiceManaged"
+              ],
+              "metadata": {
+                "description": "Optional. The server key type."
+              }
+            },
+            "uri": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI is required to be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion'."
+              }
+            }
+          },
+          "variables": {
+            "splittedKeyUri": "[split(parameters('uri'), '/')]",
+            "serverKeyName": "[if(empty(parameters('uri')), 'ServiceManaged', format('{0}_{1}_{2}', split(variables('splittedKeyUri')[2], '.')[0], variables('splittedKeyUri')[4], variables('splittedKeyUri')[5]))]"
+          },
+          "resources": {
+            "server": {
+              "existing": true,
+              "type": "Microsoft.Sql/servers",
+              "apiVersion": "2023-08-01-preview",
+              "name": "[parameters('serverName')]"
+            },
+            "key": {
+              "type": "Microsoft.Sql/servers/keys",
+              "apiVersion": "2023-08-01-preview",
+              "name": "[format('{0}/{1}', parameters('serverName'), coalesce(parameters('name'), variables('serverKeyName')))]",
+              "properties": {
+                "serverKeyType": "[parameters('serverKeyType')]",
+                "uri": "[parameters('uri')]"
+              }
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the deployed server key."
+              },
+              "value": "[coalesce(parameters('name'), variables('serverKeyName'))]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the deployed server key."
+              },
+              "value": "[resourceId('Microsoft.Sql/servers/keys', parameters('serverName'), coalesce(parameters('name'), variables('serverKeyName')))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the deployed server key."
+              },
+              "value": "[resourceGroup().name]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "server"
+      ]
+    },
+    "cmk_key": {
       "condition": "[not(equals(parameters('customerManagedKey'), null()))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
@@ -5250,7 +5383,7 @@
             "value": "[parameters('name')]"
           },
           "serverKeyName": {
-            "value": "[reference('server_key').outputs.name.value]"
+            "value": "[reference('cmk_key').outputs.name.value]"
           },
           "serverKeyType": {
             "value": "AzureKeyVault"
@@ -5341,8 +5474,8 @@
         }
       },
       "dependsOn": [
-        "server",
-        "server_key"
+        "cmk_key",
+        "server"
       ]
     },
     "server_audit_settings": {

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "10864738477477872287"
+      "templateHash": "4352487787268132718"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -2403,8 +2403,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "15990296903519132880"
+              "version": "0.33.93.31351",
+              "templateHash": "16881410177731489630"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database."
@@ -3115,8 +3115,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "9756378998309991315"
+                      "version": "0.33.93.31351",
+                      "templateHash": "8340051145755870485"
                     },
                     "name": "Azure SQL Server Database Short Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."
@@ -3232,8 +3232,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "7793476949981656377"
+                      "version": "0.33.93.31351",
+                      "templateHash": "3863560552324183850"
                     },
                     "name": "SQL Server Database Long Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."
@@ -3459,8 +3459,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "13169370796754277035"
+              "version": "0.33.93.31351",
+              "templateHash": "17349112224241666638"
             },
             "name": "SQL Server Elastic Pool",
             "description": "This module deploys an Azure SQL Server Elastic Pool."
@@ -4533,8 +4533,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "5038261177858434729"
+              "version": "0.33.93.31351",
+              "templateHash": "1944178906791741244"
             },
             "name": "Azure SQL Server Firewall Rule",
             "description": "This module deploys an Azure SQL Server Firewall Rule."
@@ -4640,8 +4640,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "5181261702127555829"
+              "version": "0.33.93.31351",
+              "templateHash": "17146907795911099724"
             },
             "name": "Azure SQL Server Virtual Network Rules",
             "description": "This module deploys an Azure SQL Server Virtual Network Rule."
@@ -4762,8 +4762,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "14971385092253198970"
+              "version": "0.33.93.31351",
+              "templateHash": "8937041272173907173"
             },
             "name": "Azure SQL Server Security Alert Policies",
             "description": "This module deploys an Azure SQL Server Security Alert Policy."
@@ -4937,8 +4937,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "13028930090028114053"
+              "version": "0.33.93.31351",
+              "templateHash": "7783878739561489902"
             },
             "name": "Azure SQL Server Vulnerability Assessments",
             "description": "This module deploys an Azure SQL Server Vulnerability Assessment."
@@ -5064,8 +5064,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "8374589607291714415"
+                      "version": "0.33.93.31351",
+                      "templateHash": "8921652227508160151"
                     }
                   },
                   "parameters": {
@@ -5278,8 +5278,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "10362246469517057380"
+              "version": "0.33.93.31351",
+              "templateHash": "16484015504682658620"
             },
             "name": "Azure SQL Server Keys",
             "description": "This module deploys an Azure SQL Server Key."
@@ -5398,8 +5398,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "13396787316963181635"
+              "version": "0.33.93.31351",
+              "templateHash": "3546869587910650701"
             },
             "name": "Azure SQL Server Encryption Protector",
             "description": "This module deploys an Azure SQL Server Encryption Protector."
@@ -5530,8 +5530,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "13147629904798099652"
+              "version": "0.33.93.31351",
+              "templateHash": "18193643807269591015"
             },
             "name": "Azure SQL Server Audit Settings",
             "description": "This module deploys an Azure SQL Server Audit Settings."
@@ -5671,8 +5671,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "11188920490207833313"
+                      "version": "0.33.93.31351",
+                      "templateHash": "3456585740193014655"
                     }
                   },
                   "parameters": {
@@ -5759,8 +5759,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "14045530027687796477"
+              "version": "0.33.93.31351",
+              "templateHash": "8063348652715653257"
             }
           },
           "definitions": {

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "15781736031753199939"
+      "templateHash": "380221310876456571"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -1124,6 +1124,50 @@
         }
       }
     },
+    "customerManagedKeyWithAutoRotateType": {
+      "type": "object",
+      "properties": {
+        "keyVaultResourceId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
+          }
+        },
+        "keyName": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the customer managed key to use for encryption."
+          }
+        },
+        "keyVersion": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting."
+          }
+        },
+        "autoRotationEnabled": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used."
+          }
+        },
+        "userAssignedIdentityResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use."
+          }
+        }
+      },
+      "metadata": {
+        "description": "An AVM-aligned type for a customer-managed key. To be used if the resource type supports auto-rotation of the customer-managed key.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+        }
+      }
+    },
     "databaseSkuType": {
       "type": "object",
       "properties": {
@@ -1963,14 +2007,11 @@
         "description": "Optional. The security alert policies to create in the server."
       }
     },
-    "keys": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/keyType"
-      },
-      "defaultValue": [],
+    "customerManagedKey": {
+      "$ref": "#/definitions/customerManagedKeyWithAutoRotateType",
+      "nullable": true,
       "metadata": {
-        "description": "Optional. The keys to configure."
+        "description": "Optional. The customer managed key definition for server TDE."
       }
     },
     "administrators": {
@@ -1987,13 +2028,6 @@
       "maxLength": 36,
       "metadata": {
         "description": "Optional. The Client id used for cross tenant CMK scenario."
-      }
-    },
-    "keyId": {
-      "type": "string",
-      "nullable": true,
-      "metadata": {
-        "description": "Optional. A CMK URI of the key to use for encryption."
       }
     },
     "minimalTlsVersion": {
@@ -2053,13 +2087,6 @@
       ],
       "metadata": {
         "description": "Optional. Whether or not to restrict outbound network access for this server."
-      }
-    },
-    "encryptionProtectorObj": {
-      "$ref": "#/definitions/encryptionProtectorType",
-      "nullable": true,
-      "metadata": {
-        "description": "Optional. The encryption protection configuration."
       }
     },
     "vulnerabilityAssessmentsObj": {
@@ -2123,6 +2150,24 @@
     }
   },
   "resources": {
+    "cMKKeyVault::cMKKey": {
+      "condition": "[and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName')))))]",
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults/keys",
+      "apiVersion": "2023-07-01",
+      "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+      "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+      "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
+    },
+    "cMKKeyVault": {
+      "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId')))]",
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2023-07-01",
+      "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+      "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+      "name": "[last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))]"
+    },
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
@@ -2156,13 +2201,16 @@
         "administrators": "[union(createObject('administratorType', 'ActiveDirectory'), coalesce(parameters('administrators'), createObject()))]",
         "federatedClientId": "[parameters('federatedClientId')]",
         "isIPv6Enabled": "[parameters('isIPv6Enabled')]",
-        "keyId": "[parameters('keyId')]",
+        "keyId": "[if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), if(coalesce(tryGet(parameters('customerManagedKey'), 'autoRotationEnabled'), true()), reference('cMKKeyVault::cMKKey').keyUri, reference('cMKKeyVault::cMKKey').keyUriWithVersion))]",
         "version": "12.0",
         "minimalTlsVersion": "[parameters('minimalTlsVersion')]",
         "primaryUserAssignedIdentityId": "[if(not(empty(parameters('primaryUserAssignedIdentityId'))), parameters('primaryUserAssignedIdentityId'), null())]",
         "publicNetworkAccess": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(and(and(not(empty(parameters('privateEndpoints'))), empty(parameters('firewallRules'))), empty(parameters('virtualNetworkRules'))), 'Disabled', null()))]",
         "restrictOutboundNetworkAccess": "[if(not(empty(parameters('restrictOutboundNetworkAccess'))), parameters('restrictOutboundNetworkAccess'), null())]"
-      }
+      },
+      "dependsOn": [
+        "cMKKeyVault::cMKKey"
+      ]
     },
     "server_lock": {
       "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
@@ -5068,14 +5116,11 @@
         "server_securityAlertPolicies"
       ]
     },
-    "server_keys": {
-      "copy": {
-        "name": "server_keys",
-        "count": "[length(parameters('keys'))]"
-      },
+    "server_key": {
+      "condition": "[not(equals(parameters('customerManagedKey'), null()))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-Sql-Key-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+      "name": "[format('{0}-Sql-Key', uniqueString(deployment().name, parameters('location')))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -5086,14 +5131,12 @@
             "value": "[parameters('name')]"
           },
           "name": {
-            "value": "[tryGet(parameters('keys')[copyIndex()], 'name')]"
+            "value": "[format('{0}_{1}_{2}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'), tryGet(parameters('customerManagedKey'), 'keyVersion'))]"
           },
           "serverKeyType": {
-            "value": "[tryGet(parameters('keys')[copyIndex()], 'serverKeyType')]"
+            "value": "AzureKeyVault"
           },
-          "uri": {
-            "value": "[tryGet(parameters('keys')[copyIndex()], 'uri')]"
-          }
+          "uri": "[if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), createObject('value', format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion'))), if(coalesce(tryGet(parameters('customerManagedKey'), 'autoRotationEnabled'), true()), createObject('value', reference('cMKKeyVault::cMKKey').keyUri), createObject('value', reference('cMKKeyVault::cMKKey').keyUriWithVersion)))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -5188,11 +5231,12 @@
         }
       },
       "dependsOn": [
+        "cMKKeyVault::cMKKey",
         "server"
       ]
     },
     "server_encryptionProtector": {
-      "condition": "[not(equals(parameters('encryptionProtectorObj'), null()))]",
+      "condition": "[not(equals(parameters('customerManagedKey'), null()))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
       "name": "[format('{0}-Sql-EncryProtector', uniqueString(deployment().name, parameters('location')))]",
@@ -5206,13 +5250,13 @@
             "value": "[parameters('name')]"
           },
           "serverKeyName": {
-            "value": "[parameters('encryptionProtectorObj').serverKeyName]"
+            "value": "[reference('server_key').outputs.name.value]"
           },
           "serverKeyType": {
-            "value": "[tryGet(parameters('encryptionProtectorObj'), 'serverKeyType')]"
+            "value": "AzureKeyVault"
           },
           "autoRotationEnabled": {
-            "value": "[tryGet(parameters('encryptionProtectorObj'), 'autoRotationEnabled')]"
+            "value": "[tryGet(parameters('customerManagedKey'), 'autoRotationEnabled')]"
           }
         },
         "template": {
@@ -5298,7 +5342,7 @@
       },
       "dependsOn": [
         "server",
-        "server_keys"
+        "server_key"
       ]
     },
     "server_audit_settings": {

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "4352487787268132718"
+      "templateHash": "8719459318215661010"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -2211,7 +2211,7 @@
         "administrators": "[union(createObject('administratorType', 'ActiveDirectory'), coalesce(parameters('administrators'), createObject()))]",
         "federatedClientId": "[parameters('federatedClientId')]",
         "isIPv6Enabled": "[parameters('isIPv6Enabled')]",
-        "keyId": "[if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), if(coalesce(tryGet(parameters('customerManagedKey'), 'autoRotationEnabled'), true()), reference('cMKKeyVault::cMKKey').keyUri, reference('cMKKeyVault::cMKKey').keyUriWithVersion))]",
+        "keyId": "[if(not(equals(parameters('customerManagedKey'), null())), if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), if(coalesce(tryGet(parameters('customerManagedKey'), 'autoRotationEnabled'), true()), reference('cMKKeyVault::cMKKey').keyUri, reference('cMKKeyVault::cMKKey').keyUriWithVersion)), null())]",
         "version": "12.0",
         "minimalTlsVersion": "[parameters('minimalTlsVersion')]",
         "primaryUserAssignedIdentityId": "[if(not(empty(parameters('primaryUserAssignedIdentityId'))), parameters('primaryUserAssignedIdentityId'), null())]",

--- a/avm/res/sql/server/tests/e2e/cmk/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/cmk/dependencies.bicep
@@ -1,54 +1,15 @@
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
-@description('Required. The name of the Virtual Network to create.')
-param virtualNetworkName string
-
 @description('Optional. The location to deploy resources to.')
 param location string = resourceGroup().location
 
 @description('Required. The name of the Key Vault to create.')
 param keyVaultName string
 
-var addressPrefix = '10.0.0.0/16'
-
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
   name: managedIdentityName
   location: location
-}
-
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
-  name: virtualNetworkName
-  location: location
-  properties: {
-    addressSpace: {
-      addressPrefixes: [
-        addressPrefix
-      ]
-    }
-    subnets: map(range(0, 2), i => {
-      name: 'subnet-${i}'
-      properties: {
-        addressPrefix: cidrSubnet(addressPrefix, 24, i)
-      }
-    })
-  }
-}
-
-resource privateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
-  name: 'privatelink${environment().suffixes.sqlServerHostname}'
-  location: 'global'
-
-  resource virtualNetworkLinks 'virtualNetworkLinks@2020-06-01' = {
-    name: '${virtualNetwork.name}-vnetlink'
-    location: 'global'
-    properties: {
-      virtualNetwork: {
-        id: virtualNetwork.id
-      }
-      registrationEnabled: false
-    }
-  }
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
@@ -69,7 +30,14 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   }
 
   resource key 'keys@2022-07-01' = {
-    name: 'keyEncryptionKey'
+    name: 'keyServerEncryptionKey'
+    properties: {
+      kty: 'RSA'
+    }
+  }
+
+  resource dbKey 'keys@2022-07-01' = {
+    name: 'keyDatabaseEncryptionKey'
     properties: {
       kty: 'RSA'
     }
@@ -89,26 +57,36 @@ resource keyPermissions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
 }
 
+resource dbKeyPermissions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid('msi-${keyVault::dbKey.id}-${location}-${managedIdentity.id}-Key-Vault-Crypto-Service-Encryption-User-RoleAssignment')
+  scope: keyVault::dbKey
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      'e147488a-f6f5-4113-8e2d-b22465e65bf6'
+    ) // Key Vault Crypto Service Encryption User
+    principalType: 'ServicePrincipal'
+  }
+}
+
 @description('The principal ID of the created managed identity.')
 output managedIdentityPrincipalId string = managedIdentity.properties.principalId
 
 @description('The resource ID of the created managed identity.')
 output managedIdentityResourceId string = managedIdentity.id
 
-@description('The resource ID of the created virtual network subnet for a Private Endpoint.')
-output privateEndpointSubnetResourceId string = virtualNetwork.properties.subnets[0].id
-
-@description('The resource ID of the created virtual network subnet for a Service Endpoint.')
-output serviceEndpointSubnetResourceId string = virtualNetwork.properties.subnets[1].id
-
-@description('The resource ID of the created Private DNS Zone.')
-output privateDNSZoneResourceId string = privateDNSZone.id
-
 @description('The URL of the created Key Vault Encryption Key.')
 output keyVaultEncryptionKeyUrl string = keyVault::key.properties.keyUriWithVersion
 
 @description('The name of the created Key Vault Encryption Key.')
 output keyVaultKeyName string = keyVault::key.name
+
+@description('The URL of the created Key Vault Database Encryption Key.')
+output keyVaultDatabaseEncryptionKeyUrl string = keyVault::dbKey.properties.keyUriWithVersion
+
+@description('The name of the created Key Vault Database Encryption Key.')
+output keyVaultDatabaseKeyName string = keyVault::dbKey.name
 
 @description('The name of the created Key Vault.')
 output keyVaultName string = keyVault.name

--- a/avm/res/sql/server/tests/e2e/cmk/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/cmk/main.test.bicep
@@ -1,7 +1,7 @@
 targetScope = 'subscription'
 
-metadata name = 'Using only defaults'
-metadata description = 'This instance deploys the module with the minimum set of required parameters.'
+metadata name = 'Using Customer-Managed-Keys with User-Assigned identity'
+metadata description = 'This instance deploys the module with Customer-Managed-Keys using a User-Assigned Identity to access the key.'
 
 // ========== //
 // Parameters //
@@ -50,12 +50,11 @@ module nestedDependencies 'dependencies.bicep' = {
 
 @batchSize(1)
 module testDeployment '../../../main.bicep' = [
-  for iteration in ['init']: {
+  for iteration in ['init', 'idem']: {
     scope: resourceGroup
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
       primaryUserAssignedIdentityId: nestedDependencies.outputs.managedIdentityResourceId
       administrators: {
         azureADOnlyAuthentication: true

--- a/avm/res/sql/server/tests/e2e/cmk/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/cmk/main.test.bicep
@@ -1,0 +1,83 @@
+targetScope = 'subscription'
+
+metadata name = 'Using only defaults'
+metadata description = 'This instance deploys the module with the minimum set of required parameters.'
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Optional. The name of the resource group to deploy for testing purposes.')
+@maxLength(90)
+param resourceGroupName string = 'dep-${namePrefix}-sql.servers-${serviceShort}-rg'
+
+@description('Optional. The location to deploy resources to.')
+param resourceLocation string = deployment().location
+
+@description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
+param serviceShort string = 'sscmk'
+
+@description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
+param namePrefix string = '#_namePrefix_#'
+
+@description('Generated. Used as a basis for unique resource names.')
+param baseTime string = utcNow('u')
+
+// ============ //
+// Dependencies //
+// ============ //
+
+// General resources
+// =================
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: resourceGroupName
+  location: resourceLocation
+}
+
+module nestedDependencies 'dependencies.bicep' = {
+  scope: resourceGroup
+  name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
+  params: {
+    // Adding base time to make the name unique as purge protection must be enabled (but may not be longer than 24 characters total)
+    keyVaultName: 'dep-${namePrefix}-kv-${serviceShort}-${substring(uniqueString(baseTime), 0, 3)}'
+    managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
+    location: resourceLocation
+  }
+}
+// ============== //
+// Test Execution //
+// ============== //
+
+@batchSize(1)
+module testDeployment '../../../main.bicep' = [
+  for iteration in ['init']: {
+    scope: resourceGroup
+    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
+    params: {
+      name: '${namePrefix}${serviceShort}001'
+      location: resourceLocation
+      primaryUserAssignedIdentityId: nestedDependencies.outputs.managedIdentityResourceId
+      administrators: {
+        azureADOnlyAuthentication: true
+        login: 'myspn'
+        sid: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalType: 'Application'
+        tenantId: tenant().tenantId
+      }
+
+      managedIdentities: {
+        systemAssigned: false
+        userAssignedResourceIds: [
+          nestedDependencies.outputs.managedIdentityResourceId
+        ]
+      }
+
+      customerManagedKey: {
+        keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
+        keyName: nestedDependencies.outputs.keyVaultKeyName
+        keyVersion: last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))
+        autoRotationEnabled: true
+      }
+    }
+  }
+]

--- a/avm/res/sql/server/tests/e2e/max/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/max/main.test.bicep
@@ -155,9 +155,11 @@ module testDeployment '../../../main.bicep' = {
         }
       }
     ]
-    encryptionProtectorObj: {
-      serverKeyType: 'AzureKeyVault'
-      serverKeyName: '${nestedDependencies.outputs.keyVaultName}_${nestedDependencies.outputs.keyVaultKeyName}_${last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))}'
+    customerManagedKey: {
+      keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
+      keyName: nestedDependencies.outputs.keyVaultKeyName
+      keyVersion: last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))
+      autoRotationEnabled: true
     }
     firewallRules: [
       {
@@ -171,13 +173,6 @@ module testDeployment '../../../main.bicep' = {
         name: 'Default'
         state: 'Enabled'
         emailAccountAdmins: true
-      }
-    ]
-    keys: [
-      {
-        name: '${nestedDependencies.outputs.keyVaultName}_${nestedDependencies.outputs.keyVaultKeyName}_${last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))}'
-        serverKeyType: 'AzureKeyVault'
-        uri: nestedDependencies.outputs.keyVaultEncryptionKeyUrl
       }
     ]
     managedIdentities: {

--- a/avm/res/sql/server/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/waf-aligned/dependencies.bicep
@@ -112,3 +112,6 @@ output keyVaultKeyName string = keyVault::key.name
 
 @description('The name of the created Key Vault.')
 output keyVaultName string = keyVault.name
+
+@description('The resource ID of the created Key Vault.')
+output keyVaultResourceId string = keyVault.id

--- a/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
@@ -131,21 +131,17 @@ module testDeployment '../../../main.bicep' = {
         }
       }
     ]
-    encryptionProtectorObj: {
-      serverKeyType: 'AzureKeyVault'
-      serverKeyName: '${nestedDependencies.outputs.keyVaultName}_${nestedDependencies.outputs.keyVaultKeyName}_${last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))}'
+    customerManagedKey: {
+      keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
+      keyName: nestedDependencies.outputs.keyVaultKeyName
+      keyVersion: last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))
+      autoRotationEnabled: true
     }
     securityAlertPolicies: [
       {
         name: 'Default'
         state: 'Enabled'
         emailAccountAdmins: true
-      }
-    ]
-    keys: [
-      {
-        serverKeyType: 'AzureKeyVault'
-        uri: nestedDependencies.outputs.keyVaultEncryptionKeyUrl
       }
     ]
     managedIdentities: {

--- a/avm/res/sql/server/version.json
+++ b/avm/res/sql/server/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.14",
+  "version": "0.15",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
## Description

This PR adds a standard CMK implementation to the Azure SQL Server module.

* Added a new param `customerManagedKey`
* Kept the existing `keys` param if someone wants to add multiple keys and manage the key rotation / change manually
* Removed the `encryptionProtectorObj` param, as it is handled by the standard CMK param

Please note, that this is **only** for server level key management, database level key management is TBD.

Fixes #2369 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|       [![avm.res.sql.server](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg?branch=2369)](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml)   |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
