### PR TITLE
feat: EventGrid Domains: Support for property minimumTlsVersionAllowed

### DIFF
--- a/avm/res/event-grid/domain/README.md
+++ b/avm/res/event-grid/domain/README.md
@@ -643,6 +643,7 @@ param topics = [
 | [`location`](#parameter-location) | string | Location for all Resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. |
+| [`minimumTlsVersionAllowed`](#parameter-minimumtlsversionallowed) | string | The minimum TLS version allowed for the Event Grid Domain. |
 | [`privateEndpoints`](#parameter-privateendpoints) | array | Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. |
 | [`publicNetworkAccess`](#parameter-publicnetworkaccess) | string | Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and inboundIpRules are not set. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
@@ -913,6 +914,14 @@ The resource ID(s) to assign to the resource. Required if a user assigned identi
 
 - Required: No
 - Type: array
+
+### Parameter: `minimumTlsVersionAllowed`
+
+The minimum TLS version allowed for the Event Grid Domain.
+
+- Required: No
+- Type: string
+- Default: `1.2`
 
 ### Parameter: `privateEndpoints`
 

--- a/avm/res/event-grid/domain/main.bicep
+++ b/avm/res/event-grid/domain/main.bicep
@@ -56,6 +56,14 @@ param managedIdentities managedIdentityAllType?
 @description('Optional. Allow only Azure AD authentication. Should be enabled for security reasons.')
 param disableLocalAuth bool = true
 
+@description('Optional. Minimum TLS version to be used for the domain. If not specified, it will be set to 1.2.')
+@allowed([
+  '1.0'
+  '1.1'
+  '1.2'
+])
+param minimumTlsVersionAllowed string = '1.2'
+
 var enableReferencedModulesTelemetry = false
 
 var formattedUserAssignedIdentities = reduce(
@@ -149,6 +157,7 @@ resource domain 'Microsoft.EventGrid/domains@2023-06-01-preview' = {
     autoCreateTopicWithFirstSubscription: autoCreateTopicWithFirstSubscription
     autoDeleteTopicWithLastSubscription: autoDeleteTopicWithLastSubscription
     disableLocalAuth: disableLocalAuth
+    minimumTlsVersionAllowed: minimumTlsVersionAllowed
   }
 }
 

--- a/avm/res/event-grid/domain/version.json
+++ b/avm/res/event-grid/domain/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.8",
+  "version": "0.9",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
## Description

Needed support for setting a minimumTlsVersionAllowed b/c of a restricting policy in an organization.

Fixes #5014 
Closes #5014 


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
