### PR TITLE
feat: latest APIs, exportPolicy fix, replicationSchedule and remotePath updates

### DIFF
--- a/avm/res/net-app/net-app-account/README.md
+++ b/avm/res/net-app/net-app-account/README.md
@@ -17,13 +17,13 @@ This module deploys an Azure NetApp File.
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.NetApp/netAppAccounts` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts) |
-| `Microsoft.NetApp/netAppAccounts/backupPolicies` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/backupPolicies) |
-| `Microsoft.NetApp/netAppAccounts/backupVaults` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/backupVaults) |
-| `Microsoft.NetApp/netAppAccounts/backupVaults/backups` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/backupVaults/backups) |
-| `Microsoft.NetApp/netAppAccounts/capacityPools` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/capacityPools) |
-| `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/capacityPools/volumes) |
-| `Microsoft.NetApp/netAppAccounts/snapshotPolicies` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/snapshotPolicies) |
+| `Microsoft.NetApp/netAppAccounts` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts) |
+| `Microsoft.NetApp/netAppAccounts/backupPolicies` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/backupPolicies) |
+| `Microsoft.NetApp/netAppAccounts/backupVaults` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/backupVaults) |
+| `Microsoft.NetApp/netAppAccounts/backupVaults/backups` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/backupVaults/backups) |
+| `Microsoft.NetApp/netAppAccounts/capacityPools` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/capacityPools) |
+| `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/capacityPools/volumes) |
+| `Microsoft.NetApp/netAppAccounts/snapshotPolicies` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/snapshotPolicies) |
 
 ## Usage examples
 
@@ -1732,7 +1732,6 @@ Replication properties.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`endpointType`](#parameter-capacitypoolsvolumesdataprotectionreplicationendpointtype) | string | Indicates whether the local volume is the source or destination for the Volume Replication. |
-| [`replicationSchedule`](#parameter-capacitypoolsvolumesdataprotectionreplicationreplicationschedule) | string | The replication schedule for the volume. |
 
 **Optional parameters**
 
@@ -1741,6 +1740,7 @@ Replication properties.
 | [`remotePath`](#parameter-capacitypoolsvolumesdataprotectionreplicationremotepath) | object | The full path to a volume that is to be migrated into ANF. Required for Migration volumes. |
 | [`remoteVolumeRegion`](#parameter-capacitypoolsvolumesdataprotectionreplicationremotevolumeregion) | string | The remote region for the other end of the Volume Replication.Required for Data Protection volumes. |
 | [`remoteVolumeResourceId`](#parameter-capacitypoolsvolumesdataprotectionreplicationremotevolumeresourceid) | string | The resource ID of the remote volume. Required for Data Protection volumes. |
+| [`replicationSchedule`](#parameter-capacitypoolsvolumesdataprotectionreplicationreplicationschedule) | string | The replication schedule for the volume (to only be set on the destination (dst)). |
 
 ### Parameter: `capacityPools.volumes.dataProtection.replication.endpointType`
 
@@ -1753,21 +1753,6 @@ Indicates whether the local volume is the source or destination for the Volume R
   [
     'dst'
     'src'
-  ]
-  ```
-
-### Parameter: `capacityPools.volumes.dataProtection.replication.replicationSchedule`
-
-The replication schedule for the volume.
-
-- Required: Yes
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    '_10minutely'
-    'daily'
-    'hourly'
   ]
   ```
 
@@ -1820,6 +1805,21 @@ The resource ID of the remote volume. Required for Data Protection volumes.
 
 - Required: No
 - Type: string
+
+### Parameter: `capacityPools.volumes.dataProtection.replication.replicationSchedule`
+
+The replication schedule for the volume (to only be set on the destination (dst)).
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    '_10minutely'
+    'daily'
+    'hourly'
+  ]
+  ```
 
 ### Parameter: `capacityPools.volumes.dataProtection.snapshot`
 

--- a/avm/res/net-app/net-app-account/backup-policies/README.md
+++ b/avm/res/net-app/net-app-account/backup-policies/README.md
@@ -12,7 +12,7 @@ This module deploys a Backup Policy for Azure NetApp File.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.NetApp/netAppAccounts/backupPolicies` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/backupPolicies) |
+| `Microsoft.NetApp/netAppAccounts/backupPolicies` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/backupPolicies) |
 
 ## Parameters
 

--- a/avm/res/net-app/net-app-account/backup-policies/main.bicep
+++ b/avm/res/net-app/net-app-account/backup-policies/main.bicep
@@ -24,11 +24,11 @@ param weeklyBackupsToKeep int = 0
 @description('Optional. Indicates whether the backup policy is enabled.')
 param enabled bool = true
 
-resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2024-09-01' existing = {
+resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2025-01-01' existing = {
   name: netAppAccountName
 }
 
-resource backupPolicies 'Microsoft.NetApp/netAppAccounts/backupPolicies@2024-09-01' = {
+resource backupPolicies 'Microsoft.NetApp/netAppAccounts/backupPolicies@2025-01-01' = {
   name: name
   parent: netAppAccount
   location: location

--- a/avm/res/net-app/net-app-account/backup-policies/main.json
+++ b/avm/res/net-app/net-app-account/backup-policies/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "7879757037815205826"
+      "version": "0.29.47.4906",
+      "templateHash": "16001755318587725595"
     },
     "name": "Azure NetApp Files Backup Policy",
     "description": "This module deploys a Backup Policy for Azure NetApp File."
@@ -65,7 +65,7 @@
   "resources": [
     {
       "type": "Microsoft.NetApp/netAppAccounts/backupPolicies",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "properties": {

--- a/avm/res/net-app/net-app-account/backup-policies/main.json
+++ b/avm/res/net-app/net-app-account/backup-policies/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "16001755318587725595"
+      "version": "0.34.44.8038",
+      "templateHash": "5685295510343035237"
     },
     "name": "Azure NetApp Files Backup Policy",
     "description": "This module deploys a Backup Policy for Azure NetApp File."

--- a/avm/res/net-app/net-app-account/backup-vault/README.md
+++ b/avm/res/net-app/net-app-account/backup-vault/README.md
@@ -12,8 +12,8 @@ This module deploys a NetApp Files Backup Vault.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.NetApp/netAppAccounts/backupVaults` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/backupVaults) |
-| `Microsoft.NetApp/netAppAccounts/backupVaults/backups` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/backupVaults/backups) |
+| `Microsoft.NetApp/netAppAccounts/backupVaults` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/backupVaults) |
+| `Microsoft.NetApp/netAppAccounts/backupVaults/backups` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/backupVaults/backups) |
 
 ## Parameters
 

--- a/avm/res/net-app/net-app-account/backup-vault/backup/README.md
+++ b/avm/res/net-app/net-app-account/backup-vault/backup/README.md
@@ -12,7 +12,7 @@ This module deploys a backup of a NetApp Files Volume.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.NetApp/netAppAccounts/backupVaults/backups` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/backupVaults/backups) |
+| `Microsoft.NetApp/netAppAccounts/backupVaults/backups` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/backupVaults/backups) |
 
 ## Parameters
 

--- a/avm/res/net-app/net-app-account/backup-vault/backup/main.bicep
+++ b/avm/res/net-app/net-app-account/backup-vault/backup/main.bicep
@@ -22,23 +22,23 @@ param volumeName string
 @description('Required. The name of the capacity pool containing the volume.')
 param capacityPoolName string
 
-resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2024-09-01' existing = {
+resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2025-01-01' existing = {
   name: netAppAccountName
 
-  resource backupVault 'backupVaults@2024-09-01' existing = {
+  resource backupVault 'backupVaults@2025-01-01' existing = {
     name: backupVaultName
   }
 
-  resource remoteCapacityPool 'capacityPools@2024-09-01' existing = {
+  resource remoteCapacityPool 'capacityPools@2025-01-01' existing = {
     name: capacityPoolName
 
-    resource volume 'volumes@2024-07-01' existing = {
+    resource volume 'volumes@2025-01-01' existing = {
       name: volumeName
     }
   }
 }
 
-resource backup 'Microsoft.NetApp/netAppAccounts/backupVaults/backups@2024-09-01' = {
+resource backup 'Microsoft.NetApp/netAppAccounts/backupVaults/backups@2025-01-01' = {
   name: name
   parent: netAppAccount::backupVault
   properties: {

--- a/avm/res/net-app/net-app-account/backup-vault/backup/main.json
+++ b/avm/res/net-app/net-app-account/backup-vault/backup/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "8317801660539599309"
+      "version": "0.34.44.8038",
+      "templateHash": "15429195500404839384"
     },
     "name": "Azure NetApp Files Volume Backup",
     "description": "This module deploys a backup of a NetApp Files Volume."
@@ -63,28 +63,19 @@
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
       "apiVersion": "2025-01-01",
-      "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]",
-      "dependsOn": [
-        "netAppAccount::remoteCapacityPool"
-      ]
+      "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
     },
     "netAppAccount::backupVault": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
       "apiVersion": "2025-01-01",
-      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]",
-      "dependsOn": [
-        "netAppAccount"
-      ]
+      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]"
     },
     "netAppAccount::remoteCapacityPool": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
       "apiVersion": "2025-01-01",
-      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
-      "dependsOn": [
-        "netAppAccount"
-      ]
+      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
     },
     "netAppAccount": {
       "existing": true,
@@ -100,11 +91,7 @@
         "label": "[parameters('label')]",
         "snapshotName": "[parameters('snapshotName')]",
         "volumeResourceId": "[resourceId('Microsoft.NetApp/netAppAccounts/capacityPools/volumes', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
-      },
-      "dependsOn": [
-        "netAppAccount::backupVault",
-        "netAppAccount::remoteCapacityPool"
-      ]
+      }
     }
   },
   "outputs": {

--- a/avm/res/net-app/net-app-account/backup-vault/backup/main.json
+++ b/avm/res/net-app/net-app-account/backup-vault/backup/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "11103687332577035719"
+      "version": "0.29.47.4906",
+      "templateHash": "8317801660539599309"
     },
     "name": "Azure NetApp Files Volume Backup",
     "description": "This module deploys a backup of a NetApp Files Volume."
@@ -62,36 +62,49 @@
     "netAppAccount::remoteCapacityPool::volume": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-      "apiVersion": "2024-07-01",
-      "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
+      "apiVersion": "2025-01-01",
+      "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]",
+      "dependsOn": [
+        "netAppAccount::remoteCapacityPool"
+      ]
     },
     "netAppAccount::backupVault": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
-      "apiVersion": "2024-09-01",
-      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]"
+      "apiVersion": "2025-01-01",
+      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]",
+      "dependsOn": [
+        "netAppAccount"
+      ]
     },
     "netAppAccount::remoteCapacityPool": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-      "apiVersion": "2024-09-01",
-      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
+      "apiVersion": "2025-01-01",
+      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
+      "dependsOn": [
+        "netAppAccount"
+      ]
     },
     "netAppAccount": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "name": "[parameters('netAppAccountName')]"
     },
     "backup": {
       "type": "Microsoft.NetApp/netAppAccounts/backupVaults/backups",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('backupVaultName'), parameters('name'))]",
       "properties": {
         "label": "[parameters('label')]",
         "snapshotName": "[parameters('snapshotName')]",
         "volumeResourceId": "[resourceId('Microsoft.NetApp/netAppAccounts/capacityPools/volumes', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
-      }
+      },
+      "dependsOn": [
+        "netAppAccount::backupVault",
+        "netAppAccount::remoteCapacityPool"
+      ]
     }
   },
   "outputs": {

--- a/avm/res/net-app/net-app-account/backup-vault/main.bicep
+++ b/avm/res/net-app/net-app-account/backup-vault/main.bicep
@@ -13,11 +13,11 @@ param netAppAccountName string
 @description('Optional. The list of backups to create.')
 param backups backupType[]?
 
-resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2024-09-01' existing = {
+resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2025-01-01' existing = {
   name: netAppAccountName
 }
 
-resource backupVault 'Microsoft.NetApp/netAppAccounts/backupVaults@2024-09-01' = {
+resource backupVault 'Microsoft.NetApp/netAppAccounts/backupVaults@2025-01-01' = {
   name: name
   parent: netAppAccount
   location: location

--- a/avm/res/net-app/net-app-account/backup-vault/main.json
+++ b/avm/res/net-app/net-app-account/backup-vault/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "6318287714892140543"
+      "version": "0.29.47.4906",
+      "templateHash": "20164335461414036"
     },
     "name": "Azure NetApp Files Volume Backup Vault",
     "description": "This module deploys a NetApp Files Backup Vault."
@@ -91,15 +91,18 @@
     "netAppAccount": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "name": "[parameters('netAppAccountName')]"
     },
     "backupVault": {
       "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
       "location": "[parameters('location')]",
-      "properties": {}
+      "properties": {},
+      "dependsOn": [
+        "netAppAccount"
+      ]
     },
     "backupVault_backups": {
       "copy": {
@@ -144,8 +147,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "11103687332577035719"
+              "version": "0.29.47.4906",
+              "templateHash": "8317801660539599309"
             },
             "name": "Azure NetApp Files Volume Backup",
             "description": "This module deploys a backup of a NetApp Files Volume."
@@ -201,36 +204,49 @@
             "netAppAccount::remoteCapacityPool::volume": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-              "apiVersion": "2024-07-01",
-              "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
+              "apiVersion": "2025-01-01",
+              "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]",
+              "dependsOn": [
+                "netAppAccount::remoteCapacityPool"
+              ]
             },
             "netAppAccount::backupVault": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
-              "apiVersion": "2024-09-01",
-              "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]"
+              "apiVersion": "2025-01-01",
+              "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]",
+              "dependsOn": [
+                "netAppAccount"
+              ]
             },
             "netAppAccount::remoteCapacityPool": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-              "apiVersion": "2024-09-01",
-              "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
+              "apiVersion": "2025-01-01",
+              "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
+              "dependsOn": [
+                "netAppAccount"
+              ]
             },
             "netAppAccount": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[parameters('netAppAccountName')]"
             },
             "backup": {
               "type": "Microsoft.NetApp/netAppAccounts/backupVaults/backups",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('backupVaultName'), parameters('name'))]",
               "properties": {
                 "label": "[parameters('label')]",
                 "snapshotName": "[parameters('snapshotName')]",
                 "volumeResourceId": "[resourceId('Microsoft.NetApp/netAppAccounts/capacityPools/volumes', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
-              }
+              },
+              "dependsOn": [
+                "netAppAccount::backupVault",
+                "netAppAccount::remoteCapacityPool"
+              ]
             }
           },
           "outputs": {
@@ -259,7 +275,8 @@
         }
       },
       "dependsOn": [
-        "backupVault"
+        "backupVault",
+        "netAppAccount"
       ]
     }
   },
@@ -290,7 +307,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('backupVault', '2024-09-01', 'full').location]"
+      "value": "[reference('backupVault', '2025-01-01', 'full').location]"
     }
   }
 }

--- a/avm/res/net-app/net-app-account/backup-vault/main.json
+++ b/avm/res/net-app/net-app-account/backup-vault/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "20164335461414036"
+      "version": "0.34.44.8038",
+      "templateHash": "14413490968843992443"
     },
     "name": "Azure NetApp Files Volume Backup Vault",
     "description": "This module deploys a NetApp Files Backup Vault."
@@ -99,10 +99,7 @@
       "apiVersion": "2025-01-01",
       "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
       "location": "[parameters('location')]",
-      "properties": {},
-      "dependsOn": [
-        "netAppAccount"
-      ]
+      "properties": {}
     },
     "backupVault_backups": {
       "copy": {
@@ -147,8 +144,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "8317801660539599309"
+              "version": "0.34.44.8038",
+              "templateHash": "15429195500404839384"
             },
             "name": "Azure NetApp Files Volume Backup",
             "description": "This module deploys a backup of a NetApp Files Volume."
@@ -205,28 +202,19 @@
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
               "apiVersion": "2025-01-01",
-              "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]",
-              "dependsOn": [
-                "netAppAccount::remoteCapacityPool"
-              ]
+              "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
             },
             "netAppAccount::backupVault": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
               "apiVersion": "2025-01-01",
-              "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]",
-              "dependsOn": [
-                "netAppAccount"
-              ]
+              "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]"
             },
             "netAppAccount::remoteCapacityPool": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
               "apiVersion": "2025-01-01",
-              "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
-              "dependsOn": [
-                "netAppAccount"
-              ]
+              "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
             },
             "netAppAccount": {
               "existing": true,
@@ -242,11 +230,7 @@
                 "label": "[parameters('label')]",
                 "snapshotName": "[parameters('snapshotName')]",
                 "volumeResourceId": "[resourceId('Microsoft.NetApp/netAppAccounts/capacityPools/volumes', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
-              },
-              "dependsOn": [
-                "netAppAccount::backupVault",
-                "netAppAccount::remoteCapacityPool"
-              ]
+              }
             }
           },
           "outputs": {
@@ -275,8 +259,7 @@
         }
       },
       "dependsOn": [
-        "backupVault",
-        "netAppAccount"
+        "backupVault"
       ]
     }
   },

--- a/avm/res/net-app/net-app-account/capacity-pool/README.md
+++ b/avm/res/net-app/net-app-account/capacity-pool/README.md
@@ -14,8 +14,8 @@ This module deploys an Azure NetApp Files Capacity Pool.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.NetApp/netAppAccounts/capacityPools` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/capacityPools) |
-| `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/capacityPools/volumes) |
+| `Microsoft.NetApp/netAppAccounts/capacityPools` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/capacityPools) |
+| `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/capacityPools/volumes) |
 
 ## Parameters
 
