### PR TITLE
feat: Add ability to toggle subscription placement

### DIFF
--- a/avm/ptn/mgmt-groups/subscription-placement/README.md
+++ b/avm/ptn/mgmt-groups/subscription-placement/README.md
@@ -41,6 +41,7 @@ module subscriptionPlacement 'br/public:avm/ptn/mgmt-groups/subscription-placeme
   params: {
     parSubscriptionPlacement: [
       {
+        disableSubscriptionPlacement: false
         managementGroupId: '<managementGroupId>'
         subscriptionIds: [
           '<subVendingSubscriptionId>'
@@ -66,6 +67,7 @@ module subscriptionPlacement 'br/public:avm/ptn/mgmt-groups/subscription-placeme
     "parSubscriptionPlacement": {
       "value": [
         {
+          "disableSubscriptionPlacement": false,
           "managementGroupId": "<managementGroupId>",
           "subscriptionIds": [
             "<subVendingSubscriptionId>"
@@ -89,6 +91,7 @@ using 'br/public:avm/ptn/mgmt-groups/subscription-placement:<version>'
 
 param parSubscriptionPlacement = [
   {
+    disableSubscriptionPlacement: false
     managementGroupId: '<managementGroupId>'
     subscriptionIds: [
       '<subVendingSubscriptionId>'
@@ -129,6 +132,12 @@ The management group IDs along with the subscriptions to be placed underneath th
 | [`managementGroupId`](#parameter-parsubscriptionplacementmanagementgroupid) | string | The ID of the management group. |
 | [`subscriptionIds`](#parameter-parsubscriptionplacementsubscriptionids) | array | The list of subscription IDs to be placed underneath the management group. |
 
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`disableSubscriptionPlacement`](#parameter-parsubscriptionplacementdisablesubscriptionplacement) | bool | Provides ability to disable the subscription placement for a specific management group. |
+
 ### Parameter: `parSubscriptionPlacement.managementGroupId`
 
 The ID of the management group.
@@ -142,6 +151,13 @@ The list of subscription IDs to be placed underneath the management group.
 
 - Required: Yes
 - Type: array
+
+### Parameter: `parSubscriptionPlacement.disableSubscriptionPlacement`
+
+Provides ability to disable the subscription placement for a specific management group.
+
+- Required: No
+- Type: bool
 
 ### Parameter: `enableTelemetry`
 

--- a/avm/ptn/mgmt-groups/subscription-placement/README.md
+++ b/avm/ptn/mgmt-groups/subscription-placement/README.md
@@ -44,6 +44,7 @@ module subscriptionPlacement 'br/public:avm/ptn/mgmt-groups/subscription-placeme
         disableSubscriptionPlacement: false
         managementGroupId: '<managementGroupId>'
         subscriptionIds: [
+          ''
           '<subVendingSubscriptionId>'
         ]
       }
@@ -70,6 +71,7 @@ module subscriptionPlacement 'br/public:avm/ptn/mgmt-groups/subscription-placeme
           "disableSubscriptionPlacement": false,
           "managementGroupId": "<managementGroupId>",
           "subscriptionIds": [
+            "",
             "<subVendingSubscriptionId>"
           ]
         }
@@ -94,6 +96,7 @@ param parSubscriptionPlacement = [
     disableSubscriptionPlacement: false
     managementGroupId: '<managementGroupId>'
     subscriptionIds: [
+      ''
       '<subVendingSubscriptionId>'
     ]
   }

--- a/avm/ptn/mgmt-groups/subscription-placement/README.md
+++ b/avm/ptn/mgmt-groups/subscription-placement/README.md
@@ -52,7 +52,6 @@ module subscriptionPlacement 'br/public:avm/ptn/mgmt-groups/subscription-placeme
         disableSubscriptionPlacement: true
         managementGroupId: '<managementGroupId>'
         subscriptionIds: [
-          ''
           '<subVendingSubscriptionId>'
         ]
       }
@@ -87,7 +86,6 @@ module subscriptionPlacement 'br/public:avm/ptn/mgmt-groups/subscription-placeme
           "disableSubscriptionPlacement": true,
           "managementGroupId": "<managementGroupId>",
           "subscriptionIds": [
-            "",
             "<subVendingSubscriptionId>"
           ]
         }
@@ -120,7 +118,6 @@ param parSubscriptionPlacement = [
     disableSubscriptionPlacement: true
     managementGroupId: '<managementGroupId>'
     subscriptionIds: [
-      ''
       '<subVendingSubscriptionId>'
     ]
   }

--- a/avm/ptn/mgmt-groups/subscription-placement/README.md
+++ b/avm/ptn/mgmt-groups/subscription-placement/README.md
@@ -48,6 +48,14 @@ module subscriptionPlacement 'br/public:avm/ptn/mgmt-groups/subscription-placeme
           '<subVendingSubscriptionId>'
         ]
       }
+      {
+        disableSubscriptionPlacement: true
+        managementGroupId: '<managementGroupId>'
+        subscriptionIds: [
+          ''
+          '<subVendingSubscriptionId>'
+        ]
+      }
     ]
   }
 }
@@ -74,6 +82,14 @@ module subscriptionPlacement 'br/public:avm/ptn/mgmt-groups/subscription-placeme
             "",
             "<subVendingSubscriptionId>"
           ]
+        },
+        {
+          "disableSubscriptionPlacement": true,
+          "managementGroupId": "<managementGroupId>",
+          "subscriptionIds": [
+            "",
+            "<subVendingSubscriptionId>"
+          ]
         }
       ]
     }
