### PR TITLE
fix: avm/res/service-bus/namespace various fixes & improvements

### DIFF
--- a/avm/res/service-bus/namespace/README.md
+++ b/avm/res/service-bus/namespace/README.md
@@ -470,14 +470,50 @@ module namespace 'br/public:avm/res/service-bus/namespace:<version>' = {
         ]
         subscriptions: [
           {
-            name: 'subscription001'
+            name: 'subscriptionwithoutrules001'
+          }
+          {
+            name: 'subscriptionwithsqlfilterrule001'
             rules: [
               {
+                action: {
+                  compatibilityLevel: 20
+                  requiresPreprocessing: true
+                  sqlExpression: 'SET Foo = 1;'
+                }
                 filterType: 'SqlFilter'
-                name: 'test-filter'
+                name: 'test-sql-filter'
                 sqlFilter: {
                   sqlExpression: 'Test=1'
                 }
+              }
+            ]
+          }
+          {
+            name: 'subscriptionwithcorrelationfilterrule001'
+            rules: [
+              {
+                action: {
+                  compatibilityLevel: 20
+                  requiresPreprocessing: true
+                  sqlExpression: 'SET Foo = 1;'
+                }
+                correlationFilter: {
+                  contentType: 'application/json'
+                  correlationId: 'Test'
+                  label: 'Test'
+                  messageId: 'Test'
+                  properties: {
+                    barHeader: 'Bar'
+                    fooHeader: 'Foo'
+                  }
+                  replyTo: 'Test'
+                  replyToSessionId: 'Test'
+                  sessionId: 'Test'
+                  to: 'Test'
+                }
+                filterType: 'CorrelationFilter'
+                name: 'test-correlation-filter'
               }
             ]
           }
@@ -762,14 +798,50 @@ module namespace 'br/public:avm/res/service-bus/namespace:<version>' = {
           ],
           "subscriptions": [
             {
-              "name": "subscription001",
+              "name": "subscriptionwithoutrules001"
+            },
+            {
+              "name": "subscriptionwithsqlfilterrule001",
               "rules": [
                 {
+                  "action": {
+                    "compatibilityLevel": 20,
+                    "requiresPreprocessing": true,
+                    "sqlExpression": "SET Foo = 1;"
+                  },
                   "filterType": "SqlFilter",
-                  "name": "test-filter",
+                  "name": "test-sql-filter",
                   "sqlFilter": {
                     "sqlExpression": "Test=1"
                   }
+                }
+              ]
+            },
+            {
+              "name": "subscriptionwithcorrelationfilterrule001",
+              "rules": [
+                {
+                  "action": {
+                    "compatibilityLevel": 20,
+                    "requiresPreprocessing": true,
+                    "sqlExpression": "SET Foo = 1;"
+                  },
+                  "correlationFilter": {
+                    "contentType": "application/json",
+                    "correlationId": "Test",
+                    "label": "Test",
+                    "messageId": "Test",
+                    "properties": {
+                      "barHeader": "Bar",
+                      "fooHeader": "Foo"
+                    },
+                    "replyTo": "Test",
+                    "replyToSessionId": "Test",
+                    "sessionId": "Test",
+                    "to": "Test"
+                  },
+                  "filterType": "CorrelationFilter",
+                  "name": "test-correlation-filter"
                 }
               ]
             }
@@ -1020,14 +1092,50 @@ param topics = [
     ]
     subscriptions: [
       {
-        name: 'subscription001'
+        name: 'subscriptionwithoutrules001'
+      }
+      {
+        name: 'subscriptionwithsqlfilterrule001'
         rules: [
           {
+            action: {
+              compatibilityLevel: 20
+              requiresPreprocessing: true
+              sqlExpression: 'SET Foo = 1;'
+            }
             filterType: 'SqlFilter'
-            name: 'test-filter'
+            name: 'test-sql-filter'
             sqlFilter: {
               sqlExpression: 'Test=1'
             }
+          }
+        ]
+      }
+      {
+        name: 'subscriptionwithcorrelationfilterrule001'
+        rules: [
+          {
+            action: {
+              compatibilityLevel: 20
+              requiresPreprocessing: true
+              sqlExpression: 'SET Foo = 1;'
+            }
+            correlationFilter: {
+              contentType: 'application/json'
+              correlationId: 'Test'
+              label: 'Test'
+              messageId: 'Test'
+              properties: {
+                barHeader: 'Bar'
+                fooHeader: 'Foo'
+              }
+              replyTo: 'Test'
+              replyToSessionId: 'Test'
+              sessionId: 'Test'
+              to: 'Test'
+            }
+            filterType: 'CorrelationFilter'
+            name: 'test-correlation-filter'
           }
         ]
       }
@@ -1118,7 +1226,7 @@ module namespace 'br/public:avm/res/service-bus/namespace:<version>' = {
         }
       }
     ]
-    publicNetworkAccess: 'Enabled'
+    publicNetworkAccess: 'Disabled'
     queues: [
       {
         authorizationRules: [
@@ -1265,7 +1373,7 @@ module namespace 'br/public:avm/res/service-bus/namespace:<version>' = {
       ]
     },
     "publicNetworkAccess": {
-      "value": "Enabled"
+      "value": "Disabled"
     },
     "queues": {
       "value": [
@@ -1406,7 +1514,7 @@ param privateEndpoints = [
     }
   }
 ]
-param publicNetworkAccess = 'Enabled'
+param publicNetworkAccess = 'Disabled'
 param queues = [
   {
     authorizationRules: [
@@ -3339,17 +3447,17 @@ The subscriptions of the topic.
 | :-- | :-- | :-- |
 | [`autoDeleteOnIdle`](#parameter-topicssubscriptionsautodeleteonidle) | string | ISO 8601 timespan idle interval after which the syubscription is automatically deleted. The minimum duration is 5 minutes. |
 | [`clientAffineProperties`](#parameter-topicssubscriptionsclientaffineproperties) | object | The properties that are associated with a subscription that is client-affine. |
-| [`deadLetteringOnFilterEvaluationExceptions`](#parameter-topicssubscriptionsdeadletteringonfilterevaluationexceptions) | bool | A value that indicates whether a subscription has dead letter support when a message expires. |
+| [`deadLetteringOnFilterEvaluationExceptions`](#parameter-topicssubscriptionsdeadletteringonfilterevaluationexceptions) | bool | A value that indicates whether a subscription has dead letter support on filter evaluation exceptions. |
 | [`deadLetteringOnMessageExpiration`](#parameter-topicssubscriptionsdeadletteringonmessageexpiration) | bool | A value that indicates whether a subscription has dead letter support when a message expires. |
-| [`defaultMessageTimeToLive`](#parameter-topicssubscriptionsdefaultmessagetimetolive) | string | ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes. |
+| [`defaultMessageTimeToLive`](#parameter-topicssubscriptionsdefaultmessagetimetolive) | string | ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself. |
 | [`duplicateDetectionHistoryTimeWindow`](#parameter-topicssubscriptionsduplicatedetectionhistorytimewindow) | string | ISO 8601 timespan that defines the duration of the duplicate detection history. The default value is 10 minutes. |
 | [`enableBatchedOperations`](#parameter-topicssubscriptionsenablebatchedoperations) | bool | A value that indicates whether server-side batched operations are enabled. |
-| [`forwardDeadLetteredMessagesTo`](#parameter-topicssubscriptionsforwarddeadletteredmessagesto) | string | The name of the recipient entity to which all the messages sent to the subscription are forwarded to. |
-| [`forwardTo`](#parameter-topicssubscriptionsforwardto) | string | The name of the recipient entity to which all the messages sent to the subscription are forwarded to. |
-| [`isClientAffine`](#parameter-topicssubscriptionsisclientaffine) | bool | A value that indicates whether the subscription supports the concept of session. |
+| [`forwardDeadLetteredMessagesTo`](#parameter-topicssubscriptionsforwarddeadletteredmessagesto) | string | Queue/Topic name to forward the Dead Letter messages to. |
+| [`forwardTo`](#parameter-topicssubscriptionsforwardto) | string | Queue/Topic name to forward the messages to. |
+| [`isClientAffine`](#parameter-topicssubscriptionsisclientaffine) | bool | A value that indicates whether the subscription has an affinity to the client id. |
 | [`lockDuration`](#parameter-topicssubscriptionslockduration) | string | ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value for LockDuration is 5 minutes; the default value is 1 minute. |
 | [`maxDeliveryCount`](#parameter-topicssubscriptionsmaxdeliverycount) | int | Number of maximum deliveries. A message is automatically deadlettered after this number of deliveries. Default value is 10. |
-| [`requiresSession`](#parameter-topicssubscriptionsrequiressession) | bool | A value that indicates whether the subscription supports the concept of session. |
+| [`requiresSession`](#parameter-topicssubscriptionsrequiressession) | bool | A value that indicates whether the subscription supports the concept of sessions. |
 | [`rules`](#parameter-topicssubscriptionsrules) | array | The subscription rules. |
 | [`status`](#parameter-topicssubscriptionsstatus) | string | Enumerates the possible values for the status of a messaging entity. |
 
@@ -3410,7 +3518,7 @@ For client-affine subscriptions, this value indicates whether the subscription i
 
 ### Parameter: `topics.subscriptions.deadLetteringOnFilterEvaluationExceptions`
 
-A value that indicates whether a subscription has dead letter support when a message expires.
+A value that indicates whether a subscription has dead letter support on filter evaluation exceptions.
 
 - Required: No
 - Type: bool
@@ -3424,7 +3532,7 @@ A value that indicates whether a subscription has dead letter support when a mes
 
 ### Parameter: `topics.subscriptions.defaultMessageTimeToLive`
 
-ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes.
+ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.
 
 - Required: No
 - Type: string
@@ -3445,21 +3553,21 @@ A value that indicates whether server-side batched operations are enabled.
 
 ### Parameter: `topics.subscriptions.forwardDeadLetteredMessagesTo`
 
-The name of the recipient entity to which all the messages sent to the subscription are forwarded to.
+Queue/Topic name to forward the Dead Letter messages to.
 
 - Required: No
 - Type: string
 
 ### Parameter: `topics.subscriptions.forwardTo`
 
-The name of the recipient entity to which all the messages sent to the subscription are forwarded to.
+Queue/Topic name to forward the messages to.
 
 - Required: No
 - Type: string
 
 ### Parameter: `topics.subscriptions.isClientAffine`
 
-A value that indicates whether the subscription supports the concept of session.
+A value that indicates whether the subscription has an affinity to the client id.
 
 - Required: No
 - Type: bool
@@ -3480,7 +3588,7 @@ Number of maximum deliveries. A message is automatically deadlettered after this
 
 ### Parameter: `topics.subscriptions.requiresSession`
 
-A value that indicates whether the subscription supports the concept of session.
+A value that indicates whether the subscription supports the concept of sessions.
 
 - Required: No
 - Type: bool
@@ -3496,7 +3604,8 @@ The subscription rules.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`name`](#parameter-topicssubscriptionsrulesname) | string | The name of the service bus namespace topic subscription rule. |
+| [`filterType`](#parameter-topicssubscriptionsrulesfiltertype) | string | Filter type that is evaluated against a BrokeredMessage. |
+| [`name`](#parameter-topicssubscriptionsrulesname) | string | The name of the Service Bus Namespace Topic Subscription Rule. |
 
 **Optional parameters**
 
@@ -3504,12 +3613,25 @@ The subscription rules.
 | :-- | :-- | :-- |
 | [`action`](#parameter-topicssubscriptionsrulesaction) | object | Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression. |
 | [`correlationFilter`](#parameter-topicssubscriptionsrulescorrelationfilter) | object | Properties of correlationFilter. |
-| [`filterType`](#parameter-topicssubscriptionsrulesfiltertype) | string | Filter type that is evaluated against a BrokeredMessage. |
 | [`sqlFilter`](#parameter-topicssubscriptionsrulessqlfilter) | object | Properties of sqlFilter. |
+
+### Parameter: `topics.subscriptions.rules.filterType`
+
+Filter type that is evaluated against a BrokeredMessage.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'CorrelationFilter'
+    'SqlFilter'
+  ]
+  ```
 
 ### Parameter: `topics.subscriptions.rules.name`
 
-The name of the service bus namespace topic subscription rule.
+The name of the Service Bus Namespace Topic Subscription Rule.
 
 - Required: Yes
 - Type: string
@@ -3557,12 +3679,6 @@ Properties of correlationFilter.
 - Required: No
 - Type: object
 
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`to`](#parameter-topicssubscriptionsrulescorrelationfilterto) | string | Address to send to. |
-
 **Optional parameters**
 
 | Parameter | Type | Description |
@@ -3571,18 +3687,12 @@ Properties of correlationFilter.
 | [`correlationId`](#parameter-topicssubscriptionsrulescorrelationfiltercorrelationid) | string | Identifier of the correlation. |
 | [`label`](#parameter-topicssubscriptionsrulescorrelationfilterlabel) | string | Application specific label. |
 | [`messageId`](#parameter-topicssubscriptionsrulescorrelationfiltermessageid) | string | Identifier of the message. |
-| [`properties`](#parameter-topicssubscriptionsrulescorrelationfilterproperties) | array | dictionary object for custom filters. |
+| [`properties`](#parameter-topicssubscriptionsrulescorrelationfilterproperties) | object | Dictionary object for custom filters. |
 | [`replyTo`](#parameter-topicssubscriptionsrulescorrelationfilterreplyto) | string | Address of the queue to reply to. |
 | [`replyToSessionId`](#parameter-topicssubscriptionsrulescorrelationfilterreplytosessionid) | string | Session identifier to reply to. |
 | [`requiresPreprocessing`](#parameter-topicssubscriptionsrulescorrelationfilterrequirespreprocessing) | bool | Value that indicates whether the rule action requires preprocessing. |
 | [`sessionId`](#parameter-topicssubscriptionsrulescorrelationfiltersessionid) | string | Session identifier. |
-
-### Parameter: `topics.subscriptions.rules.correlationFilter.to`
-
-Address to send to.
-
-- Required: Yes
-- Type: string
+| [`to`](#parameter-topicssubscriptionsrulescorrelationfilterto) | string | Address to send to. |
 
 ### Parameter: `topics.subscriptions.rules.correlationFilter.contentType`
 
@@ -3614,16 +3724,10 @@ Identifier of the message.
 
 ### Parameter: `topics.subscriptions.rules.correlationFilter.properties`
 
-dictionary object for custom filters.
+Dictionary object for custom filters.
 
 - Required: No
-- Type: array
-- Allowed:
-  ```Bicep
-  [
-    {}
-  ]
-  ```
+- Type: object
 
 ### Parameter: `topics.subscriptions.rules.correlationFilter.replyTo`
 
@@ -3653,19 +3757,12 @@ Session identifier.
 - Required: No
 - Type: string
 
-### Parameter: `topics.subscriptions.rules.filterType`
+### Parameter: `topics.subscriptions.rules.correlationFilter.to`
 
-Filter type that is evaluated against a BrokeredMessage.
+Address to send to.
 
 - Required: No
 - Type: string
-- Allowed:
-  ```Bicep
-  [
-    'CorrelationFilter'
-    'SqlFilter'
-  ]
-  ```
 
 ### Parameter: `topics.subscriptions.rules.sqlFilter`
 
@@ -3674,13 +3771,25 @@ Properties of sqlFilter.
 - Required: No
 - Type: object
 
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`sqlExpression`](#parameter-topicssubscriptionsrulessqlfiltersqlexpression) | string | The SQL expression. e.g. MyProperty='ABC'. |
+
 **Optional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`compatibilityLevel`](#parameter-topicssubscriptionsrulessqlfiltercompatibilitylevel) | int | This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20. |
 | [`requiresPreprocessing`](#parameter-topicssubscriptionsrulessqlfilterrequirespreprocessing) | bool | Value that indicates whether the rule action requires preprocessing. |
-| [`sqlExpression`](#parameter-topicssubscriptionsrulessqlfiltersqlexpression) | string | SQL expression. e.g. MyProperty='ABC'. |
+
+### Parameter: `topics.subscriptions.rules.sqlFilter.sqlExpression`
+
+The SQL expression. e.g. MyProperty='ABC'.
+
+- Required: Yes
+- Type: string
 
 ### Parameter: `topics.subscriptions.rules.sqlFilter.compatibilityLevel`
 
@@ -3695,13 +3804,6 @@ Value that indicates whether the rule action requires preprocessing.
 
 - Required: No
 - Type: bool
-
-### Parameter: `topics.subscriptions.rules.sqlFilter.sqlExpression`
-
-SQL expression. e.g. MyProperty='ABC'.
-
-- Required: No
-- Type: string
 
 ### Parameter: `topics.subscriptions.status`
 

--- a/avm/res/service-bus/namespace/authorization-rule/main.json
+++ b/avm/res/service-bus/namespace/authorization-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "17477673416429447540"
+      "version": "0.34.44.8038",
+      "templateHash": "3472309488555852386"
     },
     "name": "Service Bus Namespace Authorization Rules",
     "description": "This module deploys a Service Bus Namespace Authorization Rule."

--- a/avm/res/service-bus/namespace/disaster-recovery-config/main.json
+++ b/avm/res/service-bus/namespace/disaster-recovery-config/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "2655313592794830711"
+      "version": "0.34.44.8038",
+      "templateHash": "14109784390213501614"
     },
     "name": "Service Bus Namespace Disaster Recovery Configs",
     "description": "This module deploys a Service Bus Namespace Disaster Recovery Config"

--- a/avm/res/service-bus/namespace/main.bicep
+++ b/avm/res/service-bus/namespace/main.bicep
@@ -379,8 +379,7 @@ resource serviceBusNamespace_diagnosticSettings 'Microsoft.Insights/diagnosticSe
 
 module serviceBusNamespace_privateEndpoints 'br/public:avm/res/network/private-endpoint:0.10.1' = [
   for (privateEndpoint, index) in (privateEndpoints ?? []): {
-    #disable-next-line BCP335
-    name: '${uniqueString(deployment().name, location)}-serviceBusNamespace-PrivateEndpoint-${index}'
+    name: '${uniqueString(deployment().name, location)}-serviceBusNamespace-PEP-${index}'
     scope: resourceGroup(
       split(privateEndpoint.?resourceGroupResourceId ?? resourceGroup().id, '/')[2],
       split(privateEndpoint.?resourceGroupResourceId ?? resourceGroup().id, '/')[4]

--- a/avm/res/service-bus/namespace/main.bicep
+++ b/avm/res/service-bus/namespace/main.bicep
@@ -379,6 +379,7 @@ resource serviceBusNamespace_diagnosticSettings 'Microsoft.Insights/diagnosticSe
 
 module serviceBusNamespace_privateEndpoints 'br/public:avm/res/network/private-endpoint:0.10.1' = [
   for (privateEndpoint, index) in (privateEndpoints ?? []): {
+    #disable-next-line BCP335
     name: '${uniqueString(deployment().name, location)}-serviceBusNamespace-PrivateEndpoint-${index}'
     scope: resourceGroup(
       split(privateEndpoint.?resourceGroupResourceId ?? resourceGroup().id, '/')[2],

--- a/avm/res/service-bus/namespace/main.json
+++ b/avm/res/service-bus/namespace/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "4731007417584724942"
+      "version": "0.34.44.8038",
+      "templateHash": "17174269008871886291"
     },
     "name": "Service Bus Namespaces",
     "description": "This module deploys a Service Bus Namespace."
@@ -684,162 +684,163 @@
         }
       }
     },
+    "_2.actionType": {
+      "type": "object",
+      "properties": {
+        "compatibilityLevel": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+          }
+        },
+        "requiresPreprocessing": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+          }
+        },
+        "sqlExpression": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
+          }
+        }
+      },
+      "metadata": {
+        "description": "A type for the filter actions of a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "topic/subscription/rule/main.bicep"
+        }
+      }
+    },
+    "_2.correlationFilterType": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Content type of the message."
+          }
+        },
+        "correlationId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Identifier of the correlation."
+          }
+        },
+        "label": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Application specific label."
+          }
+        },
+        "messageId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Identifier of the message."
+          }
+        },
+        "properties": {
+          "type": "object",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Dictionary object for custom filters."
+          }
+        },
+        "replyTo": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Address of the queue to reply to."
+          }
+        },
+        "replyToSessionId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Session identifier to reply to."
+          }
+        },
+        "requiresPreprocessing": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+          }
+        },
+        "sessionId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Session identifier."
+          }
+        },
+        "to": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Address to send to."
+          }
+        }
+      },
+      "metadata": {
+        "description": "A type for the properties of a correlation filter of a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "topic/subscription/rule/main.bicep"
+        }
+      }
+    },
+    "_2.filterTypeType": {
+      "type": "string",
+      "allowedValues": [
+        "CorrelationFilter",
+        "SqlFilter"
+      ],
+      "metadata": {
+        "description": "A type for the type of a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "topic/subscription/rule/main.bicep"
+        }
+      }
+    },
     "_2.ruleType": {
       "type": "object",
       "properties": {
         "name": {
           "type": "string",
           "metadata": {
-            "description": "Required. The name of the service bus namespace topic subscription rule."
+            "description": "Required. The name of the Service Bus Namespace Topic Subscription Rule."
           }
         },
         "action": {
-          "type": "object",
-          "properties": {
-            "compatibilityLevel": {
-              "type": "int",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
-              }
-            },
-            "requiresPreprocessing": {
-              "type": "bool",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-              }
-            },
-            "sqlExpression": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
-              }
-            }
-          },
+          "$ref": "#/definitions/_2.actionType",
           "nullable": true,
           "metadata": {
             "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
           }
         },
         "correlationFilter": {
-          "type": "object",
-          "properties": {
-            "contentType": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Content type of the message."
-              }
-            },
-            "correlationId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Identifier of the correlation."
-              }
-            },
-            "label": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Application specific label."
-              }
-            },
-            "messageId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Identifier of the message."
-              }
-            },
-            "properties": {
-              "type": "array",
-              "allowedValues": [
-                {}
-              ],
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. dictionary object for custom filters."
-              }
-            },
-            "replyTo": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Address of the queue to reply to."
-              }
-            },
-            "replyToSessionId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Session identifier to reply to."
-              }
-            },
-            "requiresPreprocessing": {
-              "type": "bool",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-              }
-            },
-            "sessionId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Session identifier."
-              }
-            },
-            "to": {
-              "type": "string",
-              "metadata": {
-                "description": "Required. Address to send to."
-              }
-            }
-          },
+          "$ref": "#/definitions/_2.correlationFilterType",
           "nullable": true,
           "metadata": {
             "description": "Optional. Properties of correlationFilter."
           }
         },
         "filterType": {
-          "type": "string",
-          "allowedValues": [
-            "CorrelationFilter",
-            "SqlFilter"
-          ],
-          "nullable": true,
+          "$ref": "#/definitions/_2.filterTypeType",
           "metadata": {
-            "description": "Optional. Filter type that is evaluated against a BrokeredMessage."
+            "description": "Required. Filter type that is evaluated against a BrokeredMessage."
           }
         },
         "sqlFilter": {
-          "type": "object",
-          "properties": {
-            "compatibilityLevel": {
-              "type": "int",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
-              }
-            },
-            "requiresPreprocessing": {
-              "type": "bool",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-              }
-            },
-            "sqlExpression": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
-              }
-            }
-          },
+          "$ref": "#/definitions/_2.sqlFilterType",
           "nullable": true,
           "metadata": {
             "description": "Optional. Properties of sqlFilter."
@@ -847,9 +848,40 @@
         }
       },
       "metadata": {
-        "description": "Optional. The type for rules.",
+        "description": "A type for a Service Bus Namespace Topic Subscription Rule.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "topic/subscription/main.bicep"
+          "sourceTemplate": "topic/subscription/rule/main.bicep"
+        }
+      }
+    },
+    "_2.sqlFilterType": {
+      "type": "object",
+      "properties": {
+        "compatibilityLevel": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+          }
+        },
+        "requiresPreprocessing": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+          }
+        },
+        "sqlExpression": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The SQL expression. e.g. MyProperty='ABC'."
+          }
+        }
+      },
+      "metadata": {
+        "description": "A type for the properties of a SQL filter of a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "topic/subscription/rule/main.bicep"
         }
       }
     },
@@ -1350,14 +1382,14 @@
           "type": "bool",
           "nullable": true,
           "metadata": {
-            "description": "Optional. A value that indicates whether a subscription has dead letter support when a message expires."
+            "description": "Optional. A value that indicates whether a subscription has dead letter support on filter evaluation exceptions."
           }
         },
         "defaultMessageTimeToLive": {
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes."
+            "description": "Optional. ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself."
           }
         },
         "duplicateDetectionHistoryTimeWindow": {
@@ -1378,21 +1410,21 @@
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to."
+            "description": "Optional. Queue/Topic name to forward the Dead Letter messages to."
           }
         },
         "forwardTo": {
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to."
+            "description": "Optional. Queue/Topic name to forward the messages to."
           }
         },
         "isClientAffine": {
           "type": "bool",
           "nullable": true,
           "metadata": {
-            "description": "Optional. A value that indicates whether the subscription supports the concept of session."
+            "description": "Optional. A value that indicates whether the subscription has an affinity to the client id."
           }
         },
         "lockDuration": {
@@ -1413,7 +1445,7 @@
           "type": "bool",
           "nullable": true,
           "metadata": {
-            "description": "Optional. A value that indicates whether the subscription supports the concept of session."
+            "description": "Optional. A value that indicates whether the subscription supports the concept of sessions."
           }
         },
         "rules": {
@@ -1755,8 +1787,8 @@
         "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('keySource', 'Microsoft.KeyVault', 'keyVaultProperties', createArray(createObject('identity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), createObject('userAssignedIdentity', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[2], split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')))), null()), 'keyName', parameters('customerManagedKey').keyName, 'keyVaultUri', reference('cMKKeyVault').vaultUri, 'keyVersion', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'keyVersion'), ''))), tryGet(parameters('customerManagedKey'), 'keyVersion'), if(coalesce(tryGet(parameters('customerManagedKey'), 'autoRotationEnabled'), true()), null(), last(split(reference('cMKKeyVault::cMKKey').keyUriWithVersion, '/')))))), 'requireInfrastructureEncryption', parameters('requireInfrastructureEncryption')), null())]"
       },
       "dependsOn": [
-        "cMKKeyVault::cMKKey",
-        "cMKKeyVault"
+        "cMKKeyVault",
+        "cMKKeyVault::cMKKey"
       ]
     },
     "serviceBusNamespace_lock": {
@@ -1866,8 +1898,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "17477673416429447540"
+              "version": "0.34.44.8038",
+              "templateHash": "3472309488555852386"
             },
             "name": "Service Bus Namespace Authorization Rules",
             "description": "This module deploys a Service Bus Namespace Authorization Rule."
@@ -1969,8 +2001,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2655313592794830711"
+              "version": "0.34.44.8038",
+              "templateHash": "14109784390213501614"
             },
             "name": "Service Bus Namespace Disaster Recovery Configs",
             "description": "This module deploys a Service Bus Namespace Disaster Recovery Config"
@@ -2073,8 +2105,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "8888372741848926270"
+              "version": "0.34.44.8038",
+              "templateHash": "15719533438339680488"
             },
             "name": "Service Bus Namespace Migration Configuration",
             "description": "This module deploys a Service Bus Namespace Migration Configuration."
@@ -2177,8 +2209,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "8455455085685736737"
+              "version": "0.34.44.8038",
+              "templateHash": "6180219953560179899"
             },
             "name": "Service Bus Namespace Network Rule Sets",
             "description": "This module deploys a ServiceBus Namespace Network Rule Set."
@@ -2376,8 +2408,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "17714956813335477440"
+              "version": "0.34.44.8038",
+              "templateHash": "6215388008501436423"
             },
             "name": "Service Bus Namespace Queue",
             "description": "This module deploys a Service Bus Namespace Queue."
@@ -2775,8 +2807,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "17543469200710595087"
+                      "version": "0.34.44.8038",
+                      "templateHash": "6508430894548859396"
                     },
                     "name": "Service Bus Namespace Queue Authorization Rules",
                     "description": "This module deploys a Service Bus Namespace Queue Authorization Rule."
@@ -2955,8 +2987,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "3613850961357682472"
+              "version": "0.34.44.8038",
+              "templateHash": "38000433144185993"
             },
             "name": "Service Bus Namespace Topic",
             "description": "This module deploys a Service Bus Namespace Topic."
@@ -3018,14 +3050,14 @@
                   "type": "bool",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. A value that indicates whether a subscription has dead letter support when a message expires."
+                    "description": "Optional. A value that indicates whether a subscription has dead letter support on filter evaluation exceptions."
                   }
                 },
                 "defaultMessageTimeToLive": {
                   "type": "string",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes."
+                    "description": "Optional. ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself."
                   }
                 },
                 "duplicateDetectionHistoryTimeWindow": {
@@ -3046,21 +3078,21 @@
                   "type": "string",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to."
+                    "description": "Optional. Queue/Topic name to forward the Dead Letter messages to."
                   }
                 },
                 "forwardTo": {
                   "type": "string",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to."
+                    "description": "Optional. Queue/Topic name to forward the messages to."
                   }
                 },
                 "isClientAffine": {
                   "type": "bool",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. A value that indicates whether the subscription supports the concept of session."
+                    "description": "Optional. A value that indicates whether the subscription has an affinity to the client id."
                   }
                 },
                 "lockDuration": {
@@ -3081,7 +3113,7 @@
                   "type": "bool",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. A value that indicates whether the subscription supports the concept of session."
+                    "description": "Optional. A value that indicates whether the subscription supports the concept of sessions."
                   }
                 },
                 "rules": {
@@ -3116,6 +3148,163 @@
               "metadata": {
                 "__bicep_export!": true,
                 "description": "The type for a subscription."
+              }
+            },
+            "_1.actionType": {
+              "type": "object",
+              "properties": {
+                "compatibilityLevel": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+                  }
+                },
+                "requiresPreprocessing": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                  }
+                },
+                "sqlExpression": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "A type for the filter actions of a Service Bus Namespace Topic Subscription Rule.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "subscription/rule/main.bicep"
+                }
+              }
+            },
+            "_1.correlationFilterType": {
+              "type": "object",
+              "properties": {
+                "contentType": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Content type of the message."
+                  }
+                },
+                "correlationId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Identifier of the correlation."
+                  }
+                },
+                "label": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Application specific label."
+                  }
+                },
+                "messageId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Identifier of the message."
+                  }
+                },
+                "properties": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Dictionary object for custom filters."
+                  }
+                },
+                "replyTo": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Address of the queue to reply to."
+                  }
+                },
+                "replyToSessionId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Session identifier to reply to."
+                  }
+                },
+                "requiresPreprocessing": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                  }
+                },
+                "sessionId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Session identifier."
+                  }
+                },
+                "to": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Address to send to."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "A type for the properties of a correlation filter of a Service Bus Namespace Topic Subscription Rule.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "subscription/rule/main.bicep"
+                }
+              }
+            },
+            "_1.filterTypeType": {
+              "type": "string",
+              "allowedValues": [
+                "CorrelationFilter",
+                "SqlFilter"
+              ],
+              "metadata": {
+                "description": "A type for the type of a Service Bus Namespace Topic Subscription Rule.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "subscription/rule/main.bicep"
+                }
+              }
+            },
+            "_1.sqlFilterType": {
+              "type": "object",
+              "properties": {
+                "compatibilityLevel": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+                  }
+                },
+                "requiresPreprocessing": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                  }
+                },
+                "sqlExpression": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The SQL expression. e.g. MyProperty='ABC'."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "A type for the properties of a SQL filter of a Service Bus Namespace Topic Subscription Rule.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "subscription/rule/main.bicep"
+                }
               }
             },
             "lockType": {
@@ -3229,156 +3418,31 @@
                 "name": {
                   "type": "string",
                   "metadata": {
-                    "description": "Required. The name of the service bus namespace topic subscription rule."
+                    "description": "Required. The name of the Service Bus Namespace Topic Subscription Rule."
                   }
                 },
                 "action": {
-                  "type": "object",
-                  "properties": {
-                    "compatibilityLevel": {
-                      "type": "int",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
-                      }
-                    },
-                    "requiresPreprocessing": {
-                      "type": "bool",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-                      }
-                    },
-                    "sqlExpression": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
-                      }
-                    }
-                  },
+                  "$ref": "#/definitions/_1.actionType",
                   "nullable": true,
                   "metadata": {
                     "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
                   }
                 },
                 "correlationFilter": {
-                  "type": "object",
-                  "properties": {
-                    "contentType": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Content type of the message."
-                      }
-                    },
-                    "correlationId": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Identifier of the correlation."
-                      }
-                    },
-                    "label": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Application specific label."
-                      }
-                    },
-                    "messageId": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Identifier of the message."
-                      }
-                    },
-                    "properties": {
-                      "type": "array",
-                      "allowedValues": [
-                        {}
-                      ],
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. dictionary object for custom filters."
-                      }
-                    },
-                    "replyTo": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Address of the queue to reply to."
-                      }
-                    },
-                    "replyToSessionId": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Session identifier to reply to."
-                      }
-                    },
-                    "requiresPreprocessing": {
-                      "type": "bool",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-                      }
-                    },
-                    "sessionId": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Session identifier."
-                      }
-                    },
-                    "to": {
-                      "type": "string",
-                      "metadata": {
-                        "description": "Required. Address to send to."
-                      }
-                    }
-                  },
+                  "$ref": "#/definitions/_1.correlationFilterType",
                   "nullable": true,
                   "metadata": {
                     "description": "Optional. Properties of correlationFilter."
                   }
                 },
                 "filterType": {
-                  "type": "string",
-                  "allowedValues": [
-                    "CorrelationFilter",
-                    "SqlFilter"
-                  ],
-                  "nullable": true,
+                  "$ref": "#/definitions/_1.filterTypeType",
                   "metadata": {
-                    "description": "Optional. Filter type that is evaluated against a BrokeredMessage."
+                    "description": "Required. Filter type that is evaluated against a BrokeredMessage."
                   }
                 },
                 "sqlFilter": {
-                  "type": "object",
-                  "properties": {
-                    "compatibilityLevel": {
-                      "type": "int",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
-                      }
-                    },
-                    "requiresPreprocessing": {
-                      "type": "bool",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-                      }
-                    },
-                    "sqlExpression": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
-                      }
-                    }
-                  },
+                  "$ref": "#/definitions/_1.sqlFilterType",
                   "nullable": true,
                   "metadata": {
                     "description": "Optional. Properties of sqlFilter."
@@ -3386,9 +3450,9 @@
                 }
               },
               "metadata": {
-                "description": "Optional. The type for rules.",
+                "description": "A type for a Service Bus Namespace Topic Subscription Rule.",
                 "__bicep_imported_from!": {
-                  "sourceTemplate": "subscription/main.bicep"
+                  "sourceTemplate": "subscription/rule/main.bicep"
                 }
               }
             }
@@ -3637,8 +3701,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "13311724266758161854"
+                      "version": "0.34.44.8038",
+                      "templateHash": "2788403188769701932"
                     },
                     "name": "Service Bus Namespace Topic Authorization Rules",
                     "description": "This module deploys a Service Bus Namespace Topic Authorization Rule."
@@ -3790,169 +3854,230 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "18327636281337895707"
+                      "version": "0.34.44.8038",
+                      "templateHash": "5245442494145554335"
                     },
                     "name": "Service Bus Namespace Topic Subscription",
                     "description": "This module deploys a Service Bus Namespace Topic Subscription."
                   },
                   "definitions": {
+                    "clientAffinePropertiesType": {
+                      "type": "object",
+                      "properties": {
+                        "clientId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. Indicates the Client ID of the application that created the client-affine subscription."
+                          }
+                        },
+                        "isDurable": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. For client-affine subscriptions, this value indicates whether the subscription is durable or not. Defaults to true."
+                          }
+                        },
+                        "isShared": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. For client-affine subscriptions, this value indicates whether the subscription is shared or not. Defaults to false."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "Properties specific to client affine subscriptions."
+                      }
+                    },
+                    "_1.actionType": {
+                      "type": "object",
+                      "properties": {
+                        "compatibilityLevel": {
+                          "type": "int",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+                          }
+                        },
+                        "requiresPreprocessing": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                          }
+                        },
+                        "sqlExpression": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "A type for the filter actions of a Service Bus Namespace Topic Subscription Rule.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "rule/main.bicep"
+                        }
+                      }
+                    },
+                    "_1.correlationFilterType": {
+                      "type": "object",
+                      "properties": {
+                        "contentType": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Content type of the message."
+                          }
+                        },
+                        "correlationId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Identifier of the correlation."
+                          }
+                        },
+                        "label": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Application specific label."
+                          }
+                        },
+                        "messageId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Identifier of the message."
+                          }
+                        },
+                        "properties": {
+                          "type": "object",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Dictionary object for custom filters."
+                          }
+                        },
+                        "replyTo": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Address of the queue to reply to."
+                          }
+                        },
+                        "replyToSessionId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Session identifier to reply to."
+                          }
+                        },
+                        "requiresPreprocessing": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                          }
+                        },
+                        "sessionId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Session identifier."
+                          }
+                        },
+                        "to": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Address to send to."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "A type for the properties of a correlation filter of a Service Bus Namespace Topic Subscription Rule.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "rule/main.bicep"
+                        }
+                      }
+                    },
+                    "_1.filterTypeType": {
+                      "type": "string",
+                      "allowedValues": [
+                        "CorrelationFilter",
+                        "SqlFilter"
+                      ],
+                      "metadata": {
+                        "description": "A type for the type of a Service Bus Namespace Topic Subscription Rule.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "rule/main.bicep"
+                        }
+                      }
+                    },
+                    "_1.sqlFilterType": {
+                      "type": "object",
+                      "properties": {
+                        "compatibilityLevel": {
+                          "type": "int",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+                          }
+                        },
+                        "requiresPreprocessing": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                          }
+                        },
+                        "sqlExpression": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The SQL expression. e.g. MyProperty='ABC'."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "A type for the properties of a SQL filter of a Service Bus Namespace Topic Subscription Rule.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "rule/main.bicep"
+                        }
+                      }
+                    },
                     "ruleType": {
                       "type": "object",
                       "properties": {
                         "name": {
                           "type": "string",
                           "metadata": {
-                            "description": "Required. The name of the service bus namespace topic subscription rule."
+                            "description": "Required. The name of the Service Bus Namespace Topic Subscription Rule."
                           }
                         },
                         "action": {
-                          "type": "object",
-                          "properties": {
-                            "compatibilityLevel": {
-                              "type": "int",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
-                              }
-                            },
-                            "requiresPreprocessing": {
-                              "type": "bool",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-                              }
-                            },
-                            "sqlExpression": {
-                              "type": "string",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
-                              }
-                            }
-                          },
+                          "$ref": "#/definitions/_1.actionType",
                           "nullable": true,
                           "metadata": {
                             "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
                           }
                         },
                         "correlationFilter": {
-                          "type": "object",
-                          "properties": {
-                            "contentType": {
-                              "type": "string",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. Content type of the message."
-                              }
-                            },
-                            "correlationId": {
-                              "type": "string",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. Identifier of the correlation."
-                              }
-                            },
-                            "label": {
-                              "type": "string",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. Application specific label."
-                              }
-                            },
-                            "messageId": {
-                              "type": "string",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. Identifier of the message."
-                              }
-                            },
-                            "properties": {
-                              "type": "array",
-                              "allowedValues": [
-                                {}
-                              ],
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. dictionary object for custom filters."
-                              }
-                            },
-                            "replyTo": {
-                              "type": "string",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. Address of the queue to reply to."
-                              }
-                            },
-                            "replyToSessionId": {
-                              "type": "string",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. Session identifier to reply to."
-                              }
-                            },
-                            "requiresPreprocessing": {
-                              "type": "bool",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-                              }
-                            },
-                            "sessionId": {
-                              "type": "string",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. Session identifier."
-                              }
-                            },
-                            "to": {
-                              "type": "string",
-                              "metadata": {
-                                "description": "Required. Address to send to."
-                              }
-                            }
-                          },
+                          "$ref": "#/definitions/_1.correlationFilterType",
                           "nullable": true,
                           "metadata": {
                             "description": "Optional. Properties of correlationFilter."
                           }
                         },
                         "filterType": {
-                          "type": "string",
-                          "allowedValues": [
-                            "CorrelationFilter",
-                            "SqlFilter"
-                          ],
-                          "nullable": true,
+                          "$ref": "#/definitions/_1.filterTypeType",
                           "metadata": {
-                            "description": "Optional. Filter type that is evaluated against a BrokeredMessage."
+                            "description": "Required. Filter type that is evaluated against a BrokeredMessage."
                           }
                         },
                         "sqlFilter": {
-                          "type": "object",
-                          "properties": {
-                            "compatibilityLevel": {
-                              "type": "int",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
-                              }
-                            },
-                            "requiresPreprocessing": {
-                              "type": "bool",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-                              }
-                            },
-                            "sqlExpression": {
-                              "type": "string",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
-                              }
-                            }
-                          },
+                          "$ref": "#/definitions/_1.sqlFilterType",
                           "nullable": true,
                           "metadata": {
                             "description": "Optional. Properties of sqlFilter."
@@ -3960,14 +4085,18 @@
                         }
                       },
                       "metadata": {
-                        "__bicep_export!": true,
-                        "description": "Optional. The type for rules."
+                        "description": "A type for a Service Bus Namespace Topic Subscription Rule.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "rule/main.bicep"
+                        }
                       }
                     }
                   },
                   "parameters": {
                     "name": {
                       "type": "string",
+                      "minLength": 1,
+                      "maxLength": 50,
                       "metadata": {
                         "description": "Required. The name of the service bus namespace topic subscription."
                       }
@@ -3992,17 +4121,17 @@
                       }
                     },
                     "clientAffineProperties": {
-                      "type": "object",
-                      "defaultValue": {},
+                      "$ref": "#/definitions/clientAffinePropertiesType",
+                      "nullable": true,
                       "metadata": {
-                        "description": "Optional. The properties that are associated with a subscription that is client-affine."
+                        "description": "Conditional. The properties that are associated with a subscription that is client-affine. Required if 'isClientAffine' is set to true."
                       }
                     },
                     "deadLetteringOnFilterEvaluationExceptions": {
                       "type": "bool",
                       "defaultValue": false,
                       "metadata": {
-                        "description": "Optional. A value that indicates whether a subscription has dead letter support when a message expires."
+                        "description": "Optional. A value that indicates whether a subscription has dead letter support on filter evaluation exceptions."
                       }
                     },
                     "deadLetteringOnMessageExpiration": {
@@ -4016,7 +4145,7 @@
                       "type": "string",
                       "defaultValue": "P10675199DT2H48M5.4775807S",
                       "metadata": {
-                        "description": "Optional. ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes."
+                        "description": "Optional. ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself."
                       }
                     },
                     "duplicateDetectionHistoryTimeWindow": {
@@ -4037,28 +4166,28 @@
                       "type": "string",
                       "defaultValue": "",
                       "metadata": {
-                        "description": "Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to."
+                        "description": "Optional. Queue/Topic name to forward the Dead Letter messages to."
                       }
                     },
                     "forwardTo": {
                       "type": "string",
                       "defaultValue": "",
                       "metadata": {
-                        "description": "Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to."
+                        "description": "Optional. Queue/Topic name to forward the messages to."
                       }
                     },
                     "isClientAffine": {
                       "type": "bool",
                       "defaultValue": false,
                       "metadata": {
-                        "description": "Optional. A value that indicates whether the subscription supports the concept of session."
+                        "description": "Optional. A value that indicates whether the subscription has an affinity to the client id."
                       }
                     },
                     "lockDuration": {
                       "type": "string",
                       "defaultValue": "PT1M",
                       "metadata": {
-                        "description": "Optional. ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value for LockDuration is 5 minutes; the default value is 1 minute."
+                        "description": "Optional. ISO 8061 lock duration timespan for the subscription. The default value is 1 minute."
                       }
                     },
                     "maxDeliveryCount": {
@@ -4072,7 +4201,7 @@
                       "type": "bool",
                       "defaultValue": false,
                       "metadata": {
-                        "description": "Optional. A value that indicates whether the subscription supports the concept of session."
+                        "description": "Optional. A value that indicates whether the subscription supports the concept of sessions."
                       }
                     },
                     "rules": {
@@ -4123,7 +4252,7 @@
                       "name": "[format('{0}/{1}/{2}', parameters('namespaceName'), parameters('topicName'), parameters('name'))]",
                       "properties": {
                         "autoDeleteOnIdle": "[parameters('autoDeleteOnIdle')]",
-                        "clientAffineProperties": "[parameters('clientAffineProperties')]",
+                        "clientAffineProperties": "[if(not(empty(parameters('clientAffineProperties'))), createObject('clientId', tryGet(parameters('clientAffineProperties'), 'clientId'), 'isDurable', coalesce(tryGet(parameters('clientAffineProperties'), 'isDurable'), true()), 'isShared', coalesce(tryGet(parameters('clientAffineProperties'), 'isShared'), false())), null())]",
                         "deadLetteringOnFilterEvaluationExceptions": "[parameters('deadLetteringOnFilterEvaluationExceptions')]",
                         "deadLetteringOnMessageExpiration": "[parameters('deadLetteringOnMessageExpiration')]",
                         "defaultMessageTimeToLive": "[parameters('defaultMessageTimeToLive')]",
@@ -4171,7 +4300,7 @@
                             "value": "[tryGet(coalesce(parameters('rules'), createArray())[copyIndex()], 'correlationFilter')]"
                           },
                           "filterType": {
-                            "value": "[tryGet(coalesce(parameters('rules'), createArray())[copyIndex()], 'filterType')]"
+                            "value": "[coalesce(parameters('rules'), createArray())[copyIndex()].filterType]"
                           },
                           "sqlFilter": {
                             "value": "[tryGet(coalesce(parameters('rules'), createArray())[copyIndex()], 'sqlFilter')]"
@@ -4184,15 +4313,210 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "15176672876775916889"
+                              "version": "0.34.44.8038",
+                              "templateHash": "3457937988681830091"
                             },
                             "name": "Service Bus Namespace Topic Subscription Rule",
                             "description": "This module deploys a Service Bus Namespace Topic Subscription Rule."
                           },
+                          "definitions": {
+                            "ruleType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the Service Bus Namespace Topic Subscription Rule."
+                                  }
+                                },
+                                "action": {
+                                  "$ref": "#/definitions/actionType",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
+                                  }
+                                },
+                                "correlationFilter": {
+                                  "$ref": "#/definitions/correlationFilterType",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Properties of correlationFilter."
+                                  }
+                                },
+                                "filterType": {
+                                  "$ref": "#/definitions/filterTypeType",
+                                  "metadata": {
+                                    "description": "Required. Filter type that is evaluated against a BrokeredMessage."
+                                  }
+                                },
+                                "sqlFilter": {
+                                  "$ref": "#/definitions/sqlFilterType",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Properties of sqlFilter."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "A type for a Service Bus Namespace Topic Subscription Rule."
+                              }
+                            },
+                            "actionType": {
+                              "type": "object",
+                              "properties": {
+                                "compatibilityLevel": {
+                                  "type": "int",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+                                  }
+                                },
+                                "requiresPreprocessing": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                                  }
+                                },
+                                "sqlExpression": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "A type for the filter actions of a Service Bus Namespace Topic Subscription Rule."
+                              }
+                            },
+                            "correlationFilterType": {
+                              "type": "object",
+                              "properties": {
+                                "contentType": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Content type of the message."
+                                  }
+                                },
+                                "correlationId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Identifier of the correlation."
+                                  }
+                                },
+                                "label": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Application specific label."
+                                  }
+                                },
+                                "messageId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Identifier of the message."
+                                  }
+                                },
+                                "properties": {
+                                  "type": "object",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Dictionary object for custom filters."
+                                  }
+                                },
+                                "replyTo": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Address of the queue to reply to."
+                                  }
+                                },
+                                "replyToSessionId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Session identifier to reply to."
+                                  }
+                                },
+                                "requiresPreprocessing": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                                  }
+                                },
+                                "sessionId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Session identifier."
+                                  }
+                                },
+                                "to": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Address to send to."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "A type for the properties of a correlation filter of a Service Bus Namespace Topic Subscription Rule."
+                              }
+                            },
+                            "filterTypeType": {
+                              "type": "string",
+                              "allowedValues": [
+                                "CorrelationFilter",
+                                "SqlFilter"
+                              ],
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "A type for the type of a Service Bus Namespace Topic Subscription Rule."
+                              }
+                            },
+                            "sqlFilterType": {
+                              "type": "object",
+                              "properties": {
+                                "compatibilityLevel": {
+                                  "type": "int",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+                                  }
+                                },
+                                "requiresPreprocessing": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                                  }
+                                },
+                                "sqlExpression": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The SQL expression. e.g. MyProperty='ABC'."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "A type for the properties of a SQL filter of a Service Bus Namespace Topic Subscription Rule."
+                              }
+                            }
+                          },
                           "parameters": {
                             "name": {
                               "type": "string",
+                              "minLength": 1,
+                              "maxLength": 50,
                               "metadata": {
                                 "description": "Required. The name of the service bus namespace topic subscription rule."
                               }
@@ -4212,39 +4536,34 @@
                             "subscriptionName": {
                               "type": "string",
                               "metadata": {
-                                "description": "Conditional. The name of the parent Service Bus Namespace. Required if the template is used in a standalone deployment."
+                                "description": "Conditional. The name of the parent Service Bus Namespace Topic Subscription. Required if the template is used in a standalone deployment."
                               }
                             },
                             "action": {
-                              "type": "object",
-                              "defaultValue": {},
+                              "$ref": "#/definitions/actionType",
+                              "nullable": true,
                               "metadata": {
-                                "description": "Opional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
+                                "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
                               }
                             },
                             "correlationFilter": {
-                              "type": "object",
-                              "defaultValue": {},
+                              "$ref": "#/definitions/correlationFilterType",
+                              "nullable": true,
                               "metadata": {
-                                "description": "Opional. Properties of a correlation filter."
+                                "description": "Conditional. Properties of a correlation filter. Required if 'filterType' is set to 'CorrelationFilter'."
                               }
                             },
                             "filterType": {
-                              "type": "string",
-                              "nullable": true,
-                              "allowedValues": [
-                                "CorrelationFilter",
-                                "SqlFilter"
-                              ],
+                              "$ref": "#/definitions/filterTypeType",
                               "metadata": {
-                                "description": "Optional. Filter type that is evaluated against a BrokeredMessage."
+                                "description": "Required. Filter type that is evaluated against a BrokeredMessage."
                               }
                             },
                             "sqlFilter": {
-                              "type": "object",
-                              "defaultValue": {},
+                              "$ref": "#/definitions/sqlFilterType",
+                              "nullable": true,
                               "metadata": {
-                                "description": "Opional. The properties of an SQL filter."
+                                "description": "Conditional. Properties of a SQL filter. Required if 'filterType' is set to 'SqlFilter'."
                               }
                             }
                           },
@@ -4272,10 +4591,10 @@
                               "apiVersion": "2022-10-01-preview",
                               "name": "[format('{0}/{1}/{2}/{3}', parameters('namespaceName'), parameters('topicName'), parameters('subscriptionName'), parameters('name'))]",
                               "properties": {
-                                "action": "[parameters('action')]",
-                                "correlationFilter": "[parameters('correlationFilter')]",
+                                "action": "[if(not(empty(parameters('action'))), parameters('action'), null())]",
+                                "correlationFilter": "[if(not(empty(parameters('correlationFilter'))), parameters('correlationFilter'), null())]",
                                 "filterType": "[parameters('filterType')]",
-                                "sqlFilter": "[parameters('sqlFilter')]"
+                                "sqlFilter": "[if(not(empty(parameters('sqlFilter'))), createObject('compatibilityLevel', coalesce(tryGet(parameters('sqlFilter'), 'compatibilityLevel'), 20), 'requiresPreprocessing', tryGet(parameters('sqlFilter'), 'requiresPreprocessing'), 'sqlExpression', tryGet(parameters('sqlFilter'), 'sqlExpression')), null())]"
                               }
                             }
                           },

--- a/avm/res/service-bus/namespace/migration-configuration/main.json
+++ b/avm/res/service-bus/namespace/migration-configuration/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "8888372741848926270"
+      "version": "0.34.44.8038",
+      "templateHash": "15719533438339680488"
     },
     "name": "Service Bus Namespace Migration Configuration",
     "description": "This module deploys a Service Bus Namespace Migration Configuration."

--- a/avm/res/service-bus/namespace/network-rule-set/main.json
+++ b/avm/res/service-bus/namespace/network-rule-set/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "8455455085685736737"
+      "version": "0.34.44.8038",
+      "templateHash": "6180219953560179899"
     },
     "name": "Service Bus Namespace Network Rule Sets",
     "description": "This module deploys a ServiceBus Namespace Network Rule Set."

--- a/avm/res/service-bus/namespace/queue/authorization-rule/main.json
+++ b/avm/res/service-bus/namespace/queue/authorization-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "17543469200710595087"
+      "version": "0.34.44.8038",
+      "templateHash": "6508430894548859396"
     },
     "name": "Service Bus Namespace Queue Authorization Rules",
     "description": "This module deploys a Service Bus Namespace Queue Authorization Rule."

--- a/avm/res/service-bus/namespace/queue/main.json
+++ b/avm/res/service-bus/namespace/queue/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "17714956813335477440"
+      "version": "0.34.44.8038",
+      "templateHash": "6215388008501436423"
     },
     "name": "Service Bus Namespace Queue",
     "description": "This module deploys a Service Bus Namespace Queue."
@@ -404,8 +404,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "17543469200710595087"
+              "version": "0.34.44.8038",
+              "templateHash": "6508430894548859396"
             },
             "name": "Service Bus Namespace Queue Authorization Rules",
             "description": "This module deploys a Service Bus Namespace Queue Authorization Rule."

--- a/avm/res/service-bus/namespace/tests/e2e/max/main.test.bicep
+++ b/avm/res/service-bus/namespace/tests/e2e/max/main.test.bicep
@@ -226,13 +226,49 @@ module testDeployment '../../../main.bicep' = [
           ]
           subscriptions: [
             {
-              name: 'subscription001'
+              name: 'subscriptionwithoutrules001' // this will still result in the creation of the default SqlFilter '1=1' rule
+            }
+            {
+              name: 'subscriptionwithsqlfilterrule001'
               rules: [
                 {
-                  name: '${namePrefix}-test-filter'
+                  name: '${namePrefix}-test-sql-filter'
                   filterType: 'SqlFilter'
                   sqlFilter: {
                     sqlExpression: 'Test=1'
+                  }
+                  action: {
+                    sqlExpression: 'SET Foo = 1;'
+                    requiresPreprocessing: true
+                    compatibilityLevel: 20
+                  }
+                }
+              ]
+            }
+            {
+              name: 'subscriptionwithcorrelationfilterrule001'
+              rules: [
+                {
+                  name: '${namePrefix}-test-correlation-filter'
+                  filterType: 'CorrelationFilter'
+                  correlationFilter: {
+                    contentType: 'application/json'
+                    label: 'Test'
+                    messageId: 'Test'
+                    to: 'Test'
+                    replyTo: 'Test'
+                    replyToSessionId: 'Test'
+                    sessionId: 'Test'
+                    correlationId: 'Test'
+                    properties: {
+                      fooHeader: 'Foo'
+                      barHeader: 'Bar'
+                    }
+                  }
+                  action: {
+                    sqlExpression: 'SET Foo = 1;'
+                    requiresPreprocessing: true
+                    compatibilityLevel: 20
                   }
                 }
               ]

--- a/avm/res/service-bus/namespace/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/service-bus/namespace/tests/e2e/waf-aligned/main.test.bicep
@@ -182,7 +182,7 @@ module testDeployment '../../../main.bicep' = [
           }
         }
       ]
-      publicNetworkAccess: 'Enabled'
+      publicNetworkAccess: 'Disabled'
     }
   }
 ]

--- a/avm/res/service-bus/namespace/topic/README.md
+++ b/avm/res/service-bus/namespace/topic/README.md
@@ -330,17 +330,17 @@ The subscriptions of the topic.
 | :-- | :-- | :-- |
 | [`autoDeleteOnIdle`](#parameter-subscriptionsautodeleteonidle) | string | ISO 8601 timespan idle interval after which the syubscription is automatically deleted. The minimum duration is 5 minutes. |
 | [`clientAffineProperties`](#parameter-subscriptionsclientaffineproperties) | object | The properties that are associated with a subscription that is client-affine. |
-| [`deadLetteringOnFilterEvaluationExceptions`](#parameter-subscriptionsdeadletteringonfilterevaluationexceptions) | bool | A value that indicates whether a subscription has dead letter support when a message expires. |
+| [`deadLetteringOnFilterEvaluationExceptions`](#parameter-subscriptionsdeadletteringonfilterevaluationexceptions) | bool | A value that indicates whether a subscription has dead letter support on filter evaluation exceptions. |
 | [`deadLetteringOnMessageExpiration`](#parameter-subscriptionsdeadletteringonmessageexpiration) | bool | A value that indicates whether a subscription has dead letter support when a message expires. |
-| [`defaultMessageTimeToLive`](#parameter-subscriptionsdefaultmessagetimetolive) | string | ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes. |
+| [`defaultMessageTimeToLive`](#parameter-subscriptionsdefaultmessagetimetolive) | string | ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself. |
 | [`duplicateDetectionHistoryTimeWindow`](#parameter-subscriptionsduplicatedetectionhistorytimewindow) | string | ISO 8601 timespan that defines the duration of the duplicate detection history. The default value is 10 minutes. |
 | [`enableBatchedOperations`](#parameter-subscriptionsenablebatchedoperations) | bool | A value that indicates whether server-side batched operations are enabled. |
-| [`forwardDeadLetteredMessagesTo`](#parameter-subscriptionsforwarddeadletteredmessagesto) | string | The name of the recipient entity to which all the messages sent to the subscription are forwarded to. |
-| [`forwardTo`](#parameter-subscriptionsforwardto) | string | The name of the recipient entity to which all the messages sent to the subscription are forwarded to. |
-| [`isClientAffine`](#parameter-subscriptionsisclientaffine) | bool | A value that indicates whether the subscription supports the concept of session. |
+| [`forwardDeadLetteredMessagesTo`](#parameter-subscriptionsforwarddeadletteredmessagesto) | string | Queue/Topic name to forward the Dead Letter messages to. |
+| [`forwardTo`](#parameter-subscriptionsforwardto) | string | Queue/Topic name to forward the messages to. |
+| [`isClientAffine`](#parameter-subscriptionsisclientaffine) | bool | A value that indicates whether the subscription has an affinity to the client id. |
 | [`lockDuration`](#parameter-subscriptionslockduration) | string | ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value for LockDuration is 5 minutes; the default value is 1 minute. |
 | [`maxDeliveryCount`](#parameter-subscriptionsmaxdeliverycount) | int | Number of maximum deliveries. A message is automatically deadlettered after this number of deliveries. Default value is 10. |
-| [`requiresSession`](#parameter-subscriptionsrequiressession) | bool | A value that indicates whether the subscription supports the concept of session. |
+| [`requiresSession`](#parameter-subscriptionsrequiressession) | bool | A value that indicates whether the subscription supports the concept of sessions. |
 | [`rules`](#parameter-subscriptionsrules) | array | The subscription rules. |
 | [`status`](#parameter-subscriptionsstatus) | string | Enumerates the possible values for the status of a messaging entity. |
 
@@ -401,7 +401,7 @@ For client-affine subscriptions, this value indicates whether the subscription i
 
 ### Parameter: `subscriptions.deadLetteringOnFilterEvaluationExceptions`
 
-A value that indicates whether a subscription has dead letter support when a message expires.
+A value that indicates whether a subscription has dead letter support on filter evaluation exceptions.
 
 - Required: No
 - Type: bool
@@ -415,7 +415,7 @@ A value that indicates whether a subscription has dead letter support when a mes
 
 ### Parameter: `subscriptions.defaultMessageTimeToLive`
 
-ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes.
+ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.
 
 - Required: No
 - Type: string
@@ -436,21 +436,21 @@ A value that indicates whether server-side batched operations are enabled.
 
 ### Parameter: `subscriptions.forwardDeadLetteredMessagesTo`
 
-The name of the recipient entity to which all the messages sent to the subscription are forwarded to.
+Queue/Topic name to forward the Dead Letter messages to.
 
 - Required: No
 - Type: string
 
 ### Parameter: `subscriptions.forwardTo`
 
-The name of the recipient entity to which all the messages sent to the subscription are forwarded to.
+Queue/Topic name to forward the messages to.
 
 - Required: No
 - Type: string
 
 ### Parameter: `subscriptions.isClientAffine`
 
-A value that indicates whether the subscription supports the concept of session.
+A value that indicates whether the subscription has an affinity to the client id.
 
 - Required: No
 - Type: bool
@@ -471,7 +471,7 @@ Number of maximum deliveries. A message is automatically deadlettered after this
 
 ### Parameter: `subscriptions.requiresSession`
 
-A value that indicates whether the subscription supports the concept of session.
+A value that indicates whether the subscription supports the concept of sessions.
 
 - Required: No
 - Type: bool
@@ -487,7 +487,8 @@ The subscription rules.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`name`](#parameter-subscriptionsrulesname) | string | The name of the service bus namespace topic subscription rule. |
+| [`filterType`](#parameter-subscriptionsrulesfiltertype) | string | Filter type that is evaluated against a BrokeredMessage. |
+| [`name`](#parameter-subscriptionsrulesname) | string | The name of the Service Bus Namespace Topic Subscription Rule. |
 
 **Optional parameters**
 
@@ -495,12 +496,25 @@ The subscription rules.
 | :-- | :-- | :-- |
 | [`action`](#parameter-subscriptionsrulesaction) | object | Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression. |
 | [`correlationFilter`](#parameter-subscriptionsrulescorrelationfilter) | object | Properties of correlationFilter. |
-| [`filterType`](#parameter-subscriptionsrulesfiltertype) | string | Filter type that is evaluated against a BrokeredMessage. |
 | [`sqlFilter`](#parameter-subscriptionsrulessqlfilter) | object | Properties of sqlFilter. |
+
+### Parameter: `subscriptions.rules.filterType`
+
+Filter type that is evaluated against a BrokeredMessage.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'CorrelationFilter'
+    'SqlFilter'
+  ]
+  ```
 
 ### Parameter: `subscriptions.rules.name`
 
-The name of the service bus namespace topic subscription rule.
+The name of the Service Bus Namespace Topic Subscription Rule.
 
 - Required: Yes
 - Type: string
@@ -548,12 +562,6 @@ Properties of correlationFilter.
 - Required: No
 - Type: object
 
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`to`](#parameter-subscriptionsrulescorrelationfilterto) | string | Address to send to. |
-
 **Optional parameters**
 
 | Parameter | Type | Description |
@@ -562,18 +570,12 @@ Properties of correlationFilter.
 | [`correlationId`](#parameter-subscriptionsrulescorrelationfiltercorrelationid) | string | Identifier of the correlation. |
 | [`label`](#parameter-subscriptionsrulescorrelationfilterlabel) | string | Application specific label. |
 | [`messageId`](#parameter-subscriptionsrulescorrelationfiltermessageid) | string | Identifier of the message. |
-| [`properties`](#parameter-subscriptionsrulescorrelationfilterproperties) | array | dictionary object for custom filters. |
+| [`properties`](#parameter-subscriptionsrulescorrelationfilterproperties) | object | Dictionary object for custom filters. |
 | [`replyTo`](#parameter-subscriptionsrulescorrelationfilterreplyto) | string | Address of the queue to reply to. |
 | [`replyToSessionId`](#parameter-subscriptionsrulescorrelationfilterreplytosessionid) | string | Session identifier to reply to. |
 | [`requiresPreprocessing`](#parameter-subscriptionsrulescorrelationfilterrequirespreprocessing) | bool | Value that indicates whether the rule action requires preprocessing. |
 | [`sessionId`](#parameter-subscriptionsrulescorrelationfiltersessionid) | string | Session identifier. |
-
-### Parameter: `subscriptions.rules.correlationFilter.to`
-
-Address to send to.
-
-- Required: Yes
-- Type: string
+| [`to`](#parameter-subscriptionsrulescorrelationfilterto) | string | Address to send to. |
 
 ### Parameter: `subscriptions.rules.correlationFilter.contentType`
 
@@ -605,16 +607,10 @@ Identifier of the message.
 
 ### Parameter: `subscriptions.rules.correlationFilter.properties`
 
-dictionary object for custom filters.
+Dictionary object for custom filters.
 
 - Required: No
-- Type: array
-- Allowed:
-  ```Bicep
-  [
-    {}
-  ]
-  ```
+- Type: object
 
 ### Parameter: `subscriptions.rules.correlationFilter.replyTo`
 
@@ -644,19 +640,12 @@ Session identifier.
 - Required: No
 - Type: string
 
-### Parameter: `subscriptions.rules.filterType`
+### Parameter: `subscriptions.rules.correlationFilter.to`
 
-Filter type that is evaluated against a BrokeredMessage.
+Address to send to.
 
 - Required: No
 - Type: string
-- Allowed:
-  ```Bicep
-  [
-    'CorrelationFilter'
-    'SqlFilter'
-  ]
-  ```
 
 ### Parameter: `subscriptions.rules.sqlFilter`
 
@@ -665,13 +654,25 @@ Properties of sqlFilter.
 - Required: No
 - Type: object
 
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`sqlExpression`](#parameter-subscriptionsrulessqlfiltersqlexpression) | string | The SQL expression. e.g. MyProperty='ABC'. |
+
 **Optional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`compatibilityLevel`](#parameter-subscriptionsrulessqlfiltercompatibilitylevel) | int | This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20. |
 | [`requiresPreprocessing`](#parameter-subscriptionsrulessqlfilterrequirespreprocessing) | bool | Value that indicates whether the rule action requires preprocessing. |
-| [`sqlExpression`](#parameter-subscriptionsrulessqlfiltersqlexpression) | string | SQL expression. e.g. MyProperty='ABC'. |
+
+### Parameter: `subscriptions.rules.sqlFilter.sqlExpression`
+
+The SQL expression. e.g. MyProperty='ABC'.
+
+- Required: Yes
+- Type: string
 
 ### Parameter: `subscriptions.rules.sqlFilter.compatibilityLevel`
 
@@ -686,13 +687,6 @@ Value that indicates whether the rule action requires preprocessing.
 
 - Required: No
 - Type: bool
-
-### Parameter: `subscriptions.rules.sqlFilter.sqlExpression`
-
-SQL expression. e.g. MyProperty='ABC'.
-
-- Required: No
-- Type: string
 
 ### Parameter: `subscriptions.status`
 

--- a/avm/res/service-bus/namespace/topic/authorization-rule/main.json
+++ b/avm/res/service-bus/namespace/topic/authorization-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "13311724266758161854"
+      "version": "0.34.44.8038",
+      "templateHash": "2788403188769701932"
     },
     "name": "Service Bus Namespace Topic Authorization Rules",
     "description": "This module deploys a Service Bus Namespace Topic Authorization Rule."

--- a/avm/res/service-bus/namespace/topic/main.bicep
+++ b/avm/res/service-bus/namespace/topic/main.bicep
@@ -238,10 +238,10 @@ type subscriptionType = {
   @description('Optional. A value that indicates whether a subscription has dead letter support when a message expires.')
   deadLetteringOnMessageExpiration: bool?
 
-  @description('Optional. A value that indicates whether a subscription has dead letter support when a message expires.')
+  @description('Optional. A value that indicates whether a subscription has dead letter support on filter evaluation exceptions.')
   deadLetteringOnFilterEvaluationExceptions: bool?
 
-  @description('Optional. ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes.')
+  @description('Optional. ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.')
   defaultMessageTimeToLive: string?
 
   @description('Optional. ISO 8601 timespan that defines the duration of the duplicate detection history. The default value is 10 minutes.')
@@ -250,13 +250,13 @@ type subscriptionType = {
   @description('Optional. A value that indicates whether server-side batched operations are enabled.')
   enableBatchedOperations: bool?
 
-  @description('Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to.')
+  @description('Optional. Queue/Topic name to forward the Dead Letter messages to.')
   forwardDeadLetteredMessagesTo: string?
 
-  @description('Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to.')
+  @description('Optional. Queue/Topic name to forward the messages to.')
   forwardTo: string?
 
-  @description('Optional. A value that indicates whether the subscription supports the concept of session.')
+  @description('Optional. A value that indicates whether the subscription has an affinity to the client id.')
   isClientAffine: bool?
 
   @description('Optional. ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value for LockDuration is 5 minutes; the default value is 1 minute.')
@@ -265,7 +265,7 @@ type subscriptionType = {
   @description('Optional. Number of maximum deliveries. A message is automatically deadlettered after this number of deliveries. Default value is 10.')
   maxDeliveryCount: int?
 
-  @description('Optional. A value that indicates whether the subscription supports the concept of session.')
+  @description('Optional. A value that indicates whether the subscription supports the concept of sessions.')
   requiresSession: bool?
 
   @description('Optional. The subscription rules.')

--- a/avm/res/service-bus/namespace/topic/main.bicep
+++ b/avm/res/service-bus/namespace/topic/main.bicep
@@ -212,7 +212,8 @@ output resourceGroupName string = resourceGroup().name
 //   Definitions   //
 // =============== //
 
-import { ruleType } from 'subscription/main.bicep'
+import { ruleType } from 'subscription/rule/main.bicep'
+
 @export()
 @description('The type for a subscription.')
 type subscriptionType = {

--- a/avm/res/service-bus/namespace/topic/main.json
+++ b/avm/res/service-bus/namespace/topic/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "3613850961357682472"
+      "version": "0.34.44.8038",
+      "templateHash": "38000433144185993"
     },
     "name": "Service Bus Namespace Topic",
     "description": "This module deploys a Service Bus Namespace Topic."
@@ -68,14 +68,14 @@
           "type": "bool",
           "nullable": true,
           "metadata": {
-            "description": "Optional. A value that indicates whether a subscription has dead letter support when a message expires."
+            "description": "Optional. A value that indicates whether a subscription has dead letter support on filter evaluation exceptions."
           }
         },
         "defaultMessageTimeToLive": {
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes."
+            "description": "Optional. ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself."
           }
         },
         "duplicateDetectionHistoryTimeWindow": {
@@ -96,21 +96,21 @@
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to."
+            "description": "Optional. Queue/Topic name to forward the Dead Letter messages to."
           }
         },
         "forwardTo": {
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to."
+            "description": "Optional. Queue/Topic name to forward the messages to."
           }
         },
         "isClientAffine": {
           "type": "bool",
           "nullable": true,
           "metadata": {
-            "description": "Optional. A value that indicates whether the subscription supports the concept of session."
+            "description": "Optional. A value that indicates whether the subscription has an affinity to the client id."
           }
         },
         "lockDuration": {
@@ -131,7 +131,7 @@
           "type": "bool",
           "nullable": true,
           "metadata": {
-            "description": "Optional. A value that indicates whether the subscription supports the concept of session."
+            "description": "Optional. A value that indicates whether the subscription supports the concept of sessions."
           }
         },
         "rules": {
@@ -166,6 +166,163 @@
       "metadata": {
         "__bicep_export!": true,
         "description": "The type for a subscription."
+      }
+    },
+    "_1.actionType": {
+      "type": "object",
+      "properties": {
+        "compatibilityLevel": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+          }
+        },
+        "requiresPreprocessing": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+          }
+        },
+        "sqlExpression": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
+          }
+        }
+      },
+      "metadata": {
+        "description": "A type for the filter actions of a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "subscription/rule/main.bicep"
+        }
+      }
+    },
+    "_1.correlationFilterType": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Content type of the message."
+          }
+        },
+        "correlationId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Identifier of the correlation."
+          }
+        },
+        "label": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Application specific label."
+          }
+        },
+        "messageId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Identifier of the message."
+          }
+        },
+        "properties": {
+          "type": "object",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Dictionary object for custom filters."
+          }
+        },
+        "replyTo": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Address of the queue to reply to."
+          }
+        },
+        "replyToSessionId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Session identifier to reply to."
+          }
+        },
+        "requiresPreprocessing": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+          }
+        },
+        "sessionId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Session identifier."
+          }
+        },
+        "to": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Address to send to."
+          }
+        }
+      },
+      "metadata": {
+        "description": "A type for the properties of a correlation filter of a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "subscription/rule/main.bicep"
+        }
+      }
+    },
+    "_1.filterTypeType": {
+      "type": "string",
+      "allowedValues": [
+        "CorrelationFilter",
+        "SqlFilter"
+      ],
+      "metadata": {
+        "description": "A type for the type of a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "subscription/rule/main.bicep"
+        }
+      }
+    },
+    "_1.sqlFilterType": {
+      "type": "object",
+      "properties": {
+        "compatibilityLevel": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+          }
+        },
+        "requiresPreprocessing": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+          }
+        },
+        "sqlExpression": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The SQL expression. e.g. MyProperty='ABC'."
+          }
+        }
+      },
+      "metadata": {
+        "description": "A type for the properties of a SQL filter of a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "subscription/rule/main.bicep"
+        }
       }
     },
     "lockType": {
@@ -279,156 +436,31 @@
         "name": {
           "type": "string",
           "metadata": {
-            "description": "Required. The name of the service bus namespace topic subscription rule."
+            "description": "Required. The name of the Service Bus Namespace Topic Subscription Rule."
           }
         },
         "action": {
-          "type": "object",
-          "properties": {
-            "compatibilityLevel": {
-              "type": "int",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
-              }
-            },
-            "requiresPreprocessing": {
-              "type": "bool",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-              }
-            },
-            "sqlExpression": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
-              }
-            }
-          },
+          "$ref": "#/definitions/_1.actionType",
           "nullable": true,
           "metadata": {
             "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
           }
         },
         "correlationFilter": {
-          "type": "object",
-          "properties": {
-            "contentType": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Content type of the message."
-              }
-            },
-            "correlationId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Identifier of the correlation."
-              }
-            },
-            "label": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Application specific label."
-              }
-            },
-            "messageId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Identifier of the message."
-              }
-            },
-            "properties": {
-              "type": "array",
-              "allowedValues": [
-                {}
-              ],
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. dictionary object for custom filters."
-              }
-            },
-            "replyTo": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Address of the queue to reply to."
-              }
-            },
-            "replyToSessionId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Session identifier to reply to."
-              }
-            },
-            "requiresPreprocessing": {
-              "type": "bool",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-              }
-            },
-            "sessionId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Session identifier."
-              }
-            },
-            "to": {
-              "type": "string",
-              "metadata": {
-                "description": "Required. Address to send to."
-              }
-            }
-          },
+          "$ref": "#/definitions/_1.correlationFilterType",
           "nullable": true,
           "metadata": {
             "description": "Optional. Properties of correlationFilter."
           }
         },
         "filterType": {
-          "type": "string",
-          "allowedValues": [
-            "CorrelationFilter",
-            "SqlFilter"
-          ],
-          "nullable": true,
+          "$ref": "#/definitions/_1.filterTypeType",
           "metadata": {
-            "description": "Optional. Filter type that is evaluated against a BrokeredMessage."
+            "description": "Required. Filter type that is evaluated against a BrokeredMessage."
           }
         },
         "sqlFilter": {
-          "type": "object",
-          "properties": {
-            "compatibilityLevel": {
-              "type": "int",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
-              }
-            },
-            "requiresPreprocessing": {
-              "type": "bool",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-              }
-            },
-            "sqlExpression": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
-              }
-            }
-          },
+          "$ref": "#/definitions/_1.sqlFilterType",
           "nullable": true,
           "metadata": {
             "description": "Optional. Properties of sqlFilter."
@@ -436,9 +468,9 @@
         }
       },
       "metadata": {
-        "description": "Optional. The type for rules.",
+        "description": "A type for a Service Bus Namespace Topic Subscription Rule.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "subscription/main.bicep"
+          "sourceTemplate": "subscription/rule/main.bicep"
         }
       }
     }
