### PR TITLE
feat: CI - Adding Pester test results publishing to action

### DIFF
--- a/.github/actions/templates/avm-validateModulePester/action.yml
+++ b/.github/actions/templates/avm-validateModulePester/action.yml
@@ -14,7 +14,7 @@
 ##   | Parameter                | Required | Default | Description                          | Example                                                            |
 ##   |--------------------------|----------|---------|--------------------------------------|--------------------------------------------------------------------|
 ##   | modulePath               | true     | ''      | The path to the module's folder      | 'modules/api-management/service'                                   |
-##   | moduleTestFilePath       | true     | ''      | The path to the module Pester tests. | 'utilities/pipelines/staticValidation/compliance/module.tests.ps1' |
+##   | moduleTestFilePath       | false    |         | The path to the module Pester tests. | 'utilities/pipelines/staticValidation/compliance/module.tests.ps1' |
 ##   |===========================================================================================================================================================|
 ##
 ##---------------------------------------------##
@@ -26,10 +26,9 @@ inputs:
   modulePath:
     description: "The path to the module's folder"
     required: true
-    default: ""
   moduleTestFilePath:
     description: "The path to the test file"
-    required: true
+    required: false
     default: "utilities/pipelines/staticValidation/compliance/module.tests.ps1"
 
 runs:
@@ -86,6 +85,9 @@ runs:
 
         $testResults = Invoke-Pester -Configuration $pesterConfiguration
 
+        Write-Verbose 'Storing test results in file [testResults.json]' -Verbose
+        $testResults | ConvertTo-Json -Depth 3 | Out-File -FilePath 'testResults.json' -Force -Encoding 'utf8'
+
         # ----------------------------------------- #
         # Create formatted Pester Test Results File #
         # ----------------------------------------- #
@@ -95,6 +97,7 @@ runs:
           OutputFilePath    = Join-Path $env:GITHUB_WORKSPACE 'avm' 'Pester-output.md'
           GitHubRepository  = $env:GITHUB_REPOSITORY
           BranchName        = $env:GITHUB_REF
+          ErrorAction       = 'SilentlyContinue'
         }
 
         Write-Verbose 'Invoke Pester formatting function with' -Verbose
@@ -102,10 +105,12 @@ runs:
 
         Set-PesterGitHubOutput @functionInput -Verbose
 
-        Write-Output ('{0}={1}' -f 'formattedPesterResultsPath', $functionInput.outputFilePath) >> $env:GITHUB_OUTPUT
+        if(Test-Path $functionInput.outputFilePath) {
+          Write-Output ('{0}={1}' -f 'formattedPesterResultsPath', $functionInput.outputFilePath) >> $env:GITHUB_OUTPUT
+        }
 
     - name: "Output to GitHub job summaries"
-      if: always()
+      if: always() && steps.pester_run_step.outputs.formattedPesterResultsPath != ''
       shell: pwsh
       run: |
         # Grouping task logs
@@ -121,3 +126,11 @@ runs:
         }
 
         Write-Output '::endgroup::'
+
+    - name: Upload artifacts
+      if: always()
+      uses: actions/upload-artifact@v4.6.2
+      with:
+        name: Upload & store test results
+        path: |
+          testResults.json


### PR DESCRIPTION
## Description

Publishes the Pester test result as a pipeline artifact to enable troubleshooting if needed. 

![image](https://github.com/user-attachments/assets/7a234f0a-0386-44df-8f33-3ce76ba9062a)

Steps for troubleshooting e.g., the output
- Navigate to the worklow
- Open the log and navigate to the step that publishes the artifact
- Select the published artifact's link in the log (will trigger a download)
  ![image](https://github.com/user-attachments/assets/23a65af1-7a1d-4d7d-a103-01f93504c8c7)
- Unpack the contained `testResults.json` file
- Run a script like
  ```pwsh
  $functionInput = @{
      PesterTestResults = (Get-Content -Path '<PathToJson>' -Raw | ConvertFrom-Json -AsHashtable)
      OutputFilePath    = Join-Path $PSScriptRoot 'test.md'
      GitHubRepository  = 'Azure'
      BranchName        = (git branch --show-current)
      Title             = 'Pester post-deployment validation summary'
  }
  
  Write-Verbose 'Invoke Pester formatting function with' -Verbose
  Write-Verbose ($functionInput | ConvertTo-Json -Depth 0 | Out-String) -Verbose
  
  . '<PathToRepo>\utilities\pipelines\staticValidation\compliance\Set-PesterGitHubOutput.ps1'
  Set-PesterGitHubOutput @functionInput -Verbose
  ```

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline | |
| -------- | - |
|   [![avm.ptn.virtual-machine-images.azure-image-builder](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml/badge.svg?branch=users%2Falsehr%2FpublishPesterTestResult&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml) | [ref](https://github.com/Azure/bicep-registry-modules/actions/runs/14427424417) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