@@ -94,6 +110,14 @@ using 'br/public:avm/ptn/mgmt-groups/subscription-placement:<version>'
 param parSubscriptionPlacement = [
   {
     disableSubscriptionPlacement: false
+    managementGroupId: '<managementGroupId>'
+    subscriptionIds: [
+      ''
+      '<subVendingSubscriptionId>'
+    ]
+  }
+  {
+    disableSubscriptionPlacement: true
     managementGroupId: '<managementGroupId>'
     subscriptionIds: [
       ''

--- a/avm/ptn/mgmt-groups/subscription-placement/main.bicep
+++ b/avm/ptn/mgmt-groups/subscription-placement/main.bicep
@@ -37,7 +37,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
 }
 
 module customSubscriptionPlacement './modules/helper.bicep' = [
-  for (subscriptionPlacement, index) in parSubscriptionPlacement: {
+  for (subscriptionPlacement, index) in parSubscriptionPlacement: if (!empty(subscriptionPlacement) || subscriptionPlacement.?disableSubscriptionPlacement == true) {
     name: 'subPlacment-${uniqueString(subscriptionPlacement.managementGroupId)}${index}'
     params: {
       managementGroupId: subscriptionPlacement.managementGroupId
@@ -62,6 +62,10 @@ output subscriptionPlacementSummary string = 'Subscription placements have been 
 type subscriptionPlacementType = {
   @description('Required. The ID of the management group.')
   managementGroupId: string
+
   @description('Required. The list of subscription IDs to be placed underneath the management group.')
   subscriptionIds: string[]
+
+  @description('Optional. Provides ability to disable the subscription placement for a specific management group.')
+  disableSubscriptionPlacement: bool?
 }

--- a/avm/ptn/mgmt-groups/subscription-placement/main.bicep
+++ b/avm/ptn/mgmt-groups/subscription-placement/main.bicep
@@ -37,7 +37,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
 }
 
 module customSubscriptionPlacement './modules/helper.bicep' = [
-  for (subscriptionPlacement, index) in parSubscriptionPlacement: if (!empty(subscriptionPlacement) || subscriptionPlacement.?disableSubscriptionPlacement == true) {
+  for (subscriptionPlacement, index) in parSubscriptionPlacement: if (subscriptionPlacement.?disableSubscriptionPlacement == true) {
     name: 'subPlacment-${uniqueString(subscriptionPlacement.managementGroupId)}${index}'
     params: {
       managementGroupId: subscriptionPlacement.managementGroupId

--- a/avm/ptn/mgmt-groups/subscription-placement/main.json
+++ b/avm/ptn/mgmt-groups/subscription-placement/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.13.18514",
-      "templateHash": "12502542864893705083"
+      "templateHash": "13512342340467043757"
     },
     "name": "subscription-placement",
     "description": "This module allows for placement of subscriptions to management groups."
@@ -28,6 +28,13 @@
           },
           "metadata": {
             "description": "Required. The list of subscription IDs to be placed underneath the management group."
+          }
+        },
+        "disableSubscriptionPlacement": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Provides ability to disable the subscription placement for a specific management group."
           }
         }
       },
@@ -89,6 +96,7 @@
         "name": "customSubscriptionPlacement",
         "count": "[length(parameters('parSubscriptionPlacement'))]"
       },
+      "condition": "[or(not(empty(parameters('parSubscriptionPlacement')[copyIndex()])), equals(tryGet(parameters('parSubscriptionPlacement')[copyIndex()], 'disableSubscriptionPlacement'), true()))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
       "name": "[format('subPlacment-{0}{1}', uniqueString(parameters('parSubscriptionPlacement')[copyIndex()].managementGroupId), copyIndex())]",

--- a/avm/ptn/mgmt-groups/subscription-placement/main.json
+++ b/avm/ptn/mgmt-groups/subscription-placement/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "8143221199458659468"
+      "templateHash": "17803027931414595389"
     },
     "name": "subscription-placement",
     "description": "This module allows for placement of subscriptions to management groups."
@@ -122,7 +122,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.34.44.8038",
-              "templateHash": "1425956500445063128"
+              "templateHash": "822995430469320013"
             }
           },
           "parameters": {
@@ -148,6 +148,7 @@
                 "name": "customSubscriptionPlacement",
                 "count": "[length(parameters('subscriptionIds'))]"
               },
