### PR TITLE
feat: Accounting for upcoming breaking change for `bicep publish` parameter

### DIFF
--- a/utilities/pipelines/platform/Publish-ModuleFromTagToPBR.ps1
+++ b/utilities/pipelines/platform/Publish-ModuleFromTagToPBR.ps1
@@ -80,7 +80,7 @@ function Publish-ModuleFromTagToPBR {
     $publishInput = @(
         $moduleBicepFilePath
         '--target', ('br:{0}/public/bicep/{1}:{2}' -f $plainPublicRegistryServer, $moduleRelativeFolderPath, $targetVersion)
-        '--documentationUri', $documentationUri
+        '--documentation-uri', $documentationUri
         '--with-source'
         '--force'
     )


### PR DESCRIPTION
## Description

Addressing _"DEPRECATED: The parameter --documentationUri is deprecated and will be removed in a future version of Bicep CLI. Use --documentation-uri instead"_

This is already accounted for in the main publish script here
https://github.com/Azure/bicep-registry-modules/blob/e168b2aa60f147f29b6bd73eb903a3c152fea7f7/utilities/pipelines/publish/Publish-ModuleFromPathToPBR.ps1#L111

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
