### PR TITLE
test: Make  'avm/res/sql/server' tests idempotent

### DIFF
--- a/avm/res/sql/server/tests/e2e/admin/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/admin/main.test.bicep
@@ -43,21 +43,20 @@ module nestedDependencies 'dependencies.bicep' = {
 // ============== //
 // Test Execution //
 // ============== //
-
-module testDeployment '../../../main.bicep' = {
-  scope: resourceGroup
-  name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}'
-  params: {
-    name: '${namePrefix}-${serviceShort}'
-    location: resourceLocation
-    administrators: {
-      azureADOnlyAuthentication: true
-      login: 'myspn'
-      sid: nestedDependencies.outputs.managedIdentityPrincipalId
-      principalType: 'Application'
+@batchSize(1)
+module testDeployment '../../../main.bicep' = [
+  for iteration in ['init', 'idem']: {
+    scope: resourceGroup
+    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
+    params: {
+      name: '${namePrefix}-${serviceShort}'
+      location: resourceLocation
+      administrators: {
+        azureADOnlyAuthentication: true
+        login: 'myspn'
+        sid: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalType: 'Application'
+      }
     }
   }
-  dependsOn: [
-    nestedDependencies
-  ]
-}
+]

--- a/avm/res/sql/server/tests/e2e/max/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/max/main.test.bicep
@@ -222,8 +222,4 @@ module testDeployment '../../../main.bicep' = {
       Role: 'DeploymentValidation'
     }
   }
-  dependsOn: [
-    nestedDependencies
-    diagnosticDependencies
-  ]
 }

--- a/avm/res/sql/server/tests/e2e/max/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/max/main.test.bicep
@@ -68,7 +68,7 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
 // ============== //
 // Test Execution //
 // ============== //