+              "condition": "[not(empty(parameters('subscriptionIds')[copyIndex()]))]",
               "type": "Microsoft.Management/managementGroups/subscriptions",
               "apiVersion": "2023-04-01",
               "name": "[format('{0}/{1}', parameters('managementGroupId'), parameters('subscriptionIds')[copyIndex()])]"
@@ -161,9 +162,7 @@
               },
               "copy": {
                 "count": "[length(parameters('subscriptionIds'))]",
-                "input": {
-                  "name": "[format('{0}/{1}', parameters('managementGroupId'), parameters('subscriptionIds')[copyIndex()])]"
-                }
+                "input": "[if(not(empty(parameters('subscriptionIds')[copyIndex()])), createObject('name', format('{0}/{1}', parameters('managementGroupId'), parameters('subscriptionIds')[copyIndex()])), null())]"
               }
             }
           }

--- a/avm/ptn/mgmt-groups/subscription-placement/main.json
+++ b/avm/ptn/mgmt-groups/subscription-placement/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "17803027931414595389"
+      "templateHash": "8143221199458659468"
     },
     "name": "subscription-placement",
     "description": "This module allows for placement of subscriptions to management groups."
@@ -122,7 +122,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.34.44.8038",
-              "templateHash": "822995430469320013"
+              "templateHash": "1425956500445063128"
             }
           },
           "parameters": {
@@ -148,7 +148,6 @@
                 "name": "customSubscriptionPlacement",
                 "count": "[length(parameters('subscriptionIds'))]"
               },
-              "condition": "[not(empty(parameters('subscriptionIds')[copyIndex()]))]",
               "type": "Microsoft.Management/managementGroups/subscriptions",
               "apiVersion": "2023-04-01",
               "name": "[format('{0}/{1}', parameters('managementGroupId'), parameters('subscriptionIds')[copyIndex()])]"
