### PR TITLE
fix: Remove whitespace from database name at submodule deployment names at `avm/res/sql/server`

### DIFF
--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -246,7 +246,7 @@ resource database_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021
 ]
 
 module database_backupShortTermRetentionPolicy 'backup-short-term-retention-policy/main.bicep' = if (!empty(backupShortTermRetentionPolicy)) {
-  name: '${uniqueString(deployment().name, location)}-${replace(name, ' ', '_')}-shBakRetPol'
+  name: '${uniqueString(deployment().name, location)}-shBakRetPol'
   params: {
     serverName: serverName
     databaseName: database.name
@@ -256,7 +256,7 @@ module database_backupShortTermRetentionPolicy 'backup-short-term-retention-poli
 }
 
 module database_backupLongTermRetentionPolicy 'backup-long-term-retention-policy/main.bicep' = if (!empty(backupLongTermRetentionPolicy)) {
-  name: '${uniqueString(deployment().name, location)}-${replace(name, ' ', '_')}-lgBakRetPol'
+  name: '${uniqueString(deployment().name, location)}-lgBakRetPol'
   params: {
     serverName: serverName
     databaseName: database.name

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -218,7 +218,7 @@ resource database 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
 
 resource database_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = [
   for (diagnosticSetting, index) in (diagnosticSettings ?? []): {
-    name: diagnosticSetting.?name ?? '${name}-diagnosticSettings'
+    name: diagnosticSetting.?name ?? '${replace(name, ' ', '_')}-diagnosticSettings'
     properties: {
       storageAccountId: diagnosticSetting.?storageAccountResourceId
       workspaceId: diagnosticSetting.?workspaceResourceId
@@ -246,7 +246,7 @@ resource database_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021
 ]
 
 module database_backupShortTermRetentionPolicy 'backup-short-term-retention-policy/main.bicep' = if (!empty(backupShortTermRetentionPolicy)) {
-  name: '${uniqueString(deployment().name, location)}-${name}-shBakRetPol'
+  name: '${uniqueString(deployment().name, location)}-${replace(name, ' ', '_')}-shBakRetPol'
   params: {
     serverName: serverName
     databaseName: database.name
@@ -256,7 +256,7 @@ module database_backupShortTermRetentionPolicy 'backup-short-term-retention-poli
 }
 
 module database_backupLongTermRetentionPolicy 'backup-long-term-retention-policy/main.bicep' = if (!empty(backupLongTermRetentionPolicy)) {
-  name: '${uniqueString(deployment().name, location)}-${name}-lgBakRetPol'
+  name: '${uniqueString(deployment().name, location)}-${replace(name, ' ', '_')}-lgBakRetPol'
   params: {
     serverName: serverName
     databaseName: database.name

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "3444518233599497149"
+      "templateHash": "18055604544925423843"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database."

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -686,7 +686,7 @@
       "type": "Microsoft.Insights/diagnosticSettings",
       "apiVersion": "2021-05-01-preview",
       "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', parameters('serverName'), parameters('name'))]",
-      "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
+      "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', replace(parameters('name'), ' ', '_')))]",
       "properties": {
         "copy": [
           {
@@ -723,7 +723,7 @@
       "condition": "[not(empty(parameters('backupShortTermRetentionPolicy')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-shBakRetPol', uniqueString(deployment().name, parameters('location')), parameters('name'))]",
+      "name": "[format('{0}-{1}-shBakRetPol', uniqueString(deployment().name, parameters('location')), replace(parameters('name'), ' ', '_'))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -827,7 +827,7 @@
       "condition": "[not(empty(parameters('backupLongTermRetentionPolicy')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-lgBakRetPol', uniqueString(deployment().name, parameters('location')), parameters('name'))]",
+      "name": "[format('{0}-{1}-lgBakRetPol', uniqueString(deployment().name, parameters('location')), replace(parameters('name'), ' ', '_'))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "18055604544925423843"
+      "templateHash": "15825153899458576874"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database."
@@ -723,7 +723,7 @@
       "condition": "[not(empty(parameters('backupShortTermRetentionPolicy')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-shBakRetPol', uniqueString(deployment().name, parameters('location')), replace(parameters('name'), ' ', '_'))]",
+      "name": "[format('{0}-shBakRetPol', uniqueString(deployment().name, parameters('location')))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -827,7 +827,7 @@
       "condition": "[not(empty(parameters('backupLongTermRetentionPolicy')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-lgBakRetPol', uniqueString(deployment().name, parameters('location')), replace(parameters('name'), ' ', '_'))]",
+      "name": "[format('{0}-lgBakRetPol', uniqueString(deployment().name, parameters('location')))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "5104801626852732208"
+      "templateHash": "17728755673974169411"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -2414,7 +2414,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.34.44.8038",
-              "templateHash": "18055604544925423843"
+              "templateHash": "15825153899458576874"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database."
@@ -3131,7 +3131,7 @@
               "condition": "[not(empty(parameters('backupShortTermRetentionPolicy')))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('{0}-{1}-shBakRetPol', uniqueString(deployment().name, parameters('location')), replace(parameters('name'), ' ', '_'))]",
+              "name": "[format('{0}-shBakRetPol', uniqueString(deployment().name, parameters('location')))]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
@@ -3235,7 +3235,7 @@
               "condition": "[not(empty(parameters('backupLongTermRetentionPolicy')))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('{0}-{1}-lgBakRetPol', uniqueString(deployment().name, parameters('location')), replace(parameters('name'), ' ', '_'))]",
+              "name": "[format('{0}-lgBakRetPol', uniqueString(deployment().name, parameters('location')))]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "8377942864127974447"
+      "templateHash": "17392350263115841275""templateHash": "8377942864127974447"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -2414,7 +2414,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.34.44.8038",
-              "templateHash": "3444518233599497149"
+              "templateHash": "14924834330559679582""templateHash": "3444518233599497149"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database."
@@ -3094,7 +3094,7 @@
               "type": "Microsoft.Insights/diagnosticSettings",
               "apiVersion": "2021-05-01-preview",
               "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', parameters('serverName'), parameters('name'))]",
-              "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
+              "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', replace(parameters('name'), ' ', '_')))]",
               "properties": {
                 "copy": [
                   {
@@ -3131,7 +3131,7 @@
               "condition": "[not(empty(parameters('backupShortTermRetentionPolicy')))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('{0}-{1}-shBakRetPol', uniqueString(deployment().name, parameters('location')), parameters('name'))]",
+              "name": "[format('{0}-{1}-shBakRetPol', uniqueString(deployment().name, parameters('location')), replace(parameters('name'), ' ', '_'))]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
@@ -3235,7 +3235,7 @@
               "condition": "[not(empty(parameters('backupLongTermRetentionPolicy')))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('{0}-{1}-lgBakRetPol', uniqueString(deployment().name, parameters('location')), parameters('name'))]",
+              "name": "[format('{0}-{1}-lgBakRetPol', uniqueString(deployment().name, parameters('location')), replace(parameters('name'), ' ', '_'))]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "17392350263115841275""templateHash": "8377942864127974447"
+      "templateHash": "5104801626852732208"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -2414,7 +2414,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.34.44.8038",
-              "templateHash": "14924834330559679582""templateHash": "3444518233599497149"
+              "templateHash": "18055604544925423843"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database."


### PR DESCRIPTION
## Description

This PR fixes the error that occur when deploying the `avm/res/sql/server` module with a database name that contains whitespace.

Fixes #5096

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|  [![avm.res.sql.server](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg?branch=5096)](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

