### PR TITLE
feat: Add output with IP addresses to `avm/res/network/network-interface`

### DIFF
--- a/avm/res/network/network-interface/README.md
+++ b/avm/res/network/network-interface/README.md
@@ -134,7 +134,7 @@ module networkInterface 'br/public:avm/res/network/network-interface:<version>' 
             id: '<id>'
           }
         ]
-        name: 'ipconfig01'
+        name: 'myIpconfig01'
         subnetResourceId: '<subnetResourceId>'
       }
       {
@@ -143,6 +143,7 @@ module networkInterface 'br/public:avm/res/network/network-interface:<version>' 
             id: '<id>'
           }
         ]
+        publicIPAddressResourceId: '<publicIPAddressResourceId>'
         subnetResourceId: '<subnetResourceId>'
       }
     ]
@@ -216,7 +217,7 @@ module networkInterface 'br/public:avm/res/network/network-interface:<version>' 
               "id": "<id>"
             }
           ],
-          "name": "ipconfig01",
+          "name": "myIpconfig01",
           "subnetResourceId": "<subnetResourceId>"
         },
         {
@@ -225,6 +226,7 @@ module networkInterface 'br/public:avm/res/network/network-interface:<version>' 
               "id": "<id>"
             }
           ],
+          "publicIPAddressResourceId": "<publicIPAddressResourceId>",
           "subnetResourceId": "<subnetResourceId>"
         }
       ]
@@ -308,7 +310,7 @@ param ipConfigurations = [
         id: '<id>'
       }
     ]
-    name: 'ipconfig01'
+    name: 'myIpconfig01'
     subnetResourceId: '<subnetResourceId>'
   }
   {
@@ -317,6 +319,7 @@ param ipConfigurations = [
         id: '<id>'
       }
     ]
+    publicIPAddressResourceId: '<publicIPAddressResourceId>'
     subnetResourceId: '<subnetResourceId>'
   }
 ]
@@ -1413,6 +1416,7 @@ Resource tags.
 
 | Output | Type | Description |
 | :-- | :-- | :-- |
+| `ipConfigurations` | array | The list of IP configurations of the network interface. |
 | `location` | string | The location the resource was deployed into. |
 | `name` | string | The name of the deployed resource. |
 | `resourceGroupName` | string | The resource group of the deployed resource. |

--- a/avm/res/network/network-interface/README.md
+++ b/avm/res/network/network-interface/README.md
@@ -146,6 +146,12 @@ module networkInterface 'br/public:avm/res/network/network-interface:<version>' 
         publicIPAddressResourceId: '<publicIPAddressResourceId>'
         subnetResourceId: '<subnetResourceId>'
       }
+      {
+        name: 'myIpV6Config'
+        privateIPAddressVersion: 'IPv6'
+        publicIPAddressResourceId: '<publicIPAddressResourceId>'
+        subnetResourceId: '<subnetResourceId>'
+      }
     ]
     name: 'nnimax001'
     // Non-required parameters
@@ -226,6 +232,12 @@ module networkInterface 'br/public:avm/res/network/network-interface:<version>' 
               "id": "<id>"
             }
           ],
+          "publicIPAddressResourceId": "<publicIPAddressResourceId>",
+          "subnetResourceId": "<subnetResourceId>"
+        },
+        {
+          "name": "myIpV6Config",
+          "privateIPAddressVersion": "IPv6",
           "publicIPAddressResourceId": "<publicIPAddressResourceId>",
           "subnetResourceId": "<subnetResourceId>"
         }
@@ -319,6 +331,12 @@ param ipConfigurations = [
         id: '<id>'
       }
     ]
+    publicIPAddressResourceId: '<publicIPAddressResourceId>'
+    subnetResourceId: '<subnetResourceId>'
+  }
+  {
+    name: 'myIpV6Config'
+    privateIPAddressVersion: 'IPv6'
     publicIPAddressResourceId: '<publicIPAddressResourceId>'
     subnetResourceId: '<subnetResourceId>'
   }

--- a/avm/res/network/network-interface/main.bicep
+++ b/avm/res/network/network-interface/main.bicep
@@ -102,6 +102,13 @@ var formattedRoleAssignments = [
   })
 ]
 
+resource publicIp 'Microsoft.Network/publicIPAddresses@2024-05-01' existing = [
+  for (ipConfiguration, index) in ipConfigurations: if (contains(ipConfiguration, 'publicIPAddressResourceId') && (ipConfiguration.?publicIPAddressResourceId != null)) {
+    name: last(split(ipConfiguration.?publicIPAddressResourceId ?? '', '/'))
+    scope: resourceGroup(split(ipConfiguration.?publicIPAddressResourceId ?? '', '/')[4])
+  }
+]
+
 #disable-next-line no-deployments-resources
 resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.network-networkinterface.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