@@ -162,7 +161,9 @@
               },
               "copy": {
                 "count": "[length(parameters('subscriptionIds'))]",
-                "input": "[if(not(empty(parameters('subscriptionIds')[copyIndex()])), createObject('name', format('{0}/{1}', parameters('managementGroupId'), parameters('subscriptionIds')[copyIndex()])), null())]"
+                "input": {
+                  "name": "[format('{0}/{1}', parameters('managementGroupId'), parameters('subscriptionIds')[copyIndex()])]"
+                }
               }
             }
           }

--- a/avm/ptn/mgmt-groups/subscription-placement/main.json
+++ b/avm/ptn/mgmt-groups/subscription-placement/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "13512342340467043757"
+      "version": "0.34.44.8038",
+      "templateHash": "17803027931414595389"
     },
     "name": "subscription-placement",
     "description": "This module allows for placement of subscriptions to management groups."
@@ -96,7 +96,7 @@
         "name": "customSubscriptionPlacement",
         "count": "[length(parameters('parSubscriptionPlacement'))]"
       },
-      "condition": "[or(not(empty(parameters('parSubscriptionPlacement')[copyIndex()])), equals(tryGet(parameters('parSubscriptionPlacement')[copyIndex()], 'disableSubscriptionPlacement'), true()))]",
+      "condition": "[equals(tryGet(parameters('parSubscriptionPlacement')[copyIndex()], 'disableSubscriptionPlacement'), true())]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
       "name": "[format('subPlacment-{0}{1}', uniqueString(parameters('parSubscriptionPlacement')[copyIndex()].managementGroupId), copyIndex())]",
@@ -121,8 +121,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "6413058457168295861"
+              "version": "0.34.44.8038",
+              "templateHash": "822995430469320013"
             }
           },
           "parameters": {
@@ -148,6 +148,7 @@
                 "name": "customSubscriptionPlacement",
                 "count": "[length(parameters('subscriptionIds'))]"
               },
+              "condition": "[not(empty(parameters('subscriptionIds')[copyIndex()]))]",
               "type": "Microsoft.Management/managementGroups/subscriptions",
               "apiVersion": "2023-04-01",
               "name": "[format('{0}/{1}', parameters('managementGroupId'), parameters('subscriptionIds')[copyIndex()])]"
@@ -161,9 +162,7 @@
               },
               "copy": {
                 "count": "[length(parameters('subscriptionIds'))]",
-                "input": {
-                  "name": "[format('{0}/{1}', parameters('managementGroupId'), parameters('subscriptionIds')[copyIndex()])]"
-                }
+                "input": "[if(not(empty(parameters('subscriptionIds')[copyIndex()])), createObject('name', format('{0}/{1}', parameters('managementGroupId'), parameters('subscriptionIds')[copyIndex()])), null())]"
               }
             }
           }