@@ -399,7 +399,6 @@ Replication properties.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`endpointType`](#parameter-volumesdataprotectionreplicationendpointtype) | string | Indicates whether the local volume is the source or destination for the Volume Replication. |
-| [`replicationSchedule`](#parameter-volumesdataprotectionreplicationreplicationschedule) | string | The replication schedule for the volume. |
 
 **Optional parameters**
 
@@ -408,6 +407,7 @@ Replication properties.
 | [`remotePath`](#parameter-volumesdataprotectionreplicationremotepath) | object | The full path to a volume that is to be migrated into ANF. Required for Migration volumes. |
 | [`remoteVolumeRegion`](#parameter-volumesdataprotectionreplicationremotevolumeregion) | string | The remote region for the other end of the Volume Replication.Required for Data Protection volumes. |
 | [`remoteVolumeResourceId`](#parameter-volumesdataprotectionreplicationremotevolumeresourceid) | string | The resource ID of the remote volume. Required for Data Protection volumes. |
+| [`replicationSchedule`](#parameter-volumesdataprotectionreplicationreplicationschedule) | string | The replication schedule for the volume (to only be set on the destination (dst)). |
 
 ### Parameter: `volumes.dataProtection.replication.endpointType`
 
@@ -420,21 +420,6 @@ Indicates whether the local volume is the source or destination for the Volume R
   [
     'dst'
     'src'
-  ]
-  ```
-
-### Parameter: `volumes.dataProtection.replication.replicationSchedule`
-
-The replication schedule for the volume.
-
-- Required: Yes
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    '_10minutely'
-    'daily'
-    'hourly'
   ]
   ```
 
@@ -487,6 +472,21 @@ The resource ID of the remote volume. Required for Data Protection volumes.
 
 - Required: No
 - Type: string
+
+### Parameter: `volumes.dataProtection.replication.replicationSchedule`
+
+The replication schedule for the volume (to only be set on the destination (dst)).
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    '_10minutely'
+    'daily'
+    'hourly'
+  ]
+  ```
 
 ### Parameter: `volumes.dataProtection.snapshot`
 

--- a/avm/res/net-app/net-app-account/capacity-pool/main.bicep
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.bicep
@@ -76,11 +76,11 @@ var formattedRoleAssignments = [
   })
 ]
 
-resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2024-09-01' existing = {
+resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2025-01-01' existing = {
   name: netAppAccountName
 }
 
-resource capacityPool 'Microsoft.NetApp/netAppAccounts/capacityPools@2024-09-01' = {
+resource capacityPool 'Microsoft.NetApp/netAppAccounts/capacityPools@2025-01-01' = {
   name: name
   parent: netAppAccount
   location: location

--- a/avm/res/net-app/net-app-account/capacity-pool/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "10125203863232929784"
+      "version": "0.34.44.8038",
+      "templateHash": "4385691850958293637"
     },
     "name": "Azure NetApp Files Capacity Pools",
     "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -698,10 +698,7 @@
         "qosType": "[parameters('qosType')]",
         "coolAccess": "[parameters('coolAccess')]",
         "encryptionType": "[parameters('encryptionType')]"
-      },
-      "dependsOn": [
-        "netAppAccount"
-      ]
+      }
     },
     "capacityPool_roleAssignments": {
       "copy": {
@@ -827,8 +824,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "4754938124013776833"
+              "version": "0.34.44.8038",
+              "templateHash": "107014526168729045"
             },
             "name": "Azure NetApp Files Capacity Pool Volumes",
             "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -1407,40 +1404,28 @@
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
               "apiVersion": "2025-01-01",
-              "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
-              "dependsOn": [
-                "netAppAccount"
-              ]
+              "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
             },
             "netAppAccount::backupVault": {
               "condition": "[not(empty(tryGet(parameters('dataProtection'), 'backup')))]",
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
               "apiVersion": "2025-01-01",
-              "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))]",
-              "dependsOn": [
-                "netAppAccount"
-              ]
+              "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))]"
             },
             "netAppAccount::backupPolicy": {
               "condition": "[not(empty(tryGet(parameters('dataProtection'), 'backup')))]",
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/backupPolicies",
               "apiVersion": "2025-01-01",
-              "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName'))]",
-              "dependsOn": [
-                "netAppAccount"
-              ]
+              "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName'))]"
             },
             "netAppAccount::snapshotPolicy": {
               "condition": "[not(empty(tryGet(parameters('dataProtection'), 'snapshot')))]",
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/snapshotPolicies",
               "apiVersion": "2025-01-01",
-              "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))]",
-              "dependsOn": [
-                "netAppAccount"
-              ]
+              "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))]"
             },
             "remoteNetAppAccount::remoteCapacityPool::remoteVolume": {
               "condition": "[and(and(and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName')))), and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteCapacityPoolName'), parameters('capacityPoolName'))))), not(empty(tryGet(parameters('dataProtection'), 'replication'))))]",
@@ -1449,10 +1434,7 @@
               "apiVersion": "2025-01-01",
               "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
               "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
-              "name": "[format('{0}/{1}/{2}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10], last(split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')))]",
-              "dependsOn": [
-                "remoteNetAppAccount::remoteCapacityPool"
-              ]
+              "name": "[format('{0}/{1}/{2}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10], last(split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')))]"
             },
             "remoteNetAppAccount::remoteCapacityPool": {
               "condition": "[and(and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName')))), and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteCapacityPoolName'), parameters('capacityPoolName')))))]",
@@ -1461,10 +1443,7 @@
               "apiVersion": "2025-01-01",
               "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
               "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
-              "name": "[format('{0}/{1}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10])]",
-              "dependsOn": [
-                "remoteNetAppAccount"
-              ]
+              "name": "[format('{0}/{1}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10])]"
             },
             "vnet::subnet": {
               "existing": true,
@@ -1472,10 +1451,7 @@
               "apiVersion": "2024-03-01",
               "subscriptionId": "[split(parameters('subnetResourceId'), '/')[2]]",
               "resourceGroup": "[split(parameters('subnetResourceId'), '/')[4]]",
-              "name": "[format('{0}/{1}', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/')))]",
-              "dependsOn": [
-                "vnet"
-              ]
+              "name": "[format('{0}/{1}', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/')))]"
             },
             "netAppAccount": {
               "existing": true,
@@ -1515,12 +1491,7 @@
               "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "properties": "[shallowMerge(createArray(createObject('coolAccess', parameters('coolAccess'), 'coolAccessRetrievalPolicy', parameters('coolAccessRetrievalPolicy'), 'coolnessPeriod', parameters('coolnessPeriod'), 'securityStyle', parameters('securityStyle'), 'unixPermissions', parameters('unixPermissions'), 'encryptionKeySource', parameters('encryptionKeySource')), if(not(equals(parameters('encryptionKeySource'), 'Microsoft.NetApp')), createObject('keyVaultPrivateEndpointResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('keyVaultPrivateEndpointResourceId'), '/')[2], split(parameters('keyVaultPrivateEndpointResourceId'), '/')[4]), 'Microsoft.Network/privateEndpoints', last(split(parameters('keyVaultPrivateEndpointResourceId'), '/')))), createObject()), if(not(empty(parameters('volumeType'))), createObject('volumeType', parameters('volumeType')), createObject()), createObject('dataProtection', if(not(empty(parameters('dataProtection'))), createObject('replication', if(not(empty(tryGet(parameters('dataProtection'), 'replication'))), shallowMerge(createArray(createObject('endpointType', tryGet(parameters('dataProtection'), 'replication', 'endpointType'), 'remoteVolumeRegion', if(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'))), tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'), null()), 'remoteVolumeResourceId', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId')), if(equals(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'endpointType'), 'dst'), createObject('replicationSchedule', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'replicationSchedule')), createObject()), if(equals(parameters('volumeType'), 'Migration'), createObject('remotePath', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remotePath')), createObject()))), null()), 'backup', if(not(empty(tryGet(parameters('dataProtection'), 'backup'))), createObject('backupPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/backupPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName')), 'policyEnforced', coalesce(tryGet(parameters('dataProtection'), 'backup', 'policyEnforced'), false()), 'backupVaultId', resourceId('Microsoft.NetApp/netAppAccounts/backupVaults', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))), null()), 'snapshot', if(not(empty(tryGet(parameters('dataProtection'), 'snapshot'))), createObject('snapshotPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/snapshotPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))), null())), null()), 'networkFeatures', parameters('networkFeatures'), 'serviceLevel', parameters('serviceLevel'), 'creationToken', parameters('creationToken'), 'usageThreshold', parameters('usageThreshold'), 'protocolTypes', parameters('protocolTypes'), 'subnetId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('subnetResourceId'), '/')[2], split(parameters('subnetResourceId'), '/')[4]), 'Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/'))), 'exportPolicy', coalesce(parameters('exportPolicy'), createObject('rules', createArray())), 'smbContinuouslyAvailable', parameters('smbContinuouslyAvailable'), 'smbEncryption', parameters('smbEncryption'), 'smbNonBrowsable', parameters('smbNonBrowsable'), 'kerberosEnabled', parameters('kerberosEnabled'))))]",
-              "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]",
-              "dependsOn": [
-                "netAppAccount::capacityPool",
-                "keyVaultPrivateEndpoint",
-                "vnet"
-              ]
+              "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]"
             },
             "volume_roleAssignments": {
               "copy": {
@@ -1578,8 +1549,7 @@
         }
       },
       "dependsOn": [
-        "capacityPool",
-        "netAppAccount"
+        "capacityPool"
       ]
     }
   },

--- a/avm/res/net-app/net-app-account/capacity-pool/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "16713702795865434771"
+      "version": "0.29.47.4906",
+      "templateHash": "10125203863232929784"
     },
     "name": "Azure NetApp Files Capacity Pools",
     "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -258,8 +258,9 @@
             "daily",
             "hourly"
           ],
+          "nullable": true,
           "metadata": {
-            "description": "Required. The replication schedule for the volume."
+            "description": "Optional. The replication schedule for the volume (to only be set on the destination (dst))."
           }
         },
         "remotePath": {
@@ -682,12 +683,12 @@
     "netAppAccount": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "name": "[parameters('netAppAccountName')]"
     },
     "capacityPool": {
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -697,7 +698,10 @@
         "qosType": "[parameters('qosType')]",
         "coolAccess": "[parameters('coolAccess')]",
         "encryptionType": "[parameters('encryptionType')]"
-      }
+      },
+      "dependsOn": [
+        "netAppAccount"
+      ]
     },
     "capacityPool_roleAssignments": {
       "copy": {
@@ -823,8 +827,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "13608152069295767375"
+              "version": "0.29.47.4906",
+              "templateHash": "4754938124013776833"
             },
             "name": "Azure NetApp Files Capacity Pool Volumes",
             "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -894,8 +898,9 @@
                     "daily",
                     "hourly"
                   ],
+                  "nullable": true,
                   "metadata": {
-                    "description": "Required. The replication schedule for the volume."
+                    "description": "Optional. The replication schedule for the volume (to only be set on the destination (dst))."
                   }
                 },
                 "remotePath": {
@@ -1401,47 +1406,65 @@
             "netAppAccount::capacityPool": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-              "apiVersion": "2024-09-01",
-              "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
+              "apiVersion": "2025-01-01",
+              "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
+              "dependsOn": [
+                "netAppAccount"
+              ]
             },
             "netAppAccount::backupVault": {
               "condition": "[not(empty(tryGet(parameters('dataProtection'), 'backup')))]",
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
-              "apiVersion": "2024-09-01",
-              "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))]"
+              "apiVersion": "2025-01-01",
+              "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))]",
+              "dependsOn": [
+                "netAppAccount"
+              ]
             },
             "netAppAccount::backupPolicy": {
               "condition": "[not(empty(tryGet(parameters('dataProtection'), 'backup')))]",
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/backupPolicies",
-              "apiVersion": "2024-09-01",
-              "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName'))]"
+              "apiVersion": "2025-01-01",
+              "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName'))]",
+              "dependsOn": [
+                "netAppAccount"
+              ]
             },
             "netAppAccount::snapshotPolicy": {
               "condition": "[not(empty(tryGet(parameters('dataProtection'), 'snapshot')))]",
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/snapshotPolicies",
-              "apiVersion": "2024-09-01",
-              "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))]"
+              "apiVersion": "2025-01-01",
+              "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))]",
+              "dependsOn": [
+                "netAppAccount"
+              ]
             },
             "remoteNetAppAccount::remoteCapacityPool::remoteVolume": {
               "condition": "[and(and(and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName')))), and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteCapacityPoolName'), parameters('capacityPoolName'))))), not(empty(tryGet(parameters('dataProtection'), 'replication'))))]",
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
               "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
-              "name": "[format('{0}/{1}/{2}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10], last(split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')))]"
+              "name": "[format('{0}/{1}/{2}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10], last(split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')))]",
+              "dependsOn": [
+                "remoteNetAppAccount::remoteCapacityPool"
+              ]
             },
             "remoteNetAppAccount::remoteCapacityPool": {
               "condition": "[and(and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName')))), and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteCapacityPoolName'), parameters('capacityPoolName')))))]",
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
               "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
-              "name": "[format('{0}/{1}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10])]"
+              "name": "[format('{0}/{1}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10])]",
+              "dependsOn": [
+                "remoteNetAppAccount"
+              ]
             },
             "vnet::subnet": {
               "existing": true,
@@ -1449,12 +1472,15 @@
               "apiVersion": "2024-03-01",
               "subscriptionId": "[split(parameters('subnetResourceId'), '/')[2]]",
               "resourceGroup": "[split(parameters('subnetResourceId'), '/')[4]]",
-              "name": "[format('{0}/{1}', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/')))]"
+              "name": "[format('{0}/{1}', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/')))]",
+              "dependsOn": [
+                "vnet"
+              ]
             },
             "netAppAccount": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[parameters('netAppAccountName')]"
             },
             "keyVaultPrivateEndpoint": {
@@ -1470,7 +1496,7 @@
               "condition": "[and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName'))))]",
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
               "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
               "name": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8]]"
@@ -1485,11 +1511,16 @@
             },
             "volume": {
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('name'))]",
               "location": "[parameters('location')]",
-              "properties": "[shallowMerge(createArray(createObject('coolAccess', parameters('coolAccess'), 'coolAccessRetrievalPolicy', parameters('coolAccessRetrievalPolicy'), 'coolnessPeriod', parameters('coolnessPeriod'), 'securityStyle', parameters('securityStyle'), 'unixPermissions', parameters('unixPermissions'), 'encryptionKeySource', parameters('encryptionKeySource')), if(not(equals(parameters('encryptionKeySource'), 'Microsoft.NetApp')), createObject('keyVaultPrivateEndpointResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('keyVaultPrivateEndpointResourceId'), '/')[2], split(parameters('keyVaultPrivateEndpointResourceId'), '/')[4]), 'Microsoft.Network/privateEndpoints', last(split(parameters('keyVaultPrivateEndpointResourceId'), '/')))), createObject()), if(not(empty(parameters('volumeType'))), createObject('volumeType', parameters('volumeType')), createObject()), createObject('dataProtection', if(not(empty(parameters('dataProtection'))), createObject('replication', if(not(empty(tryGet(parameters('dataProtection'), 'replication'))), createObject('endpointType', tryGet(parameters('dataProtection'), 'replication', 'endpointType'), 'remoteVolumeRegion', if(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'))), tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'), null()), 'remoteVolumeResourceId', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), 'replicationSchedule', tryGet(parameters('dataProtection'), 'replication', 'replicationSchedule'), 'remotePath', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remotePath')), null()), 'backup', if(not(empty(tryGet(parameters('dataProtection'), 'backup'))), createObject('backupPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/backupPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName')), 'policyEnforced', coalesce(tryGet(parameters('dataProtection'), 'backup', 'policyEnforced'), false()), 'backupVaultId', resourceId('Microsoft.NetApp/netAppAccounts/backupVaults', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))), null()), 'snapshot', if(not(empty(tryGet(parameters('dataProtection'), 'snapshot'))), createObject('snapshotPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/snapshotPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))), null())), null()), 'networkFeatures', parameters('networkFeatures'), 'serviceLevel', parameters('serviceLevel'), 'creationToken', parameters('creationToken'), 'usageThreshold', parameters('usageThreshold'), 'protocolTypes', parameters('protocolTypes'), 'subnetId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('subnetResourceId'), '/')[2], split(parameters('subnetResourceId'), '/')[4]), 'Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/'))), 'exportPolicy', parameters('exportPolicy'), 'smbContinuouslyAvailable', parameters('smbContinuouslyAvailable'), 'smbEncryption', parameters('smbEncryption'), 'smbNonBrowsable', parameters('smbNonBrowsable'), 'kerberosEnabled', parameters('kerberosEnabled'))))]",
-              "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]"
+              "properties": "[shallowMerge(createArray(createObject('coolAccess', parameters('coolAccess'), 'coolAccessRetrievalPolicy', parameters('coolAccessRetrievalPolicy'), 'coolnessPeriod', parameters('coolnessPeriod'), 'securityStyle', parameters('securityStyle'), 'unixPermissions', parameters('unixPermissions'), 'encryptionKeySource', parameters('encryptionKeySource')), if(not(equals(parameters('encryptionKeySource'), 'Microsoft.NetApp')), createObject('keyVaultPrivateEndpointResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('keyVaultPrivateEndpointResourceId'), '/')[2], split(parameters('keyVaultPrivateEndpointResourceId'), '/')[4]), 'Microsoft.Network/privateEndpoints', last(split(parameters('keyVaultPrivateEndpointResourceId'), '/')))), createObject()), if(not(empty(parameters('volumeType'))), createObject('volumeType', parameters('volumeType')), createObject()), createObject('dataProtection', if(not(empty(parameters('dataProtection'))), createObject('replication', if(not(empty(tryGet(parameters('dataProtection'), 'replication'))), shallowMerge(createArray(createObject('endpointType', tryGet(parameters('dataProtection'), 'replication', 'endpointType'), 'remoteVolumeRegion', if(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'))), tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'), null()), 'remoteVolumeResourceId', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId')), if(equals(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'endpointType'), 'dst'), createObject('replicationSchedule', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'replicationSchedule')), createObject()), if(equals(parameters('volumeType'), 'Migration'), createObject('remotePath', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remotePath')), createObject()))), null()), 'backup', if(not(empty(tryGet(parameters('dataProtection'), 'backup'))), createObject('backupPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/backupPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName')), 'policyEnforced', coalesce(tryGet(parameters('dataProtection'), 'backup', 'policyEnforced'), false()), 'backupVaultId', resourceId('Microsoft.NetApp/netAppAccounts/backupVaults', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))), null()), 'snapshot', if(not(empty(tryGet(parameters('dataProtection'), 'snapshot'))), createObject('snapshotPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/snapshotPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))), null())), null()), 'networkFeatures', parameters('networkFeatures'), 'serviceLevel', parameters('serviceLevel'), 'creationToken', parameters('creationToken'), 'usageThreshold', parameters('usageThreshold'), 'protocolTypes', parameters('protocolTypes'), 'subnetId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('subnetResourceId'), '/')[2], split(parameters('subnetResourceId'), '/')[4]), 'Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/'))), 'exportPolicy', coalesce(parameters('exportPolicy'), createObject('rules', createArray())), 'smbContinuouslyAvailable', parameters('smbContinuouslyAvailable'), 'smbEncryption', parameters('smbEncryption'), 'smbNonBrowsable', parameters('smbNonBrowsable'), 'kerberosEnabled', parameters('kerberosEnabled'))))]",
+              "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]",
+              "dependsOn": [
+                "netAppAccount::capacityPool",
+                "keyVaultPrivateEndpoint",
+                "vnet"
+              ]
             },
             "volume_roleAssignments": {
               "copy": {
@@ -1541,13 +1572,14 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('volume', '2024-09-01', 'full').location]"
+              "value": "[reference('volume', '2025-01-01', 'full').location]"
             }
           }
         }
       },
       "dependsOn": [
-        "capacityPool"
+        "capacityPool",
+        "netAppAccount"
       ]
     }
   },
@@ -1578,7 +1610,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('capacityPool', '2024-09-01', 'full').location]"
+      "value": "[reference('capacityPool', '2025-01-01', 'full').location]"
     },
     "volumeResourceIds": {
       "type": "array",

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/README.md
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/README.md
@@ -14,7 +14,7 @@ This module deploys an Azure NetApp Files Capacity Pool Volume.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/capacityPools/volumes) |
+| `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/capacityPools/volumes) |
 
 ## Parameters
 
@@ -209,7 +209,6 @@ Replication properties.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`endpointType`](#parameter-dataprotectionreplicationendpointtype) | string | Indicates whether the local volume is the source or destination for the Volume Replication. |
-| [`replicationSchedule`](#parameter-dataprotectionreplicationreplicationschedule) | string | The replication schedule for the volume. |
 
 **Optional parameters**
 
@@ -218,6 +217,7 @@ Replication properties.
 | [`remotePath`](#parameter-dataprotectionreplicationremotepath) | object | The full path to a volume that is to be migrated into ANF. Required for Migration volumes. |
 | [`remoteVolumeRegion`](#parameter-dataprotectionreplicationremotevolumeregion) | string | The remote region for the other end of the Volume Replication.Required for Data Protection volumes. |
 | [`remoteVolumeResourceId`](#parameter-dataprotectionreplicationremotevolumeresourceid) | string | The resource ID of the remote volume. Required for Data Protection volumes. |
+| [`replicationSchedule`](#parameter-dataprotectionreplicationreplicationschedule) | string | The replication schedule for the volume (to only be set on the destination (dst)). |
 
 ### Parameter: `dataProtection.replication.endpointType`
 
@@ -230,21 +230,6 @@ Indicates whether the local volume is the source or destination for the Volume R
   [
     'dst'
     'src'
-  ]
-  ```
-
-### Parameter: `dataProtection.replication.replicationSchedule`
-
-The replication schedule for the volume.
-
-- Required: Yes
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    '_10minutely'
-    'daily'
-    'hourly'
   ]
   ```
 
@@ -297,6 +282,21 @@ The resource ID of the remote volume. Required for Data Protection volumes.
 
 - Required: No
 - Type: string
+
+### Parameter: `dataProtection.replication.replicationSchedule`
+
+The replication schedule for the volume (to only be set on the destination (dst)).
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    '_10minutely'
+    'daily'
+    'hourly'
+  ]
+  ```
 
 ### Parameter: `dataProtection.snapshot`
 

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/main.bicep
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/main.bicep
@@ -143,23 +143,23 @@ var formattedRoleAssignments = [
   })
 ]
 
-resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2024-09-01' existing = {
+resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2025-01-01' existing = {
   name: netAppAccountName
 
   //cp-na-anfs-swc-y01
-  resource capacityPool 'capacityPools@2024-09-01' existing = {
+  resource capacityPool 'capacityPools@2025-01-01' existing = {
     name: capacityPoolName
   }
 
-  resource backupVault 'backupVaults@2024-09-01' existing = if (!empty(dataProtection.?backup)) {
+  resource backupVault 'backupVaults@2025-01-01' existing = if (!empty(dataProtection.?backup)) {
     name: dataProtection.?backup!.backupVaultName
   }
 
-  resource backupPolicy 'backupPolicies@2024-09-01' existing = if (!empty(dataProtection.?backup)) {
+  resource backupPolicy 'backupPolicies@2025-01-01' existing = if (!empty(dataProtection.?backup)) {
     name: dataProtection.?backup!.backupPolicyName
   }
 
-  resource snapshotPolicy 'snapshotPolicies@2024-09-01' existing = if (!empty(dataProtection.?snapshot)) {
+  resource snapshotPolicy 'snapshotPolicies@2025-01-01' existing = if (!empty(dataProtection.?snapshot)) {
     name: dataProtection.?snapshot!.snapshotPolicyName
   }
 }
@@ -172,7 +172,7 @@ resource keyVaultPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-03-01'
   )
 }
 
-resource remoteNetAppAccount 'Microsoft.NetApp/netAppAccounts@2024-09-01' existing = if (!empty(dataProtection.?replication.?remoteVolumeResourceId) && (remoteNetAppName != netAppAccountName)) {
+resource remoteNetAppAccount 'Microsoft.NetApp/netAppAccounts@2025-01-01' existing = if (!empty(dataProtection.?replication.?remoteVolumeResourceId) && (remoteNetAppName != netAppAccountName)) {
   name: split(dataProtection.?replication.?remoteVolumeResourceId!, '/')[8]
   scope: resourceGroup(
     split(dataProtection.?replication.?remoteVolumeResourceId!, '/')[2],
@@ -180,10 +180,10 @@ resource remoteNetAppAccount 'Microsoft.NetApp/netAppAccounts@2024-09-01' existi
   )
 
   //cp-na-anfs-swc-y01
-  resource remoteCapacityPool 'capacityPools@2024-09-01' existing = if (!empty(dataProtection.?replication.?remoteVolumeResourceId) && (remoteCapacityPoolName != capacityPoolName)) {
+  resource remoteCapacityPool 'capacityPools@2025-01-01' existing = if (!empty(dataProtection.?replication.?remoteVolumeResourceId) && (remoteCapacityPoolName != capacityPoolName)) {
     name: split(dataProtection.?replication.?remoteVolumeResourceId!, '/')[10]
 
-    resource remoteVolume 'volumes@2024-09-01' existing = if (!empty(dataProtection.?replication)) {
+    resource remoteVolume 'volumes@2025-01-01' existing = if (!empty(dataProtection.?replication)) {
       name: last(split(dataProtection.?replication.?remoteVolumeResourceId!, '/'))
     }
   }
@@ -198,7 +198,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-03-01' existing = {
   }
 }
 
-resource volume 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2024-09-01' = {
+resource volume 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2025-01-01' = {
   name: name
   parent: netAppAccount::capacityPool
   location: location
@@ -225,11 +225,19 @@ resource volume 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2024-09-0
             ? {
                 endpointType: dataProtection.?replication!.endpointType
                 remoteVolumeRegion: !empty(dataProtection.?replication.?remoteVolumeRegion)
-                  ? dataProtection.?replication.?remoteVolumeRegion
+                  ? dataProtection.?replication!.?remoteVolumeRegion
                   : null
                 remoteVolumeResourceId: dataProtection.?replication!.?remoteVolumeResourceId
-                replicationSchedule: dataProtection.?replication!.replicationSchedule
-                remotePath: dataProtection.?replication!.?remotePath
+                ...(dataProtection.?replication!.?endpointType == 'dst')
+                  ? {
+                      replicationSchedule: dataProtection.?replication!.?replicationSchedule
+                    }
+                  : {}
+                ...(volumeType == 'Migration')
+                  ? {
+                      remotePath: dataProtection.?replication!.?remotePath
+                    }
+                  : {}
               }
             : null
           backup: !empty(dataProtection.?backup)
@@ -252,7 +260,9 @@ resource volume 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2024-09-0
     usageThreshold: usageThreshold
     protocolTypes: protocolTypes
     subnetId: vnet::subnet.id
-    exportPolicy: exportPolicy
+    exportPolicy: exportPolicy ?? {
+      rules: []
+    }
     smbContinuouslyAvailable: smbContinuouslyAvailable
     smbEncryption: smbEncryption
     smbNonBrowsable: smbNonBrowsable
@@ -316,8 +326,8 @@ type replicationType = {
   @description('Optional. The resource ID of the remote volume. Required for Data Protection volumes.')
   remoteVolumeResourceId: string?
 
-  @description('Required. The replication schedule for the volume.')
-  replicationSchedule: ('_10minutely' | 'daily' | 'hourly')
+  @description('Optional. The replication schedule for the volume (to only be set on the destination (dst)).')
+  replicationSchedule: ('_10minutely' | 'daily' | 'hourly')?
 
   @description('Optional. The full path to a volume that is to be migrated into ANF. Required for Migration volumes.')
   remotePath: {

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "4754938124013776833"
+      "version": "0.34.44.8038",
+      "templateHash": "107014526168729045"
     },
     "name": "Azure NetApp Files Capacity Pool Volumes",
     "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -585,40 +585,28 @@
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
       "apiVersion": "2025-01-01",
-      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
-      "dependsOn": [
-        "netAppAccount"
-      ]
+      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
     },
     "netAppAccount::backupVault": {
       "condition": "[not(empty(tryGet(parameters('dataProtection'), 'backup')))]",
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
       "apiVersion": "2025-01-01",
-      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))]",
-      "dependsOn": [
-        "netAppAccount"
-      ]
+      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))]"
     },
     "netAppAccount::backupPolicy": {
       "condition": "[not(empty(tryGet(parameters('dataProtection'), 'backup')))]",
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/backupPolicies",
       "apiVersion": "2025-01-01",
-      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName'))]",
-      "dependsOn": [
-        "netAppAccount"
-      ]
+      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName'))]"
     },
     "netAppAccount::snapshotPolicy": {
       "condition": "[not(empty(tryGet(parameters('dataProtection'), 'snapshot')))]",
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/snapshotPolicies",
       "apiVersion": "2025-01-01",
-      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))]",
-      "dependsOn": [
-        "netAppAccount"
-      ]
+      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))]"
     },
     "remoteNetAppAccount::remoteCapacityPool::remoteVolume": {
       "condition": "[and(and(and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName')))), and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteCapacityPoolName'), parameters('capacityPoolName'))))), not(empty(tryGet(parameters('dataProtection'), 'replication'))))]",
@@ -627,10 +615,7 @@
       "apiVersion": "2025-01-01",
       "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
       "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
-      "name": "[format('{0}/{1}/{2}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10], last(split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')))]",
-      "dependsOn": [
-        "remoteNetAppAccount::remoteCapacityPool"
-      ]
+      "name": "[format('{0}/{1}/{2}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10], last(split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')))]"
     },
     "remoteNetAppAccount::remoteCapacityPool": {
       "condition": "[and(and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName')))), and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteCapacityPoolName'), parameters('capacityPoolName')))))]",
@@ -639,10 +624,7 @@
       "apiVersion": "2025-01-01",
       "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
       "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
-      "name": "[format('{0}/{1}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10])]",
-      "dependsOn": [
-        "remoteNetAppAccount"
-      ]
+      "name": "[format('{0}/{1}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10])]"
     },
     "vnet::subnet": {
       "existing": true,
@@ -650,10 +632,7 @@
       "apiVersion": "2024-03-01",
       "subscriptionId": "[split(parameters('subnetResourceId'), '/')[2]]",
       "resourceGroup": "[split(parameters('subnetResourceId'), '/')[4]]",
-      "name": "[format('{0}/{1}', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/')))]",
-      "dependsOn": [
-        "vnet"
-      ]
+      "name": "[format('{0}/{1}', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/')))]"
     },
     "netAppAccount": {
       "existing": true,
@@ -693,12 +672,7 @@
       "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "properties": "[shallowMerge(createArray(createObject('coolAccess', parameters('coolAccess'), 'coolAccessRetrievalPolicy', parameters('coolAccessRetrievalPolicy'), 'coolnessPeriod', parameters('coolnessPeriod'), 'securityStyle', parameters('securityStyle'), 'unixPermissions', parameters('unixPermissions'), 'encryptionKeySource', parameters('encryptionKeySource')), if(not(equals(parameters('encryptionKeySource'), 'Microsoft.NetApp')), createObject('keyVaultPrivateEndpointResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('keyVaultPrivateEndpointResourceId'), '/')[2], split(parameters('keyVaultPrivateEndpointResourceId'), '/')[4]), 'Microsoft.Network/privateEndpoints', last(split(parameters('keyVaultPrivateEndpointResourceId'), '/')))), createObject()), if(not(empty(parameters('volumeType'))), createObject('volumeType', parameters('volumeType')), createObject()), createObject('dataProtection', if(not(empty(parameters('dataProtection'))), createObject('replication', if(not(empty(tryGet(parameters('dataProtection'), 'replication'))), shallowMerge(createArray(createObject('endpointType', tryGet(parameters('dataProtection'), 'replication', 'endpointType'), 'remoteVolumeRegion', if(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'))), tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'), null()), 'remoteVolumeResourceId', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId')), if(equals(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'endpointType'), 'dst'), createObject('replicationSchedule', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'replicationSchedule')), createObject()), if(equals(parameters('volumeType'), 'Migration'), createObject('remotePath', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remotePath')), createObject()))), null()), 'backup', if(not(empty(tryGet(parameters('dataProtection'), 'backup'))), createObject('backupPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/backupPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName')), 'policyEnforced', coalesce(tryGet(parameters('dataProtection'), 'backup', 'policyEnforced'), false()), 'backupVaultId', resourceId('Microsoft.NetApp/netAppAccounts/backupVaults', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))), null()), 'snapshot', if(not(empty(tryGet(parameters('dataProtection'), 'snapshot'))), createObject('snapshotPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/snapshotPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))), null())), null()), 'networkFeatures', parameters('networkFeatures'), 'serviceLevel', parameters('serviceLevel'), 'creationToken', parameters('creationToken'), 'usageThreshold', parameters('usageThreshold'), 'protocolTypes', parameters('protocolTypes'), 'subnetId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('subnetResourceId'), '/')[2], split(parameters('subnetResourceId'), '/')[4]), 'Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/'))), 'exportPolicy', coalesce(parameters('exportPolicy'), createObject('rules', createArray())), 'smbContinuouslyAvailable', parameters('smbContinuouslyAvailable'), 'smbEncryption', parameters('smbEncryption'), 'smbNonBrowsable', parameters('smbNonBrowsable'), 'kerberosEnabled', parameters('kerberosEnabled'))))]",
-      "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]",
-      "dependsOn": [
-        "netAppAccount::capacityPool",
-        "keyVaultPrivateEndpoint",
-        "vnet"
-      ]
+      "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]"
     },
     "volume_roleAssignments": {
       "copy": {

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "13608152069295767375"
+      "version": "0.29.47.4906",
+      "templateHash": "4754938124013776833"
     },
     "name": "Azure NetApp Files Capacity Pool Volumes",
     "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -76,8 +76,9 @@
             "daily",
             "hourly"
           ],
+          "nullable": true,
           "metadata": {
-            "description": "Required. The replication schedule for the volume."
+            "description": "Optional. The replication schedule for the volume (to only be set on the destination (dst))."
           }
         },
         "remotePath": {
@@ -583,47 +584,65 @@
     "netAppAccount::capacityPool": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-      "apiVersion": "2024-09-01",
-      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
+      "apiVersion": "2025-01-01",
+      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
+      "dependsOn": [
+        "netAppAccount"
+      ]
     },
     "netAppAccount::backupVault": {
       "condition": "[not(empty(tryGet(parameters('dataProtection'), 'backup')))]",
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
-      "apiVersion": "2024-09-01",
-      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))]"
+      "apiVersion": "2025-01-01",
+      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))]",
+      "dependsOn": [
+        "netAppAccount"
+      ]
     },
     "netAppAccount::backupPolicy": {
       "condition": "[not(empty(tryGet(parameters('dataProtection'), 'backup')))]",
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/backupPolicies",
-      "apiVersion": "2024-09-01",
-      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName'))]"
+      "apiVersion": "2025-01-01",
+      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName'))]",
+      "dependsOn": [
+        "netAppAccount"
+      ]
     },
     "netAppAccount::snapshotPolicy": {
       "condition": "[not(empty(tryGet(parameters('dataProtection'), 'snapshot')))]",
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/snapshotPolicies",
-      "apiVersion": "2024-09-01",
-      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))]"
+      "apiVersion": "2025-01-01",
+      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))]",
+      "dependsOn": [
+        "netAppAccount"
+      ]
     },
     "remoteNetAppAccount::remoteCapacityPool::remoteVolume": {
       "condition": "[and(and(and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName')))), and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteCapacityPoolName'), parameters('capacityPoolName'))))), not(empty(tryGet(parameters('dataProtection'), 'replication'))))]",
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
       "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
-      "name": "[format('{0}/{1}/{2}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10], last(split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')))]"
+      "name": "[format('{0}/{1}/{2}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10], last(split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')))]",
+      "dependsOn": [
+        "remoteNetAppAccount::remoteCapacityPool"
+      ]
     },
     "remoteNetAppAccount::remoteCapacityPool": {
       "condition": "[and(and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName')))), and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteCapacityPoolName'), parameters('capacityPoolName')))))]",
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
       "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
-      "name": "[format('{0}/{1}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10])]"
+      "name": "[format('{0}/{1}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10])]",
+      "dependsOn": [
+        "remoteNetAppAccount"
+      ]
     },
     "vnet::subnet": {
       "existing": true,
@@ -631,12 +650,15 @@
       "apiVersion": "2024-03-01",
       "subscriptionId": "[split(parameters('subnetResourceId'), '/')[2]]",
       "resourceGroup": "[split(parameters('subnetResourceId'), '/')[4]]",
-      "name": "[format('{0}/{1}', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/')))]"
+      "name": "[format('{0}/{1}', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/')))]",
+      "dependsOn": [
+        "vnet"
+      ]
     },
     "netAppAccount": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "name": "[parameters('netAppAccountName')]"
     },
     "keyVaultPrivateEndpoint": {
@@ -652,7 +674,7 @@
       "condition": "[and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName'))))]",
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
       "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
       "name": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8]]"
@@ -667,11 +689,16 @@
     },
     "volume": {
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('name'))]",
       "location": "[parameters('location')]",
-      "properties": "[shallowMerge(createArray(createObject('coolAccess', parameters('coolAccess'), 'coolAccessRetrievalPolicy', parameters('coolAccessRetrievalPolicy'), 'coolnessPeriod', parameters('coolnessPeriod'), 'securityStyle', parameters('securityStyle'), 'unixPermissions', parameters('unixPermissions'), 'encryptionKeySource', parameters('encryptionKeySource')), if(not(equals(parameters('encryptionKeySource'), 'Microsoft.NetApp')), createObject('keyVaultPrivateEndpointResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('keyVaultPrivateEndpointResourceId'), '/')[2], split(parameters('keyVaultPrivateEndpointResourceId'), '/')[4]), 'Microsoft.Network/privateEndpoints', last(split(parameters('keyVaultPrivateEndpointResourceId'), '/')))), createObject()), if(not(empty(parameters('volumeType'))), createObject('volumeType', parameters('volumeType')), createObject()), createObject('dataProtection', if(not(empty(parameters('dataProtection'))), createObject('replication', if(not(empty(tryGet(parameters('dataProtection'), 'replication'))), createObject('endpointType', tryGet(parameters('dataProtection'), 'replication', 'endpointType'), 'remoteVolumeRegion', if(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'))), tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'), null()), 'remoteVolumeResourceId', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), 'replicationSchedule', tryGet(parameters('dataProtection'), 'replication', 'replicationSchedule'), 'remotePath', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remotePath')), null()), 'backup', if(not(empty(tryGet(parameters('dataProtection'), 'backup'))), createObject('backupPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/backupPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName')), 'policyEnforced', coalesce(tryGet(parameters('dataProtection'), 'backup', 'policyEnforced'), false()), 'backupVaultId', resourceId('Microsoft.NetApp/netAppAccounts/backupVaults', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))), null()), 'snapshot', if(not(empty(tryGet(parameters('dataProtection'), 'snapshot'))), createObject('snapshotPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/snapshotPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))), null())), null()), 'networkFeatures', parameters('networkFeatures'), 'serviceLevel', parameters('serviceLevel'), 'creationToken', parameters('creationToken'), 'usageThreshold', parameters('usageThreshold'), 'protocolTypes', parameters('protocolTypes'), 'subnetId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('subnetResourceId'), '/')[2], split(parameters('subnetResourceId'), '/')[4]), 'Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/'))), 'exportPolicy', parameters('exportPolicy'), 'smbContinuouslyAvailable', parameters('smbContinuouslyAvailable'), 'smbEncryption', parameters('smbEncryption'), 'smbNonBrowsable', parameters('smbNonBrowsable'), 'kerberosEnabled', parameters('kerberosEnabled'))))]",
-      "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]"
+      "properties": "[shallowMerge(createArray(createObject('coolAccess', parameters('coolAccess'), 'coolAccessRetrievalPolicy', parameters('coolAccessRetrievalPolicy'), 'coolnessPeriod', parameters('coolnessPeriod'), 'securityStyle', parameters('securityStyle'), 'unixPermissions', parameters('unixPermissions'), 'encryptionKeySource', parameters('encryptionKeySource')), if(not(equals(parameters('encryptionKeySource'), 'Microsoft.NetApp')), createObject('keyVaultPrivateEndpointResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('keyVaultPrivateEndpointResourceId'), '/')[2], split(parameters('keyVaultPrivateEndpointResourceId'), '/')[4]), 'Microsoft.Network/privateEndpoints', last(split(parameters('keyVaultPrivateEndpointResourceId'), '/')))), createObject()), if(not(empty(parameters('volumeType'))), createObject('volumeType', parameters('volumeType')), createObject()), createObject('dataProtection', if(not(empty(parameters('dataProtection'))), createObject('replication', if(not(empty(tryGet(parameters('dataProtection'), 'replication'))), shallowMerge(createArray(createObject('endpointType', tryGet(parameters('dataProtection'), 'replication', 'endpointType'), 'remoteVolumeRegion', if(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'))), tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'), null()), 'remoteVolumeResourceId', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId')), if(equals(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'endpointType'), 'dst'), createObject('replicationSchedule', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'replicationSchedule')), createObject()), if(equals(parameters('volumeType'), 'Migration'), createObject('remotePath', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remotePath')), createObject()))), null()), 'backup', if(not(empty(tryGet(parameters('dataProtection'), 'backup'))), createObject('backupPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/backupPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName')), 'policyEnforced', coalesce(tryGet(parameters('dataProtection'), 'backup', 'policyEnforced'), false()), 'backupVaultId', resourceId('Microsoft.NetApp/netAppAccounts/backupVaults', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))), null()), 'snapshot', if(not(empty(tryGet(parameters('dataProtection'), 'snapshot'))), createObject('snapshotPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/snapshotPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))), null())), null()), 'networkFeatures', parameters('networkFeatures'), 'serviceLevel', parameters('serviceLevel'), 'creationToken', parameters('creationToken'), 'usageThreshold', parameters('usageThreshold'), 'protocolTypes', parameters('protocolTypes'), 'subnetId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('subnetResourceId'), '/')[2], split(parameters('subnetResourceId'), '/')[4]), 'Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/'))), 'exportPolicy', coalesce(parameters('exportPolicy'), createObject('rules', createArray())), 'smbContinuouslyAvailable', parameters('smbContinuouslyAvailable'), 'smbEncryption', parameters('smbEncryption'), 'smbNonBrowsable', parameters('smbNonBrowsable'), 'kerberosEnabled', parameters('kerberosEnabled'))))]",
+      "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]",
+      "dependsOn": [
+        "netAppAccount::capacityPool",
+        "keyVaultPrivateEndpoint",
+        "vnet"
+      ]
     },
     "volume_roleAssignments": {
       "copy": {
@@ -723,7 +750,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('volume', '2024-09-01', 'full').location]"
+      "value": "[reference('volume', '2025-01-01', 'full').location]"
     }
   }
 }

--- a/avm/res/net-app/net-app-account/main.bicep
+++ b/avm/res/net-app/net-app-account/main.bicep
@@ -180,7 +180,7 @@ resource cMKUserAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentiti
   )
 }
 
-resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2024-09-01' = {
+resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2025-01-01' = {
   name: name
   tags: tags
   identity: identity

--- a/avm/res/net-app/net-app-account/main.json
+++ b/avm/res/net-app/net-app-account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "9880258354599224503"
+      "version": "0.29.47.4906",
+      "templateHash": "16981476684882745943"
     },
     "name": "Azure NetApp Files",
     "description": "This module deploys an Azure NetApp File."
@@ -462,8 +462,9 @@
             "daily",
             "hourly"
           ],
+          "nullable": true,
           "metadata": {
-            "description": "Required. The replication schedule for the volume."
+            "description": "Optional. The replication schedule for the volume (to only be set on the destination (dst))."
           }
         },
         "remotePath": {
@@ -1331,7 +1332,10 @@
       "apiVersion": "2023-02-01",
       "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
       "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
-      "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
+      "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]",
+      "dependsOn": [
+        "cMKKeyVault"
+      ]
     },
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
@@ -1373,7 +1377,7 @@
     },
     "netAppAccount": {
       "type": "Microsoft.NetApp/netAppAccounts",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "name": "[parameters('name')]",
       "tags": "[parameters('tags')]",
       "identity": "[variables('identity')]",
@@ -1383,7 +1387,8 @@
         "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('identity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), createObject('userAssignedIdentity', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[2], split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')))), null()), 'keySource', 'Microsoft.KeyVault', 'keyVaultProperties', createObject('keyName', parameters('customerManagedKey').keyName, 'keyVaultResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2], split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]), 'Microsoft.KeyVault/vaults', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))), 'keyVaultUri', reference('cMKKeyVault').vaultUri)), null())]"
       },
       "dependsOn": [
-        "cMKKeyVault"
+        "cMKKeyVault",
+        "cMKUserAssignedIdentity"
       ]
     },
     "netAppAccount_lock": {
@@ -1464,8 +1469,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "7879757037815205826"
+              "version": "0.29.47.4906",
+              "templateHash": "16001755318587725595"
             },
             "name": "Azure NetApp Files Backup Policy",
             "description": "This module deploys a Backup Policy for Azure NetApp File."
@@ -1525,7 +1530,7 @@
           "resources": [
             {
               "type": "Microsoft.NetApp/netAppAccounts/backupPolicies",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "properties": {
@@ -1611,8 +1616,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "5076757961005626576"
+              "version": "0.29.47.4906",
+              "templateHash": "1044860453592207069"
             },
             "name": "Azure NetApp Files Snapshot Policy",
             "description": "This module deploys a Snapshot Policy for an Azure NetApp File."
@@ -1853,12 +1858,12 @@
             "netAppAccount": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[parameters('netAppAccountName')]"
             },
             "snapshotPolicies": {
               "type": "Microsoft.NetApp/netAppAccounts/snapshotPolicies",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "properties": {
@@ -1867,7 +1872,10 @@
                 "hourlySchedule": "[parameters('hourlySchedule')]",
                 "monthlySchedule": "[parameters('monthlySchedule')]",
                 "weeklySchedule": "[parameters('weeklySchedule')]"
-              }
+              },
+              "dependsOn": [
+                "netAppAccount"
+              ]
             }
           },
           "outputs": {
@@ -1927,8 +1935,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "6318287714892140543"
+              "version": "0.29.47.4906",
+              "templateHash": "20164335461414036"
             },
             "name": "Azure NetApp Files Volume Backup Vault",
             "description": "This module deploys a NetApp Files Backup Vault."
@@ -2013,15 +2021,18 @@
             "netAppAccount": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[parameters('netAppAccountName')]"
             },
             "backupVault": {
               "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
               "location": "[parameters('location')]",
-              "properties": {}
+              "properties": {},
+              "dependsOn": [
+                "netAppAccount"
+              ]
             },
             "backupVault_backups": {
               "copy": {
@@ -2066,8 +2077,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "11103687332577035719"
+                      "version": "0.29.47.4906",
+                      "templateHash": "8317801660539599309"
                     },
                     "name": "Azure NetApp Files Volume Backup",
                     "description": "This module deploys a backup of a NetApp Files Volume."
@@ -2123,36 +2134,49 @@
                     "netAppAccount::remoteCapacityPool::volume": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-                      "apiVersion": "2024-07-01",
-                      "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
+                      "apiVersion": "2025-01-01",
+                      "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]",
+                      "dependsOn": [
+                        "netAppAccount::remoteCapacityPool"
+                      ]
                     },
                     "netAppAccount::backupVault": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
-                      "apiVersion": "2024-09-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]"
+                      "apiVersion": "2025-01-01",
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]",
+                      "dependsOn": [
+                        "netAppAccount"
+                      ]
                     },
                     "netAppAccount::remoteCapacityPool": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-                      "apiVersion": "2024-09-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
+                      "apiVersion": "2025-01-01",
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
+                      "dependsOn": [
+                        "netAppAccount"
+                      ]
                     },
                     "netAppAccount": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts",
-                      "apiVersion": "2024-09-01",
+                      "apiVersion": "2025-01-01",
                       "name": "[parameters('netAppAccountName')]"
                     },
                     "backup": {
                       "type": "Microsoft.NetApp/netAppAccounts/backupVaults/backups",
-                      "apiVersion": "2024-09-01",
+                      "apiVersion": "2025-01-01",
                       "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('backupVaultName'), parameters('name'))]",
                       "properties": {
                         "label": "[parameters('label')]",
                         "snapshotName": "[parameters('snapshotName')]",
                         "volumeResourceId": "[resourceId('Microsoft.NetApp/netAppAccounts/capacityPools/volumes', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
-                      }
+                      },
+                      "dependsOn": [
+                        "netAppAccount::backupVault",
+                        "netAppAccount::remoteCapacityPool"
+                      ]
                     }
                   },
                   "outputs": {
@@ -2181,7 +2205,8 @@
                 }
               },
               "dependsOn": [
-                "backupVault"
+                "backupVault",
+                "netAppAccount"
               ]
             }
           },
@@ -2212,7 +2237,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('backupVault', '2024-09-01', 'full').location]"
+              "value": "[reference('backupVault', '2025-01-01', 'full').location]"
             }
           }
         }
@@ -2276,8 +2301,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "16713702795865434771"
+              "version": "0.29.47.4906",
+              "templateHash": "10125203863232929784"
             },
             "name": "Azure NetApp Files Capacity Pools",
             "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -2529,8 +2554,9 @@
                     "daily",
                     "hourly"
                   ],
+                  "nullable": true,
                   "metadata": {
-                    "description": "Required. The replication schedule for the volume."
+                    "description": "Optional. The replication schedule for the volume (to only be set on the destination (dst))."
                   }
                 },
                 "remotePath": {
@@ -2953,12 +2979,12 @@
             "netAppAccount": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[parameters('netAppAccountName')]"
             },
             "capacityPool": {
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
@@ -2968,7 +2994,10 @@
                 "qosType": "[parameters('qosType')]",
                 "coolAccess": "[parameters('coolAccess')]",
                 "encryptionType": "[parameters('encryptionType')]"
-              }
+              },
+              "dependsOn": [
+                "netAppAccount"
+              ]
             },
             "capacityPool_roleAssignments": {
               "copy": {
@@ -3094,8 +3123,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "13608152069295767375"
+                      "version": "0.29.47.4906",
+                      "templateHash": "4754938124013776833"
                     },
                     "name": "Azure NetApp Files Capacity Pool Volumes",
                     "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -3165,8 +3194,9 @@
                             "daily",
                             "hourly"
                           ],
+                          "nullable": true,
                           "metadata": {
-                            "description": "Required. The replication schedule for the volume."
+                            "description": "Optional. The replication schedule for the volume (to only be set on the destination (dst))."
                           }
                         },
                         "remotePath": {
@@ -3672,47 +3702,65 @@
                     "netAppAccount::capacityPool": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-                      "apiVersion": "2024-09-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
+                      "apiVersion": "2025-01-01",
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
+                      "dependsOn": [
+                        "netAppAccount"
+                      ]
                     },
                     "netAppAccount::backupVault": {
                       "condition": "[not(empty(tryGet(parameters('dataProtection'), 'backup')))]",
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
-                      "apiVersion": "2024-09-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))]"
+                      "apiVersion": "2025-01-01",
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))]",
+                      "dependsOn": [
+                        "netAppAccount"
+                      ]
                     },
                     "netAppAccount::backupPolicy": {
                       "condition": "[not(empty(tryGet(parameters('dataProtection'), 'backup')))]",
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/backupPolicies",
-                      "apiVersion": "2024-09-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName'))]"
+                      "apiVersion": "2025-01-01",
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName'))]",
+                      "dependsOn": [
+                        "netAppAccount"
+                      ]
                     },
                     "netAppAccount::snapshotPolicy": {
                       "condition": "[not(empty(tryGet(parameters('dataProtection'), 'snapshot')))]",
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/snapshotPolicies",
-                      "apiVersion": "2024-09-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))]"
+                      "apiVersion": "2025-01-01",
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))]",
+                      "dependsOn": [
+                        "netAppAccount"
+                      ]
                     },
                     "remoteNetAppAccount::remoteCapacityPool::remoteVolume": {
                       "condition": "[and(and(and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName')))), and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteCapacityPoolName'), parameters('capacityPoolName'))))), not(empty(tryGet(parameters('dataProtection'), 'replication'))))]",
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-                      "apiVersion": "2024-09-01",
+                      "apiVersion": "2025-01-01",
                       "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
                       "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
-                      "name": "[format('{0}/{1}/{2}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10], last(split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')))]"
+                      "name": "[format('{0}/{1}/{2}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10], last(split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')))]",
+                      "dependsOn": [
+                        "remoteNetAppAccount::remoteCapacityPool"
+                      ]
                     },
                     "remoteNetAppAccount::remoteCapacityPool": {
                       "condition": "[and(and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName')))), and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteCapacityPoolName'), parameters('capacityPoolName')))))]",
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-                      "apiVersion": "2024-09-01",
+                      "apiVersion": "2025-01-01",
                       "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
                       "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
-                      "name": "[format('{0}/{1}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10])]"
+                      "name": "[format('{0}/{1}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10])]",
+                      "dependsOn": [
+                        "remoteNetAppAccount"
+                      ]
                     },
                     "vnet::subnet": {
                       "existing": true,
@@ -3720,12 +3768,15 @@
                       "apiVersion": "2024-03-01",
                       "subscriptionId": "[split(parameters('subnetResourceId'), '/')[2]]",
                       "resourceGroup": "[split(parameters('subnetResourceId'), '/')[4]]",
-                      "name": "[format('{0}/{1}', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/')))]"
+                      "name": "[format('{0}/{1}', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/')))]",
+                      "dependsOn": [
+                        "vnet"
+                      ]
                     },
                     "netAppAccount": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts",
-                      "apiVersion": "2024-09-01",
+                      "apiVersion": "2025-01-01",
                       "name": "[parameters('netAppAccountName')]"
                     },
                     "keyVaultPrivateEndpoint": {
@@ -3741,7 +3792,7 @@
                       "condition": "[and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName'))))]",
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts",
-                      "apiVersion": "2024-09-01",
+                      "apiVersion": "2025-01-01",
                       "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
                       "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
                       "name": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8]]"
@@ -3756,11 +3807,16 @@
                     },
                     "volume": {
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-                      "apiVersion": "2024-09-01",
+                      "apiVersion": "2025-01-01",
                       "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('name'))]",
                       "location": "[parameters('location')]",
-                      "properties": "[shallowMerge(createArray(createObject('coolAccess', parameters('coolAccess'), 'coolAccessRetrievalPolicy', parameters('coolAccessRetrievalPolicy'), 'coolnessPeriod', parameters('coolnessPeriod'), 'securityStyle', parameters('securityStyle'), 'unixPermissions', parameters('unixPermissions'), 'encryptionKeySource', parameters('encryptionKeySource')), if(not(equals(parameters('encryptionKeySource'), 'Microsoft.NetApp')), createObject('keyVaultPrivateEndpointResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('keyVaultPrivateEndpointResourceId'), '/')[2], split(parameters('keyVaultPrivateEndpointResourceId'), '/')[4]), 'Microsoft.Network/privateEndpoints', last(split(parameters('keyVaultPrivateEndpointResourceId'), '/')))), createObject()), if(not(empty(parameters('volumeType'))), createObject('volumeType', parameters('volumeType')), createObject()), createObject('dataProtection', if(not(empty(parameters('dataProtection'))), createObject('replication', if(not(empty(tryGet(parameters('dataProtection'), 'replication'))), createObject('endpointType', tryGet(parameters('dataProtection'), 'replication', 'endpointType'), 'remoteVolumeRegion', if(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'))), tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'), null()), 'remoteVolumeResourceId', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), 'replicationSchedule', tryGet(parameters('dataProtection'), 'replication', 'replicationSchedule'), 'remotePath', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remotePath')), null()), 'backup', if(not(empty(tryGet(parameters('dataProtection'), 'backup'))), createObject('backupPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/backupPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName')), 'policyEnforced', coalesce(tryGet(parameters('dataProtection'), 'backup', 'policyEnforced'), false()), 'backupVaultId', resourceId('Microsoft.NetApp/netAppAccounts/backupVaults', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))), null()), 'snapshot', if(not(empty(tryGet(parameters('dataProtection'), 'snapshot'))), createObject('snapshotPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/snapshotPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))), null())), null()), 'networkFeatures', parameters('networkFeatures'), 'serviceLevel', parameters('serviceLevel'), 'creationToken', parameters('creationToken'), 'usageThreshold', parameters('usageThreshold'), 'protocolTypes', parameters('protocolTypes'), 'subnetId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('subnetResourceId'), '/')[2], split(parameters('subnetResourceId'), '/')[4]), 'Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/'))), 'exportPolicy', parameters('exportPolicy'), 'smbContinuouslyAvailable', parameters('smbContinuouslyAvailable'), 'smbEncryption', parameters('smbEncryption'), 'smbNonBrowsable', parameters('smbNonBrowsable'), 'kerberosEnabled', parameters('kerberosEnabled'))))]",
-                      "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]"
+                      "properties": "[shallowMerge(createArray(createObject('coolAccess', parameters('coolAccess'), 'coolAccessRetrievalPolicy', parameters('coolAccessRetrievalPolicy'), 'coolnessPeriod', parameters('coolnessPeriod'), 'securityStyle', parameters('securityStyle'), 'unixPermissions', parameters('unixPermissions'), 'encryptionKeySource', parameters('encryptionKeySource')), if(not(equals(parameters('encryptionKeySource'), 'Microsoft.NetApp')), createObject('keyVaultPrivateEndpointResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('keyVaultPrivateEndpointResourceId'), '/')[2], split(parameters('keyVaultPrivateEndpointResourceId'), '/')[4]), 'Microsoft.Network/privateEndpoints', last(split(parameters('keyVaultPrivateEndpointResourceId'), '/')))), createObject()), if(not(empty(parameters('volumeType'))), createObject('volumeType', parameters('volumeType')), createObject()), createObject('dataProtection', if(not(empty(parameters('dataProtection'))), createObject('replication', if(not(empty(tryGet(parameters('dataProtection'), 'replication'))), shallowMerge(createArray(createObject('endpointType', tryGet(parameters('dataProtection'), 'replication', 'endpointType'), 'remoteVolumeRegion', if(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'))), tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'), null()), 'remoteVolumeResourceId', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId')), if(equals(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'endpointType'), 'dst'), createObject('replicationSchedule', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'replicationSchedule')), createObject()), if(equals(parameters('volumeType'), 'Migration'), createObject('remotePath', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remotePath')), createObject()))), null()), 'backup', if(not(empty(tryGet(parameters('dataProtection'), 'backup'))), createObject('backupPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/backupPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName')), 'policyEnforced', coalesce(tryGet(parameters('dataProtection'), 'backup', 'policyEnforced'), false()), 'backupVaultId', resourceId('Microsoft.NetApp/netAppAccounts/backupVaults', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))), null()), 'snapshot', if(not(empty(tryGet(parameters('dataProtection'), 'snapshot'))), createObject('snapshotPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/snapshotPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))), null())), null()), 'networkFeatures', parameters('networkFeatures'), 'serviceLevel', parameters('serviceLevel'), 'creationToken', parameters('creationToken'), 'usageThreshold', parameters('usageThreshold'), 'protocolTypes', parameters('protocolTypes'), 'subnetId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('subnetResourceId'), '/')[2], split(parameters('subnetResourceId'), '/')[4]), 'Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/'))), 'exportPolicy', coalesce(parameters('exportPolicy'), createObject('rules', createArray())), 'smbContinuouslyAvailable', parameters('smbContinuouslyAvailable'), 'smbEncryption', parameters('smbEncryption'), 'smbNonBrowsable', parameters('smbNonBrowsable'), 'kerberosEnabled', parameters('kerberosEnabled'))))]",
+                      "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]",
+                      "dependsOn": [
+                        "netAppAccount::capacityPool",
+                        "keyVaultPrivateEndpoint",
+                        "vnet"
+                      ]
                     },
                     "volume_roleAssignments": {
                       "copy": {
@@ -3812,13 +3868,14 @@
                       "metadata": {
                         "description": "The location the resource was deployed into."
                       },
-                      "value": "[reference('volume', '2024-09-01', 'full').location]"
+                      "value": "[reference('volume', '2025-01-01', 'full').location]"
                     }
                   }
                 }
               },
               "dependsOn": [
-                "capacityPool"
+                "capacityPool",
+                "netAppAccount"
               ]
             }
           },
@@ -3849,7 +3906,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('capacityPool', '2024-09-01', 'full').location]"
+              "value": "[reference('capacityPool', '2025-01-01', 'full').location]"
             },
             "volumeResourceIds": {
               "type": "array",
@@ -3905,8 +3962,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "6318287714892140543"
+              "version": "0.29.47.4906",
+              "templateHash": "20164335461414036"
             },
             "name": "Azure NetApp Files Volume Backup Vault",
             "description": "This module deploys a NetApp Files Backup Vault."
@@ -3991,15 +4048,18 @@
             "netAppAccount": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[parameters('netAppAccountName')]"
             },
             "backupVault": {
               "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
-              "apiVersion": "2024-09-01",
+              "apiVersion": "2025-01-01",
               "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
               "location": "[parameters('location')]",
-              "properties": {}
+              "properties": {},
+              "dependsOn": [
+                "netAppAccount"
+              ]
             },
             "backupVault_backups": {
               "copy": {
@@ -4044,8 +4104,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "11103687332577035719"
+                      "version": "0.29.47.4906",
+                      "templateHash": "8317801660539599309"
                     },
                     "name": "Azure NetApp Files Volume Backup",
                     "description": "This module deploys a backup of a NetApp Files Volume."
@@ -4101,36 +4161,49 @@
                     "netAppAccount::remoteCapacityPool::volume": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-                      "apiVersion": "2024-07-01",
-                      "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
+                      "apiVersion": "2025-01-01",
+                      "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]",
+                      "dependsOn": [
+                        "netAppAccount::remoteCapacityPool"
+                      ]
                     },
                     "netAppAccount::backupVault": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
-                      "apiVersion": "2024-09-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]"
+                      "apiVersion": "2025-01-01",
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]",
+                      "dependsOn": [
+                        "netAppAccount"
+                      ]
                     },
                     "netAppAccount::remoteCapacityPool": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-                      "apiVersion": "2024-09-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
+                      "apiVersion": "2025-01-01",
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
+                      "dependsOn": [
+                        "netAppAccount"
+                      ]
                     },
                     "netAppAccount": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts",
-                      "apiVersion": "2024-09-01",
+                      "apiVersion": "2025-01-01",
                       "name": "[parameters('netAppAccountName')]"
                     },
                     "backup": {
                       "type": "Microsoft.NetApp/netAppAccounts/backupVaults/backups",
-                      "apiVersion": "2024-09-01",
+                      "apiVersion": "2025-01-01",
                       "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('backupVaultName'), parameters('name'))]",
                       "properties": {
                         "label": "[parameters('label')]",
                         "snapshotName": "[parameters('snapshotName')]",
                         "volumeResourceId": "[resourceId('Microsoft.NetApp/netAppAccounts/capacityPools/volumes', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
-                      }
+                      },
+                      "dependsOn": [
+                        "netAppAccount::backupVault",
+                        "netAppAccount::remoteCapacityPool"
+                      ]
                     }
                   },
                   "outputs": {
@@ -4159,7 +4232,8 @@
                 }
               },
               "dependsOn": [
-                "backupVault"
+                "backupVault",
+                "netAppAccount"
               ]
             }
           },
@@ -4190,7 +4264,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('backupVault', '2024-09-01', 'full').location]"
+              "value": "[reference('backupVault', '2025-01-01', 'full').location]"
             }
           }
         }
@@ -4228,7 +4302,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('netAppAccount', '2024-09-01', 'full').location]"
+      "value": "[reference('netAppAccount', '2025-01-01', 'full').location]"
     },
     "capacityPoolResourceIds": {
       "type": "array",

--- a/avm/res/net-app/net-app-account/main.json
+++ b/avm/res/net-app/net-app-account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "16981476684882745943"
+      "version": "0.34.44.8038",
+      "templateHash": "3602945835134853701"
     },
     "name": "Azure NetApp Files",
     "description": "This module deploys an Azure NetApp File."
@@ -1332,10 +1332,7 @@
       "apiVersion": "2023-02-01",
       "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
       "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
-      "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]",
-      "dependsOn": [
-        "cMKKeyVault"
-      ]
+      "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
     },
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
@@ -1387,8 +1384,7 @@
         "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('identity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), createObject('userAssignedIdentity', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[2], split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')))), null()), 'keySource', 'Microsoft.KeyVault', 'keyVaultProperties', createObject('keyName', parameters('customerManagedKey').keyName, 'keyVaultResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2], split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]), 'Microsoft.KeyVault/vaults', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))), 'keyVaultUri', reference('cMKKeyVault').vaultUri)), null())]"
       },
       "dependsOn": [
-        "cMKKeyVault",
-        "cMKUserAssignedIdentity"
+        "cMKKeyVault"
       ]
     },
     "netAppAccount_lock": {
@@ -1469,8 +1465,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "16001755318587725595"
+              "version": "0.34.44.8038",
+              "templateHash": "5685295510343035237"
             },
             "name": "Azure NetApp Files Backup Policy",
             "description": "This module deploys a Backup Policy for Azure NetApp File."
@@ -1616,8 +1612,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "1044860453592207069"
+              "version": "0.34.44.8038",
+              "templateHash": "10770394726791174694"
             },
             "name": "Azure NetApp Files Snapshot Policy",
             "description": "This module deploys a Snapshot Policy for an Azure NetApp File."
@@ -1872,10 +1868,7 @@
                 "hourlySchedule": "[parameters('hourlySchedule')]",
                 "monthlySchedule": "[parameters('monthlySchedule')]",
                 "weeklySchedule": "[parameters('weeklySchedule')]"
-              },
-              "dependsOn": [
-                "netAppAccount"
-              ]
+              }
             }
           },
           "outputs": {
@@ -1935,8 +1928,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "20164335461414036"
+              "version": "0.34.44.8038",
+              "templateHash": "14413490968843992443"
             },
             "name": "Azure NetApp Files Volume Backup Vault",
             "description": "This module deploys a NetApp Files Backup Vault."
@@ -2029,10 +2022,7 @@
               "apiVersion": "2025-01-01",
               "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
               "location": "[parameters('location')]",
-              "properties": {},
-              "dependsOn": [
-                "netAppAccount"
-              ]
+              "properties": {}
             },
             "backupVault_backups": {
               "copy": {
@@ -2077,8 +2067,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "8317801660539599309"
+                      "version": "0.34.44.8038",
+                      "templateHash": "15429195500404839384"
                     },
                     "name": "Azure NetApp Files Volume Backup",
                     "description": "This module deploys a backup of a NetApp Files Volume."
@@ -2135,28 +2125,19 @@
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
                       "apiVersion": "2025-01-01",
-                      "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]",
-                      "dependsOn": [
-                        "netAppAccount::remoteCapacityPool"
-                      ]
+                      "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
                     },
                     "netAppAccount::backupVault": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
                       "apiVersion": "2025-01-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]",
-                      "dependsOn": [
-                        "netAppAccount"
-                      ]
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]"
                     },
                     "netAppAccount::remoteCapacityPool": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
                       "apiVersion": "2025-01-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
-                      "dependsOn": [
-                        "netAppAccount"
-                      ]
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
                     },
                     "netAppAccount": {
                       "existing": true,
@@ -2172,11 +2153,7 @@
                         "label": "[parameters('label')]",
                         "snapshotName": "[parameters('snapshotName')]",
                         "volumeResourceId": "[resourceId('Microsoft.NetApp/netAppAccounts/capacityPools/volumes', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
-                      },
-                      "dependsOn": [
-                        "netAppAccount::backupVault",
-                        "netAppAccount::remoteCapacityPool"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -2205,8 +2182,7 @@
                 }
               },
               "dependsOn": [
-                "backupVault",
-                "netAppAccount"
+                "backupVault"
               ]
             }
           },
@@ -2301,8 +2277,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "10125203863232929784"
+              "version": "0.34.44.8038",
+              "templateHash": "4385691850958293637"
             },
             "name": "Azure NetApp Files Capacity Pools",
             "description": "This module deploys an Azure NetApp Files Capacity Pool."
@@ -2994,10 +2970,7 @@
                 "qosType": "[parameters('qosType')]",
                 "coolAccess": "[parameters('coolAccess')]",
                 "encryptionType": "[parameters('encryptionType')]"
-              },
-              "dependsOn": [
-                "netAppAccount"
-              ]
+              }
             },
             "capacityPool_roleAssignments": {
               "copy": {
@@ -3123,8 +3096,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "4754938124013776833"
+                      "version": "0.34.44.8038",
+                      "templateHash": "107014526168729045"
                     },
                     "name": "Azure NetApp Files Capacity Pool Volumes",
                     "description": "This module deploys an Azure NetApp Files Capacity Pool Volume."
@@ -3703,40 +3676,28 @@
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
                       "apiVersion": "2025-01-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
-                      "dependsOn": [
-                        "netAppAccount"
-                      ]
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
                     },
                     "netAppAccount::backupVault": {
                       "condition": "[not(empty(tryGet(parameters('dataProtection'), 'backup')))]",
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
                       "apiVersion": "2025-01-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))]",
-                      "dependsOn": [
-                        "netAppAccount"
-                      ]
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))]"
                     },
                     "netAppAccount::backupPolicy": {
                       "condition": "[not(empty(tryGet(parameters('dataProtection'), 'backup')))]",
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/backupPolicies",
                       "apiVersion": "2025-01-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName'))]",
-                      "dependsOn": [
-                        "netAppAccount"
-                      ]
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName'))]"
                     },
                     "netAppAccount::snapshotPolicy": {
                       "condition": "[not(empty(tryGet(parameters('dataProtection'), 'snapshot')))]",
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/snapshotPolicies",
                       "apiVersion": "2025-01-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))]",
-                      "dependsOn": [
-                        "netAppAccount"
-                      ]
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))]"
                     },
                     "remoteNetAppAccount::remoteCapacityPool::remoteVolume": {
                       "condition": "[and(and(and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName')))), and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteCapacityPoolName'), parameters('capacityPoolName'))))), not(empty(tryGet(parameters('dataProtection'), 'replication'))))]",
@@ -3745,10 +3706,7 @@
                       "apiVersion": "2025-01-01",
                       "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
                       "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
-                      "name": "[format('{0}/{1}/{2}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10], last(split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')))]",
-                      "dependsOn": [
-                        "remoteNetAppAccount::remoteCapacityPool"
-                      ]
+                      "name": "[format('{0}/{1}/{2}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10], last(split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')))]"
                     },
                     "remoteNetAppAccount::remoteCapacityPool": {
                       "condition": "[and(and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteNetAppName'), parameters('netAppAccountName')))), and(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'))), not(equals(variables('remoteCapacityPoolName'), parameters('capacityPoolName')))))]",
@@ -3757,10 +3715,7 @@
                       "apiVersion": "2025-01-01",
                       "subscriptionId": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[2]]",
                       "resourceGroup": "[split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[4]]",
-                      "name": "[format('{0}/{1}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10])]",
-                      "dependsOn": [
-                        "remoteNetAppAccount"
-                      ]
+                      "name": "[format('{0}/{1}', split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[8], split(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId'), '/')[10])]"
                     },
                     "vnet::subnet": {
                       "existing": true,
@@ -3768,10 +3723,7 @@
                       "apiVersion": "2024-03-01",
                       "subscriptionId": "[split(parameters('subnetResourceId'), '/')[2]]",
                       "resourceGroup": "[split(parameters('subnetResourceId'), '/')[4]]",
-                      "name": "[format('{0}/{1}', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/')))]",
-                      "dependsOn": [
-                        "vnet"
-                      ]
+                      "name": "[format('{0}/{1}', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/')))]"
                     },
                     "netAppAccount": {
                       "existing": true,
@@ -3811,12 +3763,7 @@
                       "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('name'))]",
                       "location": "[parameters('location')]",
                       "properties": "[shallowMerge(createArray(createObject('coolAccess', parameters('coolAccess'), 'coolAccessRetrievalPolicy', parameters('coolAccessRetrievalPolicy'), 'coolnessPeriod', parameters('coolnessPeriod'), 'securityStyle', parameters('securityStyle'), 'unixPermissions', parameters('unixPermissions'), 'encryptionKeySource', parameters('encryptionKeySource')), if(not(equals(parameters('encryptionKeySource'), 'Microsoft.NetApp')), createObject('keyVaultPrivateEndpointResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('keyVaultPrivateEndpointResourceId'), '/')[2], split(parameters('keyVaultPrivateEndpointResourceId'), '/')[4]), 'Microsoft.Network/privateEndpoints', last(split(parameters('keyVaultPrivateEndpointResourceId'), '/')))), createObject()), if(not(empty(parameters('volumeType'))), createObject('volumeType', parameters('volumeType')), createObject()), createObject('dataProtection', if(not(empty(parameters('dataProtection'))), createObject('replication', if(not(empty(tryGet(parameters('dataProtection'), 'replication'))), shallowMerge(createArray(createObject('endpointType', tryGet(parameters('dataProtection'), 'replication', 'endpointType'), 'remoteVolumeRegion', if(not(empty(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'))), tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeRegion'), null()), 'remoteVolumeResourceId', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remoteVolumeResourceId')), if(equals(tryGet(tryGet(parameters('dataProtection'), 'replication'), 'endpointType'), 'dst'), createObject('replicationSchedule', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'replicationSchedule')), createObject()), if(equals(parameters('volumeType'), 'Migration'), createObject('remotePath', tryGet(tryGet(parameters('dataProtection'), 'replication'), 'remotePath')), createObject()))), null()), 'backup', if(not(empty(tryGet(parameters('dataProtection'), 'backup'))), createObject('backupPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/backupPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupPolicyName')), 'policyEnforced', coalesce(tryGet(parameters('dataProtection'), 'backup', 'policyEnforced'), false()), 'backupVaultId', resourceId('Microsoft.NetApp/netAppAccounts/backupVaults', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'backup', 'backupVaultName'))), null()), 'snapshot', if(not(empty(tryGet(parameters('dataProtection'), 'snapshot'))), createObject('snapshotPolicyId', resourceId('Microsoft.NetApp/netAppAccounts/snapshotPolicies', parameters('netAppAccountName'), tryGet(parameters('dataProtection'), 'snapshot', 'snapshotPolicyName'))), null())), null()), 'networkFeatures', parameters('networkFeatures'), 'serviceLevel', parameters('serviceLevel'), 'creationToken', parameters('creationToken'), 'usageThreshold', parameters('usageThreshold'), 'protocolTypes', parameters('protocolTypes'), 'subnetId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('subnetResourceId'), '/')[2], split(parameters('subnetResourceId'), '/')[4]), 'Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetResourceId'), '/')[8], last(split(parameters('subnetResourceId'), '/'))), 'exportPolicy', coalesce(parameters('exportPolicy'), createObject('rules', createArray())), 'smbContinuouslyAvailable', parameters('smbContinuouslyAvailable'), 'smbEncryption', parameters('smbEncryption'), 'smbNonBrowsable', parameters('smbNonBrowsable'), 'kerberosEnabled', parameters('kerberosEnabled'))))]",
-                      "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]",
-                      "dependsOn": [
-                        "netAppAccount::capacityPool",
-                        "keyVaultPrivateEndpoint",
-                        "vnet"
-                      ]
+                      "zones": "[if(not(equals(parameters('zone'), 0)), createArray(string(parameters('zone'))), null())]"
                     },
                     "volume_roleAssignments": {
                       "copy": {
@@ -3874,8 +3821,7 @@
                 }
               },
               "dependsOn": [
-                "capacityPool",
-                "netAppAccount"
+                "capacityPool"
               ]
             }
           },
@@ -3962,8 +3908,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "20164335461414036"
+              "version": "0.34.44.8038",
+              "templateHash": "14413490968843992443"
             },
             "name": "Azure NetApp Files Volume Backup Vault",
             "description": "This module deploys a NetApp Files Backup Vault."
@@ -4056,10 +4002,7 @@
               "apiVersion": "2025-01-01",
               "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
               "location": "[parameters('location')]",
-              "properties": {},
-              "dependsOn": [
-                "netAppAccount"
-              ]
+              "properties": {}
             },
             "backupVault_backups": {
               "copy": {
@@ -4104,8 +4047,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "8317801660539599309"
+                      "version": "0.34.44.8038",
+                      "templateHash": "15429195500404839384"
                     },
                     "name": "Azure NetApp Files Volume Backup",
                     "description": "This module deploys a backup of a NetApp Files Volume."
@@ -4162,28 +4105,19 @@
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
                       "apiVersion": "2025-01-01",
-                      "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]",
-                      "dependsOn": [
-                        "netAppAccount::remoteCapacityPool"
-                      ]
+                      "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
                     },
                     "netAppAccount::backupVault": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/backupVaults",
                       "apiVersion": "2025-01-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]",
-                      "dependsOn": [
-                        "netAppAccount"
-                      ]
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('backupVaultName'))]"
                     },
                     "netAppAccount::remoteCapacityPool": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
                       "apiVersion": "2025-01-01",
-                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
-                      "dependsOn": [
-                        "netAppAccount"
-                      ]
+                      "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]"
                     },
                     "netAppAccount": {
                       "existing": true,
@@ -4199,11 +4133,7 @@
                         "label": "[parameters('label')]",
                         "snapshotName": "[parameters('snapshotName')]",
                         "volumeResourceId": "[resourceId('Microsoft.NetApp/netAppAccounts/capacityPools/volumes', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('volumeName'))]"
-                      },
-                      "dependsOn": [
-                        "netAppAccount::backupVault",
-                        "netAppAccount::remoteCapacityPool"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -4232,8 +4162,7 @@
                 }
               },
               "dependsOn": [
-                "backupVault",
-                "netAppAccount"
+                "backupVault"
               ]
             }
           },

--- a/avm/res/net-app/net-app-account/snapshot-policies/README.md
+++ b/avm/res/net-app/net-app-account/snapshot-policies/README.md
@@ -12,7 +12,7 @@ This module deploys a Snapshot Policy for an Azure NetApp File.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.NetApp/netAppAccounts/snapshotPolicies` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2024-09-01/netAppAccounts/snapshotPolicies) |
+| `Microsoft.NetApp/netAppAccounts/snapshotPolicies` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2025-01-01/netAppAccounts/snapshotPolicies) |
 
 ## Parameters
 

--- a/avm/res/net-app/net-app-account/snapshot-policies/main.bicep
+++ b/avm/res/net-app/net-app-account/snapshot-policies/main.bicep
@@ -25,11 +25,11 @@ param weeklySchedule weeklyScheduleType?
 @description('Optional. Indicates whether the snapshot policy is enabled.')
 param snapEnabled bool = false
 
-resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2024-09-01' existing = {
+resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2025-01-01' existing = {
   name: netAppAccountName
 }
 
-resource snapshotPolicies 'Microsoft.NetApp/netAppAccounts/snapshotPolicies@2024-09-01' = {
+resource snapshotPolicies 'Microsoft.NetApp/netAppAccounts/snapshotPolicies@2025-01-01' = {
   name: name
   parent: netAppAccount
   location: location

--- a/avm/res/net-app/net-app-account/snapshot-policies/main.json
+++ b/avm/res/net-app/net-app-account/snapshot-policies/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "5076757961005626576"
+      "version": "0.29.47.4906",
+      "templateHash": "1044860453592207069"
     },
     "name": "Azure NetApp Files Snapshot Policy",
     "description": "This module deploys a Snapshot Policy for an Azure NetApp File."
@@ -247,12 +247,12 @@
     "netAppAccount": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "name": "[parameters('netAppAccountName')]"
     },
     "snapshotPolicies": {
       "type": "Microsoft.NetApp/netAppAccounts/snapshotPolicies",
-      "apiVersion": "2024-09-01",
+      "apiVersion": "2025-01-01",
       "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "properties": {
@@ -261,7 +261,10 @@
         "hourlySchedule": "[parameters('hourlySchedule')]",
         "monthlySchedule": "[parameters('monthlySchedule')]",
         "weeklySchedule": "[parameters('weeklySchedule')]"
-      }
+      },
+      "dependsOn": [
+        "netAppAccount"
+      ]
     }
   },
   "outputs": {

--- a/avm/res/net-app/net-app-account/snapshot-policies/main.json
+++ b/avm/res/net-app/net-app-account/snapshot-policies/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "1044860453592207069"
+      "version": "0.34.44.8038",
+      "templateHash": "10770394726791174694"
     },
     "name": "Azure NetApp Files Snapshot Policy",
     "description": "This module deploys a Snapshot Policy for an Azure NetApp File."
@@ -261,10 +261,7 @@
         "hourlySchedule": "[parameters('hourlySchedule')]",
         "monthlySchedule": "[parameters('monthlySchedule')]",
         "weeklySchedule": "[parameters('weeklySchedule')]"
-      },
-      "dependsOn": [
-        "netAppAccount"
-      ]
+      }
     }
   },
   "outputs": {


### PR DESCRIPTION
## Description

- Fixes exportPolicy{rules[]} for CIFS Volumes
- Update to the latest ANF API (2025-01-01) for additional ANF Migration Tool features and replicationId bug fix
- replicationSchedule - add Ternary so only gets used with 'dst' endpointType
- remotePath - add Ternary so only gets used with ANF Tool 'Migration' volumeType

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.net-app.net-app-account](https://github.com/bobmclane999/bicep-registry-modules/actions/workflows/avm.res.net-app.net-app-account.yml/badge.svg)](https://github.com/bobmclane999/bicep-registry-modules/actions/workflows/avm.res.net-app.net-app-account.yml)         |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
