### PR TITLE
fix: configure rp registration before moving subscription

### DIFF
--- a/avm/ptn/lz/sub-vending/main.json
+++ b/avm/ptn/lz/sub-vending/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "14492369251792990746"
+      "templateHash": "12989261925612624422"
     },
     "name": "Sub-vending",
     "description": "This module deploys a subscription to accelerate deployment of landing zones. For more information on how to use it, please visit this [Wiki](https://github.com/Azure/bicep-lz-vending/wiki).",
@@ -1499,7 +1499,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.34.44.8038",
-              "templateHash": "874881940488545006"
+              "templateHash": "9801746893947569882"
             },
             "name": "`/subResourcesWrapper/deploy.bicep` Parameters",
             "description": "This module is used by the [`bicep-lz-vending`](https://aka.ms/sub-vending/bicep) module to help orchestrate the deployment",
@@ -2805,7 +2805,8 @@
                 }
               },
               "dependsOn": [
-                "moveSubscriptionToManagementGroupDelay"
+                "moveSubscriptionToManagementGroupDelay",
+                "registerResourceProviders"
               ]
             },
             "tagSubscription": {

--- a/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
+++ b/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
@@ -408,6 +408,7 @@ module moveSubscriptionToManagementGroup './managementGroupSubscription.bicep' =
   scope: managementGroup(subscriptionManagementGroupId)
   dependsOn: [
     moveSubscriptionToManagementGroupDelay
+    registerResourceProviders
   ]
   name: deploymentNames.moveSubscriptionToManagementGroup
   params: {


### PR DESCRIPTION
## Description

Configure resource provide registration before moving the subscription to the management group structure

fixes #4964 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|  [![avm.ptn.lz.sub-vending](https://github.com/sebassem/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml/badge.svg?branch=avm/vending/rp-move-sub)](https://github.com/sebassem/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml)        |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [X] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
