### PR TITLE
docs: avm\res\app\container-app-Add clarity to secret UDT descriptions

### DIFF
--- a/avm/res/app/container-app/README.md
+++ b/avm/res/app/container-app/README.md
@@ -2017,26 +2017,26 @@ The secrets of the Container App.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`keyVaultUrl`](#parameter-secretskeyvaulturl) | string | Azure Key Vault URL pointing to the secret referenced by the Container App Job. Required if `value` is null. |
-| [`value`](#parameter-secretsvalue) | securestring | The secret value, if not fetched from Key Vault. Required if `keyVaultUrl` is not null. |
+| [`keyVaultUrl`](#parameter-secretskeyvaulturl) | string | The URL of the Azure Key Vault secret referenced by the Container App. Required if `value` is null. |
+| [`value`](#parameter-secretsvalue) | securestring | The container app secret value, if not fetched from the Key Vault. Required if `keyVaultUrl` is not null. |
 
 **Optional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`identity`](#parameter-secretsidentity) | string | Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a system-assigned identity. |
-| [`name`](#parameter-secretsname) | string | The name of the secret. |
+| [`name`](#parameter-secretsname) | string | The name of the container app secret. |
 
 ### Parameter: `secrets.keyVaultUrl`
 
-Azure Key Vault URL pointing to the secret referenced by the Container App Job. Required if `value` is null.
+The URL of the Azure Key Vault secret referenced by the Container App. Required if `value` is null.
 
 - Required: No
 - Type: string
 
 ### Parameter: `secrets.value`
 
-The secret value, if not fetched from Key Vault. Required if `keyVaultUrl` is not null.
+The container app secret value, if not fetched from the Key Vault. Required if `keyVaultUrl` is not null.
 
 - Required: No
 - Type: securestring
@@ -2050,7 +2050,7 @@ Resource ID of a managed identity to authenticate with Azure Key Vault, or Syste
 
 ### Parameter: `secrets.name`
 
-The name of the secret.
+The name of the container app secret.
 
 - Required: No
 - Type: string

--- a/avm/res/app/container-app/main.bicep
+++ b/avm/res/app/container-app/main.bicep
@@ -581,13 +581,13 @@ type secretType = {
   @description('Optional. Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a system-assigned identity.')
   identity: string?
 
-  @description('Conditional. Azure Key Vault URL pointing to the secret referenced by the Container App Job. Required if `value` is null.')
+  @description('Conditional. The URL of the Azure Key Vault secret referenced by the Container App. Required if `value` is null.')
   keyVaultUrl: string?
 
-  @description('Optional. The name of the secret.')
+  @description('Optional. The name of the container app secret.')
   name: string?
 
-  @description('Conditional. The secret value, if not fetched from Key Vault. Required if `keyVaultUrl` is not null.')
+  @description('Conditional. The container app secret value, if not fetched from the Key Vault. Required if `keyVaultUrl` is not null.')
   @secure()
   value: string?
 }

--- a/avm/res/app/container-app/main.json
+++ b/avm/res/app/container-app/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "14843677762258257428"
+      "version": "0.33.13.18514",
+      "templateHash": "4848415833432031586"
     },
     "name": "Container Apps",
     "description": "This module deploys a Container App."
@@ -611,21 +611,21 @@
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Conditional. Azure Key Vault URL pointing to the secret referenced by the Container App Job. Required if `value` is null."
+            "description": "Conditional. The URL of the Azure Key Vault secret referenced by the Container App. Required if `value` is null."
           }
         },
         "name": {
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. The name of the secret."
+            "description": "Optional. The name of the container app secret."
           }
         },
         "value": {
           "type": "securestring",
           "nullable": true,
           "metadata": {
-            "description": "Conditional. The secret value, if not fetched from Key Vault. Required if `keyVaultUrl` is not null."
+            "description": "Conditional. The container app secret value, if not fetched from the Key Vault. Required if `keyVaultUrl` is not null."
           }
         }
       },


### PR DESCRIPTION
## Description
This pull request includes changes to the `type secretType` in the `avm/res/app/container-app/main.bicep` file to improve the clarity of descriptions for various properties related to Azure Key Vault and container app secrets.

Clarifications to property descriptions:

* Updated the description for the `keyVaultUrl` property to specify that it references the Azure Key Vault secret for the Container App.
* Updated the description for the `name` property to specify that it is the name of the container app secret.
* Updated the description for the `value` property to clarify that it is the container app secret value, if not fetched from the Key Vault.

Closes #4868

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.res.app.container-app](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.res.app.container-app.yml/badge.svg?branch=ca-fix-descriptions)](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.res.app.container-app.yml)       |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