@@ -687,8 +719,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "13311724266758161854"
+              "version": "0.34.44.8038",
+              "templateHash": "2788403188769701932"
             },
             "name": "Service Bus Namespace Topic Authorization Rules",
             "description": "This module deploys a Service Bus Namespace Topic Authorization Rule."
@@ -840,169 +872,230 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "18327636281337895707"
+              "version": "0.34.44.8038",
+              "templateHash": "5245442494145554335"
             },
             "name": "Service Bus Namespace Topic Subscription",
             "description": "This module deploys a Service Bus Namespace Topic Subscription."
           },
           "definitions": {
+            "clientAffinePropertiesType": {
+              "type": "object",
+              "properties": {
+                "clientId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Indicates the Client ID of the application that created the client-affine subscription."
+                  }
+                },
+                "isDurable": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. For client-affine subscriptions, this value indicates whether the subscription is durable or not. Defaults to true."
+                  }
+                },
+                "isShared": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. For client-affine subscriptions, this value indicates whether the subscription is shared or not. Defaults to false."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "Properties specific to client affine subscriptions."
+              }
+            },
+            "_1.actionType": {
+              "type": "object",
+              "properties": {
+                "compatibilityLevel": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+                  }
+                },
+                "requiresPreprocessing": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                  }
+                },
+                "sqlExpression": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "A type for the filter actions of a Service Bus Namespace Topic Subscription Rule.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "rule/main.bicep"
+                }
+              }
+            },
+            "_1.correlationFilterType": {
+              "type": "object",
+              "properties": {
+                "contentType": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Content type of the message."
+                  }
+                },
+                "correlationId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Identifier of the correlation."
+                  }
+                },
+                "label": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Application specific label."
+                  }
+                },
+                "messageId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Identifier of the message."
+                  }
+                },
+                "properties": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Dictionary object for custom filters."
+                  }
+                },
+                "replyTo": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Address of the queue to reply to."
+                  }
+                },
+                "replyToSessionId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Session identifier to reply to."
+                  }
+                },
+                "requiresPreprocessing": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                  }
+                },
+                "sessionId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Session identifier."
+                  }
+                },
+                "to": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Address to send to."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "A type for the properties of a correlation filter of a Service Bus Namespace Topic Subscription Rule.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "rule/main.bicep"
+                }
+              }
+            },
+            "_1.filterTypeType": {
+              "type": "string",
+              "allowedValues": [
+                "CorrelationFilter",
+                "SqlFilter"
+              ],
+              "metadata": {
+                "description": "A type for the type of a Service Bus Namespace Topic Subscription Rule.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "rule/main.bicep"
+                }
+              }
+            },
+            "_1.sqlFilterType": {
+              "type": "object",
+              "properties": {
+                "compatibilityLevel": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+                  }
+                },
+                "requiresPreprocessing": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                  }
+                },
+                "sqlExpression": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The SQL expression. e.g. MyProperty='ABC'."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "A type for the properties of a SQL filter of a Service Bus Namespace Topic Subscription Rule.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "rule/main.bicep"
+                }
+              }
+            },
             "ruleType": {
               "type": "object",
               "properties": {
                 "name": {
                   "type": "string",
                   "metadata": {
-                    "description": "Required. The name of the service bus namespace topic subscription rule."
+                    "description": "Required. The name of the Service Bus Namespace Topic Subscription Rule."
                   }
                 },
                 "action": {
-                  "type": "object",
-                  "properties": {
-                    "compatibilityLevel": {
-                      "type": "int",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
-                      }
-                    },
-                    "requiresPreprocessing": {
-                      "type": "bool",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-                      }
-                    },
-                    "sqlExpression": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
-                      }
-                    }
-                  },
+                  "$ref": "#/definitions/_1.actionType",
                   "nullable": true,
                   "metadata": {
                     "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
                   }
                 },
                 "correlationFilter": {
-                  "type": "object",
-                  "properties": {
-                    "contentType": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Content type of the message."
-                      }
-                    },
-                    "correlationId": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Identifier of the correlation."
-                      }
-                    },
-                    "label": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Application specific label."
-                      }
-                    },
-                    "messageId": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Identifier of the message."
-                      }
-                    },
-                    "properties": {
-                      "type": "array",
-                      "allowedValues": [
-                        {}
-                      ],
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. dictionary object for custom filters."
-                      }
-                    },
-                    "replyTo": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Address of the queue to reply to."
-                      }
-                    },
-                    "replyToSessionId": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Session identifier to reply to."
-                      }
-                    },
-                    "requiresPreprocessing": {
-                      "type": "bool",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-                      }
-                    },
-                    "sessionId": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Session identifier."
-                      }
-                    },
-                    "to": {
-                      "type": "string",
-                      "metadata": {
-                        "description": "Required. Address to send to."
-                      }
-                    }
-                  },
+                  "$ref": "#/definitions/_1.correlationFilterType",
                   "nullable": true,
                   "metadata": {
                     "description": "Optional. Properties of correlationFilter."
                   }
                 },
                 "filterType": {
-                  "type": "string",
-                  "allowedValues": [
-                    "CorrelationFilter",
-                    "SqlFilter"
-                  ],
-                  "nullable": true,
+                  "$ref": "#/definitions/_1.filterTypeType",
                   "metadata": {
-                    "description": "Optional. Filter type that is evaluated against a BrokeredMessage."
+                    "description": "Required. Filter type that is evaluated against a BrokeredMessage."
                   }
                 },
                 "sqlFilter": {
-                  "type": "object",
-                  "properties": {
-                    "compatibilityLevel": {
-                      "type": "int",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
-                      }
-                    },
-                    "requiresPreprocessing": {
-                      "type": "bool",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-                      }
-                    },
-                    "sqlExpression": {
-                      "type": "string",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
-                      }
-                    }
-                  },
+                  "$ref": "#/definitions/_1.sqlFilterType",
                   "nullable": true,
                   "metadata": {
                     "description": "Optional. Properties of sqlFilter."
@@ -1010,14 +1103,18 @@
                 }
               },
               "metadata": {
-                "__bicep_export!": true,
-                "description": "Optional. The type for rules."
+                "description": "A type for a Service Bus Namespace Topic Subscription Rule.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "rule/main.bicep"
+                }
               }
             }
           },
           "parameters": {
             "name": {
               "type": "string",
+              "minLength": 1,
+              "maxLength": 50,
               "metadata": {
                 "description": "Required. The name of the service bus namespace topic subscription."
               }
@@ -1042,17 +1139,17 @@
               }
             },
             "clientAffineProperties": {
-              "type": "object",
-              "defaultValue": {},
+              "$ref": "#/definitions/clientAffinePropertiesType",
+              "nullable": true,
               "metadata": {
-                "description": "Optional. The properties that are associated with a subscription that is client-affine."
+                "description": "Conditional. The properties that are associated with a subscription that is client-affine. Required if 'isClientAffine' is set to true."
               }
             },
             "deadLetteringOnFilterEvaluationExceptions": {
               "type": "bool",
               "defaultValue": false,
               "metadata": {
-                "description": "Optional. A value that indicates whether a subscription has dead letter support when a message expires."
+                "description": "Optional. A value that indicates whether a subscription has dead letter support on filter evaluation exceptions."
               }
             },
             "deadLetteringOnMessageExpiration": {
@@ -1066,7 +1163,7 @@
               "type": "string",
               "defaultValue": "P10675199DT2H48M5.4775807S",
               "metadata": {
-                "description": "Optional. ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes."
+                "description": "Optional. ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself."
               }
             },
             "duplicateDetectionHistoryTimeWindow": {
@@ -1087,28 +1184,28 @@
               "type": "string",
               "defaultValue": "",
               "metadata": {
-                "description": "Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to."
+                "description": "Optional. Queue/Topic name to forward the Dead Letter messages to."
               }
             },
             "forwardTo": {
               "type": "string",
               "defaultValue": "",
               "metadata": {
-                "description": "Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to."
+                "description": "Optional. Queue/Topic name to forward the messages to."
               }
             },
             "isClientAffine": {
               "type": "bool",
               "defaultValue": false,
               "metadata": {
-                "description": "Optional. A value that indicates whether the subscription supports the concept of session."
+                "description": "Optional. A value that indicates whether the subscription has an affinity to the client id."
               }
             },
             "lockDuration": {
               "type": "string",
               "defaultValue": "PT1M",
               "metadata": {
-                "description": "Optional. ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value for LockDuration is 5 minutes; the default value is 1 minute."
+                "description": "Optional. ISO 8061 lock duration timespan for the subscription. The default value is 1 minute."
               }
             },
             "maxDeliveryCount": {
@@ -1122,7 +1219,7 @@
               "type": "bool",
               "defaultValue": false,
               "metadata": {
-                "description": "Optional. A value that indicates whether the subscription supports the concept of session."
+                "description": "Optional. A value that indicates whether the subscription supports the concept of sessions."
               }
             },
             "rules": {
@@ -1173,7 +1270,7 @@
               "name": "[format('{0}/{1}/{2}', parameters('namespaceName'), parameters('topicName'), parameters('name'))]",
               "properties": {
                 "autoDeleteOnIdle": "[parameters('autoDeleteOnIdle')]",
-                "clientAffineProperties": "[parameters('clientAffineProperties')]",
+                "clientAffineProperties": "[if(not(empty(parameters('clientAffineProperties'))), createObject('clientId', tryGet(parameters('clientAffineProperties'), 'clientId'), 'isDurable', coalesce(tryGet(parameters('clientAffineProperties'), 'isDurable'), true()), 'isShared', coalesce(tryGet(parameters('clientAffineProperties'), 'isShared'), false())), null())]",
                 "deadLetteringOnFilterEvaluationExceptions": "[parameters('deadLetteringOnFilterEvaluationExceptions')]",
                 "deadLetteringOnMessageExpiration": "[parameters('deadLetteringOnMessageExpiration')]",
                 "defaultMessageTimeToLive": "[parameters('defaultMessageTimeToLive')]",
@@ -1221,7 +1318,7 @@
                     "value": "[tryGet(coalesce(parameters('rules'), createArray())[copyIndex()], 'correlationFilter')]"
                   },
                   "filterType": {
-                    "value": "[tryGet(coalesce(parameters('rules'), createArray())[copyIndex()], 'filterType')]"
+                    "value": "[coalesce(parameters('rules'), createArray())[copyIndex()].filterType]"
                   },
                   "sqlFilter": {
                     "value": "[tryGet(coalesce(parameters('rules'), createArray())[copyIndex()], 'sqlFilter')]"
@@ -1234,15 +1331,210 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "15176672876775916889"
+                      "version": "0.34.44.8038",
+                      "templateHash": "3457937988681830091"
                     },
                     "name": "Service Bus Namespace Topic Subscription Rule",
                     "description": "This module deploys a Service Bus Namespace Topic Subscription Rule."
                   },