@@ -236,6 +243,17 @@ output resourceGroupName string = resourceGroup().name
 
 @description('The location the resource was deployed into.')
 output location string = networkInterface.location
+
+@description('The list of IP configurations of the network interface.')
+output ipConfigurations networkInterfaceIPConfigurationOutputType[] = [
+  for (ipConfiguration, index) in ipConfigurations: {
+    name: networkInterface.properties.ipConfigurations[index].name
+    privateIP: networkInterface.properties.ipConfigurations[index].properties.?privateIPAddress ?? ''
+    publicIP: (contains(ipConfiguration, 'publicIPAddressResourceId') && (ipConfiguration.?publicIPAddressResourceId != null))
+      ? publicIp[index].properties.ipAddress ?? ''
+      : ''
+  }
+]
 
 // ================ //
 // Definitions      //
@@ -393,4 +411,16 @@ type virtualNetworkTapType = {
 
   @description('Optional. Tags of the virtual network tap.')
   tags: object?
+}
+
+@export()
+type networkInterfaceIPConfigurationOutputType = {
+  @description('The name of the IP configuration.')
+  name: string
+
+  @description('The private IP address.')
+  privateIP: string?
+
+  @description('The public IP address.')
+  publicIP: string?
 }

--- a/avm/res/network/network-interface/main.json
+++ b/avm/res/network/network-interface/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "226424885599603100"
+      "templateHash": "15946066273946929527"
     },
     "name": "Network Interface",
     "description": "This module deploys a Network Interface."
@@ -405,6 +405,34 @@
         "description": "The type for the virtual network tap."
       }
     },
+    "networkInterfaceIPConfigurationOutputType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "The name of the IP configuration."
+          }
+        },
+        "privateIP": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "The private IP address."
+          }
+        },
+        "publicIP": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "The public IP address."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true
+      }
+    },
     "diagnosticSettingFullType": {
       "type": "object",
       "properties": {
@@ -782,6 +810,18 @@
     }
   },
   "resources": {
+    "publicIp": {
+      "copy": {
+        "name": "publicIp",
+        "count": "[length(parameters('ipConfigurations'))]"
+      },
+      "condition": "[and(contains(parameters('ipConfigurations')[copyIndex()], 'publicIPAddressResourceId'), not(equals(tryGet(parameters('ipConfigurations')[copyIndex()], 'publicIPAddressResourceId'), null())))]",
+      "existing": true,
+      "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2024-05-01",
+      "resourceGroup": "[split(coalesce(tryGet(parameters('ipConfigurations')[copyIndex()], 'publicIPAddressResourceId'), ''), '/')[4]]",
+      "name": "[last(split(coalesce(tryGet(parameters('ipConfigurations')[copyIndex()], 'publicIPAddressResourceId'), ''), '/'))]"
+    },
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
@@ -940,6 +980,23 @@
         "description": "The location the resource was deployed into."
       },
       "value": "[reference('networkInterface', '2024-05-01', 'full').location]"
+    },
+    "ipConfigurations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/networkInterfaceIPConfigurationOutputType"
+      },
+      "metadata": {
+        "description": "The list of IP configurations of the network interface."
+      },
+      "copy": {
+        "count": "[length(parameters('ipConfigurations'))]",
+        "input": {
+          "name": "[reference('networkInterface').ipConfigurations[copyIndex()].name]",
+          "privateIP": "[coalesce(tryGet(reference('networkInterface').ipConfigurations[copyIndex()].properties, 'privateIPAddress'), '')]",
+          "publicIP": "[if(and(contains(parameters('ipConfigurations')[copyIndex()], 'publicIPAddressResourceId'), not(equals(tryGet(parameters('ipConfigurations')[copyIndex()], 'publicIPAddressResourceId'), null()))), coalesce(reference(format('publicIp[{0}]', copyIndex())).ipAddress, ''), '')]"
+        }
+      }
     }
   }
 }

--- a/avm/res/network/network-interface/tests/e2e/max/dependencies.bicep
+++ b/avm/res/network/network-interface/tests/e2e/max/dependencies.bicep
@@ -79,42 +79,41 @@ resource loadBalancer 'Microsoft.Network/loadBalancers@2024-05-01' = {
   resource backendPool 'backendAddressPools@2024-05-01' = {
     name: 'default'
   }
-}
 