-
+@batchSize(1)
 module testDeployment '../../../main.bicep' = [
   for iteration in ['init', 'idem']: {
     scope: resourceGroup

--- a/avm/res/sql/server/tests/e2e/max/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/max/main.test.bicep
@@ -69,157 +69,159 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
 // Test Execution //
 // ============== //
 
-module testDeployment '../../../main.bicep' = {
-  scope: resourceGroup
-  name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}'
-  params: {
-    name: '${namePrefix}-${serviceShort}'
-    lock: {
-      kind: 'CanNotDelete'
-      name: 'myCustomLockName'
-    }
-    primaryUserAssignedIdentityId: nestedDependencies.outputs.managedIdentityResourceId
-    administratorLogin: 'adminUserName'
-    administratorLoginPassword: password
-    location: enforcedLocation
-    roleAssignments: [
-      {
-        name: '7027a5c5-d1b1-49e0-80cc-ffdff3a3ada9'
-        roleDefinitionIdOrName: 'Owner'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
-        principalType: 'ServicePrincipal'
+module testDeployment '../../../main.bicep' = [
+  for iteration in ['init', 'idem']: {
+    scope: resourceGroup
+    name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-${iteration}'
+    params: {
+      name: '${namePrefix}-${serviceShort}'
+      lock: {
+        kind: 'CanNotDelete'
+        name: 'myCustomLockName'
       }
-      {
-        name: guid('Custom seed ${namePrefix}${serviceShort}')
-        roleDefinitionIdOrName: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
-        principalType: 'ServicePrincipal'
-      }
-      {
-        roleDefinitionIdOrName: subscriptionResourceId(
-          'Microsoft.Authorization/roleDefinitions',
-          'acdd72a7-3385-48ef-bd42-f606fba81ae7'
-        )
-        principalId: nestedDependencies.outputs.managedIdentityPrincipalId
-        principalType: 'ServicePrincipal'
-      }
-    ]
-    vulnerabilityAssessmentsObj: {
-      name: 'default'
-      recurringScans: {
-        emailSubscriptionAdmins: true
-        isEnabled: true
-        emails: [
-          'test1@contoso.com'
-          'test2@contoso.com'
-        ]
-      }
-      storageAccountResourceId: diagnosticDependencies.outputs.storageAccountResourceId
-    }
-    elasticPools: [
-      {
-        name: '${namePrefix}-${serviceShort}-ep-001'
-        sku: {
-          name: 'GP_Gen5'
-          tier: 'GeneralPurpose'
-          capacity: 10
+      primaryUserAssignedIdentityId: nestedDependencies.outputs.managedIdentityResourceId
+      administratorLogin: 'adminUserName'
+      administratorLoginPassword: password
+      location: enforcedLocation
+      roleAssignments: [
+        {
+          name: '7027a5c5-d1b1-49e0-80cc-ffdff3a3ada9'
+          roleDefinitionIdOrName: 'Owner'
+          principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+          principalType: 'ServicePrincipal'
         }
-      }
-    ]
-    databases: [
-      {
-        name: '${namePrefix}-${serviceShort}db-001'
-        collation: 'SQL_Latin1_General_CP1_CI_AS'
-        sku: {
-          name: 'ElasticPool'
-          tier: 'GeneralPurpose'
-          capacity: 0
+        {
+          name: guid('Custom seed ${namePrefix}${serviceShort}')
+          roleDefinitionIdOrName: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+          principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+          principalType: 'ServicePrincipal'
         }
-        maxSizeBytes: 34359738368
-        licenseType: 'LicenseIncluded'
-        diagnosticSettings: [
-          {
-            name: 'customSetting'
-            eventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
-            eventHubAuthorizationRuleResourceId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
-            storageAccountResourceId: diagnosticDependencies.outputs.storageAccountResourceId
-            workspaceResourceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
-          }
-        ]
-        elasticPoolResourceId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/${namePrefix}-${serviceShort}/elasticPools/${namePrefix}-${serviceShort}-ep-001'
-        backupShortTermRetentionPolicy: {
-          retentionDays: 14
+        {
+          roleDefinitionIdOrName: subscriptionResourceId(
+            'Microsoft.Authorization/roleDefinitions',
+            'acdd72a7-3385-48ef-bd42-f606fba81ae7'
+          )
+          principalId: nestedDependencies.outputs.managedIdentityPrincipalId
+          principalType: 'ServicePrincipal'
         }
-        backupLongTermRetentionPolicy: {
-          monthlyRetention: 'P6M'
-        }
-      }
-    ]
-    customerManagedKey: {
-      keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
-      keyName: nestedDependencies.outputs.keyVaultKeyName
-      keyVersion: last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))
-      autoRotationEnabled: true
-    }
-    firewallRules: [
-      {
-        name: 'AllowAllWindowsAzureIps'
-        endIpAddress: '0.0.0.0'
-        startIpAddress: '0.0.0.0'
-      }
-    ]
-    securityAlertPolicies: [
-      {
-        name: 'Default'
-        state: 'Enabled'
-        emailAccountAdmins: true
-      }
-    ]
-    managedIdentities: {
-      systemAssigned: true
-      userAssignedResourceIds: [
-        nestedDependencies.outputs.managedIdentityResourceId
       ]
-    }
-    privateEndpoints: [
-      {
-        subnetResourceId: nestedDependencies.outputs.privateEndpointSubnetResourceId
-        privateDnsZoneGroup: {
-          privateDnsZoneGroupConfigs: [
-            {
-              privateDnsZoneResourceId: nestedDependencies.outputs.privateDNSZoneResourceId
-            }
+      vulnerabilityAssessmentsObj: {
+        name: 'default'
+        recurringScans: {
+          emailSubscriptionAdmins: true
+          isEnabled: true
+          emails: [
+            'test1@contoso.com'
+            'test2@contoso.com'
           ]
         }
-        tags: {
-          'hidden-title': 'This is visible in the resource name'
-          Environment: 'Non-Prod'
-          Role: 'DeploymentValidation'
-        }
+        storageAccountResourceId: diagnosticDependencies.outputs.storageAccountResourceId
       }
-      {
-        subnetResourceId: nestedDependencies.outputs.privateEndpointSubnetResourceId
-        privateDnsZoneGroup: {
-          privateDnsZoneGroupConfigs: [
+      elasticPools: [
+        {
+          name: '${namePrefix}-${serviceShort}-ep-001'
+          sku: {
+            name: 'GP_Gen5'
+            tier: 'GeneralPurpose'
+            capacity: 10
+          }
+        }
+      ]
+      databases: [
+        {
+          name: '${namePrefix}-${serviceShort}db-001'
+          collation: 'SQL_Latin1_General_CP1_CI_AS'
+          sku: {
+            name: 'ElasticPool'
+            tier: 'GeneralPurpose'
+            capacity: 0
+          }
+          maxSizeBytes: 34359738368
+          licenseType: 'LicenseIncluded'
+          diagnosticSettings: [
             {
-              privateDnsZoneResourceId: nestedDependencies.outputs.privateDNSZoneResourceId
+              name: 'customSetting'
+              eventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
+              eventHubAuthorizationRuleResourceId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
+              storageAccountResourceId: diagnosticDependencies.outputs.storageAccountResourceId
+              workspaceResourceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
             }
           ]
+          elasticPoolResourceId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/${namePrefix}-${serviceShort}/elasticPools/${namePrefix}-${serviceShort}-ep-001'
+          backupShortTermRetentionPolicy: {
+            retentionDays: 14
+          }
+          backupLongTermRetentionPolicy: {
+            monthlyRetention: 'P6M'
+          }
         }
+      ]
+      customerManagedKey: {
+        keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
+        keyName: nestedDependencies.outputs.keyVaultKeyName
+        keyVersion: last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))
+        autoRotationEnabled: true
       }
-    ]
-    virtualNetworkRules: [
-      {
-        ignoreMissingVnetServiceEndpoint: true
-        name: 'newVnetRule1'
-        virtualNetworkSubnetId: nestedDependencies.outputs.serviceEndpointSubnetResourceId
+      firewallRules: [
+        {
+          name: 'AllowAllWindowsAzureIps'
+          endIpAddress: '0.0.0.0'
+          startIpAddress: '0.0.0.0'
+        }
+      ]
+      securityAlertPolicies: [
+        {
+          name: 'Default'
+          state: 'Enabled'
+          emailAccountAdmins: true
+        }
+      ]
+      managedIdentities: {
+        systemAssigned: true
+        userAssignedResourceIds: [
+          nestedDependencies.outputs.managedIdentityResourceId
+        ]
       }
-    ]
-    restrictOutboundNetworkAccess: 'Disabled'
-    tags: {
-      'hidden-title': 'This is visible in the resource name'
-      Environment: 'Non-Prod'
-      Role: 'DeploymentValidation'
+      privateEndpoints: [
+        {
+          subnetResourceId: nestedDependencies.outputs.privateEndpointSubnetResourceId
+          privateDnsZoneGroup: {
+            privateDnsZoneGroupConfigs: [
+              {
+                privateDnsZoneResourceId: nestedDependencies.outputs.privateDNSZoneResourceId
+              }
+            ]
+          }
+          tags: {
+            'hidden-title': 'This is visible in the resource name'
+            Environment: 'Non-Prod'
+            Role: 'DeploymentValidation'
+          }
+        }
+        {
+          subnetResourceId: nestedDependencies.outputs.privateEndpointSubnetResourceId
+          privateDnsZoneGroup: {
+            privateDnsZoneGroupConfigs: [
+              {
+                privateDnsZoneResourceId: nestedDependencies.outputs.privateDNSZoneResourceId
+              }
+            ]
+          }
+        }
+      ]
+      virtualNetworkRules: [
+        {
+          ignoreMissingVnetServiceEndpoint: true
+          name: 'newVnetRule1'
+          virtualNetworkSubnetId: nestedDependencies.outputs.serviceEndpointSubnetResourceId
+        }
+      ]
+      restrictOutboundNetworkAccess: 'Disabled'
+      tags: {
+        'hidden-title': 'This is visible in the resource name'
+        Environment: 'Non-Prod'
+        Role: 'DeploymentValidation'
+      }
     }
   }
-}
+]

--- a/avm/res/sql/server/tests/e2e/secondary/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/secondary/main.test.bicep
@@ -47,35 +47,34 @@ module nestedDependencies 'dependencies.bicep' = {
 // ============== //
 // Test Execution //
 // ============== //
-
-module testDeployment '../../../main.bicep' = {
-  scope: resourceGroup
-  name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}'
-  params: {
-    name: '${namePrefix}-${serviceShort}-sec'
-    location: resourceLocation
-    administratorLogin: 'adminUserName'
-    administratorLoginPassword: password
-    databases: [
-      {
-        name: nestedDependencies.outputs.databaseName
-        sku: {
-          name: 'Basic'
-          tier: 'Basic'
+@batchSize(1)
+module testDeployment '../../../main.bicep' = [
+  for iteration in ['init', 'idem']: {
+    scope: resourceGroup
+    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
+    params: {
+      name: '${namePrefix}-${serviceShort}-sec'
+      location: resourceLocation
+      administratorLogin: 'adminUserName'
+      administratorLoginPassword: password
+      databases: [
+        {
+          name: nestedDependencies.outputs.databaseName
+          sku: {
+            name: 'Basic'
+            tier: 'Basic'
+          }
+          maxSizeBytes: 2147483648
+          createMode: 'Secondary'
+          sourceDatabaseResourceId: nestedDependencies.outputs.databaseResourceId
+          zoneRedundant: false
         }
-        maxSizeBytes: 2147483648
-        createMode: 'Secondary'
-        sourceDatabaseResourceId: nestedDependencies.outputs.databaseResourceId
-        zoneRedundant: false
+      ]
+      tags: {
+        'hidden-title': 'This is visible in the resource name'
+        Environment: 'Non-Prod'
+        Role: 'DeploymentValidation'
       }
-    ]
-    tags: {
-      'hidden-title': 'This is visible in the resource name'
-      Environment: 'Non-Prod'
-      Role: 'DeploymentValidation'
     }
   }
-  dependsOn: [
-    nestedDependencies
-  ]
-}
+]

--- a/avm/res/sql/server/tests/e2e/vulnAssm/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/vulnAssm/main.test.bicep
@@ -48,50 +48,49 @@ module nestedDependencies 'dependencies.bicep' = {
 // ============== //
 // Test Execution //
 // ============== //
-
-module testDeployment '../../../main.bicep' = {
-  scope: resourceGroup
-  name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}'
-  params: {
-    name: '${namePrefix}-${serviceShort}'
-    primaryUserAssignedIdentityId: nestedDependencies.outputs.managedIdentityResourceId
-    administratorLogin: 'adminUserName'
-    administratorLoginPassword: password
-    location: resourceLocation
-    vulnerabilityAssessmentsObj: {
-      name: 'default'
-      recurringScans: {
-        emails: [
-          'test1@contoso.com'
-          'test2@contoso.com'
-        ]
-        emailSubscriptionAdmins: true
-        isEnabled: true
+@batchSize(1)
+module testDeployment '../../../main.bicep' = [
+  for iteration in ['init', 'idem']: {
+    scope: resourceGroup
+    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
+    params: {
+      name: '${namePrefix}-${serviceShort}'
+      primaryUserAssignedIdentityId: nestedDependencies.outputs.managedIdentityResourceId
+      administratorLogin: 'adminUserName'
+      administratorLoginPassword: password
+      location: resourceLocation
+      vulnerabilityAssessmentsObj: {
+        name: 'default'
+        recurringScans: {
+          emails: [
+            'test1@contoso.com'
+            'test2@contoso.com'
+          ]
+          emailSubscriptionAdmins: true
+          isEnabled: true
+        }
+        storageAccountResourceId: nestedDependencies.outputs.storageAccountResourceId
+        useStorageAccountAccessKey: false
+        createStorageRoleAssignment: true
       }
-      storageAccountResourceId: nestedDependencies.outputs.storageAccountResourceId
-      useStorageAccountAccessKey: false
-      createStorageRoleAssignment: true
-    }
-    securityAlertPolicies: [
-      {
-        name: 'Default'
-        state: 'Enabled'
-        emailAccountAdmins: true
-      }
-    ]
-    managedIdentities: {
-      systemAssigned: true
-      userAssignedResourceIds: [
-        nestedDependencies.outputs.managedIdentityResourceId
+      securityAlertPolicies: [
+        {
+          name: 'Default'
+          state: 'Enabled'
+          emailAccountAdmins: true
+        }
       ]
-    }
-    tags: {
-      'hidden-title': 'This is visible in the resource name'
-      Environment: 'Non-Prod'
-      Role: 'DeploymentValidation'
+      managedIdentities: {
+        systemAssigned: true
+        userAssignedResourceIds: [
+          nestedDependencies.outputs.managedIdentityResourceId
+        ]
+      }
+      tags: {
+        'hidden-title': 'This is visible in the resource name'
+        Environment: 'Non-Prod'
+        Role: 'DeploymentValidation'
+      }
     }
   }
-  dependsOn: [
-    nestedDependencies
-  ]
-}
+]

--- a/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
@@ -182,8 +182,4 @@ module testDeployment '../../../main.bicep' = {
       Role: 'DeploymentValidation'
     }
   }
-  dependsOn: [
-    nestedDependencies
-    diagnosticDependencies
-  ]
 }

--- a/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
@@ -64,7 +64,7 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
 // ============== //
 // Test Execution //
 // ============== //
-
+@batchSize(1)
 module testDeployment '../../../main.bicep' = [
   for iteration in ['init', 'idem']: {
     scope: resourceGroup

--- a/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
@@ -65,121 +65,123 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
 // Test Execution //
 // ============== //
 
-module testDeployment '../../../main.bicep' = {
-  scope: resourceGroup
-  name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}'
-  params: {
-    name: '${namePrefix}-${serviceShort}'
-    primaryUserAssignedIdentityId: nestedDependencies.outputs.managedIdentityResourceId
-    administrators: {
-      azureADOnlyAuthentication: true
-      login: 'myspn'
-      sid: nestedDependencies.outputs.managedIdentityPrincipalId
-      principalType: 'Application'
-      tenantId: tenant().tenantId
-    }
-    location: enforcedLocation
-    vulnerabilityAssessmentsObj: {
-      name: 'default'
-      recurringScans: {
-        emailSubscriptionAdmins: true
-        isEnabled: true
-        emails: [
-          'test1@contoso.com'
-          'test2@contoso.com'
-        ]
+module testDeployment '../../../main.bicep' = [
+  for iteration in ['init', 'idem']: {
+    scope: resourceGroup
+    name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-${iteration}'
+    params: {
+      name: '${namePrefix}-${serviceShort}'
+      primaryUserAssignedIdentityId: nestedDependencies.outputs.managedIdentityResourceId
+      administrators: {
+        azureADOnlyAuthentication: true
+        login: 'myspn'
+        sid: nestedDependencies.outputs.managedIdentityPrincipalId
+        principalType: 'Application'
+        tenantId: tenant().tenantId
       }
-      storageAccountResourceId: diagnosticDependencies.outputs.storageAccountResourceId
-    }
-    elasticPools: [
-      {
-        name: '${namePrefix}-${serviceShort}-ep-001'
-        sku: {
-          name: 'GP_Gen5'
-          tier: 'GeneralPurpose'
-          capacity: 10
-        }
-        maintenanceConfigurationId: '${subscription().id}/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_${enforcedLocation}_DB_1'
-      }
-    ]
-    databases: [
-      {
-        name: '${namePrefix}-${serviceShort}db-001'
-        collation: 'SQL_Latin1_General_CP1_CI_AS'
-        sku: {
-          name: 'ElasticPool'
-          tier: 'GeneralPurpose'
-          capacity: 0
-        }
-        maxSizeBytes: 34359738368
-        licenseType: 'LicenseIncluded'
-        diagnosticSettings: [
-          {
-            name: 'customSetting'
-            eventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
-            eventHubAuthorizationRuleResourceId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
-            storageAccountResourceId: diagnosticDependencies.outputs.storageAccountResourceId
-            workspaceResourceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
-          }
-        ]
-        elasticPoolResourceId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/${namePrefix}-${serviceShort}/elasticPools/${namePrefix}-${serviceShort}-ep-001'
-        backupShortTermRetentionPolicy: {
-          retentionDays: 14
-        }
-        backupLongTermRetentionPolicy: {
-          monthlyRetention: 'P6M'
-        }
-      }
-    ]
-    customerManagedKey: {
-      keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
-      keyName: nestedDependencies.outputs.keyVaultKeyName
-      keyVersion: last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))
-      autoRotationEnabled: true
-    }
-    securityAlertPolicies: [
-      {
-        name: 'Default'
-        state: 'Enabled'
-        emailAccountAdmins: true
-      }
-    ]
-    managedIdentities: {
-      systemAssigned: true
-      userAssignedResourceIds: [
-        nestedDependencies.outputs.managedIdentityResourceId
-      ]
-    }
-    privateEndpoints: [
-      {
-        subnetResourceId: nestedDependencies.outputs.privateEndpointSubnetResourceId
-        service: 'sqlServer'
-        privateDnsZoneGroup: {
-          privateDnsZoneGroupConfigs: [
-            {
-              privateDnsZoneResourceId: nestedDependencies.outputs.privateDNSZoneResourceId
-            }
+      location: enforcedLocation
+      vulnerabilityAssessmentsObj: {
+        name: 'default'
+        recurringScans: {
+          emailSubscriptionAdmins: true
+          isEnabled: true
+          emails: [
+            'test1@contoso.com'
+            'test2@contoso.com'
           ]
         }
-        tags: {
-          'hidden-title': 'This is visible in the resource name'
-          Environment: 'Non-Prod'
-          Role: 'DeploymentValidation'
+        storageAccountResourceId: diagnosticDependencies.outputs.storageAccountResourceId
+      }
+      elasticPools: [
+        {
+          name: '${namePrefix}-${serviceShort}-ep-001'
+          sku: {
+            name: 'GP_Gen5'
+            tier: 'GeneralPurpose'
+            capacity: 10
+          }
+          maintenanceConfigurationId: '${subscription().id}/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_${enforcedLocation}_DB_1'
         }
+      ]
+      databases: [
+        {
+          name: '${namePrefix}-${serviceShort}db-001'
+          collation: 'SQL_Latin1_General_CP1_CI_AS'
+          sku: {
+            name: 'ElasticPool'
+            tier: 'GeneralPurpose'
+            capacity: 0
+          }
+          maxSizeBytes: 34359738368
+          licenseType: 'LicenseIncluded'
+          diagnosticSettings: [
+            {
+              name: 'customSetting'
+              eventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
+              eventHubAuthorizationRuleResourceId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
+              storageAccountResourceId: diagnosticDependencies.outputs.storageAccountResourceId
+              workspaceResourceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
+            }
+          ]
+          elasticPoolResourceId: '${resourceGroup.id}/providers/Microsoft.Sql/servers/${namePrefix}-${serviceShort}/elasticPools/${namePrefix}-${serviceShort}-ep-001'
+          backupShortTermRetentionPolicy: {
+            retentionDays: 14
+          }
+          backupLongTermRetentionPolicy: {
+            monthlyRetention: 'P6M'
+          }
+        }
+      ]
+      customerManagedKey: {
+        keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
+        keyName: nestedDependencies.outputs.keyVaultKeyName
+        keyVersion: last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))
+        autoRotationEnabled: true
       }
-    ]
-    virtualNetworkRules: [
-      {
-        ignoreMissingVnetServiceEndpoint: true
-        name: 'newVnetRule1'
-        virtualNetworkSubnetId: nestedDependencies.outputs.serviceEndpointSubnetResourceId
+      securityAlertPolicies: [
+        {
+          name: 'Default'
+          state: 'Enabled'
+          emailAccountAdmins: true
+        }
+      ]
+      managedIdentities: {
+        systemAssigned: true
+        userAssignedResourceIds: [
+          nestedDependencies.outputs.managedIdentityResourceId
+        ]
       }
-    ]
-    restrictOutboundNetworkAccess: 'Disabled'
-    tags: {
-      'hidden-title': 'This is visible in the resource name'
-      Environment: 'Non-Prod'
-      Role: 'DeploymentValidation'
+      privateEndpoints: [
+        {
+          subnetResourceId: nestedDependencies.outputs.privateEndpointSubnetResourceId
+          service: 'sqlServer'
+          privateDnsZoneGroup: {
+            privateDnsZoneGroupConfigs: [
+              {
+                privateDnsZoneResourceId: nestedDependencies.outputs.privateDNSZoneResourceId
+              }
+            ]
+          }
+          tags: {
+            'hidden-title': 'This is visible in the resource name'
+            Environment: 'Non-Prod'
+            Role: 'DeploymentValidation'
+          }
+        }
+      ]
+      virtualNetworkRules: [
+        {
+          ignoreMissingVnetServiceEndpoint: true
+          name: 'newVnetRule1'
+          virtualNetworkSubnetId: nestedDependencies.outputs.serviceEndpointSubnetResourceId
+        }
+      ]
+      restrictOutboundNetworkAccess: 'Disabled'
+      tags: {
+        'hidden-title': 'This is visible in the resource name'
+        Environment: 'Non-Prod'
+        Role: 'DeploymentValidation'
+      }
     }
   }
-}
+]


### PR DESCRIPTION
## Description

I have reviewed the SQL Server tests, and made the following changes:

* Added `init` & `idem` for tests where they were missing to ensure that tests are running in idempotent way
* Removed unnecessary dependencies

I left the `max` and `waf` tests as single, as they are already running 20+ mins, if we would add the `init` and `idem` for them (which I believe would be possible), it would take even longer to run them in CI. LMK if you would like me to add them as well.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.sql.server](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg?branch=sql-tests)](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml)     |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