--- a/avm/ptn/mgmt-groups/subscription-placement/modules/helper.bicep
+++ b/avm/ptn/mgmt-groups/subscription-placement/modules/helper.bicep
@@ -6,14 +6,14 @@ param managementGroupId string
 param subscriptionIds string[]
 
 resource customSubscriptionPlacement 'Microsoft.Management/managementGroups/subscriptions@2023-04-01' = [
-  for (subscription, i) in subscriptionIds: if (!empty(subscription)) {
+  for (subscription, i) in subscriptionIds: {
     name: '${managementGroupId}/${subscription}'
   }
 ]
 
 @description('Output of the Management Group and Subscription Resource ID placements.')
 output subscriptionPlacements array = [
-  for (subscription, i) in subscriptionIds: (!empty(subscription)) ? {
+  for (subscription, i) in subscriptionIds: {
     name: '${managementGroupId}/${subscription}'
-  } : null
+  }
 ]

--- a/avm/ptn/mgmt-groups/subscription-placement/modules/helper.bicep
+++ b/avm/ptn/mgmt-groups/subscription-placement/modules/helper.bicep
@@ -6,14 +6,14 @@ param managementGroupId string
 param subscriptionIds string[]
 
 resource customSubscriptionPlacement 'Microsoft.Management/managementGroups/subscriptions@2023-04-01' = [
-  for (subscription, i) in subscriptionIds: {
+  for (subscription, i) in subscriptionIds: if (!empty(subscription)) {
     name: '${managementGroupId}/${subscription}'
   }
 ]
 
 @description('Output of the Management Group and Subscription Resource ID placements.')
 output subscriptionPlacements array = [
-  for (subscription, i) in subscriptionIds: {
+  for (subscription, i) in subscriptionIds: (!empty(subscription)) ? {
     name: '${managementGroupId}/${subscription}'
-  }
+  } : null
 ]

--- a/avm/ptn/mgmt-groups/subscription-placement/tests/e2e/defaults/dependencies.bicep
+++ b/avm/ptn/mgmt-groups/subscription-placement/tests/e2e/defaults/dependencies.bicep
@@ -21,6 +21,18 @@ resource managementGroup 'Microsoft.Management/managementGroups@2023-04-01' = {
   }
 }
 
+resource managementGroup2 'Microsoft.Management/managementGroups@2023-04-01' = {
+  name: 'test-mgmt-group-2'
+  properties: {
+    displayName: 'Test Management Group'
+    details:{
+      parent:{
+        id: rootManagementGroupResourceId
+      }
+    }
+  }
+}
+
 module subVending 'br/public:avm/ptn/lz/sub-vending:0.2.4' = {
   name: 'subVendingDeployment'
   scope: managementGroup
@@ -42,6 +54,12 @@ output managementGroupId string = managementGroup.id
 
 @description('Output of the management group name.')
 output managementGroupName string = managementGroup.name
+
+@description('Output of the second management group resource ID.')
+output managementGroupId2 string = managementGroup2.id
+
+@description('Output of the second management group name.')
+output managementGroupName2 string = managementGroup2.name
 
 @description('Output of the subscription vending resource ID.')
 output subVendingResourceId string = subVending.outputs.subscriptionResourceId

--- a/avm/ptn/mgmt-groups/subscription-placement/tests/e2e/defaults/main.test.bicep
+++ b/avm/ptn/mgmt-groups/subscription-placement/tests/e2e/defaults/main.test.bicep
@@ -50,7 +50,6 @@ module testDeployment '../../../main.bicep' = {
         managementGroupId: dependencies.outputs.managementGroupName2
         subscriptionIds: [
           dependencies.outputs.subVendingSubscriptionId
-          ''
         ]
         disableSubscriptionPlacement: true
       }

--- a/avm/ptn/mgmt-groups/subscription-placement/tests/e2e/defaults/main.test.bicep
+++ b/avm/ptn/mgmt-groups/subscription-placement/tests/e2e/defaults/main.test.bicep
@@ -43,6 +43,7 @@ module testDeployment '../../../main.bicep' = {
         subscriptionIds: [
           dependencies.outputs.subVendingSubscriptionId
         ]
+        disableSubscriptionPlacement: false
       }
     ]
   }

--- a/avm/ptn/mgmt-groups/subscription-placement/tests/e2e/defaults/main.test.bicep
+++ b/avm/ptn/mgmt-groups/subscription-placement/tests/e2e/defaults/main.test.bicep
@@ -46,6 +46,14 @@ module testDeployment '../../../main.bicep' = {
         ]
         disableSubscriptionPlacement: false
       }
+      {
+        managementGroupId: dependencies.outputs.managementGroupName2
+        subscriptionIds: [
+          dependencies.outputs.subVendingSubscriptionId
+          ''
+        ]
+        disableSubscriptionPlacement: true
+      }
     ]
   }
 }

