### PR TITLE
fix: avm/lz/sub-vending - Fix a missing UDT parameter in PIM role assignments

### DIFF
--- a/avm/ptn/lz/sub-vending/README.md
+++ b/avm/ptn/lz/sub-vending/README.md
@@ -2052,10 +2052,10 @@ To use this variant, set the property `templateName` to `excludeRoles`.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`ExludededRoles`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolesexludededroles) | array | The list of roles that are not allowed to be assigned by the delegate. |
+| [`ExcludedRoles`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolesexcludedroles) | array | The list of roles that are not allowed to be assigned by the delegate. |
 | [`templateName`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolestemplatename) | string | Name of the RBAC condition template. |
 
-### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-excludeRoles.ExludededRoles`
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-excludeRoles.ExcludedRoles`
 
 The list of roles that are not allowed to be assigned by the delegate.
 
@@ -2444,10 +2444,10 @@ To use this variant, set the property `templateName` to `excludeRoles`.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`ExludededRoles`](#parameter-roleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolesexludededroles) | array | The list of roles that are not allowed to be assigned by the delegate. |
+| [`ExcludedRoles`](#parameter-roleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolesexcludedroles) | array | The list of roles that are not allowed to be assigned by the delegate. |
 | [`templateName`](#parameter-roleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolestemplatename) | string | Name of the RBAC condition template. |
 
-### Parameter: `roleAssignments.roleAssignmentCondition.roleConditionType.templateName-excludeRoles.ExludededRoles`
+### Parameter: `roleAssignments.roleAssignmentCondition.roleConditionType.templateName-excludeRoles.ExcludedRoles`
 
 The list of roles that are not allowed to be assigned by the delegate.
 

--- a/avm/ptn/lz/sub-vending/README.md
+++ b/avm/ptn/lz/sub-vending/README.md
@@ -2052,10 +2052,10 @@ To use this variant, set the property `templateName` to `excludeRoles`.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`ExcludedRoles`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolesexcludedroles) | array | The list of roles that are not allowed to be assigned by the delegate. |
+| [`excludedRoles`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolesexcludedroles) | array | The list of roles that are not allowed to be assigned by the delegate. |
 | [`templateName`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolestemplatename) | string | Name of the RBAC condition template. |
 
-### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-excludeRoles.ExcludedRoles`
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-excludeRoles.excludedRoles`
 
 The list of roles that are not allowed to be assigned by the delegate.
 
@@ -2444,10 +2444,10 @@ To use this variant, set the property `templateName` to `excludeRoles`.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`ExcludedRoles`](#parameter-roleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolesexcludedroles) | array | The list of roles that are not allowed to be assigned by the delegate. |
+| [`excludedRoles`](#parameter-roleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolesexcludedroles) | array | The list of roles that are not allowed to be assigned by the delegate. |
 | [`templateName`](#parameter-roleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolestemplatename) | string | Name of the RBAC condition template. |
 
-### Parameter: `roleAssignments.roleAssignmentCondition.roleConditionType.templateName-excludeRoles.ExcludedRoles`
+### Parameter: `roleAssignments.roleAssignmentCondition.roleConditionType.templateName-excludeRoles.excludedRoles`
 
 The list of roles that are not allowed to be assigned by the delegate.
 

--- a/avm/ptn/lz/sub-vending/README.md
+++ b/avm/ptn/lz/sub-vending/README.md
@@ -896,6 +896,7 @@ module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
         justification: 'This is a justification from an AVM test.'
         principalId: '<principalId>'
         relativeScope: '<relativeScope>'
+        requestType: 'AdminAssign'
         roleAssignmentType: 'Active'
         scheduleInfo: {
           duration: 'PT4H'
@@ -948,6 +949,7 @@ module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
           "justification": "This is a justification from an AVM test.",
           "principalId": "<principalId>",
           "relativeScope": "<relativeScope>",
+          "requestType": "AdminAssign",
           "roleAssignmentType": "Active",
           "scheduleInfo": {
             "duration": "PT4H",
@@ -1030,6 +1032,7 @@ param pimRoleAssignments = [
     justification: 'This is a justification from an AVM test.'
     principalId: '<principalId>'
     relativeScope: '<relativeScope>'
+    requestType: 'AdminAssign'
     roleAssignmentType: 'Active'
     scheduleInfo: {
       duration: 'PT4H'
@@ -1083,6 +1086,7 @@ module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
         justification: 'This is a justification from an AVM test.'
         principalId: '<principalId>'
         relativeScope: ''
+        requestType: 'AdminUpdate'
         roleAssignmentType: 'Eligible'
         scheduleInfo: {
           duration: 'PT4H'
@@ -1131,6 +1135,7 @@ module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
           "justification": "This is a justification from an AVM test.",
           "principalId": "<principalId>",
           "relativeScope": "",
+          "requestType": "AdminUpdate",
           "roleAssignmentType": "Eligible",
           "scheduleInfo": {
             "duration": "PT4H",
@@ -1205,6 +1210,7 @@ param pimRoleAssignments = [
     justification: 'This is a justification from an AVM test.'
     principalId: '<principalId>'
     relativeScope: ''
+    requestType: 'AdminUpdate'
     roleAssignmentType: 'Eligible'
     scheduleInfo: {
       duration: 'PT4H'
@@ -1798,6 +1804,8 @@ Supply an array of objects containing the details of the PIM role assignments to
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`justification`](#parameter-pimroleassignmentsjustification) | string | The justification for the role assignment. |
+| [`requestType`](#parameter-pimroleassignmentsrequesttype) | string | The type of the PIM request. |
+| [`roleAssignmentCondition`](#parameter-pimroleassignmentsroleassignmentcondition) | object | The condition for the role assignment. |
 | [`ticketInfo`](#parameter-pimroleassignmentsticketinfo) | object | The ticket information for the role assignment. |
 
 ### Parameter: `pimRoleAssignments.definition`
@@ -1961,6 +1969,231 @@ The justification for the role assignment.
 
 - Required: No
 - Type: string
+
+### Parameter: `pimRoleAssignments.requestType`
+
+The type of the PIM request.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'AdminAssign'
+    'AdminExtend'
+    'AdminRemove'
+    'AdminRenew'
+    'AdminUpdate'
+    'SelfActivate'
+    'SelfDeactivate'
+    'SelfExtend'
+    'SelfRenew'
+  ]
+  ```
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition`
+
+The condition for the role assignment.
+
+- Required: No
+- Type: object
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`conditionVersion`](#parameter-pimroleassignmentsroleassignmentconditionconditionversion) | string | The version of the condition template. |
+| [`delegationCode`](#parameter-pimroleassignmentsroleassignmentconditiondelegationcode) | string | The code for a custom condition if no template is used. The user should supply their own custom code if the available templates are not matching their requirements. If a value is provided, this will overwrite any added template. All single quotes needs to be skipped using '. |
+| [`roleConditionType`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontype) | object | The type of template for the role assignment condition. |
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.conditionVersion`
+
+The version of the condition template.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    '2.0'
+  ]
+  ```
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.delegationCode`
+
+The code for a custom condition if no template is used. The user should supply their own custom code if the available templates are not matching their requirements. If a value is provided, this will overwrite any added template. All single quotes needs to be skipped using '.
+
+- Required: No
+- Type: string
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType`
+
+The type of template for the role assignment condition.
+
+- Required: No
+- Type: object
+- Discriminator: `templateName`
+
+<h4>The available variants are:</h4>
+
+| Variant | Description |
+| :-- | :-- |
+| [`excludeRoles`](#variant-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderoles) |  |
+| [`constrainRoles`](#variant-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-constrainroles) |  |
+| [`constrainRolesAndPrincipalTypes`](#variant-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-constrainrolesandprincipaltypes) |  |
+| [`constrainRolesAndPrincipals`](#variant-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-constrainrolesandprincipals) |  |
+
+### Variant: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-excludeRoles`
+
+
+To use this variant, set the property `templateName` to `excludeRoles`.
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`ExludededRoles`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolesexludededroles) | array | The list of roles that are not allowed to be assigned by the delegate. |
+| [`templateName`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-excluderolestemplatename) | string | Name of the RBAC condition template. |
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-excludeRoles.ExludededRoles`
+
+The list of roles that are not allowed to be assigned by the delegate.
+
+- Required: Yes
+- Type: array
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-excludeRoles.templateName`
+
+Name of the RBAC condition template.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'excludeRoles'
+  ]
+  ```
+
+### Variant: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-constrainRoles`
+
+
+To use this variant, set the property `templateName` to `constrainRoles`.
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`rolesToAssign`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-constrainrolesrolestoassign) | array | The list of roles that are allowed to be assigned by the delegate. |
+| [`templateName`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-constrainrolestemplatename) | string | Name of the RBAC condition template. |
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-constrainRoles.rolesToAssign`
+
+The list of roles that are allowed to be assigned by the delegate.
+
+- Required: Yes
+- Type: array
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-constrainRoles.templateName`
+
+Name of the RBAC condition template.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'constrainRoles'
+  ]
+  ```
+
+### Variant: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-constrainRolesAndPrincipalTypes`
+
+
+To use this variant, set the property `templateName` to `constrainRolesAndPrincipalTypes`.
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`principleTypesToAssign`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-constrainrolesandprincipaltypesprincipletypestoassign) | array | The list of principle types that are allowed to be assigned roles by the delegate. |
+| [`rolesToAssign`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-constrainrolesandprincipaltypesrolestoassign) | array | The list of roles that are allowed to be assigned by the delegate. |
+| [`templateName`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-constrainrolesandprincipaltypestemplatename) | string | Name of the RBAC condition template. |
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-constrainRolesAndPrincipalTypes.principleTypesToAssign`
+
+The list of principle types that are allowed to be assigned roles by the delegate.
+
+- Required: Yes
+- Type: array
+- Allowed:
+  ```Bicep
+  [
+    'Group'
+    'ServicePrincipal'
+    'User'
+  ]
+  ```
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-constrainRolesAndPrincipalTypes.rolesToAssign`
+
+The list of roles that are allowed to be assigned by the delegate.
+
+- Required: Yes
+- Type: array
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-constrainRolesAndPrincipalTypes.templateName`
+
+Name of the RBAC condition template.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'constrainRolesAndPrincipalTypes'
+  ]
+  ```
+
+### Variant: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-constrainRolesAndPrincipals`
+
+
+To use this variant, set the property `templateName` to `constrainRolesAndPrincipals`.
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`principalsToAssignTo`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-constrainrolesandprincipalsprincipalstoassignto) | array | The list of principals that are allowed to be assigned roles by the delegate. |
+| [`rolesToAssign`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-constrainrolesandprincipalsrolestoassign) | array | The list of roles that are allowed to be assigned by the delegate. |
+| [`templateName`](#parameter-pimroleassignmentsroleassignmentconditionroleconditiontypetemplatename-constrainrolesandprincipalstemplatename) | string | Name of the RBAC condition template. |
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-constrainRolesAndPrincipals.principalsToAssignTo`
+
+The list of principals that are allowed to be assigned roles by the delegate.
+
+- Required: Yes
+- Type: array
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-constrainRolesAndPrincipals.rolesToAssign`
+
+The list of roles that are allowed to be assigned by the delegate.
+
+- Required: Yes
+- Type: array
+
+### Parameter: `pimRoleAssignments.roleAssignmentCondition.roleConditionType.templateName-constrainRolesAndPrincipals.templateName`
+
+Name of the RBAC condition template.
+
+- Required: Yes
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'constrainRolesAndPrincipals'
+  ]
+  ```
 
 ### Parameter: `pimRoleAssignments.ticketInfo`
 

--- a/avm/ptn/lz/sub-vending/main.json
+++ b/avm/ptn/lz/sub-vending/main.json
@@ -142,7 +142,7 @@
             "description": "Required. Name of the RBAC condition template."
           }
         },
-        "ExcludedRoles": {
+        "excludedRoles": {
           "type": "array",
           "metadata": {
             "description": "Required. The list of roles that are not allowed to be assigned by the delegate."
@@ -1741,7 +1741,7 @@
                     "description": "Required. Name of the RBAC condition template."
                   }
                 },
-                "ExcludedRoles": {
+                "excludedRoles": {
                   "type": "array",
                   "metadata": {
                     "description": "Required. The list of roles that are not allowed to be assigned by the delegate."
@@ -2273,7 +2273,7 @@
                   ],
                   "output": {
                     "type": "string",
-                    "value": "[format('((!(ActionMatches{{''Microsoft.Authorization/roleAssignments/write''}}) OR ( @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {{{0}}})) AND ((!(ActionMatches{{''Microsoft.Authorization/roleAssignments/delete''}}) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {{{1}}}))))', __bicep.joinArray(parameters('excludeRoles').ExcludedRoles), __bicep.joinArray(parameters('excludeRoles').ExcludedRoles))]"
+                    "value": "[format('((!(ActionMatches{{''Microsoft.Authorization/roleAssignments/write''}}) OR ( @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {{{0}}})) AND ((!(ActionMatches{{''Microsoft.Authorization/roleAssignments/delete''}}) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {{{1}}}))))', __bicep.joinArray(parameters('excludeRoles').excludedRoles), __bicep.joinArray(parameters('excludeRoles').excludedRoles))]"
                   },
                   "metadata": {
                     "description": "Generates the code for the \"Exclude Roles\" condition template.",

--- a/avm/ptn/lz/sub-vending/main.json
+++ b/avm/ptn/lz/sub-vending/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "16153057753927113353"
+      "templateHash": "2715646121176899410"
     },
     "name": "Sub-vending",
     "description": "This module deploys a subscription to accelerate deployment of landing zones. For more information on how to use it, please visit this [Wiki](https://github.com/Azure/bicep-lz-vending/wiki).",
@@ -142,7 +142,7 @@
             "description": "Required. Name of the RBAC condition template."
           }
         },
-        "ExludededRoles": {
+        "ExcludedRoles": {
           "type": "array",
           "metadata": {
             "description": "Required. The list of roles that are not allowed to be assigned by the delegate."
@@ -1499,7 +1499,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.34.44.8038",
-              "templateHash": "16969123252740625755"
+              "templateHash": "18382732073254731113"
             },
             "name": "`/subResourcesWrapper/deploy.bicep` Parameters",
             "description": "This module is used by the [`bicep-lz-vending`](https://aka.ms/sub-vending/bicep) module to help orchestrate the deployment",
@@ -1741,7 +1741,7 @@
                     "description": "Required. Name of the RBAC condition template."
                   }
                 },
-                "ExludededRoles": {
+                "ExcludedRoles": {
                   "type": "array",
                   "metadata": {
                     "description": "Required. The list of roles that are not allowed to be assigned by the delegate."
@@ -2273,7 +2273,7 @@
                   ],
                   "output": {
                     "type": "string",
-                    "value": "[format('((!(ActionMatches{{''Microsoft.Authorization/roleAssignments/write''}}) OR ( @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {{{0}}})) AND ((!(ActionMatches{{''Microsoft.Authorization/roleAssignments/delete''}}) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {{{1}}}))))', __bicep.joinArray(parameters('excludeRoles').ExludededRoles), __bicep.joinArray(parameters('excludeRoles').ExludededRoles))]"
+                    "value": "[format('((!(ActionMatches{{''Microsoft.Authorization/roleAssignments/write''}}) OR ( @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {{{0}}})) AND ((!(ActionMatches{{''Microsoft.Authorization/roleAssignments/delete''}}) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {{{1}}}))))', __bicep.joinArray(parameters('excludeRoles').ExcludedRoles), __bicep.joinArray(parameters('excludeRoles').ExcludedRoles))]"
                   },
                   "metadata": {
                     "description": "Generates the code for the \"Exclude Roles\" condition template.",

--- a/avm/ptn/lz/sub-vending/main.json
+++ b/avm/ptn/lz/sub-vending/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "4728679665886035782"
+      "version": "0.34.44.8038",
+      "templateHash": "16153057753927113353"
     },
     "name": "Sub-vending",
     "description": "This module deploys a subscription to accelerate deployment of landing zones. For more information on how to use it, please visit this [Wiki](https://github.com/Azure/bicep-lz-vending/wiki).",
@@ -229,6 +229,26 @@
         }
       },
       "metadata": {
+        "__bicep_imported_from!": {
+          "sourceTemplate": "modules/subResourceWrapper.bicep"
+        }
+      }
+    },
+    "_1.requestTypeType": {
+      "type": "string",
+      "allowedValues": [
+        "AdminAssign",
+        "AdminExtend",
+        "AdminRemove",
+        "AdminRenew",
+        "AdminUpdate",
+        "SelfActivate",
+        "SelfDeactivate",
+        "SelfExtend",
+        "SelfRenew"
+      ],
+      "metadata": {
+        "description": "Optional. The request type of the role assignment.",
         "__bicep_imported_from!": {
           "sourceTemplate": "modules/subResourceWrapper.bicep"
         }
@@ -505,6 +525,13 @@
             "description": "Required. The type of the role assignment."
           }
         },
+        "requestType": {
+          "$ref": "#/definitions/_1.requestTypeType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The type of the PIM request."
+          }
+        },
         "scheduleInfo": {
           "$ref": "#/definitions/_1.roleAssignmentScheduleType",
           "metadata": {
@@ -541,6 +568,13 @@
           "nullable": true,
           "metadata": {
             "description": "Optional. The justification for the role assignment."
+          }
+        },
+        "roleAssignmentCondition": {
+          "$ref": "#/definitions/_1.roleAssignmentConditionType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The condition for the role assignment."
           }
         }
       },
@@ -1235,8 +1269,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "8425865084067531624"
+              "version": "0.34.44.8038",
+              "templateHash": "2299207875893670124"
             }
           },
           "parameters": {
@@ -1464,8 +1498,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "11709090420766635636"
+              "version": "0.34.44.8038",
+              "templateHash": "16969123252740625755"
             },
             "name": "`/subResourcesWrapper/deploy.bicep` Parameters",
             "description": "This module is used by the [`bicep-lz-vending`](https://aka.ms/sub-vending/bicep) module to help orchestrate the deployment",
@@ -2033,6 +2067,13 @@
                     "description": "Required. The type of the role assignment."
                   }
                 },
+                "requestType": {
+                  "$ref": "#/definitions/requestTypeType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The type of the PIM request."
+                  }
+                },
                 "scheduleInfo": {
                   "$ref": "#/definitions/roleAssignmentScheduleType",
                   "metadata": {
@@ -2069,6 +2110,13 @@
                   "nullable": true,
                   "metadata": {
                     "description": "Optional. The justification for the role assignment."
+                  }
+                },
+                "roleAssignmentCondition": {
+                  "$ref": "#/definitions/roleAssignmentConditionType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The condition for the role assignment."
                   }
                 }
               },
@@ -2640,6 +2688,7 @@
               "createLzVirtualWanConnection": "[take(format('lz-vend-vhc-create-{0}', uniqueString(parameters('subscriptionId'), parameters('virtualNetworkResourceGroupName'), parameters('virtualNetworkLocation'), parameters('virtualNetworkName'), variables('virtualHubResourceIdChecked'), deployment().name)), 64)]",
               "createLzNsg": "[take(format('lz-vend-nsg-create-{0}', uniqueString(parameters('subscriptionId'), parameters('virtualNetworkResourceGroupName'), parameters('virtualNetworkLocation'), parameters('virtualNetworkName'), deployment().name)), 64)]",
               "createBastionNsg": "[take(format('lz-vend-bastion-nsg-create-{0}', uniqueString(parameters('subscriptionId'), parameters('virtualNetworkResourceGroupName'), parameters('virtualNetworkLocation'), parameters('virtualNetworkName'), deployment().name)), 64)]",
+              "createBastionHost": "[take(format('lz-vend-bastion-create-{0}', uniqueString(parameters('subscriptionId'), parameters('virtualNetworkResourceGroupName'), parameters('virtualNetworkLocation'), parameters('virtualNetworkName'), deployment().name)), 64)]",
               "createLzRoleAssignmentsSub": "[take(format('lz-vend-rbac-sub-create-{0}', uniqueString(parameters('subscriptionId'), deployment().name)), 64)]",
               "createLzRoleAssignmentsRsgsSelf": "[take(format('lz-vend-rbac-rsg-self-create-{0}', uniqueString(parameters('subscriptionId'), deployment().name)), 64)]",
               "createLzRoleAssignmentsRsgsNotSelf": "[take(format('lz-vend-rbac-rsg-nself-create-{0}', uniqueString(parameters('subscriptionId'), deployment().name)), 64)]",
@@ -2727,8 +2776,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "8452628568304993719"
+                      "version": "0.34.44.8038",
+                      "templateHash": "10171076818497029341"
                     }
                   },
                   "parameters": {
@@ -2788,8 +2837,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "11019372772177629958"
+                      "version": "0.34.44.8038",
+                      "templateHash": "17760161620795039177"
                     }
                   },
                   "parameters": {
@@ -2848,8 +2897,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "8397259050503224920"
+                              "version": "0.34.44.8038",
+                              "templateHash": "15155659393206962294"
                             }
                           },
                           "parameters": {
@@ -2904,8 +2953,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "7623404265819505597"
+                                      "version": "0.34.44.8038",
+                                      "templateHash": "11361529448519193838"
                                     }
                                   },
                                   "parameters": {
@@ -2982,8 +3031,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "8957892045766331539"
+                              "version": "0.34.44.8038",
+                              "templateHash": "12330446698888719301"
                             }
                           },
                           "parameters": {
@@ -3037,8 +3086,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "14513856367602857749"
+                                      "version": "0.34.44.8038",
+                                      "templateHash": "18198824601755075788"
                                     }
                                   },
                                   "parameters": {
@@ -3638,8 +3687,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "11019372772177629958"
+                      "version": "0.34.44.8038",
+                      "templateHash": "17760161620795039177"
                     }
                   },
                   "parameters": {
@@ -3698,8 +3747,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "8397259050503224920"
+                              "version": "0.34.44.8038",
+                              "templateHash": "15155659393206962294"
                             }
                           },
                           "parameters": {
@@ -3754,8 +3803,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "7623404265819505597"
+                                      "version": "0.34.44.8038",
+                                      "templateHash": "11361529448519193838"
                                     }
                                   },
                                   "parameters": {
@@ -3832,8 +3881,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.33.93.31351",
-                              "templateHash": "8957892045766331539"
+                              "version": "0.34.44.8038",
+                              "templateHash": "12330446698888719301"
                             }
                           },
                           "parameters": {
@@ -3887,8 +3936,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.33.93.31351",
-                                      "templateHash": "14513856367602857749"
+                                      "version": "0.34.44.8038",
+                                      "templateHash": "18198824601755075788"
                                     }
                                   },
                                   "parameters": {
@@ -7001,8 +7050,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "12390675321128699904"
+                      "version": "0.34.44.8038",
+                      "templateHash": "10550847613760163837"
                     }
                   },
                   "parameters": {
@@ -35370,7 +35419,7 @@
               "condition": "[and(parameters('virtualNetworkDeployBastion'), and(and(and(and(parameters('virtualNetworkEnabled'), not(empty(parameters('virtualNetworkName')))), not(empty(parameters('virtualNetworkAddressSpace')))), not(empty(parameters('virtualNetworkLocation')))), not(empty(parameters('virtualNetworkResourceGroupName')))))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('bastion-{0}', parameters('virtualNetworkName'))]",
+              "name": "[variables('deploymentNames').createBastionHost]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('virtualNetworkResourceGroupName')]",
               "properties": {

--- a/avm/ptn/lz/sub-vending/main.json
+++ b/avm/ptn/lz/sub-vending/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "2715646121176899410"
+      "templateHash": "10318004586526838056"
     },
     "name": "Sub-vending",
     "description": "This module deploys a subscription to accelerate deployment of landing zones. For more information on how to use it, please visit this [Wiki](https://github.com/Azure/bicep-lz-vending/wiki).",
@@ -1499,7 +1499,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.34.44.8038",
-              "templateHash": "18382732073254731113"
+              "templateHash": "874881940488545006"
             },
             "name": "`/subResourcesWrapper/deploy.bicep` Parameters",
             "description": "This module is used by the [`bicep-lz-vending`](https://aka.ms/sub-vending/bicep) module to help orchestrate the deployment",
@@ -9273,7 +9273,7 @@
                     "value": "[variables('pimRoleAssignmentsSubscription')[copyIndex()].principalId]"
                   },
                   "requestType": {
-                    "value": "[coalesce(tryGet(variables('pimRoleAssignmentsSubscription')[copyIndex()], 'requestType'), 'AdminAssign')]"
+                    "value": "[coalesce(tryGet(variables('pimRoleAssignmentsSubscription')[copyIndex()], 'requestType'), 'AdminUpdate')]"
                   },
                   "roleDefinitionIdOrName": {
                     "value": "[variables('pimRoleAssignmentsSubscription')[copyIndex()].definition]"
@@ -11096,7 +11096,7 @@
                     "value": "[variables('pimRoleAssignmentsSubscription')[copyIndex()].principalId]"
                   },
                   "requestType": {
-                    "value": "[coalesce(tryGet(variables('pimRoleAssignmentsSubscription')[copyIndex()], 'requestType'), 'AdminAssign')]"
+                    "value": "[coalesce(tryGet(variables('pimRoleAssignmentsSubscription')[copyIndex()], 'requestType'), 'AdminUpdate')]"
                   },
                   "roleDefinitionIdOrName": {
                     "value": "[variables('pimRoleAssignmentsSubscription')[copyIndex()].definition]"
@@ -12913,7 +12913,7 @@
                     "value": "[parameters('subscriptionId')]"
                   },
                   "requestType": {
-                    "value": "[coalesce(tryGet(variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()], 'requestType'), 'AdminAssign')]"
+                    "value": "[coalesce(tryGet(variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()], 'requestType'), 'AdminUpdate')]"
                   },
                   "resourceGroupName": {
                     "value": "[split(variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()].relativeScope, '/')[2]]"
@@ -14739,7 +14739,7 @@
                     "value": "[parameters('subscriptionId')]"
                   },
                   "requestType": {
-                    "value": "[coalesce(tryGet(variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()], 'requestType'), 'AdminAssign')]"
+                    "value": "[coalesce(tryGet(variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()], 'requestType'), 'AdminUpdate')]"
                   },
                   "resourceGroupName": {
                     "value": "[split(variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()].relativeScope, '/')[2]]"
@@ -16568,7 +16568,7 @@
                     "value": "[variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()].principalId]"
                   },
                   "requestType": {
-                    "value": "[coalesce(tryGet(variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()], 'requestType'), 'AdminAssign')]"
+                    "value": "[coalesce(tryGet(variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()], 'requestType'), 'AdminUpdate')]"
                   },
                   "roleDefinitionIdOrName": {
                     "value": "[variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()].definition]"
@@ -18388,7 +18388,7 @@
                     "value": "[variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()].principalId]"
                   },
                   "requestType": {
-                    "value": "[coalesce(tryGet(variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()], 'requestType'), 'AdminAssign')]"
+                    "value": "[coalesce(tryGet(variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()], 'requestType'), 'AdminUpdate')]"
                   },
                   "roleDefinitionIdOrName": {
                     "value": "[variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()].definition]"

--- a/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
+++ b/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
@@ -246,6 +246,10 @@ var deploymentNames = {
     'lz-vend-bastion-nsg-create-${uniqueString(subscriptionId, virtualNetworkResourceGroupName, virtualNetworkLocation, virtualNetworkName, deployment().name)}',
     64
   )
+  createBastionHost: take(
+    'lz-vend-bastion-create-${uniqueString(subscriptionId, virtualNetworkResourceGroupName, virtualNetworkLocation, virtualNetworkName, deployment().name)}',
+    64
+  )
   createLzRoleAssignmentsSub: take('lz-vend-rbac-sub-create-${uniqueString(subscriptionId, deployment().name)}', 64)
   createLzRoleAssignmentsRsgsSelf: take(
     'lz-vend-rbac-rsg-self-create-${uniqueString(subscriptionId, deployment().name)}',
@@ -1249,7 +1253,7 @@ module createNatGateway 'br/public:avm/res/network/nat-gateway:1.2.1' = if (virt
 }
 
 module createBastionHost 'br/public:avm/res/network/bastion-host:0.5.0' = if (virtualNetworkDeployBastion && (virtualNetworkEnabled && !empty(virtualNetworkName) && !empty(virtualNetworkAddressSpace) && !empty(virtualNetworkLocation) && !empty(virtualNetworkResourceGroupName))) {
-  name: 'bastion-${virtualNetworkName}'
+  name: deploymentNames.createBastionHost
   scope: resourceGroup(subscriptionId, virtualNetworkResourceGroupName)
   dependsOn: [
     createResourceGroupForLzNetworking
@@ -1536,6 +1540,9 @@ type pimRoleAssignmentTypeType = {
   @description('Required. The type of the role assignment.')
   roleAssignmentType: 'Active' | 'Eligible'
 
+  @description('Optional. The type of the PIM request.')
+  requestType: requestTypeType?
+
   @description('Required. The schedule information for the role assignment.')
   scheduleInfo: roleAssignmentScheduleType
 
@@ -1553,6 +1560,9 @@ type pimRoleAssignmentTypeType = {
 
   @description('Optional. The justification for the role assignment.')
   justification: string?
+
+  @description('Optional. The condition for the role assignment.')
+  roleAssignmentCondition: roleAssignmentConditionType?
 }
 
 @discriminator('durationType')

--- a/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
+++ b/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
@@ -1382,7 +1382,7 @@ type excludeRolesType = {
   templateName: 'excludeRoles'
 
   @description('Required. The list of roles that are not allowed to be assigned by the delegate.')
-  ExcludedRoles: array
+  excludedRoles: array
 }
 
 // Discriminator for the constrainedDelegationTemplatesType
@@ -1427,7 +1427,7 @@ func generateCodeRolesAndPrincipals(constrainRolesAndPrincipals constrainRolesAn
 @description('Generates the code for the "Exclude Roles" condition template.')
 @export()
 func generateCodeExcludeRoles(excludeRoles excludeRolesType) string =>
-  '((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/write\'}) OR ( @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${joinArray(excludeRoles.ExcludedRoles)}})) AND ((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/delete\'}) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${joinArray(excludeRoles.ExcludedRoles)}}))))'
+  '((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/write\'}) OR ( @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${joinArray(excludeRoles.excludedRoles)}})) AND ((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/delete\'}) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${joinArray(excludeRoles.excludedRoles)}}))))'
 
 // Helper functions
 @export()

--- a/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
+++ b/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
@@ -807,7 +807,7 @@ module createLzPimActiveRoleAssignmentsSub 'br/public:avm/ptn/authorization/pim-
         scheduleInfo: assignment.scheduleInfo
       }
       principalId: assignment.principalId
-      requestType: assignment.?requestType ?? 'AdminAssign'
+      requestType: assignment.?requestType ?? 'AdminUpdate'
       roleDefinitionIdOrName: assignment.definition
       justification: assignment.?justification ?? null
       enableTelemetry: enableTelemetry
@@ -846,7 +846,7 @@ module createLzPimEligibleRoleAssignmentsSub 'br/public:avm/ptn/authorization/pi
       }
       subscriptionId: subscriptionId
       principalId: assignment.principalId
-      requestType: assignment.?requestType ?? 'AdminAssign'
+      requestType: assignment.?requestType ?? 'AdminUpdate'
       roleDefinitionIdOrName: assignment.definition
       justification: assignment.?justification ?? null
       enableTelemetry: enableTelemetry
@@ -886,7 +886,7 @@ module createLzPimEligibleRoleAssignmentsRsgsSelf 'br/public:avm/ptn/authorizati
         scheduleInfo: assignment.scheduleInfo
       }
       subscriptionId: subscriptionId
-      requestType: assignment.?requestType ?? 'AdminAssign'
+      requestType: assignment.?requestType ?? 'AdminUpdate'
       resourceGroupName: split(assignment.relativeScope, '/')[2]
       principalId: assignment.principalId
       roleDefinitionIdOrName: assignment.definition
@@ -928,7 +928,7 @@ module createLzPimActiveRoleAssignmentsRsgsSelf 'br/public:avm/ptn/authorization
         scheduleInfo: assignment.scheduleInfo
       }
       subscriptionId: subscriptionId
-      requestType: assignment.?requestType ?? 'AdminAssign'
+      requestType: assignment.?requestType ?? 'AdminUpdate'
       resourceGroupName: split(assignment.relativeScope, '/')[2]
       principalId: assignment.principalId
       roleDefinitionIdOrName: assignment.definition
@@ -968,7 +968,7 @@ module createLzEliglblePimRoleAssignmentsRsgsNotSelf 'br/public:avm/ptn/authoriz
       }
       subscriptionId: subscriptionId
       principalId: assignment.principalId
-      requestType: assignment.?requestType ?? 'AdminAssign'
+      requestType: assignment.?requestType ?? 'AdminUpdate'
       roleDefinitionIdOrName: assignment.definition
       justification: assignment.?justification ?? null
       enableTelemetry: enableTelemetry
@@ -1006,7 +1006,7 @@ module createLzActivePimRoleAssignmentsRsgsNotSelf 'br/public:avm/ptn/authorizat
       }
       subscriptionId: subscriptionId
       principalId: assignment.principalId
-      requestType: assignment.?requestType ?? 'AdminAssign'
+      requestType: assignment.?requestType ?? 'AdminUpdate'
       roleDefinitionIdOrName: assignment.definition
       justification: assignment.?justification ?? null
       enableTelemetry: enableTelemetry

--- a/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
+++ b/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
@@ -1382,7 +1382,7 @@ type excludeRolesType = {
   templateName: 'excludeRoles'
 
   @description('Required. The list of roles that are not allowed to be assigned by the delegate.')
-  ExludededRoles: array
+  ExcludedRoles: array
 }
 
 // Discriminator for the constrainedDelegationTemplatesType
@@ -1427,7 +1427,7 @@ func generateCodeRolesAndPrincipals(constrainRolesAndPrincipals constrainRolesAn
 @description('Generates the code for the "Exclude Roles" condition template.')
 @export()
 func generateCodeExcludeRoles(excludeRoles excludeRolesType) string =>
-  '((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/write\'}) OR ( @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${joinArray(excludeRoles.ExludededRoles)}})) AND ((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/delete\'}) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${joinArray(excludeRoles.ExludededRoles)}}))))'
+  '((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/write\'}) OR ( @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${joinArray(excludeRoles.ExcludedRoles)}})) AND ((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/delete\'}) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${joinArray(excludeRoles.ExcludedRoles)}}))))'
 
 // Helper functions
 @export()

--- a/avm/ptn/lz/sub-vending/tests/e2e/pim-active-role-assignments/main.test.bicep
+++ b/avm/ptn/lz/sub-vending/tests/e2e/pim-active-role-assignments/main.test.bicep
@@ -56,6 +56,7 @@ module testDeployment '../../../main.bicep' = {
         principalId: testUserObjectId
         relativeScope: '/resourceGroups/rsg-${resourceLocation}-net-hs-${namePrefix}-${serviceShort}'
         roleAssignmentType: 'Active'
+        requestType: 'AdminAssign'
         definition: '/providers/Microsoft.Authorization/roleDefinitions/f58310d9-a9f6-439a-9e8d-f62e7b41a168'
         scheduleInfo: {
           duration: 'PT4H'

--- a/avm/ptn/lz/sub-vending/tests/e2e/pim-eligible-role-assignments/main.test.bicep
+++ b/avm/ptn/lz/sub-vending/tests/e2e/pim-eligible-role-assignments/main.test.bicep
@@ -52,6 +52,7 @@ module testDeployment '../../../main.bicep' = {
         principalId: testUserObjectId
         relativeScope: ''
         roleAssignmentType: 'Eligible'
+        requestType: 'AdminUpdate'
         definition: '/providers/Microsoft.Authorization/roleDefinitions/f58310d9-a9f6-439a-9e8d-f62e7b41a168'
         scheduleInfo: {
           duration: 'PT4H'


### PR DESCRIPTION
## Description

Add missing `requestType` parameter to the `PIMRoleAssignment` UDT in the `lz/sub-vending` module
Fixes #5057 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.ptn.lz.sub-vending](https://github.com/sebassem/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml/badge.svg?branch=avm%2Fsub-vending%2Fpim%2Fpatch)](https://github.com/sebassem/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml)    |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [X] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [X] Update to documentation

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