+                  "definitions": {
+                    "ruleType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the Service Bus Namespace Topic Subscription Rule."
+                          }
+                        },
+                        "action": {
+                          "$ref": "#/definitions/actionType",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
+                          }
+                        },
+                        "correlationFilter": {
+                          "$ref": "#/definitions/correlationFilterType",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Properties of correlationFilter."
+                          }
+                        },
+                        "filterType": {
+                          "$ref": "#/definitions/filterTypeType",
+                          "metadata": {
+                            "description": "Required. Filter type that is evaluated against a BrokeredMessage."
+                          }
+                        },
+                        "sqlFilter": {
+                          "$ref": "#/definitions/sqlFilterType",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Properties of sqlFilter."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "A type for a Service Bus Namespace Topic Subscription Rule."
+                      }
+                    },
+                    "actionType": {
+                      "type": "object",
+                      "properties": {
+                        "compatibilityLevel": {
+                          "type": "int",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+                          }
+                        },
+                        "requiresPreprocessing": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                          }
+                        },
+                        "sqlExpression": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "A type for the filter actions of a Service Bus Namespace Topic Subscription Rule."
+                      }
+                    },
+                    "correlationFilterType": {
+                      "type": "object",
+                      "properties": {
+                        "contentType": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Content type of the message."
+                          }
+                        },
+                        "correlationId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Identifier of the correlation."
+                          }
+                        },
+                        "label": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Application specific label."
+                          }
+                        },
+                        "messageId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Identifier of the message."
+                          }
+                        },
+                        "properties": {
+                          "type": "object",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Dictionary object for custom filters."
+                          }
+                        },
+                        "replyTo": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Address of the queue to reply to."
+                          }
+                        },
+                        "replyToSessionId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Session identifier to reply to."
+                          }
+                        },
+                        "requiresPreprocessing": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                          }
+                        },
+                        "sessionId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Session identifier."
+                          }
+                        },
+                        "to": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Address to send to."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "A type for the properties of a correlation filter of a Service Bus Namespace Topic Subscription Rule."
+                      }
+                    },
+                    "filterTypeType": {
+                      "type": "string",
+                      "allowedValues": [
+                        "CorrelationFilter",
+                        "SqlFilter"
+                      ],
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "A type for the type of a Service Bus Namespace Topic Subscription Rule."
+                      }
+                    },
+                    "sqlFilterType": {
+                      "type": "object",
+                      "properties": {
+                        "compatibilityLevel": {
+                          "type": "int",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+                          }
+                        },
+                        "requiresPreprocessing": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                          }
+                        },
+                        "sqlExpression": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The SQL expression. e.g. MyProperty='ABC'."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "A type for the properties of a SQL filter of a Service Bus Namespace Topic Subscription Rule."
+                      }
+                    }
+                  },
                   "parameters": {
                     "name": {
                       "type": "string",
+                      "minLength": 1,
+                      "maxLength": 50,
                       "metadata": {
                         "description": "Required. The name of the service bus namespace topic subscription rule."
                       }
@@ -1262,39 +1554,34 @@
                     "subscriptionName": {
                       "type": "string",
                       "metadata": {
-                        "description": "Conditional. The name of the parent Service Bus Namespace. Required if the template is used in a standalone deployment."
+                        "description": "Conditional. The name of the parent Service Bus Namespace Topic Subscription. Required if the template is used in a standalone deployment."
                       }
                     },
                     "action": {
-                      "type": "object",
-                      "defaultValue": {},
+                      "$ref": "#/definitions/actionType",
+                      "nullable": true,
                       "metadata": {
-                        "description": "Opional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
+                        "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
                       }
                     },
                     "correlationFilter": {
-                      "type": "object",
-                      "defaultValue": {},
+                      "$ref": "#/definitions/correlationFilterType",
+                      "nullable": true,
                       "metadata": {
-                        "description": "Opional. Properties of a correlation filter."
+                        "description": "Conditional. Properties of a correlation filter. Required if 'filterType' is set to 'CorrelationFilter'."
                       }
                     },
                     "filterType": {
-                      "type": "string",
-                      "nullable": true,
-                      "allowedValues": [
-                        "CorrelationFilter",
-                        "SqlFilter"
-                      ],
+                      "$ref": "#/definitions/filterTypeType",
                       "metadata": {
-                        "description": "Optional. Filter type that is evaluated against a BrokeredMessage."
+                        "description": "Required. Filter type that is evaluated against a BrokeredMessage."
                       }
                     },
                     "sqlFilter": {
-                      "type": "object",
-                      "defaultValue": {},
+                      "$ref": "#/definitions/sqlFilterType",
+                      "nullable": true,
                       "metadata": {
-                        "description": "Opional. The properties of an SQL filter."
+                        "description": "Conditional. Properties of a SQL filter. Required if 'filterType' is set to 'SqlFilter'."
                       }
                     }
                   },
@@ -1322,10 +1609,10 @@
                       "apiVersion": "2022-10-01-preview",
                       "name": "[format('{0}/{1}/{2}/{3}', parameters('namespaceName'), parameters('topicName'), parameters('subscriptionName'), parameters('name'))]",
                       "properties": {
-                        "action": "[parameters('action')]",
-                        "correlationFilter": "[parameters('correlationFilter')]",
+                        "action": "[if(not(empty(parameters('action'))), parameters('action'), null())]",
+                        "correlationFilter": "[if(not(empty(parameters('correlationFilter'))), parameters('correlationFilter'), null())]",
                         "filterType": "[parameters('filterType')]",
-                        "sqlFilter": "[parameters('sqlFilter')]"
+                        "sqlFilter": "[if(not(empty(parameters('sqlFilter'))), createObject('compatibilityLevel', coalesce(tryGet(parameters('sqlFilter'), 'compatibilityLevel'), 20), 'requiresPreprocessing', tryGet(parameters('sqlFilter'), 'requiresPreprocessing'), 'sqlExpression', tryGet(parameters('sqlFilter'), 'sqlExpression')), null())]"
                       }
                     }
                   },