-resource inboundNatRule 'Microsoft.Network/loadBalancers/inboundNatRules@2024-05-01' = {
-  name: 'inboundNatRule1'
-  properties: {
-    frontendPort: 443
-    backendPort: 443
-    enableFloatingIP: false
-    enableTcpReset: false
-    frontendIPConfiguration: {
-      id: loadBalancer.properties.frontendIPConfigurations[0].id
+  resource inboundNatRule1 'inboundNatRules@2024-05-01' = {
+    name: 'inboundNatRule1'
+    properties: {
+      frontendPort: 443
+      backendPort: 443
+      enableFloatingIP: false
+      enableTcpReset: false
+      frontendIPConfiguration: {
+        id: loadBalancer.properties.frontendIPConfigurations[0].id
+      }
+      idleTimeoutInMinutes: 4
+      protocol: 'Tcp'
     }
-    idleTimeoutInMinutes: 4
-    protocol: 'Tcp'
+    dependsOn: [
+      backendPool
+    ]
   }
-  parent: loadBalancer
-  dependsOn: [
-    loadBalancer::backendPool
-  ]
-}
 
-resource inboundNatRule2 'Microsoft.Network/loadBalancers/inboundNatRules@2024-05-01' = {
-  name: 'inboundNatRule2'
-  properties: {
-    frontendPort: 3389
-    backendPort: 3389
-    frontendIPConfiguration: {
-      id: loadBalancer.properties.frontendIPConfigurations[0].id
+  resource inboundNatRule2 'inboundNatRules@2024-05-01' = {
+    name: 'inboundNatRule2'
+    properties: {
+      frontendPort: 3389
+      backendPort: 3389
+      frontendIPConfiguration: {
+        id: loadBalancer.properties.frontendIPConfigurations[0].id
+      }
+      idleTimeoutInMinutes: 4
+      protocol: 'Tcp'
     }
-    idleTimeoutInMinutes: 4
-    protocol: 'Tcp'
+    dependsOn: [
+      backendPool
+      inboundNatRule1
+    ]
   }
-  parent: loadBalancer
-  dependsOn: [
-    inboundNatRule
-  ]
 }
 
 resource publicIPv4 'Microsoft.Network/publicIPAddresses@2024-05-01' = {

--- a/avm/res/network/network-interface/tests/e2e/max/dependencies.bicep
+++ b/avm/res/network/network-interface/tests/e2e/max/dependencies.bicep
@@ -13,6 +13,9 @@ param applicationSecurityGroupName string
 @description('Required. The name of the Load Balancer to create.')
 param loadBalancerName string
 
+@description('Required. The name of the Public IP to create.')
+param publicIPName string
+
 var addressPrefix = '10.0.0.0/16'
 
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
@@ -84,6 +87,9 @@ resource inboundNatRule 'Microsoft.Network/loadBalancers/inboundNatRules@2024-05
     protocol: 'Tcp'
   }
   parent: loadBalancer
+  dependsOn: [
+    loadBalancer::backendPool
+  ]
 }
 
 resource inboundNatRule2 'Microsoft.Network/loadBalancers/inboundNatRules@2024-05-01' = {
@@ -98,6 +104,26 @@ resource inboundNatRule2 'Microsoft.Network/loadBalancers/inboundNatRules@2024-0
     protocol: 'Tcp'
   }
   parent: loadBalancer
+  dependsOn: [
+    inboundNatRule
+  ]
+}
+
+resource publicIP 'Microsoft.Network/publicIPAddresses@2024-05-01' = {
+  name: publicIPName
+  location: location
+  sku: {
+    name: 'Standard'
+    tier: 'Regional'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+  }
+  zones: [
+    '1'
+    '2'
+    '3'
+  ]
 }
 
 @description('The resource ID of the created Virtual Network Subnet.')
@@ -111,3 +137,6 @@ output applicationSecurityGroupResourceId string = applicationSecurityGroup.id
 
 @description('The resource ID of the created Load Balancer Backend Pool.')
 output loadBalancerBackendPoolResourceId string = loadBalancer::backendPool.id
+
+@description('The resource ID of the created Public IP.')
+output publicIPResourceId string = publicIP.id

--- a/avm/res/network/network-interface/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/network-interface/tests/e2e/max/main.test.bicep
@@ -40,6 +40,7 @@ module nestedDependencies 'dependencies.bicep' = {
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
     applicationSecurityGroupName: 'dep-${namePrefix}-asg-${serviceShort}'
     loadBalancerName: 'dep-${namePrefix}-lb-${serviceShort}'
+    publicIPName: 'dep-${namePrefix}-pip-${serviceShort}'
   }
 }
 
@@ -81,7 +82,7 @@ module testDeployment '../../../main.bicep' = [
               id: nestedDependencies.outputs.loadBalancerBackendPoolResourceId
             }
           ]