--- a/avm/ptn/mgmt-groups/subscription-placement/tests/e2e/defaults/main.test.bicep
+++ b/avm/ptn/mgmt-groups/subscription-placement/tests/e2e/defaults/main.test.bicep
@@ -42,6 +42,7 @@ module testDeployment '../../../main.bicep' = {
         managementGroupId: dependencies.outputs.managementGroupName
         subscriptionIds: [
           dependencies.outputs.subVendingSubscriptionId
+          ''
         ]
         disableSubscriptionPlacement: false
       }

--- a/avm/ptn/mgmt-groups/subscription-placement/version.json
+++ b/avm/ptn/mgmt-groups/subscription-placement/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1",
+  "version": "0.2",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
## Description
This pull request introduces a new optional parameter `disableSubscriptionPlacement` to the `subscriptionPlacement` module, allowing users to disable subscription placement for specific management groups. The changes span across multiple files to incorporate this new functionality.

Key changes include:

### Enhancements to `subscriptionPlacement` module:

* [`README.md`](diffhunk://#diff-a6525710bd16191f489ea133568dba05ca95bb61fdb8cfde416a0823cbb8de4eR44): Added `disableSubscriptionPlacement` parameter to the documentation, including its description and usage. [[1]](diffhunk://#diff-a6525710bd16191f489ea133568dba05ca95bb61fdb8cfde416a0823cbb8de4eR44) [[2]](diffhunk://#diff-a6525710bd16191f489ea133568dba05ca95bb61fdb8cfde416a0823cbb8de4eR70) [[3]](diffhunk://#diff-a6525710bd16191f489ea133568dba05ca95bb61fdb8cfde416a0823cbb8de4eR94) [[4]](diffhunk://#diff-a6525710bd16191f489ea133568dba05ca95bb61fdb8cfde416a0823cbb8de4eR135-R140) [[5]](diffhunk://#diff-a6525710bd16191f489ea133568dba05ca95bb61fdb8cfde416a0823cbb8de4eR155-R161)
* [`main.bicep`](diffhunk://#diff-28549e7c6354d2beaa9a82eb90294564140584a95afb356c56aeb9f9ec7a33dcL40-R40): Updated the `customSubscriptionPlacement` module to conditionally include or exclude entries based on the `disableSubscriptionPlacement` parameter. [[1]](diffhunk://#diff-28549e7c6354d2beaa9a82eb90294564140584a95afb356c56aeb9f9ec7a33dcL40-R40) [[2]](diffhunk://#diff-28549e7c6354d2beaa9a82eb90294564140584a95afb356c56aeb9f9ec7a33dcR65-R70)
* [`main.json`](diffhunk://#diff-bcf1a90bcb974c978e41d44247a7a0cbfad388c12dc8a3647611641948ce6957L9-R9): Added the `disableSubscriptionPlacement` parameter with metadata and updated the deployment conditions to handle this new parameter. [[1]](diffhunk://#diff-bcf1a90bcb974c978e41d44247a7a0cbfad388c12dc8a3647611641948ce6957L9-R9) [[2]](diffhunk://#diff-bcf1a90bcb974c978e41d44247a7a0cbfad388c12dc8a3647611641948ce6957R32-R38) [[3]](diffhunk://#diff-bcf1a90bcb974c978e41d44247a7a0cbfad388c12dc8a3647611641948ce6957R99)
* [`defaults/main.test.bicep`](diffhunk://#diff-5659899112b237c1147488785f11b13a72ead33dcf7e506e2ce0324aa0c05437R46): Included the `disableSubscriptionPlacement` parameter in the test deployment configuration.

Closes #4948 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.ptn.mgmt-groups.subscription-placement](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.ptn.mgmt-groups.subscription-placement.yml/badge.svg?branch=feat-sub-placement)](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.ptn.mgmt-groups.subscription-placement.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