--- a/avm/res/service-bus/namespace/topic/subscription/README.md
+++ b/avm/res/service-bus/namespace/topic/subscription/README.md
@@ -27,6 +27,7 @@ This module deploys a Service Bus Namespace Topic Subscription.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`clientAffineProperties`](#parameter-clientaffineproperties) | object | The properties that are associated with a subscription that is client-affine. Required if 'isClientAffine' is set to true. |
 | [`namespaceName`](#parameter-namespacename) | string | The name of the parent Service Bus Namespace. Required if the template is used in a standalone deployment. |
 | [`topicName`](#parameter-topicname) | string | The name of the parent Service Bus Namespace Topic. Required if the template is used in a standalone deployment. |
 
@@ -35,18 +36,17 @@ This module deploys a Service Bus Namespace Topic Subscription.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`autoDeleteOnIdle`](#parameter-autodeleteonidle) | string | ISO 8601 timespan idle interval after which the subscription is automatically deleted. The minimum duration is 5 minutes. |
-| [`clientAffineProperties`](#parameter-clientaffineproperties) | object | The properties that are associated with a subscription that is client-affine. |
-| [`deadLetteringOnFilterEvaluationExceptions`](#parameter-deadletteringonfilterevaluationexceptions) | bool | A value that indicates whether a subscription has dead letter support when a message expires. |
+| [`deadLetteringOnFilterEvaluationExceptions`](#parameter-deadletteringonfilterevaluationexceptions) | bool | A value that indicates whether a subscription has dead letter support on filter evaluation exceptions. |
 | [`deadLetteringOnMessageExpiration`](#parameter-deadletteringonmessageexpiration) | bool | A value that indicates whether a subscription has dead letter support when a message expires. |
-| [`defaultMessageTimeToLive`](#parameter-defaultmessagetimetolive) | string | ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes. |
+| [`defaultMessageTimeToLive`](#parameter-defaultmessagetimetolive) | string | ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself. |
 | [`duplicateDetectionHistoryTimeWindow`](#parameter-duplicatedetectionhistorytimewindow) | string | ISO 8601 timespan that defines the duration of the duplicate detection history. The default value is 10 minutes. |
 | [`enableBatchedOperations`](#parameter-enablebatchedoperations) | bool | A value that indicates whether server-side batched operations are enabled. |
-| [`forwardDeadLetteredMessagesTo`](#parameter-forwarddeadletteredmessagesto) | string | The name of the recipient entity to which all the messages sent to the subscription are forwarded to. |
-| [`forwardTo`](#parameter-forwardto) | string | The name of the recipient entity to which all the messages sent to the subscription are forwarded to. |
-| [`isClientAffine`](#parameter-isclientaffine) | bool | A value that indicates whether the subscription supports the concept of session. |
-| [`lockDuration`](#parameter-lockduration) | string | ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value for LockDuration is 5 minutes; the default value is 1 minute. |
+| [`forwardDeadLetteredMessagesTo`](#parameter-forwarddeadletteredmessagesto) | string | Queue/Topic name to forward the Dead Letter messages to. |
+| [`forwardTo`](#parameter-forwardto) | string | Queue/Topic name to forward the messages to. |
+| [`isClientAffine`](#parameter-isclientaffine) | bool | A value that indicates whether the subscription has an affinity to the client id. |
+| [`lockDuration`](#parameter-lockduration) | string | ISO 8061 lock duration timespan for the subscription. The default value is 1 minute. |
 | [`maxDeliveryCount`](#parameter-maxdeliverycount) | int | Number of maximum deliveries. A message is automatically deadlettered after this number of deliveries. Default value is 10. |
-| [`requiresSession`](#parameter-requiressession) | bool | A value that indicates whether the subscription supports the concept of session. |
+| [`requiresSession`](#parameter-requiressession) | bool | A value that indicates whether the subscription supports the concept of sessions. |
 | [`rules`](#parameter-rules) | array | The subscription rules. |
 | [`status`](#parameter-status) | string | Enumerates the possible values for the status of a messaging entity. |
 
@@ -56,6 +56,47 @@ The name of the service bus namespace topic subscription.
 
 - Required: Yes
 - Type: string
+
+### Parameter: `clientAffineProperties`
+
+The properties that are associated with a subscription that is client-affine. Required if 'isClientAffine' is set to true.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`clientId`](#parameter-clientaffinepropertiesclientid) | string | Indicates the Client ID of the application that created the client-affine subscription. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`isDurable`](#parameter-clientaffinepropertiesisdurable) | bool | For client-affine subscriptions, this value indicates whether the subscription is durable or not. Defaults to true. |
+| [`isShared`](#parameter-clientaffinepropertiesisshared) | bool | For client-affine subscriptions, this value indicates whether the subscription is shared or not. Defaults to false. |
+
+### Parameter: `clientAffineProperties.clientId`
+
+Indicates the Client ID of the application that created the client-affine subscription.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `clientAffineProperties.isDurable`
+
+For client-affine subscriptions, this value indicates whether the subscription is durable or not. Defaults to true.
+
+- Required: No
+- Type: bool
+
+### Parameter: `clientAffineProperties.isShared`
+
+For client-affine subscriptions, this value indicates whether the subscription is shared or not. Defaults to false.
+
+- Required: No
+- Type: bool
 
 ### Parameter: `namespaceName`
 
@@ -79,17 +120,9 @@ ISO 8601 timespan idle interval after which the subscription is automatically de
 - Type: string
 - Default: `'P10675198DT2H48M5.477S'`
 
-### Parameter: `clientAffineProperties`
-
-The properties that are associated with a subscription that is client-affine.
-
-- Required: No
-- Type: object
-- Default: `{}`
-
 ### Parameter: `deadLetteringOnFilterEvaluationExceptions`
 
-A value that indicates whether a subscription has dead letter support when a message expires.
+A value that indicates whether a subscription has dead letter support on filter evaluation exceptions.
 
 - Required: No
 - Type: bool
@@ -105,7 +138,7 @@ A value that indicates whether a subscription has dead letter support when a mes
 
 ### Parameter: `defaultMessageTimeToLive`
 
-ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes.
+ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.
 
 - Required: No
 - Type: string
@@ -129,7 +162,7 @@ A value that indicates whether server-side batched operations are enabled.
 
 ### Parameter: `forwardDeadLetteredMessagesTo`
 
-The name of the recipient entity to which all the messages sent to the subscription are forwarded to.
+Queue/Topic name to forward the Dead Letter messages to.
 
 - Required: No
 - Type: string
@@ -137,7 +170,7 @@ The name of the recipient entity to which all the messages sent to the subscript
 
 ### Parameter: `forwardTo`
 
-The name of the recipient entity to which all the messages sent to the subscription are forwarded to.
+Queue/Topic name to forward the messages to.
 
 - Required: No
 - Type: string
@@ -145,7 +178,7 @@ The name of the recipient entity to which all the messages sent to the subscript
 
 ### Parameter: `isClientAffine`
 
-A value that indicates whether the subscription supports the concept of session.
+A value that indicates whether the subscription has an affinity to the client id.
 
 - Required: No
 - Type: bool
@@ -153,7 +186,7 @@ A value that indicates whether the subscription supports the concept of session.
 
 ### Parameter: `lockDuration`
 
-ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value for LockDuration is 5 minutes; the default value is 1 minute.
+ISO 8061 lock duration timespan for the subscription. The default value is 1 minute.
 
 - Required: No
 - Type: string
@@ -169,7 +202,7 @@ Number of maximum deliveries. A message is automatically deadlettered after this
 
 ### Parameter: `requiresSession`
 
-A value that indicates whether the subscription supports the concept of session.
+A value that indicates whether the subscription supports the concept of sessions.
 
 - Required: No
 - Type: bool
@@ -186,7 +219,8 @@ The subscription rules.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`name`](#parameter-rulesname) | string | The name of the service bus namespace topic subscription rule. |
+| [`filterType`](#parameter-rulesfiltertype) | string | Filter type that is evaluated against a BrokeredMessage. |
+| [`name`](#parameter-rulesname) | string | The name of the Service Bus Namespace Topic Subscription Rule. |
 
 **Optional parameters**
 
@@ -194,12 +228,25 @@ The subscription rules.
 | :-- | :-- | :-- |
 | [`action`](#parameter-rulesaction) | object | Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression. |
 | [`correlationFilter`](#parameter-rulescorrelationfilter) | object | Properties of correlationFilter. |
-| [`filterType`](#parameter-rulesfiltertype) | string | Filter type that is evaluated against a BrokeredMessage. |
 | [`sqlFilter`](#parameter-rulessqlfilter) | object | Properties of sqlFilter. |
+
+### Parameter: `rules.filterType`
+
+Filter type that is evaluated against a BrokeredMessage.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'CorrelationFilter'
+    'SqlFilter'
+  ]
+  ```
 
 ### Parameter: `rules.name`
 
-The name of the service bus namespace topic subscription rule.
+The name of the Service Bus Namespace Topic Subscription Rule.
 
 - Required: Yes
 - Type: string
@@ -247,12 +294,6 @@ Properties of correlationFilter.
 - Required: No
 - Type: object
 
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`to`](#parameter-rulescorrelationfilterto) | string | Address to send to. |
-
 **Optional parameters**
 
 | Parameter | Type | Description |
@@ -261,18 +302,12 @@ Properties of correlationFilter.
 | [`correlationId`](#parameter-rulescorrelationfiltercorrelationid) | string | Identifier of the correlation. |
 | [`label`](#parameter-rulescorrelationfilterlabel) | string | Application specific label. |
 | [`messageId`](#parameter-rulescorrelationfiltermessageid) | string | Identifier of the message. |
-| [`properties`](#parameter-rulescorrelationfilterproperties) | array | dictionary object for custom filters. |
+| [`properties`](#parameter-rulescorrelationfilterproperties) | object | Dictionary object for custom filters. |
 | [`replyTo`](#parameter-rulescorrelationfilterreplyto) | string | Address of the queue to reply to. |
 | [`replyToSessionId`](#parameter-rulescorrelationfilterreplytosessionid) | string | Session identifier to reply to. |
 | [`requiresPreprocessing`](#parameter-rulescorrelationfilterrequirespreprocessing) | bool | Value that indicates whether the rule action requires preprocessing. |
 | [`sessionId`](#parameter-rulescorrelationfiltersessionid) | string | Session identifier. |
-
-### Parameter: `rules.correlationFilter.to`
-
-Address to send to.
-
-- Required: Yes
-- Type: string
+| [`to`](#parameter-rulescorrelationfilterto) | string | Address to send to. |
 
 ### Parameter: `rules.correlationFilter.contentType`
 
@@ -304,16 +339,10 @@ Identifier of the message.
 
 ### Parameter: `rules.correlationFilter.properties`
 
-dictionary object for custom filters.
+Dictionary object for custom filters.
 
 - Required: No
-- Type: array
-- Allowed:
-  ```Bicep
-  [
-    {}
-  ]
-  ```
+- Type: object
 
 ### Parameter: `rules.correlationFilter.replyTo`
 
@@ -343,19 +372,12 @@ Session identifier.
 - Required: No
 - Type: string
 
-### Parameter: `rules.filterType`
+### Parameter: `rules.correlationFilter.to`
 
-Filter type that is evaluated against a BrokeredMessage.
+Address to send to.
 
 - Required: No
 - Type: string
-- Allowed:
-  ```Bicep
-  [
-    'CorrelationFilter'
-    'SqlFilter'
-  ]
-  ```
 
 ### Parameter: `rules.sqlFilter`
 
@@ -364,13 +386,25 @@ Properties of sqlFilter.
 - Required: No
 - Type: object
 
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`sqlExpression`](#parameter-rulessqlfiltersqlexpression) | string | The SQL expression. e.g. MyProperty='ABC'. |
+
 **Optional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`compatibilityLevel`](#parameter-rulessqlfiltercompatibilitylevel) | int | This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20. |
 | [`requiresPreprocessing`](#parameter-rulessqlfilterrequirespreprocessing) | bool | Value that indicates whether the rule action requires preprocessing. |
-| [`sqlExpression`](#parameter-rulessqlfiltersqlexpression) | string | SQL expression. e.g. MyProperty='ABC'. |
+
+### Parameter: `rules.sqlFilter.sqlExpression`
+
+The SQL expression. e.g. MyProperty='ABC'.
+
+- Required: Yes
+- Type: string
 
 ### Parameter: `rules.sqlFilter.compatibilityLevel`
 
@@ -385,13 +419,6 @@ Value that indicates whether the rule action requires preprocessing.
 
 - Required: No
 - Type: bool
-
-### Parameter: `rules.sqlFilter.sqlExpression`
-
-SQL expression. e.g. MyProperty='ABC'.
-
-- Required: No
-- Type: string
 
 ### Parameter: `status`
 

--- a/avm/res/service-bus/namespace/topic/subscription/main.bicep
+++ b/avm/res/service-bus/namespace/topic/subscription/main.bicep
@@ -2,6 +2,8 @@ metadata name = 'Service Bus Namespace Topic Subscription'
 metadata description = 'This module deploys a Service Bus Namespace Topic Subscription.'
 
 @description('Required. The name of the service bus namespace topic subscription.')
+@minLength(1)
+@maxLength(50)
 param name string
 
 @description('Conditional. The name of the parent Service Bus Namespace. Required if the template is used in a standalone deployment.')
@@ -13,16 +15,16 @@ param topicName string
 @description('Optional. ISO 8601 timespan idle interval after which the subscription is automatically deleted. The minimum duration is 5 minutes.')
 param autoDeleteOnIdle string = 'P10675198DT2H48M5.477S'
 
-@description('Optional. The properties that are associated with a subscription that is client-affine.')
-param clientAffineProperties object = {}
+@description('Conditional. The properties that are associated with a subscription that is client-affine. Required if \'isClientAffine\' is set to true.')
+param clientAffineProperties clientAffinePropertiesType?
 
-@description('Optional. A value that indicates whether a subscription has dead letter support when a message expires.')
+@description('Optional. A value that indicates whether a subscription has dead letter support on filter evaluation exceptions.')
 param deadLetteringOnFilterEvaluationExceptions bool = false
 
 @description('Optional. A value that indicates whether a subscription has dead letter support when a message expires.')
 param deadLetteringOnMessageExpiration bool = false
 
-@description('Optional. ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes.')
+@description('Optional. ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.')
 param defaultMessageTimeToLive string = 'P10675199DT2H48M5.4775807S'
 
 @description('Optional. ISO 8601 timespan that defines the duration of the duplicate detection history. The default value is 10 minutes.')
@@ -31,22 +33,22 @@ param duplicateDetectionHistoryTimeWindow string = 'PT10M'
 @description('Optional. A value that indicates whether server-side batched operations are enabled.')
 param enableBatchedOperations bool = true
 
-@description('Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to.')
+@description('Optional. Queue/Topic name to forward the Dead Letter messages to.')
 param forwardDeadLetteredMessagesTo string = ''
 
-@description('Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to.')
+@description('Optional. Queue/Topic name to forward the messages to.')
 param forwardTo string = ''
 
-@description('Optional. A value that indicates whether the subscription supports the concept of session.')
+@description('Optional. A value that indicates whether the subscription has an affinity to the client id.')
 param isClientAffine bool = false
 
-@description('Optional. ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value for LockDuration is 5 minutes; the default value is 1 minute.')
+@description('Optional. ISO 8061 lock duration timespan for the subscription. The default value is 1 minute.')
 param lockDuration string = 'PT1M'
 
 @description('Optional. Number of maximum deliveries. A message is automatically deadlettered after this number of deliveries. Default value is 10.')
 param maxDeliveryCount int = 10
 
-@description('Optional. A value that indicates whether the subscription supports the concept of session.')
+@description('Optional. A value that indicates whether the subscription supports the concept of sessions.')
 param requiresSession bool = false
 
 @description('Optional. The subscription rules.')

--- a/avm/res/service-bus/namespace/topic/subscription/main.json
+++ b/avm/res/service-bus/namespace/topic/subscription/main.json
@@ -5,169 +5,230 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "18327636281337895707"
+      "version": "0.34.44.8038",
+      "templateHash": "5245442494145554335"
     },
     "name": "Service Bus Namespace Topic Subscription",
     "description": "This module deploys a Service Bus Namespace Topic Subscription."
   },
   "definitions": {
+    "clientAffinePropertiesType": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. Indicates the Client ID of the application that created the client-affine subscription."
+          }
+        },
+        "isDurable": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. For client-affine subscriptions, this value indicates whether the subscription is durable or not. Defaults to true."
+          }
+        },
+        "isShared": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. For client-affine subscriptions, this value indicates whether the subscription is shared or not. Defaults to false."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "Properties specific to client affine subscriptions."
+      }
+    },
+    "_1.actionType": {
+      "type": "object",
+      "properties": {
+        "compatibilityLevel": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+          }
+        },
+        "requiresPreprocessing": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+          }
+        },
+        "sqlExpression": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
+          }
+        }
+      },
+      "metadata": {
+        "description": "A type for the filter actions of a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "rule/main.bicep"
+        }
+      }
+    },
+    "_1.correlationFilterType": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Content type of the message."
+          }
+        },
+        "correlationId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Identifier of the correlation."
+          }
+        },
+        "label": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Application specific label."
+          }
+        },
+        "messageId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Identifier of the message."
+          }
+        },
+        "properties": {
+          "type": "object",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Dictionary object for custom filters."
+          }
+        },
+        "replyTo": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Address of the queue to reply to."
+          }
+        },
+        "replyToSessionId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Session identifier to reply to."
+          }
+        },
+        "requiresPreprocessing": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+          }
+        },
+        "sessionId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Session identifier."
+          }
+        },
+        "to": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Address to send to."
+          }
+        }
+      },
+      "metadata": {
+        "description": "A type for the properties of a correlation filter of a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "rule/main.bicep"
+        }
+      }
+    },
+    "_1.filterTypeType": {
+      "type": "string",
+      "allowedValues": [
+        "CorrelationFilter",
+        "SqlFilter"
+      ],
+      "metadata": {
+        "description": "A type for the type of a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "rule/main.bicep"
+        }
+      }
+    },
+    "_1.sqlFilterType": {
+      "type": "object",
+      "properties": {
+        "compatibilityLevel": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+          }
+        },
+        "requiresPreprocessing": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+          }
+        },
+        "sqlExpression": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The SQL expression. e.g. MyProperty='ABC'."
+          }
+        }
+      },
+      "metadata": {
+        "description": "A type for the properties of a SQL filter of a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "rule/main.bicep"
+        }
+      }
+    },
     "ruleType": {
       "type": "object",
       "properties": {
         "name": {
           "type": "string",
           "metadata": {
-            "description": "Required. The name of the service bus namespace topic subscription rule."
+            "description": "Required. The name of the Service Bus Namespace Topic Subscription Rule."
           }
         },
         "action": {
-          "type": "object",
-          "properties": {
-            "compatibilityLevel": {
-              "type": "int",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
-              }
-            },
-            "requiresPreprocessing": {
-              "type": "bool",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-              }
-            },
-            "sqlExpression": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
-              }
-            }
-          },
+          "$ref": "#/definitions/_1.actionType",
           "nullable": true,
           "metadata": {
             "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
           }
         },
         "correlationFilter": {
-          "type": "object",
-          "properties": {
-            "contentType": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Content type of the message."
-              }
-            },
-            "correlationId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Identifier of the correlation."
-              }
-            },
-            "label": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Application specific label."
-              }
-            },
-            "messageId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Identifier of the message."
-              }
-            },
-            "properties": {
-              "type": "array",
-              "allowedValues": [
-                {}
-              ],
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. dictionary object for custom filters."
-              }
-            },
-            "replyTo": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Address of the queue to reply to."
-              }
-            },
-            "replyToSessionId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Session identifier to reply to."
-              }
-            },
-            "requiresPreprocessing": {
-              "type": "bool",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-              }
-            },
-            "sessionId": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Session identifier."
-              }
-            },
-            "to": {
-              "type": "string",
-              "metadata": {
-                "description": "Required. Address to send to."
-              }
-            }
-          },
+          "$ref": "#/definitions/_1.correlationFilterType",
           "nullable": true,
           "metadata": {
             "description": "Optional. Properties of correlationFilter."
           }
         },
         "filterType": {
-          "type": "string",
-          "allowedValues": [
-            "CorrelationFilter",
-            "SqlFilter"
-          ],
-          "nullable": true,
+          "$ref": "#/definitions/_1.filterTypeType",
           "metadata": {
-            "description": "Optional. Filter type that is evaluated against a BrokeredMessage."
+            "description": "Required. Filter type that is evaluated against a BrokeredMessage."
           }
         },
         "sqlFilter": {
-          "type": "object",
-          "properties": {
-            "compatibilityLevel": {
-              "type": "int",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
-              }
-            },
-            "requiresPreprocessing": {
-              "type": "bool",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Value that indicates whether the rule action requires preprocessing."
-              }
-            },
-            "sqlExpression": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
-              }
-            }
-          },
+          "$ref": "#/definitions/_1.sqlFilterType",
           "nullable": true,
           "metadata": {
             "description": "Optional. Properties of sqlFilter."
@@ -175,14 +236,18 @@
         }
       },
       "metadata": {
-        "__bicep_export!": true,
-        "description": "Optional. The type for rules."
+        "description": "A type for a Service Bus Namespace Topic Subscription Rule.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "rule/main.bicep"
+        }
       }
     }
   },
   "parameters": {
     "name": {
       "type": "string",
+      "minLength": 1,
+      "maxLength": 50,
       "metadata": {
         "description": "Required. The name of the service bus namespace topic subscription."
       }
@@ -207,17 +272,17 @@
       }
     },
     "clientAffineProperties": {
-      "type": "object",
-      "defaultValue": {},
+      "$ref": "#/definitions/clientAffinePropertiesType",
+      "nullable": true,
       "metadata": {
-        "description": "Optional. The properties that are associated with a subscription that is client-affine."
+        "description": "Conditional. The properties that are associated with a subscription that is client-affine. Required if 'isClientAffine' is set to true."
       }
     },
     "deadLetteringOnFilterEvaluationExceptions": {
       "type": "bool",
       "defaultValue": false,
       "metadata": {
-        "description": "Optional. A value that indicates whether a subscription has dead letter support when a message expires."
+        "description": "Optional. A value that indicates whether a subscription has dead letter support on filter evaluation exceptions."
       }
     },
     "deadLetteringOnMessageExpiration": {
@@ -231,7 +296,7 @@
       "type": "string",
       "defaultValue": "P10675199DT2H48M5.4775807S",
       "metadata": {
-        "description": "Optional. ISO 8601 timespan idle interval after which the message expires. The minimum duration is 5 minutes."
+        "description": "Optional. ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself."
       }
     },
     "duplicateDetectionHistoryTimeWindow": {
@@ -252,28 +317,28 @@
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to."
+        "description": "Optional. Queue/Topic name to forward the Dead Letter messages to."
       }
     },
     "forwardTo": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Optional. The name of the recipient entity to which all the messages sent to the subscription are forwarded to."
+        "description": "Optional. Queue/Topic name to forward the messages to."
       }
     },
     "isClientAffine": {
       "type": "bool",
       "defaultValue": false,
       "metadata": {
-        "description": "Optional. A value that indicates whether the subscription supports the concept of session."
+        "description": "Optional. A value that indicates whether the subscription has an affinity to the client id."
       }
     },
     "lockDuration": {
       "type": "string",
       "defaultValue": "PT1M",
       "metadata": {
-        "description": "Optional. ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value for LockDuration is 5 minutes; the default value is 1 minute."
+        "description": "Optional. ISO 8061 lock duration timespan for the subscription. The default value is 1 minute."
       }
     },
     "maxDeliveryCount": {
@@ -287,7 +352,7 @@
       "type": "bool",
       "defaultValue": false,
       "metadata": {
-        "description": "Optional. A value that indicates whether the subscription supports the concept of session."
+        "description": "Optional. A value that indicates whether the subscription supports the concept of sessions."
       }
     },
     "rules": {
@@ -338,7 +403,7 @@
       "name": "[format('{0}/{1}/{2}', parameters('namespaceName'), parameters('topicName'), parameters('name'))]",
       "properties": {
         "autoDeleteOnIdle": "[parameters('autoDeleteOnIdle')]",
-        "clientAffineProperties": "[parameters('clientAffineProperties')]",
+        "clientAffineProperties": "[if(not(empty(parameters('clientAffineProperties'))), createObject('clientId', tryGet(parameters('clientAffineProperties'), 'clientId'), 'isDurable', coalesce(tryGet(parameters('clientAffineProperties'), 'isDurable'), true()), 'isShared', coalesce(tryGet(parameters('clientAffineProperties'), 'isShared'), false())), null())]",
         "deadLetteringOnFilterEvaluationExceptions": "[parameters('deadLetteringOnFilterEvaluationExceptions')]",
         "deadLetteringOnMessageExpiration": "[parameters('deadLetteringOnMessageExpiration')]",
         "defaultMessageTimeToLive": "[parameters('defaultMessageTimeToLive')]",
@@ -386,7 +451,7 @@
             "value": "[tryGet(coalesce(parameters('rules'), createArray())[copyIndex()], 'correlationFilter')]"
           },
           "filterType": {
-            "value": "[tryGet(coalesce(parameters('rules'), createArray())[copyIndex()], 'filterType')]"
+            "value": "[coalesce(parameters('rules'), createArray())[copyIndex()].filterType]"
           },
           "sqlFilter": {
             "value": "[tryGet(coalesce(parameters('rules'), createArray())[copyIndex()], 'sqlFilter')]"
@@ -399,15 +464,210 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "15176672876775916889"
+              "version": "0.34.44.8038",
+              "templateHash": "3457937988681830091"
             },
             "name": "Service Bus Namespace Topic Subscription Rule",
             "description": "This module deploys a Service Bus Namespace Topic Subscription Rule."
           },
+          "definitions": {
+            "ruleType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the Service Bus Namespace Topic Subscription Rule."
+                  }
+                },
+                "action": {
+                  "$ref": "#/definitions/actionType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
+                  }
+                },
+                "correlationFilter": {
+                  "$ref": "#/definitions/correlationFilterType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Properties of correlationFilter."
+                  }
+                },
+                "filterType": {
+                  "$ref": "#/definitions/filterTypeType",
+                  "metadata": {
+                    "description": "Required. Filter type that is evaluated against a BrokeredMessage."
+                  }
+                },
+                "sqlFilter": {
+                  "$ref": "#/definitions/sqlFilterType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Properties of sqlFilter."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "A type for a Service Bus Namespace Topic Subscription Rule."
+              }
+            },
+            "actionType": {
+              "type": "object",
+              "properties": {
+                "compatibilityLevel": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+                  }
+                },
+                "requiresPreprocessing": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                  }
+                },
+                "sqlExpression": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "A type for the filter actions of a Service Bus Namespace Topic Subscription Rule."
+              }
+            },
+            "correlationFilterType": {
+              "type": "object",
+              "properties": {
+                "contentType": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Content type of the message."
+                  }
+                },
+                "correlationId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Identifier of the correlation."
+                  }
+                },
+                "label": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Application specific label."
+                  }
+                },
+                "messageId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Identifier of the message."
+                  }
+                },
+                "properties": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Dictionary object for custom filters."
+                  }
+                },
+                "replyTo": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Address of the queue to reply to."
+                  }
+                },
+                "replyToSessionId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Session identifier to reply to."
+                  }
+                },
+                "requiresPreprocessing": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                  }
+                },
+                "sessionId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Session identifier."
+                  }
+                },
+                "to": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Address to send to."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "A type for the properties of a correlation filter of a Service Bus Namespace Topic Subscription Rule."
+              }
+            },
+            "filterTypeType": {
+              "type": "string",
+              "allowedValues": [
+                "CorrelationFilter",
+                "SqlFilter"
+              ],
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "A type for the type of a Service Bus Namespace Topic Subscription Rule."
+              }
+            },
+            "sqlFilterType": {
+              "type": "object",
+              "properties": {
+                "compatibilityLevel": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+                  }
+                },
+                "requiresPreprocessing": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+                  }
+                },
+                "sqlExpression": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The SQL expression. e.g. MyProperty='ABC'."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "A type for the properties of a SQL filter of a Service Bus Namespace Topic Subscription Rule."
+              }
+            }
+          },
           "parameters": {
             "name": {
               "type": "string",
+              "minLength": 1,
+              "maxLength": 50,
               "metadata": {
                 "description": "Required. The name of the service bus namespace topic subscription rule."
               }
@@ -427,39 +687,34 @@
             "subscriptionName": {
               "type": "string",
               "metadata": {
-                "description": "Conditional. The name of the parent Service Bus Namespace. Required if the template is used in a standalone deployment."
+                "description": "Conditional. The name of the parent Service Bus Namespace Topic Subscription. Required if the template is used in a standalone deployment."
               }
             },
             "action": {
-              "type": "object",
-              "defaultValue": {},
+              "$ref": "#/definitions/actionType",
+              "nullable": true,
               "metadata": {
-                "description": "Opional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
+                "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
               }
             },
             "correlationFilter": {
-              "type": "object",
-              "defaultValue": {},
+              "$ref": "#/definitions/correlationFilterType",
+              "nullable": true,
               "metadata": {
-                "description": "Opional. Properties of a correlation filter."
+                "description": "Conditional. Properties of a correlation filter. Required if 'filterType' is set to 'CorrelationFilter'."
               }
             },
             "filterType": {
-              "type": "string",
-              "nullable": true,
-              "allowedValues": [
-                "CorrelationFilter",
-                "SqlFilter"
-              ],
+              "$ref": "#/definitions/filterTypeType",
               "metadata": {
-                "description": "Optional. Filter type that is evaluated against a BrokeredMessage."
+                "description": "Required. Filter type that is evaluated against a BrokeredMessage."
               }
             },
             "sqlFilter": {
-              "type": "object",
-              "defaultValue": {},
+              "$ref": "#/definitions/sqlFilterType",
+              "nullable": true,
               "metadata": {
-                "description": "Opional. The properties of an SQL filter."
+                "description": "Conditional. Properties of a SQL filter. Required if 'filterType' is set to 'SqlFilter'."
               }
             }
           },
@@ -487,10 +742,10 @@
               "apiVersion": "2022-10-01-preview",
               "name": "[format('{0}/{1}/{2}/{3}', parameters('namespaceName'), parameters('topicName'), parameters('subscriptionName'), parameters('name'))]",
               "properties": {
-                "action": "[parameters('action')]",
-                "correlationFilter": "[parameters('correlationFilter')]",
+                "action": "[if(not(empty(parameters('action'))), parameters('action'), null())]",
+                "correlationFilter": "[if(not(empty(parameters('correlationFilter'))), parameters('correlationFilter'), null())]",
                 "filterType": "[parameters('filterType')]",
-                "sqlFilter": "[parameters('sqlFilter')]"
+                "sqlFilter": "[if(not(empty(parameters('sqlFilter'))), createObject('compatibilityLevel', coalesce(tryGet(parameters('sqlFilter'), 'compatibilityLevel'), 20), 'requiresPreprocessing', tryGet(parameters('sqlFilter'), 'requiresPreprocessing'), 'sqlExpression', tryGet(parameters('sqlFilter'), 'sqlExpression')), null())]"
               }
             }
           },

--- a/avm/res/service-bus/namespace/topic/subscription/rule/README.md
+++ b/avm/res/service-bus/namespace/topic/subscription/rule/README.md
@@ -20,35 +20,136 @@ This module deploys a Service Bus Namespace Topic Subscription Rule.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`filterType`](#parameter-filtertype) | string | Filter type that is evaluated against a BrokeredMessage. |
 | [`name`](#parameter-name) | string | The name of the service bus namespace topic subscription rule. |
 
 **Conditional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`correlationFilter`](#parameter-correlationfilter) | object | Properties of a correlation filter. Required if 'filterType' is set to 'CorrelationFilter'. |
 | [`namespaceName`](#parameter-namespacename) | string | The name of the parent Service Bus Namespace. Required if the template is used in a standalone deployment. |
-| [`subscriptionName`](#parameter-subscriptionname) | string | The name of the parent Service Bus Namespace. Required if the template is used in a standalone deployment. |
+| [`sqlFilter`](#parameter-sqlfilter) | object | Properties of a SQL filter. Required if 'filterType' is set to 'SqlFilter'. |
+| [`subscriptionName`](#parameter-subscriptionname) | string | The name of the parent Service Bus Namespace Topic Subscription. Required if the template is used in a standalone deployment. |
 | [`topicName`](#parameter-topicname) | string | The name of the parent Service Bus Namespace Topic. Required if the template is used in a standalone deployment. |
 
 **Optional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`filterType`](#parameter-filtertype) | string | Filter type that is evaluated against a BrokeredMessage. |
-
-**Opional parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
 | [`action`](#parameter-action) | object | Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression. |
-| [`correlationFilter`](#parameter-correlationfilter) | object | Properties of a correlation filter. |
-| [`sqlFilter`](#parameter-sqlfilter) | object | The properties of an SQL filter. |
+
+### Parameter: `filterType`
+
+Filter type that is evaluated against a BrokeredMessage.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'CorrelationFilter'
+    'SqlFilter'
+  ]
+  ```
 
 ### Parameter: `name`
 
 The name of the service bus namespace topic subscription rule.
 
 - Required: Yes
+- Type: string
+
+### Parameter: `correlationFilter`
+
+Properties of a correlation filter. Required if 'filterType' is set to 'CorrelationFilter'.
+
+- Required: No
+- Type: object
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`contentType`](#parameter-correlationfiltercontenttype) | string | Content type of the message. |
+| [`correlationId`](#parameter-correlationfiltercorrelationid) | string | Identifier of the correlation. |
+| [`label`](#parameter-correlationfilterlabel) | string | Application specific label. |
+| [`messageId`](#parameter-correlationfiltermessageid) | string | Identifier of the message. |
+| [`properties`](#parameter-correlationfilterproperties) | object | Dictionary object for custom filters. |
+| [`replyTo`](#parameter-correlationfilterreplyto) | string | Address of the queue to reply to. |
+| [`replyToSessionId`](#parameter-correlationfilterreplytosessionid) | string | Session identifier to reply to. |
+| [`requiresPreprocessing`](#parameter-correlationfilterrequirespreprocessing) | bool | Value that indicates whether the rule action requires preprocessing. |
+| [`sessionId`](#parameter-correlationfiltersessionid) | string | Session identifier. |
+| [`to`](#parameter-correlationfilterto) | string | Address to send to. |
+
+### Parameter: `correlationFilter.contentType`
+
+Content type of the message.
+
+- Required: No
+- Type: string
+
+### Parameter: `correlationFilter.correlationId`
+
+Identifier of the correlation.
+
+- Required: No
+- Type: string
+
+### Parameter: `correlationFilter.label`
+
+Application specific label.
+
+- Required: No
+- Type: string
+
+### Parameter: `correlationFilter.messageId`
+
+Identifier of the message.
+
+- Required: No
+- Type: string
+
+### Parameter: `correlationFilter.properties`
+
+Dictionary object for custom filters.
+
+- Required: No
+- Type: object
+
+### Parameter: `correlationFilter.replyTo`
+
+Address of the queue to reply to.
+
+- Required: No
+- Type: string
+
+### Parameter: `correlationFilter.replyToSessionId`
+
+Session identifier to reply to.
+
+- Required: No
+- Type: string
+
+### Parameter: `correlationFilter.requiresPreprocessing`
+
+Value that indicates whether the rule action requires preprocessing.
+
+- Required: No
+- Type: bool
+
+### Parameter: `correlationFilter.sessionId`
+
+Session identifier.
+
+- Required: No
+- Type: string
+
+### Parameter: `correlationFilter.to`
+
+Address to send to.
+
+- Required: No
 - Type: string
 
 ### Parameter: `namespaceName`
@@ -58,9 +159,50 @@ The name of the parent Service Bus Namespace. Required if the template is used i
 - Required: Yes
 - Type: string
 
+### Parameter: `sqlFilter`
+
+Properties of a SQL filter. Required if 'filterType' is set to 'SqlFilter'.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`sqlExpression`](#parameter-sqlfiltersqlexpression) | string | The SQL expression. e.g. MyProperty='ABC'. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`compatibilityLevel`](#parameter-sqlfiltercompatibilitylevel) | int | This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20. |
+| [`requiresPreprocessing`](#parameter-sqlfilterrequirespreprocessing) | bool | Value that indicates whether the rule action requires preprocessing. |
+
+### Parameter: `sqlFilter.sqlExpression`
+
+The SQL expression. e.g. MyProperty='ABC'.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `sqlFilter.compatibilityLevel`
+
+This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20.
+
+- Required: No
+- Type: int
+
+### Parameter: `sqlFilter.requiresPreprocessing`
+
+Value that indicates whether the rule action requires preprocessing.
+
+- Required: No
+- Type: bool
+
 ### Parameter: `subscriptionName`
 
-The name of the parent Service Bus Namespace. Required if the template is used in a standalone deployment.
+The name of the parent Service Bus Namespace Topic Subscription. Required if the template is used in a standalone deployment.
 
 - Required: Yes
 - Type: string
@@ -72,43 +214,41 @@ The name of the parent Service Bus Namespace Topic. Required if the template is 
 - Required: Yes
 - Type: string
 
-### Parameter: `filterType`
-
-Filter type that is evaluated against a BrokeredMessage.
-
-- Required: No
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'CorrelationFilter'
-    'SqlFilter'
-  ]
-  ```
-
 ### Parameter: `action`
 
 Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.
 
 - Required: No
 - Type: object
-- Default: `{}`
 
-### Parameter: `correlationFilter`
+**Optional parameters**
 
-Properties of a correlation filter.
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`compatibilityLevel`](#parameter-actioncompatibilitylevel) | int | This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20. |
+| [`requiresPreprocessing`](#parameter-actionrequirespreprocessing) | bool | Value that indicates whether the rule action requires preprocessing. |
+| [`sqlExpression`](#parameter-actionsqlexpression) | string | SQL expression. e.g. MyProperty='ABC'. |
+
+### Parameter: `action.compatibilityLevel`
+
+This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20.
 
 - Required: No
-- Type: object
-- Default: `{}`
+- Type: int
 
-### Parameter: `sqlFilter`
+### Parameter: `action.requiresPreprocessing`
 
-The properties of an SQL filter.
+Value that indicates whether the rule action requires preprocessing.
 
 - Required: No
-- Type: object
-- Default: `{}`
+- Type: bool
+
+### Parameter: `action.sqlExpression`
+
+SQL expression. e.g. MyProperty='ABC'.
+
+- Required: No
+- Type: string
 
 ## Outputs
 

--- a/avm/res/service-bus/namespace/topic/subscription/rule/main.bicep
+++ b/avm/res/service-bus/namespace/topic/subscription/rule/main.bicep
@@ -43,10 +43,16 @@ resource rule 'Microsoft.ServiceBus/namespaces/topics/subscriptions/rules@2022-1
   name: name
   parent: namespace::topic::subscription
   properties: {
-    action: action
-    correlationFilter: correlationFilter
+    action: !empty(action) ? action : null
+    correlationFilter: !empty(correlationFilter) ? correlationFilter : null
     filterType: filterType
-    sqlFilter: sqlFilter
+    sqlFilter: !empty(sqlFilter)
+      ? {
+          compatibilityLevel: sqlFilter.?compatibilityLevel ?? 20
+          requiresPreprocessing: sqlFilter.?requiresPreprocessing
+          sqlExpression: sqlFilter.?sqlExpression
+        }
+      : null
   }
 }
 

--- a/avm/res/service-bus/namespace/topic/subscription/rule/main.bicep
+++ b/avm/res/service-bus/namespace/topic/subscription/rule/main.bicep
@@ -2,6 +2,8 @@ metadata name = 'Service Bus Namespace Topic Subscription Rule'
 metadata description = 'This module deploys a Service Bus Namespace Topic Subscription Rule.'
 
 @description('Required. The name of the service bus namespace topic subscription rule.')
+@minLength(1)
+@maxLength(50)
 param name string
 
 @description('Conditional. The name of the parent Service Bus Namespace. Required if the template is used in a standalone deployment.')
@@ -10,24 +12,20 @@ param namespaceName string
 @description('Conditional. The name of the parent Service Bus Namespace Topic. Required if the template is used in a standalone deployment.')
 param topicName string
 
-@description('Conditional. The name of the parent Service Bus Namespace. Required if the template is used in a standalone deployment.')
+@description('Conditional. The name of the parent Service Bus Namespace Topic Subscription. Required if the template is used in a standalone deployment.')
 param subscriptionName string
 
-@description('Opional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.')
-param action object = {}
+@description('Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.')
+param action actionType?
 
-@description('Opional. Properties of a correlation filter.')
-param correlationFilter object = {}
+@description('Conditional. Properties of a correlation filter. Required if \'filterType\' is set to \'CorrelationFilter\'.')
+param correlationFilter correlationFilterType?
 
-@description('Optional. Filter type that is evaluated against a BrokeredMessage.')
-@allowed([
-  'CorrelationFilter'
-  'SqlFilter'
-])
-param filterType string?
+@description('Required. Filter type that is evaluated against a BrokeredMessage.')
+param filterType filterTypeType
 
-@description('Opional. The properties of an SQL filter.')
-param sqlFilter object = {}
+@description('Conditional. Properties of a SQL filter. Required if \'filterType\' is set to \'SqlFilter\'.')
+param sqlFilter sqlFilterType?
 
 resource namespace 'Microsoft.ServiceBus/namespaces@2022-10-01-preview' existing = {
   name: namespaceName
@@ -60,3 +58,89 @@ output resourceId string = rule.id
 
 @description('The name of the Resource Group the rule was created in.')
 output resourceGroupName string = resourceGroup().name
+
+// =============== //
+//   Definitions   //
+// =============== //
+@export()
+@description('A type for a Service Bus Namespace Topic Subscription Rule.')
+type ruleType = {
+  @description('Required. The name of the Service Bus Namespace Topic Subscription Rule.')
+  name: string
+
+  @description('Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression.')
+  action: actionType?
+
+  @description('Optional. Properties of correlationFilter.')
+  correlationFilter: correlationFilterType?
+
+  @description('Required. Filter type that is evaluated against a BrokeredMessage.')
+  filterType: filterTypeType
+
+  @description('Optional. Properties of sqlFilter.')
+  sqlFilter: sqlFilterType?
+}
+
+@export()
+@description('A type for the filter actions of a Service Bus Namespace Topic Subscription Rule.')
+type actionType = {
+  @description('Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20.')
+  compatibilityLevel: int?
+
+  @description('Optional. Value that indicates whether the rule action requires preprocessing.')
+  requiresPreprocessing: bool?
+
+  @description('Optional. SQL expression. e.g. MyProperty=\'ABC\'.')
+  sqlExpression: string?
+}
+
+@export()
+@description('A type for the properties of a correlation filter of a Service Bus Namespace Topic Subscription Rule.')
+type correlationFilterType = {
+  @description('Optional. Content type of the message.')
+  contentType: string?
+
+  @description('Optional. Identifier of the correlation.')
+  correlationId: string?
+
+  @description('Optional. Application specific label.')
+  label: string?
+
+  @description('Optional. Identifier of the message.')
+  messageId: string?
+
+  @description('Optional. Dictionary object for custom filters.')
+  properties: object?
+
+  @description('Optional. Address of the queue to reply to.')
+  replyTo: string?
+
+  @description('Optional. Session identifier to reply to.')
+  replyToSessionId: string?
+
+  @description('Optional. Value that indicates whether the rule action requires preprocessing.')
+  requiresPreprocessing: bool?
+
+  @description('Optional. Session identifier.')
+  sessionId: string?
+
+  @description('Optional. Address to send to.')
+  to: string?
+}
+
+@export()
+@description('A type for the type of a Service Bus Namespace Topic Subscription Rule.')
+type filterTypeType = 'CorrelationFilter' | 'SqlFilter'
+
+@export()
+@description('A type for the properties of a SQL filter of a Service Bus Namespace Topic Subscription Rule.')
+type sqlFilterType = {
+  @description('Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20.')
+  compatibilityLevel: int?
+
+  @description('Optional. Value that indicates whether the rule action requires preprocessing.')
+  requiresPreprocessing: bool?
+
+  @description('Required. The SQL expression. e.g. MyProperty=\'ABC\'.')
+  sqlExpression: string
+}

--- a/avm/res/service-bus/namespace/topic/subscription/rule/main.bicep
+++ b/avm/res/service-bus/namespace/topic/subscription/rule/main.bicep
@@ -43,8 +43,8 @@ resource rule 'Microsoft.ServiceBus/namespaces/topics/subscriptions/rules@2022-1
   name: name
   parent: namespace::topic::subscription
   properties: {
-    action: !empty(action) ? action : null
-    correlationFilter: !empty(correlationFilter) ? correlationFilter : null
+    action: action
+    correlationFilter: correlationFilter
     filterType: filterType
     sqlFilter: !empty(sqlFilter)
       ? {

--- a/avm/res/service-bus/namespace/topic/subscription/rule/main.json
+++ b/avm/res/service-bus/namespace/topic/subscription/rule/main.json
@@ -5,15 +5,210 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "15176672876775916889"
+      "version": "0.34.44.8038",
+      "templateHash": "3457937988681830091"
     },
     "name": "Service Bus Namespace Topic Subscription Rule",
     "description": "This module deploys a Service Bus Namespace Topic Subscription Rule."
   },
+  "definitions": {
+    "ruleType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the Service Bus Namespace Topic Subscription Rule."
+          }
+        },
+        "action": {
+          "$ref": "#/definitions/actionType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
+          }
+        },
+        "correlationFilter": {
+          "$ref": "#/definitions/correlationFilterType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Properties of correlationFilter."
+          }
+        },
+        "filterType": {
+          "$ref": "#/definitions/filterTypeType",
+          "metadata": {
+            "description": "Required. Filter type that is evaluated against a BrokeredMessage."
+          }
+        },
+        "sqlFilter": {
+          "$ref": "#/definitions/sqlFilterType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Properties of sqlFilter."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "A type for a Service Bus Namespace Topic Subscription Rule."
+      }
+    },
+    "actionType": {
+      "type": "object",
+      "properties": {
+        "compatibilityLevel": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+          }
+        },
+        "requiresPreprocessing": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+          }
+        },
+        "sqlExpression": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. SQL expression. e.g. MyProperty='ABC'."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "A type for the filter actions of a Service Bus Namespace Topic Subscription Rule."
+      }
+    },
+    "correlationFilterType": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Content type of the message."
+          }
+        },
+        "correlationId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Identifier of the correlation."
+          }
+        },
+        "label": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Application specific label."
+          }
+        },
+        "messageId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Identifier of the message."
+          }
+        },
+        "properties": {
+          "type": "object",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Dictionary object for custom filters."
+          }
+        },
+        "replyTo": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Address of the queue to reply to."
+          }
+        },
+        "replyToSessionId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Session identifier to reply to."
+          }
+        },
+        "requiresPreprocessing": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+          }
+        },
+        "sessionId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Session identifier."
+          }
+        },
+        "to": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Address to send to."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "A type for the properties of a correlation filter of a Service Bus Namespace Topic Subscription Rule."
+      }
+    },
+    "filterTypeType": {
+      "type": "string",
+      "allowedValues": [
+        "CorrelationFilter",
+        "SqlFilter"
+      ],
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "A type for the type of a Service Bus Namespace Topic Subscription Rule."
+      }
+    },
+    "sqlFilterType": {
+      "type": "object",
+      "properties": {
+        "compatibilityLevel": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. This property is reserved for future use. An integer value showing the compatibility level, currently hard-coded to 20."
+          }
+        },
+        "requiresPreprocessing": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Value that indicates whether the rule action requires preprocessing."
+          }
+        },
+        "sqlExpression": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The SQL expression. e.g. MyProperty='ABC'."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "A type for the properties of a SQL filter of a Service Bus Namespace Topic Subscription Rule."
+      }
+    }
+  },
   "parameters": {
     "name": {
       "type": "string",
+      "minLength": 1,
+      "maxLength": 50,
       "metadata": {
         "description": "Required. The name of the service bus namespace topic subscription rule."
       }
@@ -33,39 +228,34 @@
     "subscriptionName": {
       "type": "string",
       "metadata": {
-        "description": "Conditional. The name of the parent Service Bus Namespace. Required if the template is used in a standalone deployment."
+        "description": "Conditional. The name of the parent Service Bus Namespace Topic Subscription. Required if the template is used in a standalone deployment."
       }
     },
     "action": {
-      "type": "object",
-      "defaultValue": {},
+      "$ref": "#/definitions/actionType",
+      "nullable": true,
       "metadata": {
-        "description": "Opional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
+        "description": "Optional. Represents the filter actions which are allowed for the transformation of a message that have been matched by a filter expression."
       }
     },
     "correlationFilter": {
-      "type": "object",
-      "defaultValue": {},
+      "$ref": "#/definitions/correlationFilterType",
+      "nullable": true,
       "metadata": {
-        "description": "Opional. Properties of a correlation filter."
+        "description": "Conditional. Properties of a correlation filter. Required if 'filterType' is set to 'CorrelationFilter'."
       }
     },
     "filterType": {
-      "type": "string",
-      "nullable": true,
-      "allowedValues": [
-        "CorrelationFilter",
-        "SqlFilter"
-      ],
+      "$ref": "#/definitions/filterTypeType",
       "metadata": {
-        "description": "Optional. Filter type that is evaluated against a BrokeredMessage."
+        "description": "Required. Filter type that is evaluated against a BrokeredMessage."
       }
     },
     "sqlFilter": {
-      "type": "object",
-      "defaultValue": {},
+      "$ref": "#/definitions/sqlFilterType",
+      "nullable": true,
       "metadata": {
-        "description": "Opional. The properties of an SQL filter."
+        "description": "Conditional. Properties of a SQL filter. Required if 'filterType' is set to 'SqlFilter'."
       }
     }
   },
@@ -93,10 +283,10 @@
       "apiVersion": "2022-10-01-preview",
       "name": "[format('{0}/{1}/{2}/{3}', parameters('namespaceName'), parameters('topicName'), parameters('subscriptionName'), parameters('name'))]",
       "properties": {
-        "action": "[parameters('action')]",
-        "correlationFilter": "[parameters('correlationFilter')]",
+        "action": "[if(not(empty(parameters('action'))), parameters('action'), null())]",
+        "correlationFilter": "[if(not(empty(parameters('correlationFilter'))), parameters('correlationFilter'), null())]",
         "filterType": "[parameters('filterType')]",
-        "sqlFilter": "[parameters('sqlFilter')]"
+        "sqlFilter": "[if(not(empty(parameters('sqlFilter'))), createObject('compatibilityLevel', coalesce(tryGet(parameters('sqlFilter'), 'compatibilityLevel'), 20), 'requiresPreprocessing', tryGet(parameters('sqlFilter'), 'requiresPreprocessing'), 'sqlExpression', tryGet(parameters('sqlFilter'), 'sqlExpression')), null())]"
       }
     }
   },

--- a/utilities/tools/Test-ModuleLocally.ps1
+++ b/utilities/tools/Test-ModuleLocally.ps1
@@ -318,7 +318,7 @@ function Test-ModuleLocally {
             } finally {
                 # Restore test files
                 # ------------------
-                if (($ValidationTest -or $DeploymentTest) -and $ValidateOrDeployParameters) {
+                if (($ValidationTest -or $DeploymentTest -or $WhatIfTest) -and $ValidateOrDeployParameters) {
                     # Replace Values with Tokens For Repo Updates
                     Write-Verbose 'Restoring Tokens'
                     $null = Convert-TokensInFileList @tokenConfiguration -SwapValueWithName $true


### PR DESCRIPTION
## Description

I stumbled upon some issues when working with some of the Service Bus Namespace (SBNS) related modules, so I decided to implement some improvements. The root cause of this PR is mainly an issue when trying to deploy SBNS topic subscriptions with a SqlFilter and/or CorrelationFilter, which slipped between the cracks of tests.

Example of a failing scenario:
- not defining a SqlFilter for a SBNS topic subscription caused default initialization to an empty object, which eventually resulted in Azure Resource Manager returning errors due the `sqlExpression` param being null (even though we're not even trying to deploy SBNS topic subscription with a SqlFilter)

In general, this PR contains the following:
- Fixed issue when deploying SBNS topic subscription without a SqlFilter
- Fixed invalid datatype of Correlation filter custom properties for SBNS topic subscription
- Updated property 'to' in a Correlation filter from required to optional
- Added user-defined ruleType to avm\res\service-bus\namespace\topic\subscription\rule
- Added user-defined clientAffinePropertiesType to avm\res\service-bus\namespace\topic\subscription
- Updated/Extended tests accordingly
- Updated descriptions of input params in various SBNS-related modules
- Added namePrefix token restore for WhatIfTest in utilities\tools\Test-ModuleLocally.ps1

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|[![avm.res.service-bus.namespace](https://github.com/Gen1a/bicep-registry-modules/actions/workflows/avm.res.service-bus.namespace.yml/badge.svg?branch=servicebus-improvements)](https://github.com/Gen1a/bicep-registry-modules/actions/workflows/avm.res.service-bus.namespace.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