-          name: 'ipconfig01'
+          name: 'myIpconfig01'
           subnetResourceId: nestedDependencies.outputs.subnetResourceId
         }
         {
@@ -91,6 +92,7 @@ module testDeployment '../../../main.bicep' = [
               id: nestedDependencies.outputs.applicationSecurityGroupResourceId
             }
           ]
+          publicIPAddressResourceId: nestedDependencies.outputs.publicIPResourceId
         }
       ]
       diagnosticSettings: [

--- a/avm/res/network/network-interface/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/network-interface/tests/e2e/max/main.test.bicep
@@ -40,7 +40,8 @@ module nestedDependencies 'dependencies.bicep' = {
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
     applicationSecurityGroupName: 'dep-${namePrefix}-asg-${serviceShort}'
     loadBalancerName: 'dep-${namePrefix}-lb-${serviceShort}'
-    publicIPName: 'dep-${namePrefix}-pip-${serviceShort}'
+    publicIPNameV4: 'dep-${namePrefix}-pipv4-${serviceShort}'
+    publicIPNameV6: 'dep-${namePrefix}-pipv6-${serviceShort}'
   }
 }
 
@@ -92,7 +93,13 @@ module testDeployment '../../../main.bicep' = [
               id: nestedDependencies.outputs.applicationSecurityGroupResourceId
             }
           ]
-          publicIPAddressResourceId: nestedDependencies.outputs.publicIPResourceId
+          publicIPAddressResourceId: nestedDependencies.outputs.publicIPv4ResourceId
+        }
+        {
+          name: 'myIpV6Config'
+          subnetResourceId: nestedDependencies.outputs.subnetResourceId
+          publicIPAddressResourceId: nestedDependencies.outputs.publicIPv6ResourceId
+          privateIPAddressVersion: 'IPv6'
         }
       ]
       diagnosticSettings: [

--- a/avm/res/network/network-interface/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/network/network-interface/tests/e2e/waf-aligned/dependencies.bicep
@@ -60,36 +60,41 @@ resource loadBalancer 'Microsoft.Network/loadBalancers@2024-05-01' = {
   resource backendPool 'backendAddressPools@2024-05-01' = {
     name: 'default'
   }
-}
 
-resource inboundNatRule 'Microsoft.Network/loadBalancers/inboundNatRules@2024-05-01' = {
-  name: 'inboundNatRule1'
-  properties: {
-    frontendPort: 443
-    backendPort: 443
-    enableFloatingIP: false
-    enableTcpReset: false
-    frontendIPConfiguration: {
-      id: loadBalancer.properties.frontendIPConfigurations[0].id
+  resource inboundNatRule1 'inboundNatRules@2024-05-01' = {
+    name: 'inboundNatRule1'
+    properties: {
+      frontendPort: 443
+      backendPort: 443
+      enableFloatingIP: false
+      enableTcpReset: false
+      frontendIPConfiguration: {
+        id: loadBalancer.properties.frontendIPConfigurations[0].id
+      }
+      idleTimeoutInMinutes: 4
+      protocol: 'Tcp'
     }
-    idleTimeoutInMinutes: 4
-    protocol: 'Tcp'
+    dependsOn: [
+      backendPool
+    ]
   }
-  parent: loadBalancer
-}
 
-resource inboundNatRule2 'Microsoft.Network/loadBalancers/inboundNatRules@2024-05-01' = {
-  name: 'inboundNatRule2'
-  properties: {
-    frontendPort: 3389
-    backendPort: 3389
-    frontendIPConfiguration: {
-      id: loadBalancer.properties.frontendIPConfigurations[0].id
+  resource inboundNatRule2 'inboundNatRules@2024-05-01' = {
+    name: 'inboundNatRule2'
+    properties: {
+      frontendPort: 3389
+      backendPort: 3389
+      frontendIPConfiguration: {
+        id: loadBalancer.properties.frontendIPConfigurations[0].id
+      }
+      idleTimeoutInMinutes: 4
+      protocol: 'Tcp'
     }
-    idleTimeoutInMinutes: 4
-    protocol: 'Tcp'
+    dependsOn: [
+      backendPool
+      inboundNatRule1
+    ]
   }
-  parent: loadBalancer
 }
 
 @description('The resource ID of the created Virtual Network Subnet.')


### PR DESCRIPTION
## Description

- add output `ipConfigurations` containing IP addresses of the network interface
- updated `max` test case to
  - also use a non-default ipConfiguration name
  - include tests with public IPv4 and PublicIPv6
  - fixed dependencies deployment
    - prevent Load balancer errors "another operation in progress"

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

fixes #4276

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.network.network-interface](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.network.network-interface.yml/badge.svg?branch=users%2Fkrbar%2FnicOutputs)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.network.network-interface.yml)     |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
