### PR TITLE
fix: CI - Fixed publish from tag token replacment check

### DIFF
--- a/utilities/pipelines/platform/Publish-ModuleFromTagToPBR.ps1
+++ b/utilities/pipelines/platform/Publish-ModuleFromTagToPBR.ps1
@@ -64,7 +64,7 @@ function Publish-ModuleFromTagToPBR {
     $templateContent = Get-Content -Path $moduleBicepFilePath
     $incorrectLines = @()
     for ($index = 0; $index -lt $templateContent.Count; $index++) {
-        if ($templateContent[$index] -match '-..--..-') {
+        if ($templateContent[$index] -match '\-\.\.-\-\.\.\-') {
             $incorrectLines += ('You have the token [{0}] in line [{1}] of file [{2}]. Please seek advice from the AVM team.' -f $matches[0], ($index + 1), $moduleBicepFilePath)
         }
     }


### PR DESCRIPTION
## Description

To token check is correct in the classic logic, but was not updated in the publish from tag one.

Original fix in main publishing logic: https://github.com/Azure/bicep-registry-modules/pull/1276

E.g. 
https://github.com/Azure/bicep-registry-modules/blob/df9ad62104e847023441366181c34a1c15daecbc/avm/ptn/aca-lza/hosting-environment/main.bicep#L279-L281

is incorrectly picked up on as the regex is incorret.

Example of the correct implementation
https://github.com/Azure/bicep-registry-modules/blob/df9ad62104e847023441366181c34a1c15daecbc/utilities/pipelines/publish/Publish-ModuleFromPathToPBR.ps1#L95

Example of the current, incorrect implementation
https://github.com/Azure/bicep-registry-modules/blob/df9ad62104e847023441366181c34a1c15daecbc/utilities/pipelines/platform/Publish-ModuleFromTagToPBR.ps1#L67

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
