### PR TITLE
fix: Update `avm/ptn/azd/aks` to use newer API version and kubernetes version

### DIFF
--- a/avm/ptn/azd/aks/README.md
+++ b/avm/ptn/azd/aks/README.md
@@ -1707,7 +1707,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 | Reference | Type |
 | :-- | :-- |
 | `br/public:avm/res/container-registry/registry:0.9.1` | Remote reference |
-| `br/public:avm/res/container-service/managed-cluster:0.8.3` | Remote reference |
+| `br/public:avm/res/container-service/managed-cluster:0.9.0` | Remote reference |
 | `br/public:avm/res/key-vault/vault:0.12.1` | Remote reference |
 
 ## Data Collection

--- a/avm/ptn/azd/aks/README.md
+++ b/avm/ptn/azd/aks/README.md
@@ -25,16 +25,16 @@ Creates an Azure Kubernetes Service (AKS) cluster with a system agent pool as we
 | `Microsoft.ContainerRegistry/registries/replications` | [2023-06-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerRegistry/2023-06-01-preview/registries/replications) |
 | `Microsoft.ContainerRegistry/registries/scopeMaps` | [2023-06-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerRegistry/2023-06-01-preview/registries/scopeMaps) |
 | `Microsoft.ContainerRegistry/registries/webhooks` | [2023-06-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerRegistry/2023-06-01-preview/registries/webhooks) |
-| `Microsoft.ContainerService/managedClusters` | [2024-03-02-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2024-03-02-preview/managedClusters) |
-| `Microsoft.ContainerService/managedClusters/agentPools` | [2023-07-02-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2023-07-02-preview/managedClusters/agentPools) |
+| `Microsoft.ContainerService/managedClusters` | [2024-09-02-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2024-09-02-preview/managedClusters) |
+| `Microsoft.ContainerService/managedClusters/agentPools` | [2024-09-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2024-09-01/managedClusters/agentPools) |
 | `Microsoft.ContainerService/managedClusters/maintenanceConfigurations` | [2023-10-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2023-10-01/managedClusters/maintenanceConfigurations) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.KeyVault/vaults` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2022-07-01/vaults) |
-| `Microsoft.KeyVault/vaults/accessPolicies` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2022-07-01/vaults/accessPolicies) |
+| `Microsoft.KeyVault/vaults/accessPolicies` | [2023-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2023-07-01/vaults/accessPolicies) |
 | `Microsoft.KeyVault/vaults/keys` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2022-07-01/vaults/keys) |
 | `Microsoft.KeyVault/vaults/secrets` | [2022-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2022-07-01/vaults/secrets) |
 | `Microsoft.KubernetesConfiguration/extensions` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KubernetesConfiguration/2022-03-01/extensions) |
-| `Microsoft.KubernetesConfiguration/fluxConfigurations` | [2022-03-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KubernetesConfiguration/2022-03-01/fluxConfigurations) |
+| `Microsoft.KubernetesConfiguration/fluxConfigurations` | [2023-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KubernetesConfiguration/2023-05-01/fluxConfigurations) |
 | `Microsoft.Network/privateEndpoints` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-11-01/privateEndpoints) |
 | `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-11-01/privateEndpoints/privateDnsZoneGroups) |
 
@@ -580,7 +580,9 @@ Custom configuration of user node pool.
 | [`enableEncryptionAtHost`](#parameter-agentpoolconfigenableencryptionathost) | bool | Whether to enable encryption at host for the agent pool. |
 | [`enableFIPS`](#parameter-agentpoolconfigenablefips) | bool | Whether to enable FIPS for the agent pool. |
 | [`enableNodePublicIP`](#parameter-agentpoolconfigenablenodepublicip) | bool | Whether to enable node public IP for the agent pool. |
+| [`enableSecureBoot`](#parameter-agentpoolconfigenablesecureboot) | bool | Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch. |
 | [`enableUltraSSD`](#parameter-agentpoolconfigenableultrassd) | bool | Whether to enable Ultra SSD for the agent pool. |
+| [`enableVTPM`](#parameter-agentpoolconfigenablevtpm) | bool | vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. |
 | [`gpuInstanceProfile`](#parameter-agentpoolconfiggpuinstanceprofile) | string | The GPU instance profile of the agent pool. |
 | [`kubeletDiskType`](#parameter-agentpoolconfigkubeletdisktype) | string | The kubelet disk type of the agent pool. |
 | [`maxCount`](#parameter-agentpoolconfigmaxcount) | int | The maximum number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). |
@@ -595,7 +597,7 @@ Custom configuration of user node pool.
 | [`orchestratorVersion`](#parameter-agentpoolconfigorchestratorversion) | string | The Kubernetes version of the agent pool. |
 | [`osDiskSizeGB`](#parameter-agentpoolconfigosdisksizegb) | int | The OS disk size in GB of the agent pool. |
 | [`osDiskType`](#parameter-agentpoolconfigosdisktype) | string | The OS disk type of the agent pool. |
-| [`osSku`](#parameter-agentpoolconfigossku) | string | The OS SKU of the agent pool. |
+| [`osSKU`](#parameter-agentpoolconfigossku) | string | The OS SKU of the agent pool. |
 | [`osType`](#parameter-agentpoolconfigostype) | string | The OS type of the agent pool. |
 | [`podSubnetResourceId`](#parameter-agentpoolconfigpodsubnetresourceid) | string | The pod subnet ID of the agent pool. |
 | [`proximityPlacementGroupResourceId`](#parameter-agentpoolconfigproximityplacementgroupresourceid) | string | The proximity placement group resource ID of the agent pool. |
@@ -666,9 +668,23 @@ Whether to enable node public IP for the agent pool.
 - Required: No
 - Type: bool
 
+### Parameter: `agentPoolConfig.enableSecureBoot`
+
+Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch.
+
+- Required: No
+- Type: bool
+
 ### Parameter: `agentPoolConfig.enableUltraSSD`
 
 Whether to enable Ultra SSD for the agent pool.
+
+- Required: No
+- Type: bool
+
+### Parameter: `agentPoolConfig.enableVTPM`
+
+vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch.
 
 - Required: No
 - Type: bool
@@ -788,7 +804,7 @@ The OS disk type of the agent pool.
 - Required: No
 - Type: string
 
-### Parameter: `agentPoolConfig.osSku`
+### Parameter: `agentPoolConfig.osSKU`
 
 The OS SKU of the agent pool.
 
@@ -1056,7 +1072,7 @@ Kubernetes Version.
 
 - Required: No
 - Type: string
-- Default: `'1.29'`
+- Default: `'1.31'`
 
 ### Parameter: `loadBalancerSku`
 
@@ -1281,7 +1297,9 @@ Custom configuration of system node pool.
 | [`enableEncryptionAtHost`](#parameter-systempoolconfigenableencryptionathost) | bool | Whether to enable encryption at host for the agent pool. |
 | [`enableFIPS`](#parameter-systempoolconfigenablefips) | bool | Whether to enable FIPS for the agent pool. |
 | [`enableNodePublicIP`](#parameter-systempoolconfigenablenodepublicip) | bool | Whether to enable node public IP for the agent pool. |
+| [`enableSecureBoot`](#parameter-systempoolconfigenablesecureboot) | bool | Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch. |
 | [`enableUltraSSD`](#parameter-systempoolconfigenableultrassd) | bool | Whether to enable Ultra SSD for the agent pool. |
+| [`enableVTPM`](#parameter-systempoolconfigenablevtpm) | bool | vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. |
 | [`gpuInstanceProfile`](#parameter-systempoolconfiggpuinstanceprofile) | string | The GPU instance profile of the agent pool. |
 | [`kubeletDiskType`](#parameter-systempoolconfigkubeletdisktype) | string | The kubelet disk type of the agent pool. |
 | [`maxCount`](#parameter-systempoolconfigmaxcount) | int | The maximum number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). |
@@ -1296,7 +1314,7 @@ Custom configuration of system node pool.
 | [`orchestratorVersion`](#parameter-systempoolconfigorchestratorversion) | string | The Kubernetes version of the agent pool. |
 | [`osDiskSizeGB`](#parameter-systempoolconfigosdisksizegb) | int | The OS disk size in GB of the agent pool. |
 | [`osDiskType`](#parameter-systempoolconfigosdisktype) | string | The OS disk type of the agent pool. |
-| [`osSku`](#parameter-systempoolconfigossku) | string | The OS SKU of the agent pool. |
+| [`osSKU`](#parameter-systempoolconfigossku) | string | The OS SKU of the agent pool. |
 | [`osType`](#parameter-systempoolconfigostype) | string | The OS type of the agent pool. |
 | [`podSubnetResourceId`](#parameter-systempoolconfigpodsubnetresourceid) | string | The pod subnet ID of the agent pool. |
 | [`proximityPlacementGroupResourceId`](#parameter-systempoolconfigproximityplacementgroupresourceid) | string | The proximity placement group resource ID of the agent pool. |
@@ -1367,9 +1385,23 @@ Whether to enable node public IP for the agent pool.
 - Required: No
 - Type: bool
 
+### Parameter: `systemPoolConfig.enableSecureBoot`
+
+Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch.
+
+- Required: No
+- Type: bool
+
 ### Parameter: `systemPoolConfig.enableUltraSSD`
 
 Whether to enable Ultra SSD for the agent pool.
+
+- Required: No
+- Type: bool
+
+### Parameter: `systemPoolConfig.enableVTPM`
+
+vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch.
 
 - Required: No
 - Type: bool
@@ -1489,7 +1521,7 @@ The OS disk type of the agent pool.
 - Required: No
 - Type: string
 
-### Parameter: `systemPoolConfig.osSku`
+### Parameter: `systemPoolConfig.osSKU`
 
 The OS SKU of the agent pool.
 
@@ -1674,9 +1706,9 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/res/container-registry/registry:0.5.1` | Remote reference |
-| `br/public:avm/res/container-service/managed-cluster:0.5.2` | Remote reference |
-| `br/public:avm/res/key-vault/vault:0.9.0` | Remote reference |
+| `br/public:avm/res/container-registry/registry:0.9.1` | Remote reference |
+| `br/public:avm/res/container-service/managed-cluster:0.8.3` | Remote reference |
+| `br/public:avm/res/key-vault/vault:0.12.1` | Remote reference |
 
 ## Data Collection
 

--- a/avm/ptn/azd/aks/main.bicep
+++ b/avm/ptn/azd/aks/main.bicep
@@ -121,7 +121,7 @@ param containerRegistryRoleName string?
 @description('Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated.')
 param aksClusterRoleAssignmentName string?
 
-import { agentPoolType } from 'br/public:avm/res/container-service/managed-cluster:0.8.3'
+import { agentPoolType } from 'br/public:avm/res/container-service/managed-cluster:0.9.0'
 @description('Optional. Custom configuration of system node pool.')
 param systemPoolConfig agentPoolType[]?
 
@@ -177,7 +177,7 @@ param enableVaultForTemplateDeployment bool = false
 @description('Optional. Enable RBAC using AAD.')
 param enableAzureRbac bool = false
 
-import { aadProfileType } from 'br/public:avm/res/container-service/managed-cluster:0.8.3'
+import { aadProfileType } from 'br/public:avm/res/container-service/managed-cluster:0.9.0'
 @description('Optional. Enable Azure Active Directory integration.')
 param aadProfile aadProfileType?
 
@@ -279,7 +279,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.8.3' = {
+module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.9.0' = {
   name: '${uniqueString(deployment().name, location)}-managed-cluster'
   params: {
     name: name

--- a/avm/ptn/azd/aks/main.bicep
+++ b/avm/ptn/azd/aks/main.bicep
@@ -121,7 +121,7 @@ param containerRegistryRoleName string?
 @description('Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated.')
 param aksClusterRoleAssignmentName string?
 
-import { agentPoolType } from 'br/public:avm/res/container-service/managed-cluster:0.5.2'
+import { agentPoolType } from 'br/public:avm/res/container-service/managed-cluster:0.8.3'
 @description('Optional. Custom configuration of system node pool.')
 param systemPoolConfig agentPoolType[]?
 
@@ -177,7 +177,7 @@ param enableVaultForTemplateDeployment bool = false
 @description('Optional. Enable RBAC using AAD.')
 param enableAzureRbac bool = false
 
-import { aadProfileType } from 'br/public:avm/res/container-service/managed-cluster:0.5.2'
+import { aadProfileType } from 'br/public:avm/res/container-service/managed-cluster:0.8.3'
 @description('Optional. Enable Azure Active Directory integration.')
 param aadProfile aadProfileType?
 
@@ -279,7 +279,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.5.2' = {
+module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.8.3' = {
   name: '${uniqueString(deployment().name, location)}-managed-cluster'
   params: {
     name: name
@@ -345,7 +345,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.5.2
   }
 }
 
-module containerRegistry 'br/public:avm/res/container-registry/registry:0.5.1' = {
+module containerRegistry 'br/public:avm/res/container-registry/registry:0.9.1' = {
   name: '${uniqueString(deployment().name, location)}-container-registry'
   params: {
     name: containerRegistryName
@@ -386,7 +386,7 @@ module containerRegistry 'br/public:avm/res/container-registry/registry:0.5.1' =
   }
 }
 
-module keyVault 'br/public:avm/res/key-vault/vault:0.9.0' = {
+module keyVault 'br/public:avm/res/key-vault/vault:0.12.1' = {
   name: '${uniqueString(deployment().name, location)}-key-vault'
   params: {
     name: keyVaultName

--- a/avm/ptn/azd/aks/main.bicep
+++ b/avm/ptn/azd/aks/main.bicep
@@ -46,7 +46,7 @@ param principalId string
 param principalType string = 'User'
 
 @description('Optional. Kubernetes Version.')
-param kubernetesVersion string = '1.29'
+param kubernetesVersion string = '1.31'
 
 @description('Optional. Tier of a managed cluster SKU.')
 @allowed([
@@ -379,7 +379,7 @@ module containerRegistry 'br/public:avm/res/container-registry/registry:0.9.1' =
     roleAssignments: [
       {
         name: containerRegistryRoleName
-        principalId: managedCluster.outputs.kubeletIdentityObjectId
+        principalId: managedCluster.outputs.?kubeletIdentityObjectId ?? ''
         roleDefinitionIdOrName: acrPullRole
       }
     ]
@@ -397,7 +397,7 @@ module keyVault 'br/public:avm/res/key-vault/vault:0.12.1' = {
     enablePurgeProtection: enablePurgeProtection
     accessPolicies: [
       {
-        objectId: managedCluster.outputs.kubeletIdentityObjectId
+        objectId: managedCluster.outputs.?kubeletIdentityObjectId ?? ''
         permissions: {
           secrets: ['get', 'list']
         }
@@ -417,13 +417,13 @@ output resourceGroupName string = resourceGroup().name
 output managedClusterName string = managedCluster.outputs.name
 
 @description('The Client ID of the AKS identity.')
-output managedClusterClientId string = managedCluster.outputs.kubeletIdentityClientId
+output managedClusterClientId string? = managedCluster.outputs.?kubeletIdentityClientId
 
 @description('The Object ID of the AKS identity.')
-output managedClusterObjectId string = managedCluster.outputs.kubeletIdentityObjectId
+output managedClusterObjectId string? = managedCluster.outputs.?kubeletIdentityObjectId
 
 @description('The resource ID of the AKS cluster.')
-output managedClusterResourceId string = managedCluster.outputs.kubeletIdentityResourceId
+output managedClusterResourceId string? = managedCluster.outputs.?kubeletIdentityResourceId
 
 @description('The resource name of the ACR.')
 output containerRegistryName string = containerRegistry.outputs.name

--- a/avm/ptn/azd/aks/main.json
+++ b/avm/ptn/azd/aks/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "9214995165139420052"
+      "version": "0.35.1.17967",
+      "templateHash": "16961707500443257429"
     },
     "name": "Azd AKS",
     "description": "Creates an Azure Kubernetes Service (AKS) cluster with a system agent pool as well as an additional user agent pool.\n\n**Note:** This module is not intended for broad, generic use, as it was designed to cater for the requirements of the AZD CLI product. Feature requests and bug fix requests are welcome if they support the development of the AZD CLI but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case."
@@ -98,10 +98,10 @@
           }
         }
       },
-      "nullable": true,
       "metadata": {
+        "description": "The type for an AAD profile.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/container-service/managed-cluster:0.5.2"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/container-service/managed-cluster:0.8.3"
         }
       }
     },
@@ -278,7 +278,7 @@
             "description": "Optional. The OS disk type of the agent pool."
           }
         },
-        "osSku": {
+        "osSKU": {
           "type": "string",
           "nullable": true,
           "metadata": {
@@ -344,6 +344,20 @@
             "description": "Optional. The scale set priority of the agent pool."
           }
         },
+        "enableSecureBoot": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch."
+          }
+        },
+        "enableVTPM": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch."
+          }
+        },
         "spotMaxPrice": {
           "type": "int",
           "nullable": true,
@@ -406,8 +420,9 @@
         }
       },
       "metadata": {
+        "description": "The type for an agent pool.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/container-service/managed-cluster:0.5.2"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/container-service/managed-cluster:0.8.3"
         }
       }
     }
@@ -513,7 +528,7 @@
     },
     "kubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.29",
+      "defaultValue": "1.31",
       "metadata": {
         "description": "Optional. Kubernetes Version."
       }
@@ -982,12 +997,11 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "2970915888312217759"
+              "version": "0.33.93.31351",
+              "templateHash": "4954545522662307892"
             },
             "name": "Azure Kubernetes Service (AKS) Managed Clusters",
-            "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster.",
-            "owner": "Azure/module-maintainers"
+            "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster."
           },
           "definitions": {
             "agentPoolType": {
@@ -1163,7 +1177,7 @@
                     "description": "Optional. The OS disk type of the agent pool."
                   }
                 },
-                "osSku": {
+                "osSKU": {
                   "type": "string",
                   "nullable": true,
                   "metadata": {
@@ -1229,6 +1243,20 @@
                     "description": "Optional. The scale set priority of the agent pool."
                   }
                 },
+                "enableSecureBoot": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch."
+                  }
+                },
+                "enableVTPM": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch."
+                  }
+                },
                 "spotMaxPrice": {
                   "type": "int",
                   "nullable": true,
@@ -1291,266 +1319,15 @@
                 }
               },
               "metadata": {
-                "__bicep_export!": true
-              }
-            },
-            "managedIdentitiesType": {
-              "type": "object",
-              "properties": {
-                "systemAssigned": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Enables system assigned managed identity on the resource."
-                  }
-                },
-                "userAssignedResourcesIds": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The resource ID(s) to assign to the resource."
-                  }
-                }
-              },
-              "metadata": {
-                "__bicep_export!": true
-              }
-            },
-            "lockType": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Specify the name of lock."
-                  }
-                },
-                "kind": {
-                  "type": "string",
-                  "allowedValues": [
-                    "CanNotDelete",
-                    "None",
-                    "ReadOnly"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Specify the type of lock."
-                  }
-                }
-              },
-              "nullable": true,
-              "metadata": {
-                "__bicep_export!": true
-              }
-            },
-            "roleAssignmentType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
-                    }
-                  },
-                  "roleDefinitionIdOrName": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-                    }
-                  },
-                  "principalId": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-                    }
-                  },
-                  "principalType": {
-                    "type": "string",
-                    "allowedValues": [
-                      "Device",
-                      "ForeignGroup",
-                      "Group",
-                      "ServicePrincipal",
-                      "User"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The principal type of the assigned principal ID."
-                    }
-                  },
-                  "description": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The description of the role assignment."
-                    }
-                  },
-                  "condition": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-                    }
-                  },
-                  "conditionVersion": {
-                    "type": "string",
-                    "allowedValues": [
-                      "2.0"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Version of the condition."
-                    }
-                  },
-                  "delegatedManagedIdentityResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The Resource Id of the delegated managed identity resource."
-                    }
-                  }
-                }
-              },
-              "nullable": true,
-              "metadata": {
-                "__bicep_export!": true
-              }
-            },
-            "diagnosticSettingType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of diagnostic setting."
-                    }
-                  },
-                  "logCategoriesAndGroups": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "category": {
-                          "type": "string",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
-                          }
-                        },
-                        "categoryGroup": {
-                          "type": "string",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
-                          }
-                        },
-                        "enabled": {
-                          "type": "bool",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Enable or disable the category explicitly. Default is `true`."
-                          }
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
-                    }
-                  },
-                  "metricCategories": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "category": {
-                          "type": "string",
-                          "metadata": {
-                            "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
-                          }
-                        },
-                        "enabled": {
-                          "type": "bool",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Enable or disable the category explicitly. Default is `true`."
-                          }
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
-                    }
-                  },
-                  "logAnalyticsDestinationType": {
-                    "type": "string",
-                    "allowedValues": [
-                      "AzureDiagnostics",
-                      "Dedicated"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
-                    }
-                  },
-                  "workspaceResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
-                    }
-                  },
-                  "storageAccountResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
-                    }
-                  },
-                  "eventHubAuthorizationRuleResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
-                    }
-                  },
-                  "eventHubName": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
-                    }
-                  },
-                  "marketplacePartnerResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
-                    }
-                  }
-                }
-              },
-              "nullable": true,
-              "metadata": {
-                "__bicep_export!": true
+                "__bicep_export!": true,
+                "description": "The type for an agent pool."
               }
             },
             "fluxConfigurationProtectedSettingsType": {
               "type": "object",
               "properties": {
                 "sshPrivateKey": {
-                  "type": "string",
+                  "type": "securestring",
                   "nullable": true,
                   "metadata": {
                     "description": "Optional. The SSH private key to use for Git authentication."
@@ -1558,7 +1335,8 @@
                 }
               },
               "metadata": {
-                "__bicep_export!": true
+                "__bicep_export!": true,
+                "description": "The type for flux configuration protected settings."
               }
             },
             "extensionType": {
@@ -1622,44 +1400,8 @@
                 }
               },
               "metadata": {
-                "__bicep_export!": true
-              }
-            },
-            "customerManagedKeyType": {
-              "type": "object",
-              "properties": {
-                "keyVaultResourceId": {
-                  "type": "string",
-                  "metadata": {
-                    "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
-                  }
-                },
-                "keyName": {
-                  "type": "string",
-                  "metadata": {
-                    "description": "Required. The name of the customer managed key to use for encryption."
-                  }
-                },
-                "keyVersion": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The version of the customer managed key to reference for encryption. If not provided, using 'latest'."
-                  }
-                },
-                "keyVaultNetworkAccess": {
-                  "type": "string",
-                  "allowedValues": [
-                    "Private",
-                    "Public"
-                  ],
-                  "metadata": {
-                    "description": "Required. Network access of key vault. The possible values are Public and Private. Public means the key vault allows public access from all networks. Private means the key vault disables public access and enables private link. The default value is Public."
-                  }
-                }
-              },
-              "metadata": {
-                "__bicep_export!": true
+                "__bicep_export!": true,
+                "description": "The type for an extension."
               }
             },
             "maintenanceConfigurationType": {
@@ -1682,9 +1424,9 @@
                   }
                 }
               },
-              "nullable": true,
               "metadata": {
-                "__bicep_export!": true
+                "__bicep_export!": true,
+                "description": "The type of a mainenance configuration."
               }
             },
             "istioServiceMeshCertificateAuthorityType": {
@@ -1721,7 +1463,10 @@
                   }
                 }
               },
-              "nullable": true
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for an The Istio Certificate Authority definition."
+              }
             },
             "aadProfileType": {
               "type": "object",
@@ -1777,9 +1522,264 @@
                   }
                 }
               },
-              "nullable": true,
               "metadata": {
-                "__bicep_export!": true
+                "__bicep_export!": true,
+                "description": "The type for an AAD profile."
+              }
+            },
+            "diagnosticSettingFullType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the diagnostic setting."
+                  }
+                },
+                "logCategoriesAndGroups": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "category": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                        }
+                      },
+                      "categoryGroup": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                        }
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                        }
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+                  }
+                },
+                "metricCategories": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "category": {
+                        "type": "string",
+                        "metadata": {
+                          "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                        }
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                        }
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+                  }
+                },
+                "logAnalyticsDestinationType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "AzureDiagnostics",
+                    "Dedicated"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+                  }
+                },
+                "workspaceResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "storageAccountResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "eventHubAuthorizationRuleResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+                  }
+                },
+                "eventHubName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "marketplacePartnerResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "lockType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the name of lock."
+                  }
+                },
+                "kind": {
+                  "type": "string",
+                  "allowedValues": [
+                    "CanNotDelete",
+                    "None",
+                    "ReadOnly"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the type of lock."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a lock.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "managedIdentityAllType": {
+              "type": "object",
+              "properties": {
+                "systemAssigned": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enables system assigned managed identity on the resource."
+                  }
+                },
+                "userAssignedResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
               }
             }
           },
@@ -1805,7 +1805,7 @@
               }
             },
             "managedIdentities": {
-              "$ref": "#/definitions/managedIdentitiesType",
+              "$ref": "#/definitions/managedIdentityAllType",
               "nullable": true,
               "metadata": {
                 "description": "Optional. The managed identity definition for this resource. Only one type of identity is supported: system-assigned or user-assigned, but not both."
@@ -1926,7 +1926,7 @@
                 "Automatic"
               ],
               "metadata": {
-                "description": "Optional. Name of a managed cluster SKU."
+                "description": "Optional. Name of a managed cluster SKU. AUTOMATIC CLUSTER SKU IS A PARAMETER USED FOR A PREVIEW FEATURE, MICROSOFT MAY NOT PROVIDE SUPPORT FOR THIS, PLEASE CHECK THE [PRODUCT DOCS](https://learn.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-automatic-deploy?pivots=bicep#before-you-begin) FOR CLARIFICATION."
               }
             },
             "skuTier": {
@@ -1990,11 +1990,15 @@
                 "description": "Optional. If set to true, getting static credentials will be disabled for this cluster. This must only be used on Managed Clusters that are AAD enabled."
               }
             },
-            "nodeProvisioningProfile": {
-              "type": "object",
+            "nodeProvisioningProfileMode": {
+              "type": "string",
               "nullable": true,
+              "allowedValues": [
+                "Auto",
+                "Manual"
+              ],
               "metadata": {
-                "description": "Optional. Node provisioning settings that apply to the whole cluster."
+                "description": "Optional. Node provisioning settings that apply to the whole cluster. AUTO MODE IS A PARAMETER USED FOR A PREVIEW FEATURE, MICROSOFT MAY NOT PROVIDE SUPPORT FOR THIS, PLEASE CHECK THE [PRODUCT DOCS](https://learn.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-automatic-deploy?pivots=bicep#before-you-begin) FOR CLARIFICATION."
               }
             },
             "nodeResourceGroup": {
@@ -2116,6 +2120,19 @@
               "nullable": true,
               "metadata": {
                 "description": "Optional. Specifies the resource ID of connected DNS zone. It will be ignored if `webApplicationRoutingEnabled` is set to `false`."
+              }
+            },
+            "defaultIngressControllerType": {
+              "type": "string",
+              "nullable": true,
+              "allowedValues": [
+                "AnnotationControlled",
+                "External",
+                "Internal",
+                "None"
+              ],
+              "metadata": {
+                "description": "Optional. Ingress type for the default NginxIngressController custom resource. It will be ignored if `webApplicationRoutingEnabled` is set to `false`."
               }
             },
             "enableDnsZoneContributorRoleAssignment": {
@@ -2451,7 +2468,11 @@
               }
             },
             "diagnosticSettings": {
-              "$ref": "#/definitions/diagnosticSettingType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/diagnosticSettingFullType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. The diagnostic settings of the service."
               }
@@ -2461,6 +2482,13 @@
               "defaultValue": true,
               "metadata": {
                 "description": "Optional. Specifies whether the OMS agent is enabled."
+              }
+            },
+            "omsAgentUseAADAuth": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Specifies whether the OMS agent is using managed identity authentication."
               }
             },
             "monitoringWorkspaceResourceId": {
@@ -2478,13 +2506,18 @@
               }
             },
             "roleAssignments": {
-              "$ref": "#/definitions/roleAssignmentType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Array of role assignments to create."
               }
             },
             "lock": {
               "$ref": "#/definitions/lockType",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. The lock settings of the service."
               }
@@ -2536,13 +2569,6 @@
               "defaultValue": false,
               "metadata": {
                 "description": "Optional. Whether to enable VPA add-on in cluster. Default value is false."
-              }
-            },
-            "customerManagedKey": {
-              "$ref": "#/definitions/customerManagedKeyType",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. The customer managed key definition."
               }
             },
             "enableAzureMonitorProfileMetrics": {
@@ -2624,6 +2650,7 @@
             },
             "istioServiceMeshCertificateAuthority": {
               "$ref": "#/definitions/istioServiceMeshCertificateAuthorityType",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. The Istio Certificate Authority definition."
               }
@@ -2637,8 +2664,9 @@
                 "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
               }
             ],
-            "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourcesIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
-            "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), 'SystemAssigned', if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourcesIds'), createObject()))), 'UserAssigned', null())), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
+            "enableReferencedModulesTelemetry": false,
+            "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
+            "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), 'SystemAssigned', if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', null())), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
             "builtInRoleNames": {
               "Azure Kubernetes Fleet Manager Contributor Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '63bb64ad-9799-4770-b5c3-24ed299a07bf')]",
               "Azure Kubernetes Fleet Manager RBAC Admin": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '434fb43a-c01c-447e-9f67-c3ad923cfaba')]",
@@ -2662,20 +2690,11 @@
             }
           },
           "resources": {
-            "cMKKeyVault::cMKKey": {
-              "condition": "[and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName')))))]",
-              "existing": true,
-              "type": "Microsoft.KeyVault/vaults/keys",
-              "apiVersion": "2023-02-01",
-              "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '//'), '/')[2]]",
-              "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '////'), '/')[4]]",
-              "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]"
-            },
             "avmTelemetry": {
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2024-03-01",
-              "name": "[format('46d3xbcp.res.containerservice-managedcluster.{0}.{1}', replace('0.5.2', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "name": "[format('46d3xbcp.res.containerservice-managedcluster.{0}.{1}', replace('0.8.3', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -2691,18 +2710,9 @@
                 }
               }
             },
-            "cMKKeyVault": {
-              "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId')))]",
-              "existing": true,
-              "type": "Microsoft.KeyVault/vaults",
-              "apiVersion": "2023-02-01",
-              "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '//'), '/')[2]]",
-              "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '////'), '/')[4]]",
-              "name": "[last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/'))]"
-            },
             "managedCluster": {
               "type": "Microsoft.ContainerService/managedClusters",
-              "apiVersion": "2024-03-02-preview",
+              "apiVersion": "2024-09-02-preview",
               "name": "[parameters('name')]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
@@ -2712,7 +2722,7 @@
                 "tier": "[parameters('skuTier')]"
               },
               "properties": {
-                "agentPoolProfiles": "[map(parameters('primaryAgentPoolProfiles'), lambda('profile', createObject('name', lambdaVariables('profile').name, 'count', coalesce(lambdaVariables('profile').count, 1), 'availabilityZones', map(coalesce(tryGet(lambdaVariables('profile'), 'availabilityZones'), createArray(1, 2, 3)), lambda('zone', format('{0}', lambdaVariables('zone')))), 'creationData', if(not(empty(tryGet(lambdaVariables('profile'), 'sourceResourceId'))), createObject('sourceResourceId', lambdaVariables('profile').sourceResourceId), null()), 'enableAutoScaling', coalesce(tryGet(lambdaVariables('profile'), 'enableAutoScaling'), false()), 'enableEncryptionAtHost', coalesce(tryGet(lambdaVariables('profile'), 'enableEncryptionAtHost'), false()), 'enableFIPS', coalesce(tryGet(lambdaVariables('profile'), 'enableFIPS'), false()), 'enableNodePublicIP', coalesce(tryGet(lambdaVariables('profile'), 'enableNodePublicIP'), false()), 'enableUltraSSD', coalesce(tryGet(lambdaVariables('profile'), 'enableUltraSSD'), false()), 'gpuInstanceProfile', tryGet(lambdaVariables('profile'), 'gpuInstanceProfile'), 'kubeletDiskType', tryGet(lambdaVariables('profile'), 'kubeletDiskType'), 'maxCount', tryGet(lambdaVariables('profile'), 'maxCount'), 'maxPods', tryGet(lambdaVariables('profile'), 'maxPods'), 'minCount', tryGet(lambdaVariables('profile'), 'minCount'), 'mode', tryGet(lambdaVariables('profile'), 'mode'), 'nodeLabels', tryGet(lambdaVariables('profile'), 'nodeLabels'), 'nodePublicIPPrefixID', tryGet(lambdaVariables('profile'), 'nodePublicIpPrefixResourceId'), 'nodeTaints', tryGet(lambdaVariables('profile'), 'nodeTaints'), 'orchestratorVersion', tryGet(lambdaVariables('profile'), 'orchestratorVersion'), 'osDiskSizeGB', tryGet(lambdaVariables('profile'), 'osDiskSizeGB'), 'osDiskType', tryGet(lambdaVariables('profile'), 'osDiskType'), 'osType', coalesce(tryGet(lambdaVariables('profile'), 'osType'), 'Linux'), 'podSubnetID', tryGet(lambdaVariables('profile'), 'podSubnetResourceId'), 'proximityPlacementGroupID', tryGet(lambdaVariables('profile'), 'proximityPlacementGroupResourceId'), 'scaleDownMode', coalesce(tryGet(lambdaVariables('profile'), 'scaleDownMode'), 'Delete'), 'scaleSetEvictionPolicy', coalesce(tryGet(lambdaVariables('profile'), 'scaleSetEvictionPolicy'), 'Delete'), 'scaleSetPriority', tryGet(lambdaVariables('profile'), 'scaleSetPriority'), 'spotMaxPrice', tryGet(lambdaVariables('profile'), 'spotMaxPrice'), 'tags', tryGet(lambdaVariables('profile'), 'tags'), 'type', tryGet(lambdaVariables('profile'), 'type'), 'upgradeSettings', createObject('maxSurge', tryGet(lambdaVariables('profile'), 'maxSurge')), 'vmSize', coalesce(tryGet(lambdaVariables('profile'), 'vmSize'), 'Standard_D2s_v3'), 'vnetSubnetID', tryGet(lambdaVariables('profile'), 'vnetSubnetResourceId'), 'workloadRuntime', tryGet(lambdaVariables('profile'), 'workloadRuntime'))))]",
+                "agentPoolProfiles": "[map(parameters('primaryAgentPoolProfiles'), lambda('profile', createObject('name', lambdaVariables('profile').name, 'count', coalesce(lambdaVariables('profile').count, 1), 'availabilityZones', map(coalesce(tryGet(lambdaVariables('profile'), 'availabilityZones'), createArray(1, 2, 3)), lambda('zone', format('{0}', lambdaVariables('zone')))), 'creationData', if(not(empty(tryGet(lambdaVariables('profile'), 'sourceResourceId'))), createObject('sourceResourceId', lambdaVariables('profile').sourceResourceId), null()), 'enableAutoScaling', coalesce(tryGet(lambdaVariables('profile'), 'enableAutoScaling'), false()), 'enableEncryptionAtHost', coalesce(tryGet(lambdaVariables('profile'), 'enableEncryptionAtHost'), false()), 'enableFIPS', coalesce(tryGet(lambdaVariables('profile'), 'enableFIPS'), false()), 'enableNodePublicIP', coalesce(tryGet(lambdaVariables('profile'), 'enableNodePublicIP'), false()), 'enableUltraSSD', coalesce(tryGet(lambdaVariables('profile'), 'enableUltraSSD'), false()), 'gpuInstanceProfile', tryGet(lambdaVariables('profile'), 'gpuInstanceProfile'), 'kubeletDiskType', tryGet(lambdaVariables('profile'), 'kubeletDiskType'), 'maxCount', tryGet(lambdaVariables('profile'), 'maxCount'), 'maxPods', tryGet(lambdaVariables('profile'), 'maxPods'), 'minCount', tryGet(lambdaVariables('profile'), 'minCount'), 'mode', tryGet(lambdaVariables('profile'), 'mode'), 'nodeLabels', tryGet(lambdaVariables('profile'), 'nodeLabels'), 'nodePublicIPPrefixID', tryGet(lambdaVariables('profile'), 'nodePublicIpPrefixResourceId'), 'nodeTaints', tryGet(lambdaVariables('profile'), 'nodeTaints'), 'orchestratorVersion', tryGet(lambdaVariables('profile'), 'orchestratorVersion'), 'osDiskSizeGB', tryGet(lambdaVariables('profile'), 'osDiskSizeGB'), 'osDiskType', tryGet(lambdaVariables('profile'), 'osDiskType'), 'osType', coalesce(tryGet(lambdaVariables('profile'), 'osType'), 'Linux'), 'osSKU', tryGet(lambdaVariables('profile'), 'osSKU'), 'podSubnetID', tryGet(lambdaVariables('profile'), 'podSubnetResourceId'), 'proximityPlacementGroupID', tryGet(lambdaVariables('profile'), 'proximityPlacementGroupResourceId'), 'scaleDownMode', coalesce(tryGet(lambdaVariables('profile'), 'scaleDownMode'), 'Delete'), 'scaleSetEvictionPolicy', coalesce(tryGet(lambdaVariables('profile'), 'scaleSetEvictionPolicy'), 'Delete'), 'scaleSetPriority', tryGet(lambdaVariables('profile'), 'scaleSetPriority'), 'securityProfile', createObject('enableSecureBoot', coalesce(tryGet(lambdaVariables('profile'), 'enableSecureBoot'), false()), 'enableVTPM', coalesce(tryGet(lambdaVariables('profile'), 'enableVTPM'), false()), 'sshAccess', if(equals(parameters('skuName'), 'Automatic'), 'Disabled', 'LocalUser')), 'spotMaxPrice', tryGet(lambdaVariables('profile'), 'spotMaxPrice'), 'tags', tryGet(lambdaVariables('profile'), 'tags'), 'type', tryGet(lambdaVariables('profile'), 'type'), 'upgradeSettings', createObject('maxSurge', tryGet(lambdaVariables('profile'), 'maxSurge')), 'vmSize', coalesce(tryGet(lambdaVariables('profile'), 'vmSize'), 'Standard_D2s_v3'), 'vnetSubnetID', tryGet(lambdaVariables('profile'), 'vnetSubnetResourceId'), 'workloadRuntime', tryGet(lambdaVariables('profile'), 'workloadRuntime'))))]",
                 "httpProxyConfig": "[parameters('httpProxyConfig')]",
                 "identityProfile": "[parameters('identityProfile')]",
                 "diskEncryptionSetID": "[parameters('diskEncryptionSetResourceId')]",
@@ -2728,7 +2738,8 @@
                 "ingressProfile": {
                   "webAppRouting": {
                     "enabled": "[parameters('webApplicationRoutingEnabled')]",
-                    "dnsZoneResourceIds": "[if(not(empty(parameters('dnsZoneResourceId'))), createArray(parameters('dnsZoneResourceId')), null())]"
+                    "dnsZoneResourceIds": "[if(not(empty(parameters('dnsZoneResourceId'))), createArray(parameters('dnsZoneResourceId')), null())]",
+                    "nginx": "[if(not(empty(parameters('defaultIngressControllerType'))), createObject('defaultIngressControllerType', parameters('defaultIngressControllerType')), null())]"
                   }
                 },
                 "addonProfiles": {
@@ -2741,7 +2752,7 @@
                   },
                   "omsagent": {
                     "enabled": "[and(parameters('omsAgentEnabled'), not(empty(parameters('monitoringWorkspaceResourceId'))))]",
-                    "config": "[if(and(parameters('omsAgentEnabled'), not(empty(parameters('monitoringWorkspaceResourceId')))), createObject('logAnalyticsWorkspaceResourceID', parameters('monitoringWorkspaceResourceId')), null())]"
+                    "config": "[if(and(parameters('omsAgentEnabled'), not(empty(parameters('monitoringWorkspaceResourceId')))), shallowMerge(createArray(createObject('logAnalyticsWorkspaceResourceID', parameters('monitoringWorkspaceResourceId')), if(parameters('omsAgentUseAADAuth'), createObject('useAADAuth', 'true'), createObject()))), null())]"
                   },
                   "aciConnectorLinux": {
                     "enabled": "[parameters('aciConnectorLinuxEnabled')]"
@@ -2767,7 +2778,7 @@
                 "disableLocalAccounts": "[parameters('disableLocalAccounts')]",
                 "nodeResourceGroup": "[parameters('nodeResourceGroup')]",
                 "nodeResourceGroupProfile": "[parameters('nodeResourceGroupProfile')]",
-                "nodeProvisioningProfile": "[parameters('nodeProvisioningProfile')]",
+                "nodeProvisioningProfile": "[if(not(empty(parameters('nodeProvisioningProfileMode'))), createObject('mode', parameters('nodeProvisioningProfileMode')), null())]",
                 "enablePodSecurityPolicy": "[parameters('enablePodSecurityPolicy')]",
                 "workloadAutoScalerProfile": {
                   "keda": {
@@ -2987,12 +2998,11 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.32.4.45862",
-                      "templateHash": "14523573481456452623"
+                      "version": "0.33.93.31351",
+                      "templateHash": "17573192747850353863"
                     },
                     "name": "Azure Kubernetes Service (AKS) Managed Cluster Maintenance Configurations",
-                    "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Maintenance Configurations.",
-                    "owner": "Azure/module-maintainers"
+                    "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Maintenance Configurations."
                   },
                   "parameters": {
                     "maintenanceWindow": {
@@ -3134,8 +3144,8 @@
                   "osDiskType": {
                     "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'osDiskType')]"
                   },
-                  "osSku": {
-                    "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'osSku')]"
+                  "osSKU": {
+                    "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'osSKU')]"
                   },
                   "osType": {
                     "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'osType')]"
@@ -3184,12 +3194,11 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.32.4.45862",
-                      "templateHash": "8195372149835761348"
+                      "version": "0.33.93.31351",
+                      "templateHash": "7049305712242986495"
                     },
                     "name": "Azure Kubernetes Service (AKS) Managed Cluster Agent Pools",
-                    "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Agent Pool.",
-                    "owner": "Azure/module-maintainers"
+                    "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Agent Pool."
                   },
                   "parameters": {
                     "managedClusterName": {
@@ -3364,7 +3373,7 @@
                         "description": "Optional. The default is \"Ephemeral\" if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to \"Managed\". May not be changed after creation. For more information see Ephemeral OS (https://learn.microsoft.com/en-us/azure/aks/cluster-configuration#ephemeral-os)."
                       }
                     },
-                    "osSku": {
+                    "osSKU": {
                       "type": "string",
                       "nullable": true,
                       "allowedValues": [
@@ -3436,6 +3445,20 @@
                         "description": "Optional. The Virtual Machine Scale Set priority."
                       }
                     },
+                    "enableSecureBoot": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch."
+                      }
+                    },
+                    "enableVTPM": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch."
+                      }
+                    },
                     "spotMaxPrice": {
                       "type": "int",
                       "nullable": true,
@@ -3490,12 +3513,12 @@
                     "managedCluster": {
                       "existing": true,
                       "type": "Microsoft.ContainerService/managedClusters",
-                      "apiVersion": "2024-03-02-preview",
+                      "apiVersion": "2024-09-01",
                       "name": "[parameters('managedClusterName')]"
                     },
                     "agentPool": {
                       "type": "Microsoft.ContainerService/managedClusters/agentPools",
-                      "apiVersion": "2023-07-02-preview",
+                      "apiVersion": "2024-09-01",
                       "name": "[format('{0}/{1}', parameters('managedClusterName'), parameters('name'))]",
                       "properties": {
                         "availabilityZones": "[map(coalesce(parameters('availabilityZones'), createArray()), lambda('zone', format('{0}', lambdaVariables('zone'))))]",
@@ -3518,13 +3541,17 @@
                         "orchestratorVersion": "[parameters('orchestratorVersion')]",
                         "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
                         "osDiskType": "[parameters('osDiskType')]",
-                        "osSKU": "[parameters('osSku')]",
+                        "osSKU": "[parameters('osSKU')]",
                         "osType": "[parameters('osType')]",
                         "podSubnetID": "[parameters('podSubnetResourceId')]",
                         "proximityPlacementGroupID": "[parameters('proximityPlacementGroupResourceId')]",
                         "scaleDownMode": "[parameters('scaleDownMode')]",
                         "scaleSetEvictionPolicy": "[parameters('scaleSetEvictionPolicy')]",
                         "scaleSetPriority": "[parameters('scaleSetPriority')]",
+                        "securityProfile": {
+                          "enableSecureBoot": "[parameters('enableSecureBoot')]",
+                          "enableVTPM": "[parameters('enableVTPM')]"
+                        },
                         "spotMaxPrice": "[parameters('spotMaxPrice')]",
                         "tags": "[parameters('tags')]",
                         "type": "[parameters('type')]",
@@ -3587,7 +3614,7 @@
                     "value": "[tryGet(parameters('fluxExtension'), 'configurationSettings')]"
                   },
                   "enableTelemetry": {
-                    "value": "[parameters('enableTelemetry')]"
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
                   },
                   "extensionType": {
                     "value": "microsoft.flux"
@@ -3618,8 +3645,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "12293754418506359991"
+                      "version": "0.32.4.45862",
+                      "templateHash": "9966442976957263225"
                     },
                     "name": "Kubernetes Configuration Extensions",
                     "description": "This module deploys a Kubernetes Configuration Extension.",
@@ -3712,8 +3739,8 @@
                     "avmTelemetry": {
                       "condition": "[parameters('enableTelemetry')]",
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2023-07-01",
-                      "name": "[format('46d3xbcp.res.kubernetesconfiguration-fluxconfig.{0}.{1}', replace('0.2.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('46d3xbcp.res.kubernetesconfiguration-extension.{0}.{1}', replace('0.3.5', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
                       "properties": {
                         "mode": "Incremental",
                         "template": {
@@ -3751,10 +3778,7 @@
                           "namespace": "[if(not(empty(coalesce(parameters('targetNamespace'), ''))), createObject('targetNamespace', parameters('targetNamespace')), null())]"
                         },
                         "version": "[parameters('version')]"
-                      },
-                      "dependsOn": [
-                        "managedCluster"
-                      ]
+                      }
                     },
                     "fluxConfiguration": {
                       "copy": {
@@ -3771,7 +3795,7 @@
                         "mode": "Incremental",
                         "parameters": {
                           "enableTelemetry": {
-                            "value": "[parameters('enableTelemetry')]"
+                            "value": "[coalesce(tryGet(coalesce(parameters('fluxConfigurations'), createArray())[copyIndex()], 'enableTelemetry'), parameters('enableTelemetry'))]"
                           },
                           "clusterName": {
                             "value": "[parameters('clusterName')]"
@@ -3796,7 +3820,7 @@
                             "value": "[tryGet(coalesce(parameters('fluxConfigurations'), createArray())[copyIndex()], 'gitRepository')]"
                           },
                           "kustomizations": {
-                            "value": "[tryGet(coalesce(parameters('fluxConfigurations'), createArray())[copyIndex()], 'kustomizations')]"
+                            "value": "[coalesce(parameters('fluxConfigurations'), createArray())[copyIndex()].kustomizations]"
                           },
                           "suspend": {
                             "value": "[tryGet(coalesce(parameters('fluxConfigurations'), createArray())[copyIndex()], 'suspend')]"
@@ -3810,7 +3834,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.23.1.45101",
-                              "templateHash": "13420454476526931427"
+                              "templateHash": "885928168160399718"
                             },
                             "name": "Kubernetes Configuration Flux Configurations",
                             "description": "This module deploys a Kubernetes Configuration Flux Configuration.",
@@ -3866,9 +3890,8 @@
                             },
                             "kustomizations": {
                               "type": "object",
-                              "nullable": true,
                               "metadata": {
-                                "description": "Optional. Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster."
+                                "description": "Required. Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster."
                               }
                             },
                             "namespace": {
@@ -3910,7 +3933,7 @@
                               "condition": "[parameters('enableTelemetry')]",
                               "type": "Microsoft.Resources/deployments",
                               "apiVersion": "2023-07-01",
-                              "name": "[format('46d3xbcp.res.kubernetesconfiguration-extension.{0}.{1}', replace('0.2.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                              "name": "[format('46d3xbcp.res.kubernetesconfiguration-fluxconfig.{0}.{1}', replace('0.3.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
                               "properties": {
                                 "mode": "Incremental",
                                 "template": {
@@ -3934,7 +3957,7 @@
                             },
                             "fluxConfiguration": {
                               "type": "Microsoft.KubernetesConfiguration/fluxConfigurations",
-                              "apiVersion": "2022-03-01",
+                              "apiVersion": "2023-05-01",
                               "scope": "[format('Microsoft.ContainerService/managedClusters/{0}', parameters('clusterName'))]",
                               "name": "[parameters('name')]",
                               "properties": {
@@ -3978,8 +4001,7 @@
                         }
                       },
                       "dependsOn": [
-                        "extension",
-                        "managedCluster"
+                        "extension"
                       ]
                     }
                   },
@@ -4044,87 +4066,98 @@
             },
             "systemAssignedMIPrincipalId": {
               "type": "string",
+              "nullable": true,
               "metadata": {
                 "description": "The principal ID of the system assigned identity."
               },
-              "value": "[coalesce(tryGet(tryGet(reference('managedCluster', '2024-03-02-preview', 'full'), 'identity'), 'principalId'), '')]"
+              "value": "[tryGet(tryGet(reference('managedCluster', '2024-09-02-preview', 'full'), 'identity'), 'principalId')]"
             },
             "kubeletIdentityClientId": {
               "type": "string",
+              "nullable": true,
               "metadata": {
                 "description": "The Client ID of the AKS identity."
               },
-              "value": "[coalesce(tryGet(tryGet(tryGet(reference('managedCluster'), 'identityProfile'), 'kubeletidentity'), 'clientId'), '')]"
+              "value": "[tryGet(tryGet(tryGet(reference('managedCluster'), 'identityProfile'), 'kubeletidentity'), 'clientId')]"
             },
             "kubeletIdentityObjectId": {
               "type": "string",
+              "nullable": true,
               "metadata": {
                 "description": "The Object ID of the AKS identity."
               },
-              "value": "[coalesce(tryGet(tryGet(tryGet(reference('managedCluster'), 'identityProfile'), 'kubeletidentity'), 'objectId'), '')]"
+              "value": "[tryGet(tryGet(tryGet(reference('managedCluster'), 'identityProfile'), 'kubeletidentity'), 'objectId')]"
             },
             "kubeletIdentityResourceId": {
               "type": "string",
+              "nullable": true,
               "metadata": {
                 "description": "The Resource ID of the AKS identity."
               },
-              "value": "[coalesce(tryGet(tryGet(tryGet(reference('managedCluster'), 'identityProfile'), 'kubeletidentity'), 'resourceId'), '')]"
+              "value": "[tryGet(tryGet(tryGet(reference('managedCluster'), 'identityProfile'), 'kubeletidentity'), 'resourceId')]"
             },
             "omsagentIdentityObjectId": {
               "type": "string",
+              "nullable": true,
               "metadata": {
                 "description": "The Object ID of the OMS agent identity."
               },
-              "value": "[coalesce(tryGet(tryGet(tryGet(tryGet(reference('managedCluster'), 'addonProfiles'), 'omsagent'), 'identity'), 'objectId'), '')]"
+              "value": "[tryGet(tryGet(tryGet(tryGet(reference('managedCluster'), 'addonProfiles'), 'omsagent'), 'identity'), 'objectId')]"
             },
             "keyvaultIdentityObjectId": {
               "type": "string",
+              "nullable": true,
               "metadata": {
                 "description": "The Object ID of the Key Vault Secrets Provider identity."
               },
-              "value": "[coalesce(tryGet(tryGet(tryGet(tryGet(reference('managedCluster'), 'addonProfiles'), 'azureKeyvaultSecretsProvider'), 'identity'), 'objectId'), '')]"
+              "value": "[tryGet(tryGet(tryGet(tryGet(reference('managedCluster'), 'addonProfiles'), 'azureKeyvaultSecretsProvider'), 'identity'), 'objectId')]"
             },
             "keyvaultIdentityClientId": {
               "type": "string",
+              "nullable": true,
               "metadata": {
                 "description": "The Client ID of the Key Vault Secrets Provider identity."
               },
-              "value": "[coalesce(tryGet(tryGet(tryGet(tryGet(reference('managedCluster'), 'addonProfiles'), 'azureKeyvaultSecretsProvider'), 'identity'), 'clientId'), '')]"
+              "value": "[tryGet(tryGet(tryGet(tryGet(reference('managedCluster'), 'addonProfiles'), 'azureKeyvaultSecretsProvider'), 'identity'), 'clientId')]"
             },
             "ingressApplicationGatewayIdentityObjectId": {
               "type": "string",
+              "nullable": true,
               "metadata": {
                 "description": "The Object ID of Application Gateway Ingress Controller (AGIC) identity."
               },
-              "value": "[coalesce(tryGet(tryGet(tryGet(tryGet(reference('managedCluster'), 'addonProfiles'), 'ingressApplicationGateway'), 'identity'), 'objectId'), '')]"
+              "value": "[tryGet(tryGet(tryGet(tryGet(reference('managedCluster'), 'addonProfiles'), 'ingressApplicationGateway'), 'identity'), 'objectId')]"
             },
             "location": {
               "type": "string",
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('managedCluster', '2024-03-02-preview', 'full').location]"
+              "value": "[reference('managedCluster', '2024-09-02-preview', 'full').location]"
             },
             "oidcIssuerUrl": {
               "type": "string",
+              "nullable": true,
               "metadata": {
                 "description": "The OIDC token issuer URL."
               },
-              "value": "[coalesce(tryGet(tryGet(reference('managedCluster'), 'oidcIssuerProfile'), 'issuerURL'), '')]"
+              "value": "[tryGet(tryGet(reference('managedCluster'), 'oidcIssuerProfile'), 'issuerURL')]"
             },
             "addonProfiles": {
               "type": "object",
+              "nullable": true,
               "metadata": {
                 "description": "The addonProfiles of the Kubernetes cluster."
               },
-              "value": "[coalesce(tryGet(reference('managedCluster'), 'addonProfiles'), createObject())]"
+              "value": "[tryGet(reference('managedCluster'), 'addonProfiles')]"
             },
             "webAppRoutingIdentityObjectId": {
               "type": "string",
+              "nullable": true,
               "metadata": {
                 "description": "The Object ID of Web Application Routing."
               },
-              "value": "[coalesce(tryGet(tryGet(tryGet(tryGet(reference('managedCluster'), 'ingressProfile'), 'webAppRouting'), 'identity'), 'objectId'), '')]"
+              "value": "[tryGet(tryGet(tryGet(tryGet(reference('managedCluster'), 'ingressProfile'), 'webAppRouting'), 'identity'), 'objectId')]"
             }
           }
         }
@@ -4188,7 +4221,7 @@
             "value": [
               {
                 "name": "[parameters('containerRegistryRoleName')]",
-                "principalId": "[reference('managedCluster').outputs.kubeletIdentityObjectId.value]",
+                "principalId": "[coalesce(tryGet(tryGet(reference('managedCluster').outputs, 'kubeletIdentityObjectId'), 'value'), '')]",
                 "roleDefinitionIdOrName": "[variables('acrPullRole')]"
               }
             ]
@@ -4201,36 +4234,604 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "2449684443141404366"
+              "version": "0.33.93.31351",
+              "templateHash": "12422547988165106386"
             },
             "name": "Azure Container Registries (ACR)",
-            "description": "This module deploys an Azure Container Registry (ACR).",
-            "owner": "Azure/module-maintainers"
+            "description": "This module deploys an Azure Container Registry (ACR)."
           },
           "definitions": {
-            "managedIdentitiesType": {
+            "privateEndpointOutputType": {
               "type": "object",
               "properties": {
-                "systemAssigned": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "The name of the private endpoint."
+                  }
+                },
+                "resourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "The resource ID of the private endpoint."
+                  }
+                },
+                "groupId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "The group Id for the private endpoint Group."
+                  }
+                },
+                "customDnsConfigs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "fqdn": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "FQDN that resolves to private endpoint IP address."
+                        }
+                      },
+                      "ipAddresses": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "description": "A list of private IP addresses of the private endpoint."
+                        }
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "The custom DNS configurations of the private endpoint."
+                  }
+                },
+                "networkInterfaceResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "The IDs of the network interfaces associated with the private endpoint."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "scopeMapsType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the scope map."
+                  }
+                },
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "Required. The list of scoped permissions for registry artifacts."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The user friendly description of the scope map."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a scope map."
+              }
+            },
+            "cacheRuleType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the cache rule. Will be derived from the source repository name if not defined."
+                  }
+                },
+                "sourceRepository": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Source repository pulled from upstream."
+                  }
+                },
+                "targetRepository": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Target repository specified in docker pull command. E.g.: docker pull myregistry.azurecr.io/{targetRepository}:{tag}."
+                  }
+                },
+                "credentialSetResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource ID of the credential store which is associated with the cache rule."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a cache rule."
+              }
+            },
+            "credentialSetType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the credential set."
+                  }
+                },
+                "managedIdentities": {
+                  "$ref": "#/definitions/managedIdentityOnlySysAssignedType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The managed identity definition for this resource."
+                  }
+                },
+                "authCredentials": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/authCredentialsType"
+                  },
+                  "metadata": {
+                    "description": "Required. List of authentication credentials stored for an upstream. Usually consists of a primary and an optional secondary credential."
+                  }
+                },
+                "loginServer": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The credentials are stored for this upstream or login server."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a credential set."
+              }
+            },
+            "replicationType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the replication."
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Location for all resources."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Tags of the resource."
+                  }
+                },
+                "regionEndpointEnabled": {
                   "type": "bool",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. Enables system assigned managed identity on the resource."
+                    "description": "Optional. Specifies whether the replication regional endpoint is enabled. Requests will not be routed to a replication whose regional endpoint is disabled, however its data will continue to be synced with other replications."
                   }
                 },
-                "userAssignedResourceIds": {
+                "zoneRedundancy": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Disabled",
+                    "Enabled"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a replication."
+              }
+            },
+            "webhookType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "minLength": 5,
+                  "maxLength": 50,
+                  "metadata": {
+                    "description": "Optional. The name of the registry webhook."
+                  }
+                },
+                "serviceUri": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The service URI for the webhook to post notifications."
+                  }
+                },
+                "status": {
+                  "type": "string",
+                  "allowedValues": [
+                    "disabled",
+                    "enabled"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The status of the webhook at the time the operation was called."
+                  }
+                },
+                "action": {
                   "type": "array",
                   "items": {
                     "type": "string"
                   },
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. The resource ID(s) to assign to the resource."
+                    "description": "Optional. The list of actions that trigger the webhook to post notifications."
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Location for all resources."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Tags of the resource."
+                  }
+                },
+                "customHeaders": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Custom headers that will be added to the webhook notifications."
+                  }
+                },
+                "scope": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The scope of repositories where the event can be triggered. For example, 'foo:*' means events for all tags under repository 'foo'. 'foo:bar' means events for 'foo:bar' only. 'foo' is equivalent to 'foo:latest'. Empty means all events."
                   }
                 }
               },
-              "nullable": true
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a webhook."
+              }
+            },
+            "_1.privateEndpointCustomDnsConfigType": {
+              "type": "object",
+              "properties": {
+                "fqdn": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. FQDN that resolves to private endpoint IP address."
+                  }
+                },
+                "ipAddresses": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "Required. A list of private IP addresses of the private endpoint."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "_1.privateEndpointIpConfigurationType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the resource that is unique within a resource group."
+                  }
+                },
+                "properties": {
+                  "type": "object",
+                  "properties": {
+                    "groupId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to."
+                      }
+                    },
+                    "memberName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to."
+                      }
+                    },
+                    "privateIPAddress": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. Properties of private endpoint IP configurations."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "_1.privateEndpointPrivateDnsZoneGroupType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the Private DNS Zone Group."
+                  }
+                },
+                "privateDnsZoneGroupConfigs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. The name of the private DNS Zone Group config."
+                        }
+                      },
+                      "privateDnsZoneResourceId": {
+                        "type": "string",
+                        "metadata": {
+                          "description": "Required. The resource id of the private DNS zone."
+                        }
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. The private DNS Zone Groups to associate the Private Endpoint. A DNS Zone Group can support up to 5 DNS zones."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "authCredentialsType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the credential."
+                  }
+                },
+                "usernameSecretIdentifier": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. KeyVault Secret URI for accessing the username."
+                  }
+                },
+                "passwordSecretIdentifier": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. KeyVault Secret URI for accessing the password."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "The type for auth credentials.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "credential-set/main.bicep"
+                }
+              }
+            },
+            "customerManagedKeyWithAutoRotateType": {
+              "type": "object",
+              "properties": {
+                "keyVaultResourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
+                  }
+                },
+                "keyName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the customer managed key to use for encryption."
+                  }
+                },
+                "keyVersion": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting."
+                  }
+                },
+                "autoRotationEnabled": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used."
+                  }
+                },
+                "userAssignedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a customer-managed key. To be used if the resource type supports auto-rotation of the customer-managed key.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "diagnosticSettingFullType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the diagnostic setting."
+                  }
+                },
+                "logCategoriesAndGroups": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "category": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                        }
+                      },
+                      "categoryGroup": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                        }
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                        }
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+                  }
+                },
+                "metricCategories": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "category": {
+                        "type": "string",
+                        "metadata": {
+                          "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                        }
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                        }
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+                  }
+                },
+                "logAnalyticsDestinationType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "AzureDiagnostics",
+                    "Dedicated"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+                  }
+                },
+                "workspaceResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "storageAccountResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "eventHubAuthorizationRuleResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+                  }
+                },
+                "eventHubName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "marketplacePartnerResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
             },
             "lockType": {
               "type": "object",
@@ -4255,484 +4856,275 @@
                   }
                 }
               },
-              "nullable": true
-            },
-            "roleAssignmentType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
-                    }
-                  },
-                  "roleDefinitionIdOrName": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-                    }
-                  },
-                  "principalId": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-                    }
-                  },
-                  "principalType": {
-                    "type": "string",
-                    "allowedValues": [
-                      "Device",
-                      "ForeignGroup",
-                      "Group",
-                      "ServicePrincipal",
-                      "User"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The principal type of the assigned principal ID."
-                    }
-                  },
-                  "description": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The description of the role assignment."
-                    }
-                  },
-                  "condition": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-                    }
-                  },
-                  "conditionVersion": {
-                    "type": "string",
-                    "allowedValues": [
-                      "2.0"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Version of the condition."
-                    }
-                  },
-                  "delegatedManagedIdentityResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The Resource Id of the delegated managed identity resource."
-                    }
-                  }
+              "metadata": {
+                "description": "An AVM-aligned type for a lock.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
                 }
-              },
-              "nullable": true
+              }
             },
-            "privateEndpointType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of the private endpoint."
-                    }
-                  },
-                  "location": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The location to deploy the private endpoint to."
-                    }
-                  },
-                  "privateLinkServiceConnectionName": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of the private link connection to create."
-                    }
-                  },
-                  "service": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The subresource to deploy the private endpoint for. For example \"vault\", \"mysqlServer\" or \"dataFactory\"."
-                    }
-                  },
-                  "subnetResourceId": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
-                    }
-                  },
-                  "privateDnsZoneGroup": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. The name of the Private DNS Zone Group."
-                        }
-                      },
-                      "privateDnsZoneGroupConfigs": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. The name of the private DNS zone group config."
-                              }
-                            },
-                            "privateDnsZoneResourceId": {
-                              "type": "string",
-                              "metadata": {
-                                "description": "Required. The resource id of the private DNS zone."
-                              }
-                            }
-                          }
-                        },
-                        "metadata": {
-                          "description": "Required. The private DNS zone groups to associate the private endpoint. A DNS zone group can support up to 5 DNS zones."
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The private DNS zone group to configure for the private endpoint."
-                    }
-                  },
-                  "isManualConnection": {
-                    "type": "bool",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. If Manual Private Link Connection is required."
-                    }
-                  },
-                  "manualConnectionRequestMessage": {
-                    "type": "string",
-                    "nullable": true,
-                    "maxLength": 140,
-                    "metadata": {
-                      "description": "Optional. A message passed to the owner of the remote resource with the manual connection request."
-                    }
-                  },
-                  "customDnsConfigs": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "fqdn": {
-                          "type": "string",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Required. Fqdn that resolves to private endpoint IP address."
-                          }
-                        },
-                        "ipAddresses": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "metadata": {
-                            "description": "Required. A list of private IP addresses of the private endpoint."
-                          }
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Custom DNS configurations."
-                    }
-                  },
-                  "ipConfigurations": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "metadata": {
-                            "description": "Required. The name of the resource that is unique within a resource group."
-                          }
-                        },
-                        "properties": {
-                          "type": "object",
-                          "properties": {
-                            "groupId": {
-                              "type": "string",
-                              "metadata": {
-                                "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to."
-                              }
-                            },
-                            "memberName": {
-                              "type": "string",
-                              "metadata": {
-                                "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to."
-                              }
-                            },
-                            "privateIPAddress": {
-                              "type": "string",
-                              "metadata": {
-                                "description": "Required. A private IP address obtained from the private endpoint's subnet."
-                              }
-                            }
-                          },
-                          "metadata": {
-                            "description": "Required. Properties of private endpoint IP configurations."
-                          }
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
-                    }
-                  },
-                  "applicationSecurityGroupResourceIds": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Application security groups in which the private endpoint IP configuration is included."
-                    }
-                  },
-                  "customNetworkInterfaceName": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The custom name of the network interface attached to the private endpoint."
-                    }
-                  },
-                  "lock": {
-                    "$ref": "#/definitions/lockType",
-                    "metadata": {
-                      "description": "Optional. Specify the type of lock."
-                    }
-                  },
-                  "roleAssignments": {
-                    "$ref": "#/definitions/roleAssignmentType",
-                    "metadata": {
-                      "description": "Optional. Array of role assignments to create."
-                    }
-                  },
-                  "tags": {
-                    "type": "object",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Tags to be applied on all resources/resource groups in this deployment."
-                    }
-                  },
-                  "enableTelemetry": {
-                    "type": "bool",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Enable/Disable usage telemetry for module."
-                    }
-                  },
-                  "resourceGroupName": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Specify if you want to deploy the Private Endpoint into a different resource group than the main resource."
-                    }
-                  }
-                }
-              },
-              "nullable": true
-            },
-            "diagnosticSettingType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of diagnostic setting."
-                    }
-                  },
-                  "logCategoriesAndGroups": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "category": {
-                          "type": "string",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
-                          }
-                        },
-                        "categoryGroup": {
-                          "type": "string",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
-                          }
-                        },
-                        "enabled": {
-                          "type": "bool",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Enable or disable the category explicitly. Default is `true`."
-                          }
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
-                    }
-                  },
-                  "metricCategories": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "category": {
-                          "type": "string",
-                          "metadata": {
-                            "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
-                          }
-                        },
-                        "enabled": {
-                          "type": "bool",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Enable or disable the category explicitly. Default is `true`."
-                          }
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
-                    }
-                  },
-                  "logAnalyticsDestinationType": {
-                    "type": "string",
-                    "allowedValues": [
-                      "AzureDiagnostics",
-                      "Dedicated"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
-                    }
-                  },
-                  "workspaceResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
-                    }
-                  },
-                  "storageAccountResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
-                    }
-                  },
-                  "eventHubAuthorizationRuleResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
-                    }
-                  },
-                  "eventHubName": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
-                    }
-                  },
-                  "marketplacePartnerResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
-                    }
-                  }
-                }
-              },
-              "nullable": true
-            },
-            "customerManagedKeyType": {
+            "managedIdentityAllType": {
               "type": "object",
               "properties": {
-                "keyVaultResourceId": {
-                  "type": "string",
-                  "metadata": {
-                    "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
-                  }
-                },
-                "keyName": {
-                  "type": "string",
-                  "metadata": {
-                    "description": "Required. The name of the customer managed key to use for encryption."
-                  }
-                },
-                "keyVersion": {
-                  "type": "string",
+                "systemAssigned": {
+                  "type": "bool",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. The version of the customer managed key to reference for encryption. If not provided, using 'latest'."
+                    "description": "Optional. Enables system assigned managed identity on the resource."
                   }
                 },
-                "userAssignedIdentityResourceId": {
-                  "type": "string",
+                "userAssignedResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use."
+                    "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
                   }
                 }
               },
-              "nullable": true
+              "metadata": {
+                "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
             },
-            "scopeMapsType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of the scope map."
-                    }
-                  },
-                  "actions": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "metadata": {
-                      "description": "Required. The list of scoped permissions for registry artifacts."
-                    }
-                  },
-                  "description": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The user friendly description of the scope map."
-                    }
+            "managedIdentityOnlySysAssignedType": {
+              "type": "object",
+              "properties": {
+                "systemAssigned": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enables system assigned managed identity on the resource."
                   }
                 }
               },
-              "nullable": true
+              "metadata": {
+                "description": "An AVM-aligned type for a managed identity configuration. To be used if only system-assigned identities are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "privateEndpointSingleServiceType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the Private Endpoint."
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The location to deploy the Private Endpoint to."
+                  }
+                },
+                "privateLinkServiceConnectionName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the private link connection to create."
+                  }
+                },
+                "service": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The subresource to deploy the Private Endpoint for. For example \"vault\" for a Key Vault Private Endpoint."
+                  }
+                },
+                "subnetResourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                  }
+                },
+                "resourceGroupResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource ID of the Resource Group the Private Endpoint will be created in. If not specified, the Resource Group of the provided Virtual Network Subnet is used."
+                  }
+                },
+                "privateDnsZoneGroup": {
+                  "$ref": "#/definitions/_1.privateEndpointPrivateDnsZoneGroupType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The private DNS Zone Group to configure for the Private Endpoint."
+                  }
+                },
+                "isManualConnection": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. If Manual Private Link Connection is required."
+                  }
+                },
+                "manualConnectionRequestMessage": {
+                  "type": "string",
+                  "nullable": true,
+                  "maxLength": 140,
+                  "metadata": {
+                    "description": "Optional. A message passed to the owner of the remote resource with the manual connection request."
+                  }
+                },
+                "customDnsConfigs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/_1.privateEndpointCustomDnsConfigType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Custom DNS configurations."
+                  }
+                },
+                "ipConfigurations": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/_1.privateEndpointIpConfigurationType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. A list of IP configurations of the Private Endpoint. This will be used to map to the first-party Service endpoints."
+                  }
+                },
+                "applicationSecurityGroupResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Application security groups in which the Private Endpoint IP configuration is included."
+                  }
+                },
+                "customNetworkInterfaceName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The custom name of the network interface attached to the Private Endpoint."
+                  }
+                },
+                "lock": {
+                  "$ref": "#/definitions/lockType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the type of lock."
+                  }
+                },
+                "roleAssignments": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/roleAssignmentType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Array of role assignments to create."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Tags to be applied on all resources/Resource Groups in this deployment."
+                  }
+                },
+                "enableTelemetry": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable/Disable usage telemetry for module."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a private endpoint. To be used if the private endpoint's default service / groupId can be assumed (i.e., for services that only have one Private Endpoint type like 'vault' for key vault).",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
             }
           },
           "parameters": {
@@ -4759,14 +5151,18 @@
               }
             },
             "roleAssignments": {
-              "$ref": "#/definitions/roleAssignmentType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Array of role assignments to create."
               }
             },
             "acrSku": {
               "type": "string",
-              "defaultValue": "Basic",
+              "defaultValue": "Premium",
               "allowedValues": [
                 "Basic",
                 "Premium",
@@ -4835,7 +5231,7 @@
                 "enabled"
               ],
               "metadata": {
-                "description": "Optional. The value that indicates whether the policy for using ARM audience token for a container registr is enabled or not. Default is enabled."
+                "description": "Optional. The value that indicates whether the policy for using ARM audience token for a container registry is enabled or not. Default is enabled."
               }
             },
             "softDeletePolicyStatus": {
@@ -4904,14 +5300,18 @@
               }
             },
             "privateEndpoints": {
-              "$ref": "#/definitions/privateEndpointType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/privateEndpointSingleServiceType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. Note, requires the 'acrSku' to be 'Premium'."
               }
             },
             "zoneRedundancy": {
               "type": "string",
-              "defaultValue": "Disabled",
+              "defaultValue": "Enabled",
               "allowedValues": [
                 "Disabled",
                 "Enabled"
@@ -4922,6 +5322,9 @@
             },
             "replications": {
               "type": "array",
+              "items": {
+                "$ref": "#/definitions/replicationType"
+              },
               "nullable": true,
               "metadata": {
                 "description": "Optional. All replications to create."
@@ -4929,6 +5332,9 @@
             },
             "webhooks": {
               "type": "array",
+              "items": {
+                "$ref": "#/definitions/webhookType"
+              },
               "nullable": true,
               "metadata": {
                 "description": "Optional. All webhooks to create."
@@ -4936,12 +5342,14 @@
             },
             "lock": {
               "$ref": "#/definitions/lockType",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. The lock settings of the service."
               }
             },
             "managedIdentities": {
-              "$ref": "#/definitions/managedIdentitiesType",
+              "$ref": "#/definitions/managedIdentityAllType",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. The managed identity definition for this resource."
               }
@@ -4961,7 +5369,11 @@
               }
             },
             "diagnosticSettings": {
-              "$ref": "#/definitions/diagnosticSettingType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/diagnosticSettingFullType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. The diagnostic settings of the service."
               }
@@ -4974,13 +5386,17 @@
               }
             },
             "customerManagedKey": {
-              "$ref": "#/definitions/customerManagedKeyType",
+              "$ref": "#/definitions/customerManagedKeyWithAutoRotateType",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. The customer managed key definition."
               }
             },
             "cacheRules": {
               "type": "array",
+              "items": {
+                "$ref": "#/definitions/cacheRuleType"
+              },
               "nullable": true,
               "metadata": {
                 "description": "Optional. Array of Cache Rules."
@@ -4988,13 +5404,20 @@
             },
             "credentialSets": {
               "type": "array",
-              "defaultValue": [],
+              "items": {
+                "$ref": "#/definitions/credentialSetType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Array of Credential Sets."
               }
             },
             "scopeMaps": {
-              "$ref": "#/definitions/scopeMapsType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/scopeMapsType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Scope maps setting."
               }
@@ -5008,6 +5431,7 @@
                 "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
               }
             ],
+            "enableReferencedModulesTelemetry": false,
             "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
             "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned, UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
             "builtInRoleNames": {
@@ -5030,18 +5454,15 @@
               "existing": true,
               "type": "Microsoft.KeyVault/vaults/keys",
               "apiVersion": "2023-02-01",
-              "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '//'), '/')[2]]",
-              "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '////'), '/')[4]]",
-              "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]",
-              "dependsOn": [
-                "cMKKeyVault"
-              ]
+              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+              "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
             },
             "avmTelemetry": {
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2024-03-01",
-              "name": "[format('46d3xbcp.res.containerregistry-registry.{0}.{1}', replace('0.5.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "name": "[format('46d3xbcp.res.containerregistry-registry.{0}.{1}', replace('0.9.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -5062,18 +5483,18 @@
               "existing": true,
               "type": "Microsoft.KeyVault/vaults",
               "apiVersion": "2023-02-01",
-              "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '//'), '/')[2]]",
-              "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '////'), '/')[4]]",
-              "name": "[last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/'))]"
+              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+              "name": "[last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))]"
             },
             "cMKUserAssignedIdentity": {
               "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId')))]",
               "existing": true,
               "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
               "apiVersion": "2023-01-31",
-              "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2]]",
-              "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]]",
-              "name": "[last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/'))]"
+              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[2]]",
+              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[4]]",
+              "name": "[last(split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/'))]"
             },
             "registry": {
               "type": "Microsoft.ContainerRegistry/registries",
@@ -5088,7 +5509,7 @@
               "properties": {
                 "anonymousPullEnabled": "[parameters('anonymousPullEnabled')]",
                 "adminUserEnabled": "[parameters('acrAdminUserEnabled')]",
-                "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('status', 'enabled', 'keyVaultProperties', createObject('identity', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), ''))), reference('cMKUserAssignedIdentity').clientId, null()), 'keyIdentifier', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'keyVersion'), ''))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, parameters('customerManagedKey').keyVersion), reference('cMKKeyVault::cMKKey').keyUriWithVersion))), null())]",
+                "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('status', 'enabled', 'keyVaultProperties', createObject('identity', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), ''))), reference('cMKUserAssignedIdentity').clientId, null()), 'keyIdentifier', if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), if(coalesce(tryGet(parameters('customerManagedKey'), 'autoRotationEnabled'), true()), reference('cMKKeyVault::cMKKey').keyUri, reference('cMKKeyVault::cMKKey').keyUriWithVersion)))), null())]",
                 "policies": {
                   "azureADAuthenticationAsArmPolicy": {
                     "status": "[parameters('azureADAuthenticationAsArmPolicyStatus')]"
@@ -5109,7 +5530,7 @@
                 "zoneRedundancy": "[if(equals(parameters('acrSku'), 'Premium'), parameters('zoneRedundancy'), null())]"
               },
               "dependsOn": [
-                "cMKKeyVault",
+                "cMKKeyVault::cMKKey",
                 "cMKUserAssignedIdentity"
               ]
             },
@@ -5224,12 +5645,11 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "9144531012597082524"
+                      "version": "0.33.93.31351",
+                      "templateHash": "11112300500664950599"
                     },
                     "name": "Container Registries scopeMaps",
-                    "description": "This module deploys an Azure Container Registry (ACR) scopeMap.",
-                    "owner": "Azure/module-maintainers"
+                    "description": "This module deploys an Azure Container Registry (ACR) scopeMap."
                   },
                   "parameters": {
                     "registryName": {
@@ -5276,10 +5696,7 @@
                       "properties": {
                         "actions": "[parameters('actions')]",
                         "description": "[parameters('description')]"
-                      },
-                      "dependsOn": [
-                        "registry"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -5351,12 +5768,11 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "8531695368487734118"
+                      "version": "0.33.93.31351",
+                      "templateHash": "6036875058945996178"
                     },
                     "name": "Azure Container Registry (ACR) Replications",
-                    "description": "This module deploys an Azure Container Registry (ACR) Replication.",
-                    "owner": "Azure/module-maintainers"
+                    "description": "This module deploys an Azure Container Registry (ACR) Replication."
                   },
                   "parameters": {
                     "registryName": {
@@ -5420,10 +5836,7 @@
                       "properties": {
                         "regionEndpointEnabled": "[parameters('regionEndpointEnabled')]",
                         "zoneRedundancy": "[parameters('zoneRedundancy')]"
-                      },
-                      "dependsOn": [
-                        "registry"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -5499,15 +5912,41 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "12196074162662855376"
+                      "version": "0.33.93.31351",
+                      "templateHash": "15848218260506856293"
                     },
                     "name": "Container Registries Credential Sets",
-                    "description": "This module deploys an ACR Credential Set.",
-                    "owner": "Azure/module-maintainers"
+                    "description": "This module deploys an ACR Credential Set."
                   },
                   "definitions": {
-                    "managedIdentitiesType": {
+                    "authCredentialsType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the credential."
+                          }
+                        },
+                        "usernameSecretIdentifier": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. KeyVault Secret URI for accessing the username."
+                          }
+                        },
+                        "passwordSecretIdentifier": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. KeyVault Secret URI for accessing the password."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for auth credentials."
+                      }
+                    },
+                    "managedIdentityOnlySysAssignedType": {
                       "type": "object",
                       "properties": {
                         "systemAssigned": {
@@ -5517,31 +5956,11 @@
                             "description": "Optional. Enables system assigned managed identity on the resource."
                           }
                         }
-                      }
-                    },
-                    "authCredentialsType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The name of the credential."
-                            }
-                          },
-                          "usernameSecretIdentifier": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. KeyVault Secret URI for accessing the username."
-                            }
-                          },
-                          "passwordSecretIdentifier": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. KeyVault Secret URI for accessing the password."
-                            }
-                          }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a managed identity configuration. To be used if only system-assigned identities are supported by the resource provider.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
                         }
                       }
                     }
@@ -5550,7 +5969,7 @@
                     "registryName": {
                       "type": "string",
                       "metadata": {
-                        "description": "Required. The name of the parent registry. Required if the template is used in a standalone deployment."
+                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
                       }
                     },
                     "name": {
@@ -5560,13 +5979,17 @@
                       }
                     },
                     "managedIdentities": {
-                      "$ref": "#/definitions/managedIdentitiesType",
+                      "$ref": "#/definitions/managedIdentityOnlySysAssignedType",
+                      "nullable": true,
                       "metadata": {
-                        "description": "Required. The managed identity definition for this resource."
+                        "description": "Optional. The managed identity definition for this resource."
                       }
                     },
                     "authCredentials": {
-                      "$ref": "#/definitions/authCredentialsType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/authCredentialsType"
+                      },
                       "metadata": {
                         "description": "Required. List of authentication credentials stored for an upstream. Usually consists of a primary and an optional secondary credential."
                       }
@@ -5596,10 +6019,7 @@
                       "properties": {
                         "authCredentials": "[parameters('authCredentials')]",
                         "loginServer": "[parameters('loginServer')]"
-                      },
-                      "dependsOn": [
-                        "registry"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -5626,10 +6046,11 @@
                     },
                     "systemAssignedMIPrincipalId": {
                       "type": "string",
+                      "nullable": true,
                       "metadata": {
                         "description": "The principal ID of the system assigned identity."
                       },
-                      "value": "[coalesce(tryGet(tryGet(reference('credentialSet', '2023-11-01-preview', 'full'), 'identity'), 'principalId'), '')]"
+                      "value": "[tryGet(tryGet(reference('credentialSet', '2023-11-01-preview', 'full'), 'identity'), 'principalId')]"
                     }
                   }
                 }
@@ -5659,7 +6080,7 @@
                     "value": "[coalesce(parameters('cacheRules'), createArray())[copyIndex()].sourceRepository]"
                   },
                   "name": {
-                    "value": "[coalesce(tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'name'), replace(replace(coalesce(parameters('cacheRules'), createArray())[copyIndex()].sourceRepository, '/', '-'), '.', '-'))]"
+                    "value": "[tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'name')]"
                   },
                   "targetRepository": {
                     "value": "[coalesce(tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'targetRepository'), coalesce(parameters('cacheRules'), createArray())[copyIndex()].sourceRepository)]"
@@ -5670,27 +6091,27 @@
                 },
                 "template": {
                   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
                   "contentVersion": "1.0.0.0",
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "14369419482171687857"
+                      "version": "0.33.93.31351",
+                      "templateHash": "3783697279882479947"
                     },
                     "name": "Container Registries Cache",
-                    "description": "Cache for Azure Container Registry (Preview) feature allows users to cache container images in a private container registry. Cache for ACR, is a preview feature available in Basic, Standard, and Premium service tiers ([ref](https://learn.microsoft.com/en-us/azure/container-registry/tutorial-registry-cache)).",
-                    "owner": "Azure/module-maintainers"
+                    "description": "Cache for Azure Container Registry (Preview) feature allows users to cache container images in a private container registry. Cache for ACR, is a preview feature available in Basic, Standard, and Premium service tiers ([ref](https://learn.microsoft.com/en-us/azure/container-registry/tutorial-registry-cache))."
                   },
                   "parameters": {
                     "registryName": {
                       "type": "string",
                       "metadata": {
-                        "description": "Required. The name of the parent registry. Required if the template is used in a standalone deployment."
+                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
                       }
                     },
                     "name": {
                       "type": "string",
-                      "defaultValue": "[replace(replace(parameters('sourceRepository'), '/', '-'), '.', '-')]",
+                      "defaultValue": "[replace(replace(replace(parameters('sourceRepository'), '/', '-'), '.', '-'), '*', '')]",
                       "metadata": {
                         "description": "Optional. The name of the cache rule. Will be derived from the source repository name if not defined."
                       }
@@ -5710,13 +6131,20 @@
                     },
                     "credentialSetResourceId": {
                       "type": "string",
+                      "nullable": true,
                       "metadata": {
-                        "description": "Required. The resource ID of the credential store which is associated with the cache rule."
+                        "description": "Optional. The resource ID of the credential store which is associated with the cache rule."
                       }
                     }
                   },
-                  "resources": [
-                    {
+                  "resources": {
+                    "registry": {
+                      "existing": true,
+                      "type": "Microsoft.ContainerRegistry/registries",
+                      "apiVersion": "2023-06-01-preview",
+                      "name": "[parameters('registryName')]"
+                    },
+                    "cacheRule": {
                       "type": "Microsoft.ContainerRegistry/registries/cacheRules",
                       "apiVersion": "2023-06-01-preview",
                       "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
@@ -5726,7 +6154,7 @@
                         "credentialSetResourceId": "[parameters('credentialSetResourceId')]"
                       }
                     }
-                  ],
+                  },
                   "outputs": {
                     "name": {
                       "type": "string",
@@ -5781,7 +6209,7 @@
                     "value": "[coalesce(tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'location'), parameters('location'))]"
                   },
                   "action": {
-                    "value": "[coalesce(tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'action'), createArray('chart_delete', 'chart_push', 'delete', 'push', 'quarantine'))]"
+                    "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'action')]"
                   },
                   "customHeaders": {
                     "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'customHeaders')]"
@@ -5806,12 +6234,11 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "14912363209364245195"
+                      "version": "0.33.93.31351",
+                      "templateHash": "10084997815751263562"
                     },
                     "name": "Azure Container Registry (ACR) Webhooks",
-                    "description": "This module deploys an Azure Container Registry (ACR) Webhook.",
-                    "owner": "Azure/module-maintainers"
+                    "description": "This module deploys an Azure Container Registry (ACR) Webhook."
                   },
                   "parameters": {
                     "registryName": {
@@ -5848,6 +6275,9 @@
                     },
                     "action": {
                       "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
                       "defaultValue": [
                         "chart_delete",
                         "chart_push",
@@ -5907,10 +6337,7 @@
                         "scope": "[parameters('scope')]",
                         "serviceUri": "[parameters('serviceUri')]",
                         "status": "[parameters('status')]"
-                      },
-                      "dependsOn": [
-                        "registry"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -5978,7 +6405,8 @@
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
               "name": "[format('{0}-registry-PrivateEndpoint-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
-              "resourceGroup": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupName'), '')]",
+              "subscriptionId": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[2]]",
+              "resourceGroup": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[4]]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
@@ -5994,7 +6422,7 @@
                     "value": "[coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId]"
                   },
                   "enableTelemetry": {
-                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'enableTelemetry'), parameters('enableTelemetry'))]"
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
                   },
                   "location": {
                     "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'location'), reference(split(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location)]"
@@ -6031,12 +6459,11 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "1277254088602407590"
+                      "version": "0.33.13.18514",
+                      "templateHash": "15954548978129725136"
                     },
                     "name": "Private Endpoints",
-                    "description": "This module deploys a Private Endpoint.",
-                    "owner": "Azure/module-maintainers"
+                    "description": "This module deploys a Private Endpoint."
                   },
                   "definitions": {
                     "privateDnsZoneGroupType": {
@@ -6058,80 +6485,118 @@
                             "description": "Required. The private DNS zone groups to associate the private endpoint. A DNS zone group can support up to 5 DNS zones."
                           }
                         }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true
                       }
                     },
-                    "roleAssignmentType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
+                    "ipConfigurationType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the resource that is unique within a resource group."
+                          }
+                        },
                         "properties": {
-                          "name": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          "type": "object",
+                          "properties": {
+                            "groupId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
+                              }
+                            },
+                            "memberName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
+                              }
+                            },
+                            "privateIPAddress": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                              }
                             }
                           },
-                          "roleDefinitionIdOrName": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-                            }
-                          },
-                          "principalId": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-                            }
-                          },
-                          "principalType": {
-                            "type": "string",
-                            "allowedValues": [
-                              "Device",
-                              "ForeignGroup",
-                              "Group",
-                              "ServicePrincipal",
-                              "User"
-                            ],
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The principal type of the assigned principal ID."
-                            }
-                          },
-                          "description": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The description of the role assignment."
-                            }
-                          },
-                          "condition": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-                            }
-                          },
-                          "conditionVersion": {
-                            "type": "string",
-                            "allowedValues": [
-                              "2.0"
-                            ],
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. Version of the condition."
-                            }
-                          },
-                          "delegatedManagedIdentityResourceId": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The Resource Id of the delegated managed identity resource."
-                            }
+                          "metadata": {
+                            "description": "Required. Properties of private endpoint IP configurations."
                           }
                         }
                       },
-                      "nullable": true
+                      "metadata": {
+                        "__bicep_export!": true
+                      }
+                    },
+                    "privateLinkServiceConnectionType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the private link service connection."
+                          }
+                        },
+                        "properties": {
+                          "type": "object",
+                          "properties": {
+                            "groupIds": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string array `[]`."
+                              }
+                            },
+                            "privateLinkServiceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The resource id of private link service."
+                              }
+                            },
+                            "requestMessage": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars."
+                              }
+                            }
+                          },
+                          "metadata": {
+                            "description": "Required. Properties of private link service connection."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true
+                      }
+                    },
+                    "customDnsConfigType": {
+                      "type": "object",
+                      "properties": {
+                        "fqdn": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. FQDN that resolves to private endpoint IP address."
+                          }
+                        },
+                        "ipAddresses": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "description": "Required. A list of private IP addresses of the private endpoint."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true
+                      }
                     },
                     "lockType": {
                       "type": "object",
@@ -6156,161 +6621,12 @@
                           }
                         }
                       },
-                      "nullable": true
-                    },
-                    "ipConfigurationsType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The name of the resource that is unique within a resource group."
-                            }
-                          },
-                          "properties": {
-                            "type": "object",
-                            "properties": {
-                              "groupId": {
-                                "type": "string",
-                                "metadata": {
-                                  "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
-                                }
-                              },
-                              "memberName": {
-                                "type": "string",
-                                "metadata": {
-                                  "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
-                                }
-                              },
-                              "privateIPAddress": {
-                                "type": "string",
-                                "metadata": {
-                                  "description": "Required. A private IP address obtained from the private endpoint's subnet."
-                                }
-                              }
-                            },
-                            "metadata": {
-                              "description": "Required. Properties of private endpoint IP configurations."
-                            }
-                          }
+                      "metadata": {
+                        "description": "An AVM-aligned type for a lock.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
                         }
-                      },
-                      "nullable": true
-                    },
-                    "manualPrivateLinkServiceConnectionsType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The name of the private link service connection."
-                            }
-                          },
-                          "properties": {
-                            "type": "object",
-                            "properties": {
-                              "groupIds": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "metadata": {
-                                  "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string array `[]`."
-                                }
-                              },
-                              "privateLinkServiceId": {
-                                "type": "string",
-                                "metadata": {
-                                  "description": "Required. The resource id of private link service."
-                                }
-                              },
-                              "requestMessage": {
-                                "type": "string",
-                                "metadata": {
-                                  "description": "Optional. A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars."
-                                }
-                              }
-                            },
-                            "metadata": {
-                              "description": "Required. Properties of private link service connection."
-                            }
-                          }
-                        }
-                      },
-                      "nullable": true
-                    },
-                    "privateLinkServiceConnectionsType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The name of the private link service connection."
-                            }
-                          },
-                          "properties": {
-                            "type": "object",
-                            "properties": {
-                              "groupIds": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "metadata": {
-                                  "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string array `[]`."
-                                }
-                              },
-                              "privateLinkServiceId": {
-                                "type": "string",
-                                "metadata": {
-                                  "description": "Required. The resource id of private link service."
-                                }
-                              },
-                              "requestMessage": {
-                                "type": "string",
-                                "nullable": true,
-                                "metadata": {
-                                  "description": "Optional. A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars."
-                                }
-                              }
-                            },
-                            "metadata": {
-                              "description": "Required. Properties of private link service connection."
-                            }
-                          }
-                        }
-                      },
-                      "nullable": true
-                    },
-                    "customDnsConfigType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "fqdn": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. Fqdn that resolves to private endpoint IP address."
-                            }
-                          },
-                          "ipAddresses": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            },
-                            "metadata": {
-                              "description": "Required. A list of private IP addresses of the private endpoint."
-                            }
-                          }
-                        }
-                      },
-                      "nullable": true
+                      }
                     },
                     "privateDnsZoneGroupConfigType": {
                       "type": "object",
@@ -6334,6 +6650,81 @@
                           "sourceTemplate": "private-dns-zone-group/main.bicep"
                         }
                       }
+                    },
+                    "roleAssignmentType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
                     }
                   },
                   "parameters": {
@@ -6351,6 +6742,9 @@
                     },
                     "applicationSecurityGroupResourceIds": {
                       "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
                       "nullable": true,
                       "metadata": {
                         "description": "Optional. Application security groups in which the private endpoint IP configuration is included."
@@ -6364,7 +6758,11 @@
                       }
                     },
                     "ipConfigurations": {
-                      "$ref": "#/definitions/ipConfigurationsType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/ipConfigurationType"
+                      },
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
                       }
@@ -6385,12 +6783,17 @@
                     },
                     "lock": {
                       "$ref": "#/definitions/lockType",
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. The lock settings of the service."
                       }
                     },
                     "roleAssignments": {
-                      "$ref": "#/definitions/roleAssignmentType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. Array of role assignments to create."
                       }
@@ -6403,21 +6806,33 @@
                       }
                     },
                     "customDnsConfigs": {
-                      "$ref": "#/definitions/customDnsConfigType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/customDnsConfigType"
+                      },
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. Custom DNS configurations."
                       }
                     },
                     "manualPrivateLinkServiceConnections": {
-                      "$ref": "#/definitions/manualPrivateLinkServiceConnectionsType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/privateLinkServiceConnectionType"
+                      },
+                      "nullable": true,
                       "metadata": {
-                        "description": "Optional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource."
+                        "description": "Conditional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource. Required if `privateLinkServiceConnections` is empty."
                       }
                     },
                     "privateLinkServiceConnections": {
-                      "$ref": "#/definitions/privateLinkServiceConnectionsType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/privateLinkServiceConnectionType"
+                      },
+                      "nullable": true,
                       "metadata": {
-                        "description": "Optional. A grouping of information about the connection to the remote resource."
+                        "description": "Conditional. A grouping of information about the connection to the remote resource. Required if `manualPrivateLinkServiceConnections` is empty."
                       }
                     },
                     "enableTelemetry": {
@@ -6446,7 +6861,7 @@
                       "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
                       "Private DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b12aa53e-6015-4669-85d0-8515ebb3ae7f')]",
                       "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
-                      "Role Based Access Control Administrator (Preview)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+                      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
                     }
                   },
                   "resources": {
@@ -6454,7 +6869,7 @@
                       "condition": "[parameters('enableTelemetry')]",
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2024-03-01",
-                      "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.7.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.10.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
                       "properties": {
                         "mode": "Incremental",
                         "template": {
@@ -6560,12 +6975,11 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "5805178546717255803"
+                              "version": "0.33.13.18514",
+                              "templateHash": "5440815542537978381"
                             },
                             "name": "Private Endpoint Private DNS Zone Groups",
-                            "description": "This module deploys a Private Endpoint Private DNS Zone Group.",
-                            "owner": "Azure/module-maintainers"
+                            "description": "This module deploys a Private Endpoint Private DNS Zone Group."
                           },
                           "definitions": {
                             "privateDnsZoneGroupConfigType": {
@@ -6643,10 +7057,7 @@
                               "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
                               "properties": {
                                 "privateDnsZoneConfigs": "[variables('privateDnsZoneConfigsVar')]"
-                              },
-                              "dependsOn": [
-                                "privateEndpoint"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -6708,32 +7119,40 @@
                       },
                       "value": "[reference('privateEndpoint', '2023-11-01', 'full').location]"
                     },
-                    "customDnsConfig": {
-                      "$ref": "#/definitions/customDnsConfigType",
+                    "customDnsConfigs": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/customDnsConfigType"
+                      },
                       "metadata": {
                         "description": "The custom DNS configurations of the private endpoint."
                       },
                       "value": "[reference('privateEndpoint').customDnsConfigs]"
                     },
-                    "networkInterfaceIds": {
+                    "networkInterfaceResourceIds": {
                       "type": "array",
-                      "metadata": {
-                        "description": "The IDs of the network interfaces associated with the private endpoint."
+                      "items": {
+                        "type": "string"
                       },
-                      "value": "[reference('privateEndpoint').networkInterfaces]"
+                      "metadata": {
+                        "description": "The resource IDs of the network interfaces associated with the private endpoint."
+                      },
+                      "value": "[map(reference('privateEndpoint').networkInterfaces, lambda('nic', lambdaVariables('nic').id))]"
                     },
                     "groupId": {
                       "type": "string",
+                      "nullable": true,
                       "metadata": {
                         "description": "The group Id for the private endpoint Group."
                       },
-                      "value": "[if(and(not(empty(reference('privateEndpoint').manualPrivateLinkServiceConnections)), greater(length(tryGet(reference('privateEndpoint').manualPrivateLinkServiceConnections[0].properties, 'groupIds')), 0)), coalesce(tryGet(reference('privateEndpoint').manualPrivateLinkServiceConnections[0].properties, 'groupIds', 0), ''), if(and(not(empty(reference('privateEndpoint').privateLinkServiceConnections)), greater(length(tryGet(reference('privateEndpoint').privateLinkServiceConnections[0].properties, 'groupIds')), 0)), coalesce(tryGet(reference('privateEndpoint').privateLinkServiceConnections[0].properties, 'groupIds', 0), ''), ''))]"
+                      "value": "[coalesce(tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'manualPrivateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0), tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'privateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0))]"
                     }
                   }
                 }
               },
               "dependsOn": [
-                "registry"
+                "registry",
+                "registry_replications"
               ]
             }
           },
@@ -6768,10 +7187,11 @@
             },
             "systemAssignedMIPrincipalId": {
               "type": "string",
+              "nullable": true,
               "metadata": {
                 "description": "The principal ID of the system assigned identity."
               },
-              "value": "[coalesce(tryGet(tryGet(reference('registry', '2023-06-01-preview', 'full'), 'identity'), 'principalId'), '')]"
+              "value": "[tryGet(tryGet(reference('registry', '2023-06-01-preview', 'full'), 'identity'), 'principalId')]"
             },
             "location": {
               "type": "string",
@@ -6786,8 +7206,8 @@
                 "description": "The Principal IDs of the ACR Credential Sets system-assigned identities."
               },
               "copy": {
-                "count": "[length(range(0, length(parameters('credentialSets'))))]",
-                "input": "[reference(format('registry_credentialSets[{0}]', range(0, length(parameters('credentialSets')))[copyIndex()])).outputs.systemAssignedMIPrincipalId.value]"
+                "count": "[length(range(0, length(coalesce(parameters('credentialSets'), createArray()))))]",
+                "input": "[tryGet(tryGet(reference(format('registry_credentialSets[{0}]', range(0, length(coalesce(parameters('credentialSets'), createArray())))[copyIndex()])).outputs, 'systemAssignedMIPrincipalId'), 'value')]"
               }
             },
             "credentialSetsResourceIds": {
@@ -6796,23 +7216,26 @@
                 "description": "The Resource IDs of the ACR Credential Sets."
               },
               "copy": {
-                "count": "[length(range(0, length(parameters('credentialSets'))))]",
-                "input": "[reference(format('registry_credentialSets[{0}]', range(0, length(parameters('credentialSets')))[copyIndex()])).outputs.resourceId.value]"
+                "count": "[length(range(0, length(coalesce(parameters('credentialSets'), createArray()))))]",
+                "input": "[reference(format('registry_credentialSets[{0}]', range(0, length(coalesce(parameters('credentialSets'), createArray())))[copyIndex()])).outputs.resourceId.value]"
               }
             },
             "privateEndpoints": {
               "type": "array",
+              "items": {
+                "$ref": "#/definitions/privateEndpointOutputType"
+              },
               "metadata": {
                 "description": "The private endpoints of the Azure container registry."
               },
               "copy": {
-                "count": "[length(if(not(empty(parameters('privateEndpoints'))), array(parameters('privateEndpoints')), createArray()))]",
+                "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]",
                 "input": {
                   "name": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.name.value]",
                   "resourceId": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.resourceId.value]",
-                  "groupId": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.groupId.value]",
-                  "customDnsConfig": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfig.value]",
-                  "networkInterfaceIds": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceIds.value]"
+                  "groupId": "[tryGet(tryGet(reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs, 'groupId'), 'value')]",
+                  "customDnsConfigs": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfigs.value]",
+                  "networkInterfaceResourceIds": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceResourceIds.value]"
                 }
               }
             }
@@ -6854,7 +7277,7 @@
           "accessPolicies": {
             "value": [
               {
-                "objectId": "[reference('managedCluster').outputs.kubeletIdentityObjectId.value]",
+                "objectId": "[coalesce(tryGet(tryGet(reference('managedCluster').outputs, 'kubeletIdentityObjectId'), 'value'), '')]",
                 "permissions": {
                   "secrets": [
                     "get",
@@ -6872,804 +7295,461 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "10085839006881327962"
+              "version": "0.33.93.31351",
+              "templateHash": "17553975707245390963"
             },
             "name": "Key Vaults",
-            "description": "This module deploys a Key Vault.",
-            "owner": "Azure/module-maintainers"
+            "description": "This module deploys a Key Vault."
           },
           "definitions": {
-            "diagnosticSettingType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of diagnostic setting."
-                    }
-                  },
-                  "logCategoriesAndGroups": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "category": {
-                          "type": "string",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
-                          }
-                        },
-                        "categoryGroup": {
-                          "type": "string",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
-                          }
-                        },
-                        "enabled": {
-                          "type": "bool",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Enable or disable the category explicitly. Default is `true`."
-                          }
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
-                    }
-                  },
-                  "metricCategories": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "category": {
-                          "type": "string",
-                          "metadata": {
-                            "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
-                          }
-                        },
-                        "enabled": {
-                          "type": "bool",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Optional. Enable or disable the category explicitly. Default is `true`."
-                          }
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
-                    }
-                  },
-                  "logAnalyticsDestinationType": {
-                    "type": "string",
-                    "allowedValues": [
-                      "AzureDiagnostics",
-                      "Dedicated"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
-                    }
-                  },
-                  "workspaceResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
-                    }
-                  },
-                  "storageAccountResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
-                    }
-                  },
-                  "eventHubAuthorizationRuleResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
-                    }
-                  },
-                  "eventHubName": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
-                    }
-                  },
-                  "marketplacePartnerResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
-                    }
-                  }
-                }
-              },
-              "nullable": true
-            },
-            "roleAssignmentType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
-                    }
-                  },
-                  "roleDefinitionIdOrName": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-                    }
-                  },
-                  "principalId": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-                    }
-                  },
-                  "principalType": {
-                    "type": "string",
-                    "allowedValues": [
-                      "Device",
-                      "ForeignGroup",
-                      "Group",
-                      "ServicePrincipal",
-                      "User"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The principal type of the assigned principal ID."
-                    }
-                  },
-                  "description": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The description of the role assignment."
-                    }
-                  },
-                  "condition": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-                    }
-                  },
-                  "conditionVersion": {
-                    "type": "string",
-                    "allowedValues": [
-                      "2.0"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Version of the condition."
-                    }
-                  },
-                  "delegatedManagedIdentityResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The Resource Id of the delegated managed identity resource."
-                    }
-                  }
-                }
-              },
-              "nullable": true
-            },
-            "privateEndpointType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of the private endpoint."
-                    }
-                  },
-                  "location": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The location to deploy the private endpoint to."
-                    }
-                  },
-                  "privateLinkServiceConnectionName": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name of the private link connection to create."
-                    }
-                  },
-                  "service": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The subresource to deploy the private endpoint for. For example \"vault\", \"mysqlServer\" or \"dataFactory\"."
-                    }
-                  },
-                  "subnetResourceId": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
-                    }
-                  },
-                  "privateDnsZoneGroup": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. The name of the Private DNS Zone Group."
-                        }
-                      },
-                      "privateDnsZoneGroupConfigs": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string",
-                              "nullable": true,
-                              "metadata": {
-                                "description": "Optional. The name of the private DNS zone group config."
-                              }
-                            },
-                            "privateDnsZoneResourceId": {
-                              "type": "string",
-                              "metadata": {
-                                "description": "Required. The resource id of the private DNS zone."
-                              }
-                            }
-                          }
-                        },
-                        "metadata": {
-                          "description": "Required. The private DNS zone groups to associate the private endpoint. A DNS zone group can support up to 5 DNS zones."
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The private DNS zone group to configure for the private endpoint."
-                    }
-                  },
-                  "isManualConnection": {
-                    "type": "bool",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. If Manual Private Link Connection is required."
-                    }
-                  },
-                  "manualConnectionRequestMessage": {
-                    "type": "string",
-                    "nullable": true,
-                    "maxLength": 140,
-                    "metadata": {
-                      "description": "Optional. A message passed to the owner of the remote resource with the manual connection request."
-                    }
-                  },
-                  "customDnsConfigs": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "fqdn": {
-                          "type": "string",
-                          "nullable": true,
-                          "metadata": {
-                            "description": "Required. Fqdn that resolves to private endpoint IP address."
-                          }
-                        },
-                        "ipAddresses": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "metadata": {
-                            "description": "Required. A list of private IP addresses of the private endpoint."
-                          }
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Custom DNS configurations."
-                    }
-                  },
-                  "ipConfigurations": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "metadata": {
-                            "description": "Required. The name of the resource that is unique within a resource group."
-                          }
-                        },
-                        "properties": {
-                          "type": "object",
-                          "properties": {
-                            "groupId": {
-                              "type": "string",
-                              "metadata": {
-                                "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to."
-                              }
-                            },
-                            "memberName": {
-                              "type": "string",
-                              "metadata": {
-                                "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to."
-                              }
-                            },
-                            "privateIPAddress": {
-                              "type": "string",
-                              "metadata": {
-                                "description": "Required. A private IP address obtained from the private endpoint's subnet."
-                              }
-                            }
-                          },
-                          "metadata": {
-                            "description": "Required. Properties of private endpoint IP configurations."
-                          }
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
-                    }
-                  },
-                  "applicationSecurityGroupResourceIds": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Application security groups in which the private endpoint IP configuration is included."
-                    }
-                  },
-                  "customNetworkInterfaceName": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The custom name of the network interface attached to the private endpoint."
-                    }
-                  },
-                  "lock": {
-                    "$ref": "#/definitions/lockType",
-                    "metadata": {
-                      "description": "Optional. Specify the type of lock."
-                    }
-                  },
-                  "roleAssignments": {
-                    "$ref": "#/definitions/roleAssignmentType",
-                    "metadata": {
-                      "description": "Optional. Array of role assignments to create."
-                    }
-                  },
-                  "tags": {
-                    "type": "object",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Tags to be applied on all resources/resource groups in this deployment."
-                    }
-                  },
-                  "enableTelemetry": {
-                    "type": "bool",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Enable/Disable usage telemetry for module."
-                    }
-                  },
-                  "resourceGroupName": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Specify if you want to deploy the Private Endpoint into a different resource group than the main resource."
-                    }
-                  }
-                }
-              },
-              "nullable": true
-            },
-            "lockType": {
+            "privateEndpointOutputType": {
               "type": "object",
               "properties": {
                 "name": {
                   "type": "string",
-                  "nullable": true,
                   "metadata": {
-                    "description": "Optional. Specify the name of lock."
+                    "description": "The name of the private endpoint."
                   }
                 },
-                "kind": {
+                "resourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "The resource ID of the private endpoint."
+                  }
+                },
+                "groupId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "The group Id for the private endpoint Group."
+                  }
+                },
+                "customDnsConfigs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "fqdn": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "FQDN that resolves to private endpoint IP address."
+                        }
+                      },
+                      "ipAddresses": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "description": "A list of private IP addresses of the private endpoint."
+                        }
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "The custom DNS configurations of the private endpoint."
+                  }
+                },
+                "networkInterfaceResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "The IDs of the network interfaces associated with the private endpoint."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "credentialOutputType": {
+              "type": "object",
+              "properties": {
+                "resourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "The item's resourceId."
+                  }
+                },
+                "uri": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "The item's uri."
+                  }
+                },
+                "uriWithVersion": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "The item's uri with version."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a credential output."
+              }
+            },
+            "accessPolicyType": {
+              "type": "object",
+              "properties": {
+                "tenantId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The tenant ID that is used for authenticating requests to the key vault."
+                  }
+                },
+                "objectId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The object ID of a user, service principal or security group in the tenant for the vault."
+                  }
+                },
+                "applicationId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Application ID of the client making request on behalf of a principal."
+                  }
+                },
+                "permissions": {
+                  "type": "object",
+                  "properties": {
+                    "keys": {
+                      "type": "array",
+                      "allowedValues": [
+                        "all",
+                        "backup",
+                        "create",
+                        "decrypt",
+                        "delete",
+                        "encrypt",
+                        "get",
+                        "getrotationpolicy",
+                        "import",
+                        "list",
+                        "purge",
+                        "recover",
+                        "release",
+                        "restore",
+                        "rotate",
+                        "setrotationpolicy",
+                        "sign",
+                        "unwrapKey",
+                        "update",
+                        "verify",
+                        "wrapKey"
+                      ],
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Permissions to keys."
+                      }
+                    },
+                    "secrets": {
+                      "type": "array",
+                      "allowedValues": [
+                        "all",
+                        "backup",
+                        "delete",
+                        "get",
+                        "list",
+                        "purge",
+                        "recover",
+                        "restore",
+                        "set"
+                      ],
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Permissions to secrets."
+                      }
+                    },
+                    "certificates": {
+                      "type": "array",
+                      "allowedValues": [
+                        "all",
+                        "backup",
+                        "create",
+                        "delete",
+                        "deleteissuers",
+                        "get",
+                        "getissuers",
+                        "import",
+                        "list",
+                        "listissuers",
+                        "managecontacts",
+                        "manageissuers",
+                        "purge",
+                        "recover",
+                        "restore",
+                        "setissuers",
+                        "update"
+                      ],
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Permissions to certificates."
+                      }
+                    },
+                    "storage": {
+                      "type": "array",
+                      "allowedValues": [
+                        "all",
+                        "backup",
+                        "delete",
+                        "deletesas",
+                        "get",
+                        "getsas",
+                        "list",
+                        "listsas",
+                        "purge",
+                        "recover",
+                        "regeneratekey",
+                        "restore",
+                        "set",
+                        "setsas",
+                        "update"
+                      ],
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Permissions to storage accounts."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. Permissions the identity has for keys, secrets and certificates."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for an access policy."
+              }
+            },
+            "secretType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the secret."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource tags."
+                  }
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "bool",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Defines whether the secret is enabled or disabled."
+                      }
+                    },
+                    "exp": {
+                      "type": "int",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Defines when the secret will become invalid. Defined in seconds since 1970-01-01T00:00:00Z."
+                      }
+                    },
+                    "nbf": {
+                      "type": "int",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. If set, defines the date from which onwards the secret becomes valid. Defined in seconds since 1970-01-01T00:00:00Z."
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Contains attributes of the secret."
+                  }
+                },
+                "contentType": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The content type of the secret."
+                  }
+                },
+                "value": {
+                  "type": "securestring",
+                  "metadata": {
+                    "description": "Required. The value of the secret. NOTE: \"value\" will never be returned from the service, as APIs using this model are is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets."
+                  }
+                },
+                "roleAssignments": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/roleAssignmentType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Array of role assignments to create."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a secret output."
+              }
+            },
+            "keyType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the key."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource tags."
+                  }
+                },
+                "attributes": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "bool",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Defines whether the key is enabled or disabled."
+                      }
+                    },
+                    "exp": {
+                      "type": "int",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Defines when the key will become invalid. Defined in seconds since 1970-01-01T00:00:00Z."
+                      }
+                    },
+                    "nbf": {
+                      "type": "int",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. If set, defines the date from which onwards the key becomes valid. Defined in seconds since 1970-01-01T00:00:00Z."
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Contains attributes of the key."
+                  }
+                },
+                "curveName": {
                   "type": "string",
                   "allowedValues": [
-                    "CanNotDelete",
-                    "None",
-                    "ReadOnly"
+                    "P-256",
+                    "P-256K",
+                    "P-384",
+                    "P-521"
                   ],
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. Specify the type of lock."
+                    "description": "Optional. The elliptic curve name. Only works if \"keySize\" equals \"EC\" or \"EC-HSM\". Default is \"P-256\"."
+                  }
+                },
+                "keyOps": {
+                  "type": "array",
+                  "allowedValues": [
+                    "decrypt",
+                    "encrypt",
+                    "import",
+                    "release",
+                    "sign",
+                    "unwrapKey",
+                    "verify",
+                    "wrapKey"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The allowed operations on this key."
+                  }
+                },
+                "keySize": {
+                  "type": "int",
+                  "allowedValues": [
+                    2048,
+                    3072,
+                    4096
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The key size in bits. Only works if \"keySize\" equals \"RSA\" or \"RSA-HSM\". Default is \"4096\"."
+                  }
+                },
+                "kty": {
+                  "type": "string",
+                  "allowedValues": [
+                    "EC",
+                    "EC-HSM",
+                    "RSA",
+                    "RSA-HSM"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The type of the key. Default is \"EC\"."
+                  }
+                },
+                "releasePolicy": {
+                  "type": "object",
+                  "properties": {
+                    "contentType": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Content type and version of key release policy."
+                      }
+                    },
+                    "data": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Blob encoding the policy rules under which the key can be released."
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Key release policy."
+                  }
+                },
+                "rotationPolicy": {
+                  "$ref": "#/definitions/rotationPolicyType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Key rotation policy."
+                  }
+                },
+                "roleAssignments": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/roleAssignmentType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Array of role assignments to create."
                   }
                 }
               },
-              "nullable": true
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a key."
+              }
             },
-            "accessPoliciesType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "tenantId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The tenant ID that is used for authenticating requests to the key vault."
-                    }
-                  },
-                  "objectId": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The object ID of a user, service principal or security group in the tenant for the vault."
-                    }
-                  },
-                  "applicationId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Application ID of the client making request on behalf of a principal."
-                    }
-                  },
-                  "permissions": {
-                    "type": "object",
-                    "properties": {
-                      "keys": {
-                        "type": "array",
-                        "allowedValues": [
-                          "all",
-                          "backup",
-                          "create",
-                          "decrypt",
-                          "delete",
-                          "encrypt",
-                          "get",
-                          "getrotationpolicy",
-                          "import",
-                          "list",
-                          "purge",
-                          "recover",
-                          "release",
-                          "restore",
-                          "rotate",
-                          "setrotationpolicy",
-                          "sign",
-                          "unwrapKey",
-                          "update",
-                          "verify",
-                          "wrapKey"
-                        ],
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. Permissions to keys."
-                        }
-                      },
-                      "secrets": {
-                        "type": "array",
-                        "allowedValues": [
-                          "all",
-                          "backup",
-                          "delete",
-                          "get",
-                          "list",
-                          "purge",
-                          "recover",
-                          "restore",
-                          "set"
-                        ],
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. Permissions to secrets."
-                        }
-                      },
-                      "certificates": {
-                        "type": "array",
-                        "allowedValues": [
-                          "all",
-                          "backup",
-                          "create",
-                          "delete",
-                          "deleteissuers",
-                          "get",
-                          "getissuers",
-                          "import",
-                          "list",
-                          "listissuers",
-                          "managecontacts",
-                          "manageissuers",
-                          "purge",
-                          "recover",
-                          "restore",
-                          "setissuers",
-                          "update"
-                        ],
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. Permissions to certificates."
-                        }
-                      },
-                      "storage": {
-                        "type": "array",
-                        "allowedValues": [
-                          "all",
-                          "backup",
-                          "delete",
-                          "deletesas",
-                          "get",
-                          "getsas",
-                          "list",
-                          "listsas",
-                          "purge",
-                          "recover",
-                          "regeneratekey",
-                          "restore",
-                          "set",
-                          "setsas",
-                          "update"
-                        ],
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. Permissions to storage accounts."
-                        }
-                      }
-                    },
-                    "metadata": {
-                      "description": "Required. Permissions the identity has for keys, secrets and certificates."
-                    }
-                  }
-                }
-              },
-              "nullable": true
-            },
-            "secretsType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The name of the secret."
-                    }
-                  },
-                  "tags": {
-                    "type": "object",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Resource tags."
-                    }
-                  },
-                  "attributes": {
-                    "type": "object",
-                    "properties": {
-                      "enabled": {
-                        "type": "bool",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. Defines whether the secret is enabled or disabled."
-                        }
-                      },
-                      "exp": {
-                        "type": "int",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. Defines when the secret will become invalid. Defined in seconds since 1970-01-01T00:00:00Z."
-                        }
-                      },
-                      "nbf": {
-                        "type": "int",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. If set, defines the date from which onwards the secret becomes valid. Defined in seconds since 1970-01-01T00:00:00Z."
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Contains attributes of the secret."
-                    }
-                  },
-                  "contentType": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The content type of the secret."
-                    }
-                  },
-                  "value": {
-                    "type": "securestring",
-                    "metadata": {
-                      "description": "Required. The value of the secret. NOTE: \"value\" will never be returned from the service, as APIs using this model are is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets."
-                    }
-                  },
-                  "roleAssignments": {
-                    "$ref": "#/definitions/roleAssignmentType",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Array of role assignments to create."
-                    }
-                  }
-                }
-              },
-              "nullable": true
-            },
-            "keysType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The name of the key."
-                    }
-                  },
-                  "tags": {
-                    "type": "object",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Resource tags."
-                    }
-                  },
-                  "attributes": {
-                    "type": "object",
-                    "properties": {
-                      "enabled": {
-                        "type": "bool",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. Defines whether the key is enabled or disabled."
-                        }
-                      },
-                      "exp": {
-                        "type": "int",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. Defines when the key will become invalid. Defined in seconds since 1970-01-01T00:00:00Z."
-                        }
-                      },
-                      "nbf": {
-                        "type": "int",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. If set, defines the date from which onwards the key becomes valid. Defined in seconds since 1970-01-01T00:00:00Z."
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Contains attributes of the key."
-                    }
-                  },
-                  "curveName": {
-                    "type": "string",
-                    "allowedValues": [
-                      "P-256",
-                      "P-256K",
-                      "P-384",
-                      "P-521"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The elliptic curve name. Only works if \"keySize\" equals \"EC\" or \"EC-HSM\". Default is \"P-256\"."
-                    }
-                  },
-                  "keyOps": {
-                    "type": "array",
-                    "allowedValues": [
-                      "decrypt",
-                      "encrypt",
-                      "import",
-                      "release",
-                      "sign",
-                      "unwrapKey",
-                      "verify",
-                      "wrapKey"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The allowed operations on this key."
-                    }
-                  },
-                  "keySize": {
-                    "type": "int",
-                    "allowedValues": [
-                      2048,
-                      3072,
-                      4096
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The key size in bits. Only works if \"keySize\" equals \"RSA\" or \"RSA-HSM\". Default is \"4096\"."
-                    }
-                  },
-                  "kty": {
-                    "type": "string",
-                    "allowedValues": [
-                      "EC",
-                      "EC-HSM",
-                      "RSA",
-                      "RSA-HSM"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The type of the key. Default is \"EC\"."
-                    }
-                  },
-                  "releasePolicy": {
-                    "type": "object",
-                    "properties": {
-                      "contentType": {
-                        "type": "string",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. Content type and version of key release policy."
-                        }
-                      },
-                      "data": {
-                        "type": "string",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. Blob encoding the policy rules under which the key can be released."
-                        }
-                      }
-                    },
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Key release policy."
-                    }
-                  },
-                  "rotationPolicy": {
-                    "$ref": "#/definitions/rotationPoliciesType",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Key rotation policy."
-                    }
-                  },
-                  "roleAssignments": {
-                    "$ref": "#/definitions/roleAssignmentType",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Array of role assignments to create."
-                    }
-                  }
-                }
-              },
-              "nullable": true
-            },
-            "rotationPoliciesType": {
+            "rotationPolicyType": {
               "type": "object",
               "properties": {
                 "attributes": {
@@ -7744,7 +7824,487 @@
                   }
                 }
               },
-              "nullable": true
+              "metadata": {
+                "description": "The type for a rotation policy."
+              }
+            },
+            "_1.privateEndpointCustomDnsConfigType": {
+              "type": "object",
+              "properties": {
+                "fqdn": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. FQDN that resolves to private endpoint IP address."
+                  }
+                },
+                "ipAddresses": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "Required. A list of private IP addresses of the private endpoint."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "_1.privateEndpointIpConfigurationType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the resource that is unique within a resource group."
+                  }
+                },
+                "properties": {
+                  "type": "object",
+                  "properties": {
+                    "groupId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to."
+                      }
+                    },
+                    "memberName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to."
+                      }
+                    },
+                    "privateIPAddress": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. Properties of private endpoint IP configurations."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "_1.privateEndpointPrivateDnsZoneGroupType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the Private DNS Zone Group."
+                  }
+                },
+                "privateDnsZoneGroupConfigs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. The name of the private DNS Zone Group config."
+                        }
+                      },
+                      "privateDnsZoneResourceId": {
+                        "type": "string",
+                        "metadata": {
+                          "description": "Required. The resource id of the private DNS zone."
+                        }
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. The private DNS Zone Groups to associate the Private Endpoint. A DNS Zone Group can support up to 5 DNS zones."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "diagnosticSettingFullType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the diagnostic setting."
+                  }
+                },
+                "logCategoriesAndGroups": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "category": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                        }
+                      },
+                      "categoryGroup": {
+                        "type": "string",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                        }
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                        }
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+                  }
+                },
+                "metricCategories": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "category": {
+                        "type": "string",
+                        "metadata": {
+                          "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                        }
+                      },
+                      "enabled": {
+                        "type": "bool",
+                        "nullable": true,
+                        "metadata": {
+                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                        }
+                      }
+                    }
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+                  }
+                },
+                "logAnalyticsDestinationType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "AzureDiagnostics",
+                    "Dedicated"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+                  }
+                },
+                "workspaceResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "storageAccountResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "eventHubAuthorizationRuleResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+                  }
+                },
+                "eventHubName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                  }
+                },
+                "marketplacePartnerResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "lockType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the name of lock."
+                  }
+                },
+                "kind": {
+                  "type": "string",
+                  "allowedValues": [
+                    "CanNotDelete",
+                    "None",
+                    "ReadOnly"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the type of lock."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a lock.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "privateEndpointSingleServiceType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the Private Endpoint."
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The location to deploy the Private Endpoint to."
+                  }
+                },
+                "privateLinkServiceConnectionName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name of the private link connection to create."
+                  }
+                },
+                "service": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The subresource to deploy the Private Endpoint for. For example \"vault\" for a Key Vault Private Endpoint."
+                  }
+                },
+                "subnetResourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                  }
+                },
+                "resourceGroupResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource ID of the Resource Group the Private Endpoint will be created in. If not specified, the Resource Group of the provided Virtual Network Subnet is used."
+                  }
+                },
+                "privateDnsZoneGroup": {
+                  "$ref": "#/definitions/_1.privateEndpointPrivateDnsZoneGroupType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The private DNS Zone Group to configure for the Private Endpoint."
+                  }
+                },
+                "isManualConnection": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. If Manual Private Link Connection is required."
+                  }
+                },
+                "manualConnectionRequestMessage": {
+                  "type": "string",
+                  "nullable": true,
+                  "maxLength": 140,
+                  "metadata": {
+                    "description": "Optional. A message passed to the owner of the remote resource with the manual connection request."
+                  }
+                },
+                "customDnsConfigs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/_1.privateEndpointCustomDnsConfigType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Custom DNS configurations."
+                  }
+                },
+                "ipConfigurations": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/_1.privateEndpointIpConfigurationType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. A list of IP configurations of the Private Endpoint. This will be used to map to the first-party Service endpoints."
+                  }
+                },
+                "applicationSecurityGroupResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Application security groups in which the Private Endpoint IP configuration is included."
+                  }
+                },
+                "customNetworkInterfaceName": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The custom name of the network interface attached to the Private Endpoint."
+                  }
+                },
+                "lock": {
+                  "$ref": "#/definitions/lockType",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the type of lock."
+                  }
+                },
+                "roleAssignments": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/roleAssignmentType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Array of role assignments to create."
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Tags to be applied on all resources/Resource Groups in this deployment."
+                  }
+                },
+                "enableTelemetry": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable/Disable usage telemetry for module."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a private endpoint. To be used if the private endpoint's default service / groupId can be assumed (i.e., for services that only have one Private Endpoint type like 'vault' for key vault).",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
             }
           },
           "parameters": {
@@ -7763,20 +8323,30 @@
               }
             },
             "accessPolicies": {
-              "$ref": "#/definitions/accessPoliciesType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/accessPolicyType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. All access policies to create."
               }
             },
             "secrets": {
-              "$ref": "#/definitions/secretsType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/secretType"
+              },
               "nullable": true,
               "metadata": {
                 "description": "Optional. All secrets to create."
               }
             },
             "keys": {
-              "$ref": "#/definitions/keysType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/keyType"
+              },
               "nullable": true,
               "metadata": {
                 "description": "Optional. All keys to create."
@@ -7870,18 +8440,27 @@
             },
             "lock": {
               "$ref": "#/definitions/lockType",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. The lock settings of the service."
               }
             },
             "roleAssignments": {
-              "$ref": "#/definitions/roleAssignmentType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Array of role assignments to create."
               }
             },
             "privateEndpoints": {
-              "$ref": "#/definitions/privateEndpointType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/privateEndpointSingleServiceType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible."
               }
@@ -7894,7 +8473,11 @@
               }
             },
             "diagnosticSettings": {
-              "$ref": "#/definitions/diagnosticSettingType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/diagnosticSettingFullType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. The diagnostic settings of the service."
               }
@@ -7925,6 +8508,7 @@
                 }
               }
             ],
+            "enableReferencedModulesTelemetry": false,
             "builtInRoleNames": {
               "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
               "Key Vault Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')]",
@@ -7948,7 +8532,7 @@
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2024-03-01",
-              "name": "[format('46d3xbcp.res.keyvault-vault.{0}.{1}', replace('0.9.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "name": "[format('46d3xbcp.res.keyvault-vault.{0}.{1}', replace('0.12.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -8091,148 +8675,147 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "7494731697751039419"
+                      "version": "0.33.93.31351",
+                      "templateHash": "6321524620984159084"
                     },
                     "name": "Key Vault Access Policies",
-                    "description": "This module deploys a Key Vault Access Policy.",
-                    "owner": "Azure/module-maintainers"
+                    "description": "This module deploys a Key Vault Access Policy."
                   },
                   "definitions": {
                     "accessPoliciesType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "tenantId": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The tenant ID that is used for authenticating requests to the key vault."
-                            }
-                          },
-                          "objectId": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The object ID of a user, service principal or security group in the tenant for the vault."
-                            }
-                          },
-                          "applicationId": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. Application ID of the client making request on behalf of a principal."
-                            }
-                          },
-                          "permissions": {
-                            "type": "object",
-                            "properties": {
-                              "keys": {
-                                "type": "array",
-                                "allowedValues": [
-                                  "all",
-                                  "backup",
-                                  "create",
-                                  "decrypt",
-                                  "delete",
-                                  "encrypt",
-                                  "get",
-                                  "getrotationpolicy",
-                                  "import",
-                                  "list",
-                                  "purge",
-                                  "recover",
-                                  "release",
-                                  "restore",
-                                  "rotate",
-                                  "setrotationpolicy",
-                                  "sign",
-                                  "unwrapKey",
-                                  "update",
-                                  "verify",
-                                  "wrapKey"
-                                ],
-                                "nullable": true,
-                                "metadata": {
-                                  "description": "Optional. Permissions to keys."
-                                }
-                              },
-                              "secrets": {
-                                "type": "array",
-                                "allowedValues": [
-                                  "all",
-                                  "backup",
-                                  "delete",
-                                  "get",
-                                  "list",
-                                  "purge",
-                                  "recover",
-                                  "restore",
-                                  "set"
-                                ],
-                                "nullable": true,
-                                "metadata": {
-                                  "description": "Optional. Permissions to secrets."
-                                }
-                              },
-                              "certificates": {
-                                "type": "array",
-                                "allowedValues": [
-                                  "all",
-                                  "backup",
-                                  "create",
-                                  "delete",
-                                  "deleteissuers",
-                                  "get",
-                                  "getissuers",
-                                  "import",
-                                  "list",
-                                  "listissuers",
-                                  "managecontacts",
-                                  "manageissuers",
-                                  "purge",
-                                  "recover",
-                                  "restore",
-                                  "setissuers",
-                                  "update"
-                                ],
-                                "nullable": true,
-                                "metadata": {
-                                  "description": "Optional. Permissions to certificates."
-                                }
-                              },
-                              "storage": {
-                                "type": "array",
-                                "allowedValues": [
-                                  "all",
-                                  "backup",
-                                  "delete",
-                                  "deletesas",
-                                  "get",
-                                  "getsas",
-                                  "list",
-                                  "listsas",
-                                  "purge",
-                                  "recover",
-                                  "regeneratekey",
-                                  "restore",
-                                  "set",
-                                  "setsas",
-                                  "update"
-                                ],
-                                "nullable": true,
-                                "metadata": {
-                                  "description": "Optional. Permissions to storage accounts."
-                                }
+                      "type": "object",
+                      "properties": {
+                        "tenantId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The tenant ID that is used for authenticating requests to the key vault."
+                          }
+                        },
+                        "objectId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The object ID of a user, service principal or security group in the tenant for the vault."
+                          }
+                        },
+                        "applicationId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Application ID of the client making request on behalf of a principal."
+                          }
+                        },
+                        "permissions": {
+                          "type": "object",
+                          "properties": {
+                            "keys": {
+                              "type": "array",
+                              "allowedValues": [
+                                "all",
+                                "backup",
+                                "create",
+                                "decrypt",
+                                "delete",
+                                "encrypt",
+                                "get",
+                                "getrotationpolicy",
+                                "import",
+                                "list",
+                                "purge",
+                                "recover",
+                                "release",
+                                "restore",
+                                "rotate",
+                                "setrotationpolicy",
+                                "sign",
+                                "unwrapKey",
+                                "update",
+                                "verify",
+                                "wrapKey"
+                              ],
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Permissions to keys."
                               }
                             },
-                            "metadata": {
-                              "description": "Required. Permissions the identity has for keys, secrets and certificates."
+                            "secrets": {
+                              "type": "array",
+                              "allowedValues": [
+                                "all",
+                                "backup",
+                                "delete",
+                                "get",
+                                "list",
+                                "purge",
+                                "recover",
+                                "restore",
+                                "set"
+                              ],
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Permissions to secrets."
+                              }
+                            },
+                            "certificates": {
+                              "type": "array",
+                              "allowedValues": [
+                                "all",
+                                "backup",
+                                "create",
+                                "delete",
+                                "deleteissuers",
+                                "get",
+                                "getissuers",
+                                "import",
+                                "list",
+                                "listissuers",
+                                "managecontacts",
+                                "manageissuers",
+                                "purge",
+                                "recover",
+                                "restore",
+                                "setissuers",
+                                "update"
+                              ],
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Permissions to certificates."
+                              }
+                            },
+                            "storage": {
+                              "type": "array",
+                              "allowedValues": [
+                                "all",
+                                "backup",
+                                "delete",
+                                "deletesas",
+                                "get",
+                                "getsas",
+                                "list",
+                                "listsas",
+                                "purge",
+                                "recover",
+                                "regeneratekey",
+                                "restore",
+                                "set",
+                                "setsas",
+                                "update"
+                              ],
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Permissions to storage accounts."
+                              }
                             }
+                          },
+                          "metadata": {
+                            "description": "Required. Permissions the identity has for keys, secrets and certificates."
                           }
                         }
                       },
-                      "nullable": true
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for an access policy."
+                      }
                     }
                   },
                   "parameters": {
@@ -8243,25 +8826,15 @@
                       }
                     },
                     "accessPolicies": {
-                      "$ref": "#/definitions/accessPoliciesType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/accessPoliciesType"
+                      },
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. An array of 0 to 16 identities that have access to the key vault. All identities in the array must use the same tenant ID as the key vault's tenant ID."
                       }
                     }
-                  },
-                  "variables": {
-                    "copy": [
-                      {
-                        "name": "formattedAccessPolicies",
-                        "count": "[length(coalesce(parameters('accessPolicies'), createArray()))]",
-                        "input": {
-                          "applicationId": "[coalesce(tryGet(coalesce(parameters('accessPolicies'), createArray())[copyIndex('formattedAccessPolicies')], 'applicationId'), '')]",
-                          "objectId": "[coalesce(parameters('accessPolicies'), createArray())[copyIndex('formattedAccessPolicies')].objectId]",
-                          "permissions": "[coalesce(parameters('accessPolicies'), createArray())[copyIndex('formattedAccessPolicies')].permissions]",
-                          "tenantId": "[coalesce(tryGet(coalesce(parameters('accessPolicies'), createArray())[copyIndex('formattedAccessPolicies')], 'tenantId'), tenant().tenantId)]"
-                        }
-                      }
-                    ]
                   },
                   "resources": {
                     "keyVault": {
@@ -8272,14 +8845,22 @@
                     },
                     "policies": {
                       "type": "Microsoft.KeyVault/vaults/accessPolicies",
-                      "apiVersion": "2022-07-01",
+                      "apiVersion": "2023-07-01",
                       "name": "[format('{0}/{1}', parameters('keyVaultName'), 'add')]",
                       "properties": {
-                        "accessPolicies": "[variables('formattedAccessPolicies')]"
-                      },
-                      "dependsOn": [
-                        "keyVault"
-                      ]
+                        "copy": [
+                          {
+                            "name": "accessPolicies",
+                            "count": "[length(coalesce(parameters('accessPolicies'), createArray()))]",
+                            "input": {
+                              "applicationId": "[coalesce(tryGet(coalesce(parameters('accessPolicies'), createArray())[copyIndex('accessPolicies')], 'applicationId'), '')]",
+                              "objectId": "[coalesce(parameters('accessPolicies'), createArray())[copyIndex('accessPolicies')].objectId]",
+                              "permissions": "[coalesce(parameters('accessPolicies'), createArray())[copyIndex('accessPolicies')].permissions]",
+                              "tenantId": "[coalesce(tryGet(coalesce(parameters('accessPolicies'), createArray())[copyIndex('accessPolicies')], 'tenantId'), tenant().tenantId)]"
+                            }
+                          }
+                        ]
+                      }
                     }
                   },
                   "outputs": {
@@ -8360,86 +8941,87 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "114626909766354577"
+                      "version": "0.33.93.31351",
+                      "templateHash": "4741547827723795923"
                     },
                     "name": "Key Vault Secrets",
-                    "description": "This module deploys a Key Vault Secret.",
-                    "owner": "Azure/module-maintainers"
+                    "description": "This module deploys a Key Vault Secret."
                   },
                   "definitions": {
                     "roleAssignmentType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
-                            }
-                          },
-                          "roleDefinitionIdOrName": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-                            }
-                          },
-                          "principalId": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-                            }
-                          },
-                          "principalType": {
-                            "type": "string",
-                            "allowedValues": [
-                              "Device",
-                              "ForeignGroup",
-                              "Group",
-                              "ServicePrincipal",
-                              "User"
-                            ],
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The principal type of the assigned principal ID."
-                            }
-                          },
-                          "description": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The description of the role assignment."
-                            }
-                          },
-                          "condition": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-                            }
-                          },
-                          "conditionVersion": {
-                            "type": "string",
-                            "allowedValues": [
-                              "2.0"
-                            ],
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. Version of the condition."
-                            }
-                          },
-                          "delegatedManagedIdentityResourceId": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The Resource Id of the delegated managed identity resource."
-                            }
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
                           }
                         }
                       },
-                      "nullable": true
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
                     }
                   },
                   "parameters": {
@@ -8497,7 +9079,11 @@
                       }
                     },
                     "roleAssignments": {
-                      "$ref": "#/definitions/roleAssignmentType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. Array of role assignments to create."
                       }
@@ -8544,10 +9130,7 @@
                           "nbf": "[parameters('attributesNbf')]"
                         },
                         "value": "[parameters('value')]"
-                      },
-                      "dependsOn": [
-                        "keyVault"
-                      ]
+                      }
                     },
                     "secret_roleAssignments": {
                       "copy": {
@@ -8586,6 +9169,20 @@
                         "description": "The resource ID of the secret."
                       },
                       "value": "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+                    },
+                    "secretUri": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The uri of the secret."
+                      },
+                      "value": "[reference('secret').secretUri]"
+                    },
+                    "secretUriWithVersion": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The uri with version of the secret."
+                      },
+                      "value": "[reference('secret').secretUriWithVersion]"
                     },
                     "resourceGroupName": {
                       "type": "string",
@@ -8658,86 +9255,87 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "14269695922191217406"
+                      "version": "0.33.93.31351",
+                      "templateHash": "12000970886778046699"
                     },
                     "name": "Key Vault Keys",
-                    "description": "This module deploys a Key Vault Key.",
-                    "owner": "Azure/module-maintainers"
+                    "description": "This module deploys a Key Vault Key."
                   },
                   "definitions": {
                     "roleAssignmentType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
-                            }
-                          },
-                          "roleDefinitionIdOrName": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-                            }
-                          },
-                          "principalId": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-                            }
-                          },
-                          "principalType": {
-                            "type": "string",
-                            "allowedValues": [
-                              "Device",
-                              "ForeignGroup",
-                              "Group",
-                              "ServicePrincipal",
-                              "User"
-                            ],
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The principal type of the assigned principal ID."
-                            }
-                          },
-                          "description": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The description of the role assignment."
-                            }
-                          },
-                          "condition": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-                            }
-                          },
-                          "conditionVersion": {
-                            "type": "string",
-                            "allowedValues": [
-                              "2.0"
-                            ],
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. Version of the condition."
-                            }
-                          },
-                          "delegatedManagedIdentityResourceId": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The Resource Id of the delegated managed identity resource."
-                            }
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
                           }
                         }
                       },
-                      "nullable": true
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
                     }
                   },
                   "parameters": {
@@ -8838,7 +9436,11 @@
                       }
                     },
                     "roleAssignments": {
-                      "$ref": "#/definitions/roleAssignmentType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. Array of role assignments to create."
                       }
@@ -8885,22 +9487,7 @@
                       "apiVersion": "2022-07-01",
                       "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('name'))]",
                       "tags": "[parameters('tags')]",
-                      "properties": {
-                        "attributes": {
-                          "enabled": "[parameters('attributesEnabled')]",
-                          "exp": "[parameters('attributesExp')]",
-                          "nbf": "[parameters('attributesNbf')]"
-                        },
-                        "curveName": "[parameters('curveName')]",
-                        "keyOps": "[parameters('keyOps')]",
-                        "keySize": "[parameters('keySize')]",
-                        "kty": "[parameters('kty')]",
-                        "rotationPolicy": "[coalesce(parameters('rotationPolicy'), createObject())]",
-                        "release_policy": "[coalesce(parameters('releasePolicy'), createObject())]"
-                      },
-                      "dependsOn": [
-                        "keyVault"
-                      ]
+                      "properties": "[shallowMerge(createArray(createObject('attributes', createObject('enabled', parameters('attributesEnabled'), 'exp', parameters('attributesExp'), 'nbf', parameters('attributesNbf')), 'curveName', parameters('curveName'), 'keyOps', parameters('keyOps'), 'keySize', parameters('keySize'), 'kty', parameters('kty'), 'release_policy', coalesce(parameters('releasePolicy'), createObject())), if(not(empty(parameters('rotationPolicy'))), createObject('rotationPolicy', parameters('rotationPolicy')), createObject())))]"
                     },
                     "key_roleAssignments": {
                       "copy": {
@@ -8926,6 +9513,20 @@
                     }
                   },
                   "outputs": {
+                    "keyUri": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The uri of the key."
+                      },
+                      "value": "[reference('key').keyUri]"
+                    },
+                    "keyUriWithVersion": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The uri with version of the key."
+                      },
+                      "value": "[reference('key').keyUriWithVersion]"
+                    },
                     "name": {
                       "type": "string",
                       "metadata": {
@@ -8962,7 +9563,8 @@
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
               "name": "[format('{0}-keyVault-PrivateEndpoint-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
-              "resourceGroup": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupName'), '')]",
+              "subscriptionId": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[2]]",
+              "resourceGroup": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[4]]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
@@ -8978,7 +9580,7 @@
                     "value": "[coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId]"
                   },
                   "enableTelemetry": {
-                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'enableTelemetry'), parameters('enableTelemetry'))]"
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
                   },
                   "location": {
                     "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'location'), reference(split(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location)]"
@@ -9015,12 +9617,11 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "1277254088602407590"
+                      "version": "0.33.13.18514",
+                      "templateHash": "15954548978129725136"
                     },
                     "name": "Private Endpoints",
-                    "description": "This module deploys a Private Endpoint.",
-                    "owner": "Azure/module-maintainers"
+                    "description": "This module deploys a Private Endpoint."
                   },
                   "definitions": {
                     "privateDnsZoneGroupType": {
@@ -9042,80 +9643,118 @@
                             "description": "Required. The private DNS zone groups to associate the private endpoint. A DNS zone group can support up to 5 DNS zones."
                           }
                         }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true
                       }
                     },
-                    "roleAssignmentType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
+                    "ipConfigurationType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the resource that is unique within a resource group."
+                          }
+                        },
                         "properties": {
-                          "name": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          "type": "object",
+                          "properties": {
+                            "groupId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
+                              }
+                            },
+                            "memberName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
+                              }
+                            },
+                            "privateIPAddress": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                              }
                             }
                           },
-                          "roleDefinitionIdOrName": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-                            }
-                          },
-                          "principalId": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-                            }
-                          },
-                          "principalType": {
-                            "type": "string",
-                            "allowedValues": [
-                              "Device",
-                              "ForeignGroup",
-                              "Group",
-                              "ServicePrincipal",
-                              "User"
-                            ],
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The principal type of the assigned principal ID."
-                            }
-                          },
-                          "description": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The description of the role assignment."
-                            }
-                          },
-                          "condition": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-                            }
-                          },
-                          "conditionVersion": {
-                            "type": "string",
-                            "allowedValues": [
-                              "2.0"
-                            ],
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. Version of the condition."
-                            }
-                          },
-                          "delegatedManagedIdentityResourceId": {
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {
-                              "description": "Optional. The Resource Id of the delegated managed identity resource."
-                            }
+                          "metadata": {
+                            "description": "Required. Properties of private endpoint IP configurations."
                           }
                         }
                       },
-                      "nullable": true
+                      "metadata": {
+                        "__bicep_export!": true
+                      }
+                    },
+                    "privateLinkServiceConnectionType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the private link service connection."
+                          }
+                        },
+                        "properties": {
+                          "type": "object",
+                          "properties": {
+                            "groupIds": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string array `[]`."
+                              }
+                            },
+                            "privateLinkServiceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The resource id of private link service."
+                              }
+                            },
+                            "requestMessage": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars."
+                              }
+                            }
+                          },
+                          "metadata": {
+                            "description": "Required. Properties of private link service connection."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true
+                      }
+                    },
+                    "customDnsConfigType": {
+                      "type": "object",
+                      "properties": {
+                        "fqdn": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. FQDN that resolves to private endpoint IP address."
+                          }
+                        },
+                        "ipAddresses": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "description": "Required. A list of private IP addresses of the private endpoint."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true
+                      }
                     },
                     "lockType": {
                       "type": "object",
@@ -9140,161 +9779,12 @@
                           }
                         }
                       },
-                      "nullable": true
-                    },
-                    "ipConfigurationsType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The name of the resource that is unique within a resource group."
-                            }
-                          },
-                          "properties": {
-                            "type": "object",
-                            "properties": {
-                              "groupId": {
-                                "type": "string",
-                                "metadata": {
-                                  "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
-                                }
-                              },
-                              "memberName": {
-                                "type": "string",
-                                "metadata": {
-                                  "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
-                                }
-                              },
-                              "privateIPAddress": {
-                                "type": "string",
-                                "metadata": {
-                                  "description": "Required. A private IP address obtained from the private endpoint's subnet."
-                                }
-                              }
-                            },
-                            "metadata": {
-                              "description": "Required. Properties of private endpoint IP configurations."
-                            }
-                          }
+                      "metadata": {
+                        "description": "An AVM-aligned type for a lock.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
                         }
-                      },
-                      "nullable": true
-                    },
-                    "manualPrivateLinkServiceConnectionsType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The name of the private link service connection."
-                            }
-                          },
-                          "properties": {
-                            "type": "object",
-                            "properties": {
-                              "groupIds": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "metadata": {
-                                  "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string array `[]`."
-                                }
-                              },
-                              "privateLinkServiceId": {
-                                "type": "string",
-                                "metadata": {
-                                  "description": "Required. The resource id of private link service."
-                                }
-                              },
-                              "requestMessage": {
-                                "type": "string",
-                                "metadata": {
-                                  "description": "Optional. A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars."
-                                }
-                              }
-                            },
-                            "metadata": {
-                              "description": "Required. Properties of private link service connection."
-                            }
-                          }
-                        }
-                      },
-                      "nullable": true
-                    },
-                    "privateLinkServiceConnectionsType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. The name of the private link service connection."
-                            }
-                          },
-                          "properties": {
-                            "type": "object",
-                            "properties": {
-                              "groupIds": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "metadata": {
-                                  "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string array `[]`."
-                                }
-                              },
-                              "privateLinkServiceId": {
-                                "type": "string",
-                                "metadata": {
-                                  "description": "Required. The resource id of private link service."
-                                }
-                              },
-                              "requestMessage": {
-                                "type": "string",
-                                "nullable": true,
-                                "metadata": {
-                                  "description": "Optional. A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars."
-                                }
-                              }
-                            },
-                            "metadata": {
-                              "description": "Required. Properties of private link service connection."
-                            }
-                          }
-                        }
-                      },
-                      "nullable": true
-                    },
-                    "customDnsConfigType": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "fqdn": {
-                            "type": "string",
-                            "metadata": {
-                              "description": "Required. Fqdn that resolves to private endpoint IP address."
-                            }
-                          },
-                          "ipAddresses": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            },
-                            "metadata": {
-                              "description": "Required. A list of private IP addresses of the private endpoint."
-                            }
-                          }
-                        }
-                      },
-                      "nullable": true
+                      }
                     },
                     "privateDnsZoneGroupConfigType": {
                       "type": "object",
@@ -9318,6 +9808,81 @@
                           "sourceTemplate": "private-dns-zone-group/main.bicep"
                         }
                       }
+                    },
+                    "roleAssignmentType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
                     }
                   },
                   "parameters": {
@@ -9335,6 +9900,9 @@
                     },
                     "applicationSecurityGroupResourceIds": {
                       "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
                       "nullable": true,
                       "metadata": {
                         "description": "Optional. Application security groups in which the private endpoint IP configuration is included."
@@ -9348,7 +9916,11 @@
                       }
                     },
                     "ipConfigurations": {
-                      "$ref": "#/definitions/ipConfigurationsType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/ipConfigurationType"
+                      },
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
                       }
@@ -9369,12 +9941,17 @@
                     },
                     "lock": {
                       "$ref": "#/definitions/lockType",
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. The lock settings of the service."
                       }
                     },
                     "roleAssignments": {
-                      "$ref": "#/definitions/roleAssignmentType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. Array of role assignments to create."
                       }
@@ -9387,21 +9964,33 @@
                       }
                     },
                     "customDnsConfigs": {
-                      "$ref": "#/definitions/customDnsConfigType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/customDnsConfigType"
+                      },
+                      "nullable": true,
                       "metadata": {
                         "description": "Optional. Custom DNS configurations."
                       }
                     },
                     "manualPrivateLinkServiceConnections": {
-                      "$ref": "#/definitions/manualPrivateLinkServiceConnectionsType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/privateLinkServiceConnectionType"
+                      },
+                      "nullable": true,
                       "metadata": {
-                        "description": "Optional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource."
+                        "description": "Conditional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource. Required if `privateLinkServiceConnections` is empty."
                       }
                     },
                     "privateLinkServiceConnections": {
-                      "$ref": "#/definitions/privateLinkServiceConnectionsType",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/privateLinkServiceConnectionType"
+                      },
+                      "nullable": true,
                       "metadata": {
-                        "description": "Optional. A grouping of information about the connection to the remote resource."
+                        "description": "Conditional. A grouping of information about the connection to the remote resource. Required if `manualPrivateLinkServiceConnections` is empty."
                       }
                     },
                     "enableTelemetry": {
@@ -9430,7 +10019,7 @@
                       "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
                       "Private DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b12aa53e-6015-4669-85d0-8515ebb3ae7f')]",
                       "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
-                      "Role Based Access Control Administrator (Preview)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+                      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
                     }
                   },
                   "resources": {
@@ -9438,7 +10027,7 @@
                       "condition": "[parameters('enableTelemetry')]",
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2024-03-01",
-                      "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.7.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.10.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
                       "properties": {
                         "mode": "Incremental",
                         "template": {
@@ -9544,12 +10133,11 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.29.47.4906",
-                              "templateHash": "5805178546717255803"
+                              "version": "0.33.13.18514",
+                              "templateHash": "5440815542537978381"
                             },
                             "name": "Private Endpoint Private DNS Zone Groups",
-                            "description": "This module deploys a Private Endpoint Private DNS Zone Group.",
-                            "owner": "Azure/module-maintainers"
+                            "description": "This module deploys a Private Endpoint Private DNS Zone Group."
                           },
                           "definitions": {
                             "privateDnsZoneGroupConfigType": {
@@ -9627,10 +10215,7 @@
                               "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
                               "properties": {
                                 "privateDnsZoneConfigs": "[variables('privateDnsZoneConfigsVar')]"
-                              },
-                              "dependsOn": [
-                                "privateEndpoint"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -9692,26 +10277,33 @@
                       },
                       "value": "[reference('privateEndpoint', '2023-11-01', 'full').location]"
                     },
-                    "customDnsConfig": {
-                      "$ref": "#/definitions/customDnsConfigType",
+                    "customDnsConfigs": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/customDnsConfigType"
+                      },
                       "metadata": {
                         "description": "The custom DNS configurations of the private endpoint."
                       },
                       "value": "[reference('privateEndpoint').customDnsConfigs]"
                     },
-                    "networkInterfaceIds": {
+                    "networkInterfaceResourceIds": {
                       "type": "array",
-                      "metadata": {
-                        "description": "The IDs of the network interfaces associated with the private endpoint."
+                      "items": {
+                        "type": "string"
                       },
-                      "value": "[reference('privateEndpoint').networkInterfaces]"
+                      "metadata": {
+                        "description": "The resource IDs of the network interfaces associated with the private endpoint."
+                      },
+                      "value": "[map(reference('privateEndpoint').networkInterfaces, lambda('nic', lambdaVariables('nic').id))]"
                     },
                     "groupId": {
                       "type": "string",
+                      "nullable": true,
                       "metadata": {
                         "description": "The group Id for the private endpoint Group."
                       },
-                      "value": "[if(and(not(empty(reference('privateEndpoint').manualPrivateLinkServiceConnections)), greater(length(tryGet(reference('privateEndpoint').manualPrivateLinkServiceConnections[0].properties, 'groupIds')), 0)), coalesce(tryGet(reference('privateEndpoint').manualPrivateLinkServiceConnections[0].properties, 'groupIds', 0), ''), if(and(not(empty(reference('privateEndpoint').privateLinkServiceConnections)), greater(length(tryGet(reference('privateEndpoint').privateLinkServiceConnections[0].properties, 'groupIds')), 0)), coalesce(tryGet(reference('privateEndpoint').privateLinkServiceConnections[0].properties, 'groupIds', 0), ''), ''))]"
+                      "value": "[coalesce(tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'manualPrivateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0), tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'privateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0))]"
                     }
                   }
                 }
@@ -9759,17 +10351,54 @@
             },
             "privateEndpoints": {
               "type": "array",
+              "items": {
+                "$ref": "#/definitions/privateEndpointOutputType"
+              },
               "metadata": {
                 "description": "The private endpoints of the key vault."
               },
               "copy": {
-                "count": "[length(if(not(empty(parameters('privateEndpoints'))), array(parameters('privateEndpoints')), createArray()))]",
+                "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]",
                 "input": {
                   "name": "[reference(format('keyVault_privateEndpoints[{0}]', copyIndex())).outputs.name.value]",
                   "resourceId": "[reference(format('keyVault_privateEndpoints[{0}]', copyIndex())).outputs.resourceId.value]",
-                  "groupId": "[reference(format('keyVault_privateEndpoints[{0}]', copyIndex())).outputs.groupId.value]",
-                  "customDnsConfig": "[reference(format('keyVault_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfig.value]",
-                  "networkInterfaceIds": "[reference(format('keyVault_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceIds.value]"
+                  "groupId": "[tryGet(tryGet(reference(format('keyVault_privateEndpoints[{0}]', copyIndex())).outputs, 'groupId'), 'value')]",
+                  "customDnsConfigs": "[reference(format('keyVault_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfigs.value]",
+                  "networkInterfaceResourceIds": "[reference(format('keyVault_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceResourceIds.value]"
+                }
+              }
+            },
+            "secrets": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/credentialOutputType"
+              },
+              "metadata": {
+                "description": "The properties of the created secrets."
+              },
+              "copy": {
+                "count": "[length(range(0, length(coalesce(parameters('secrets'), createArray()))))]",
+                "input": {
+                  "resourceId": "[reference(format('keyVault_secrets[{0}]', range(0, length(coalesce(parameters('secrets'), createArray())))[copyIndex()])).outputs.resourceId.value]",
+                  "uri": "[reference(format('keyVault_secrets[{0}]', range(0, length(coalesce(parameters('secrets'), createArray())))[copyIndex()])).outputs.secretUri.value]",
+                  "uriWithVersion": "[reference(format('keyVault_secrets[{0}]', range(0, length(coalesce(parameters('secrets'), createArray())))[copyIndex()])).outputs.secretUriWithVersion.value]"
+                }
+              }
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/credentialOutputType"
+              },
+              "metadata": {
+                "description": "The properties of the created keys."
+              },
+              "copy": {
+                "count": "[length(range(0, length(coalesce(parameters('keys'), createArray()))))]",
+                "input": {
+                  "resourceId": "[reference(format('keyVault_keys[{0}]', range(0, length(coalesce(parameters('keys'), createArray())))[copyIndex()])).outputs.resourceId.value]",
+                  "uri": "[reference(format('keyVault_keys[{0}]', range(0, length(coalesce(parameters('keys'), createArray())))[copyIndex()])).outputs.keyUri.value]",
+                  "uriWithVersion": "[reference(format('keyVault_keys[{0}]', range(0, length(coalesce(parameters('keys'), createArray())))[copyIndex()])).outputs.keyUriWithVersion.value]"
                 }
               }
             }
@@ -9798,24 +10427,27 @@
     },
     "managedClusterClientId": {
       "type": "string",
+      "nullable": true,
       "metadata": {
         "description": "The Client ID of the AKS identity."
       },
-      "value": "[reference('managedCluster').outputs.kubeletIdentityClientId.value]"
+      "value": "[tryGet(tryGet(reference('managedCluster').outputs, 'kubeletIdentityClientId'), 'value')]"
     },
     "managedClusterObjectId": {
       "type": "string",
+      "nullable": true,
       "metadata": {
         "description": "The Object ID of the AKS identity."
       },
-      "value": "[reference('managedCluster').outputs.kubeletIdentityObjectId.value]"
+      "value": "[tryGet(tryGet(reference('managedCluster').outputs, 'kubeletIdentityObjectId'), 'value')]"
     },
     "managedClusterResourceId": {
       "type": "string",
+      "nullable": true,
       "metadata": {
         "description": "The resource ID of the AKS cluster."
       },
-      "value": "[reference('managedCluster').outputs.kubeletIdentityResourceId.value]"
+      "value": "[tryGet(tryGet(reference('managedCluster').outputs, 'kubeletIdentityResourceId'), 'value')]"
     },
     "containerRegistryName": {
       "type": "string",

--- a/avm/ptn/azd/aks/main.json
+++ b/avm/ptn/azd/aks/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.35.1.17967",
-      "templateHash": "16961707500443257429"
+      "templateHash": "18230055100620523957"
     },
     "name": "Azd AKS",
     "description": "Creates an Azure Kubernetes Service (AKS) cluster with a system agent pool as well as an additional user agent pool.\n\n**Note:** This module is not intended for broad, generic use, as it was designed to cater for the requirements of the AZD CLI product. Feature requests and bug fix requests are welcome if they support the development of the AZD CLI but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case."
@@ -101,7 +101,7 @@
       "metadata": {
         "description": "The type for an AAD profile.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/container-service/managed-cluster:0.8.3"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/container-service/managed-cluster:0.9.0"
         }
       }
     },
@@ -422,7 +422,7 @@
       "metadata": {
         "description": "The type for an agent pool.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/container-service/managed-cluster:0.8.3"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/container-service/managed-cluster:0.9.0"
         }
       }
     }
@@ -997,8 +997,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "4954545522662307892"
+              "version": "0.34.44.8038",
+              "templateHash": "7489731477943219114"
             },
             "name": "Azure Kubernetes Service (AKS) Managed Clusters",
             "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster."
@@ -2685,7 +2685,7 @@
               "Kubernetes Agentless Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'd5a2ae44-610b-4500-93be-660a0c5f5ca6')]",
               "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
               "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
-              "Role Based Access Control Administrator (Preview)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
               "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
             }
           },
@@ -2694,7 +2694,7 @@
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2024-03-01",
-              "name": "[format('46d3xbcp.res.containerservice-managedcluster.{0}.{1}', replace('0.8.3', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "name": "[format('46d3xbcp.res.containerservice-managedcluster.{0}.{1}', replace('0.9.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -2722,7 +2722,7 @@
                 "tier": "[parameters('skuTier')]"
               },
               "properties": {
-                "agentPoolProfiles": "[map(parameters('primaryAgentPoolProfiles'), lambda('profile', createObject('name', lambdaVariables('profile').name, 'count', coalesce(lambdaVariables('profile').count, 1), 'availabilityZones', map(coalesce(tryGet(lambdaVariables('profile'), 'availabilityZones'), createArray(1, 2, 3)), lambda('zone', format('{0}', lambdaVariables('zone')))), 'creationData', if(not(empty(tryGet(lambdaVariables('profile'), 'sourceResourceId'))), createObject('sourceResourceId', lambdaVariables('profile').sourceResourceId), null()), 'enableAutoScaling', coalesce(tryGet(lambdaVariables('profile'), 'enableAutoScaling'), false()), 'enableEncryptionAtHost', coalesce(tryGet(lambdaVariables('profile'), 'enableEncryptionAtHost'), false()), 'enableFIPS', coalesce(tryGet(lambdaVariables('profile'), 'enableFIPS'), false()), 'enableNodePublicIP', coalesce(tryGet(lambdaVariables('profile'), 'enableNodePublicIP'), false()), 'enableUltraSSD', coalesce(tryGet(lambdaVariables('profile'), 'enableUltraSSD'), false()), 'gpuInstanceProfile', tryGet(lambdaVariables('profile'), 'gpuInstanceProfile'), 'kubeletDiskType', tryGet(lambdaVariables('profile'), 'kubeletDiskType'), 'maxCount', tryGet(lambdaVariables('profile'), 'maxCount'), 'maxPods', tryGet(lambdaVariables('profile'), 'maxPods'), 'minCount', tryGet(lambdaVariables('profile'), 'minCount'), 'mode', tryGet(lambdaVariables('profile'), 'mode'), 'nodeLabels', tryGet(lambdaVariables('profile'), 'nodeLabels'), 'nodePublicIPPrefixID', tryGet(lambdaVariables('profile'), 'nodePublicIpPrefixResourceId'), 'nodeTaints', tryGet(lambdaVariables('profile'), 'nodeTaints'), 'orchestratorVersion', tryGet(lambdaVariables('profile'), 'orchestratorVersion'), 'osDiskSizeGB', tryGet(lambdaVariables('profile'), 'osDiskSizeGB'), 'osDiskType', tryGet(lambdaVariables('profile'), 'osDiskType'), 'osType', coalesce(tryGet(lambdaVariables('profile'), 'osType'), 'Linux'), 'osSKU', tryGet(lambdaVariables('profile'), 'osSKU'), 'podSubnetID', tryGet(lambdaVariables('profile'), 'podSubnetResourceId'), 'proximityPlacementGroupID', tryGet(lambdaVariables('profile'), 'proximityPlacementGroupResourceId'), 'scaleDownMode', coalesce(tryGet(lambdaVariables('profile'), 'scaleDownMode'), 'Delete'), 'scaleSetEvictionPolicy', coalesce(tryGet(lambdaVariables('profile'), 'scaleSetEvictionPolicy'), 'Delete'), 'scaleSetPriority', tryGet(lambdaVariables('profile'), 'scaleSetPriority'), 'securityProfile', createObject('enableSecureBoot', coalesce(tryGet(lambdaVariables('profile'), 'enableSecureBoot'), false()), 'enableVTPM', coalesce(tryGet(lambdaVariables('profile'), 'enableVTPM'), false()), 'sshAccess', if(equals(parameters('skuName'), 'Automatic'), 'Disabled', 'LocalUser')), 'spotMaxPrice', tryGet(lambdaVariables('profile'), 'spotMaxPrice'), 'tags', tryGet(lambdaVariables('profile'), 'tags'), 'type', tryGet(lambdaVariables('profile'), 'type'), 'upgradeSettings', createObject('maxSurge', tryGet(lambdaVariables('profile'), 'maxSurge')), 'vmSize', coalesce(tryGet(lambdaVariables('profile'), 'vmSize'), 'Standard_D2s_v3'), 'vnetSubnetID', tryGet(lambdaVariables('profile'), 'vnetSubnetResourceId'), 'workloadRuntime', tryGet(lambdaVariables('profile'), 'workloadRuntime'))))]",
+                "agentPoolProfiles": "[map(parameters('primaryAgentPoolProfiles'), lambda('profile', createObject('name', lambdaVariables('profile').name, 'count', coalesce(tryGet(lambdaVariables('profile'), 'count'), 1), 'availabilityZones', map(coalesce(tryGet(lambdaVariables('profile'), 'availabilityZones'), createArray(1, 2, 3)), lambda('zone', format('{0}', lambdaVariables('zone')))), 'creationData', if(not(empty(tryGet(lambdaVariables('profile'), 'sourceResourceId'))), createObject('sourceResourceId', tryGet(lambdaVariables('profile'), 'sourceResourceId')), null()), 'enableAutoScaling', coalesce(tryGet(lambdaVariables('profile'), 'enableAutoScaling'), false()), 'enableEncryptionAtHost', coalesce(tryGet(lambdaVariables('profile'), 'enableEncryptionAtHost'), false()), 'enableFIPS', coalesce(tryGet(lambdaVariables('profile'), 'enableFIPS'), false()), 'enableNodePublicIP', coalesce(tryGet(lambdaVariables('profile'), 'enableNodePublicIP'), false()), 'enableUltraSSD', coalesce(tryGet(lambdaVariables('profile'), 'enableUltraSSD'), false()), 'gpuInstanceProfile', tryGet(lambdaVariables('profile'), 'gpuInstanceProfile'), 'kubeletDiskType', tryGet(lambdaVariables('profile'), 'kubeletDiskType'), 'maxCount', tryGet(lambdaVariables('profile'), 'maxCount'), 'maxPods', tryGet(lambdaVariables('profile'), 'maxPods'), 'minCount', tryGet(lambdaVariables('profile'), 'minCount'), 'mode', tryGet(lambdaVariables('profile'), 'mode'), 'nodeLabels', tryGet(lambdaVariables('profile'), 'nodeLabels'), 'nodePublicIPPrefixID', tryGet(lambdaVariables('profile'), 'nodePublicIpPrefixResourceId'), 'nodeTaints', tryGet(lambdaVariables('profile'), 'nodeTaints'), 'orchestratorVersion', tryGet(lambdaVariables('profile'), 'orchestratorVersion'), 'osDiskSizeGB', tryGet(lambdaVariables('profile'), 'osDiskSizeGB'), 'osDiskType', tryGet(lambdaVariables('profile'), 'osDiskType'), 'osType', coalesce(tryGet(lambdaVariables('profile'), 'osType'), 'Linux'), 'osSKU', tryGet(lambdaVariables('profile'), 'osSKU'), 'podSubnetID', tryGet(lambdaVariables('profile'), 'podSubnetResourceId'), 'proximityPlacementGroupID', tryGet(lambdaVariables('profile'), 'proximityPlacementGroupResourceId'), 'scaleDownMode', coalesce(tryGet(lambdaVariables('profile'), 'scaleDownMode'), 'Delete'), 'scaleSetEvictionPolicy', coalesce(tryGet(lambdaVariables('profile'), 'scaleSetEvictionPolicy'), 'Delete'), 'scaleSetPriority', tryGet(lambdaVariables('profile'), 'scaleSetPriority'), 'securityProfile', createObject('enableSecureBoot', coalesce(tryGet(lambdaVariables('profile'), 'enableSecureBoot'), false()), 'enableVTPM', coalesce(tryGet(lambdaVariables('profile'), 'enableVTPM'), false()), 'sshAccess', if(equals(parameters('skuName'), 'Automatic'), 'Disabled', 'LocalUser')), 'spotMaxPrice', tryGet(lambdaVariables('profile'), 'spotMaxPrice'), 'tags', tryGet(lambdaVariables('profile'), 'tags'), 'type', tryGet(lambdaVariables('profile'), 'type'), 'upgradeSettings', createObject('maxSurge', tryGet(lambdaVariables('profile'), 'maxSurge')), 'vmSize', coalesce(tryGet(lambdaVariables('profile'), 'vmSize'), 'Standard_D2s_v3'), 'vnetSubnetID', tryGet(lambdaVariables('profile'), 'vnetSubnetResourceId'), 'workloadRuntime', tryGet(lambdaVariables('profile'), 'workloadRuntime'))))]",
                 "httpProxyConfig": "[parameters('httpProxyConfig')]",
                 "identityProfile": "[parameters('identityProfile')]",
                 "diskEncryptionSetID": "[parameters('diskEncryptionSetResourceId')]",
@@ -2975,7 +2975,7 @@
               },
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('{0}-ManagedCluster-MaintenanceConfiguration-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+              "name": "[format('{0}-ManagedCluster-MaintenanceCfg-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
@@ -2998,8 +2998,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "17573192747850353863"
+                      "version": "0.34.44.8038",
+                      "templateHash": "13067595449609999928"
                     },
                     "name": "Azure Kubernetes Service (AKS) Managed Cluster Maintenance Configurations",
                     "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Maintenance Configurations."
@@ -3194,8 +3194,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.93.31351",
-                      "templateHash": "7049305712242986495"
+                      "version": "0.34.44.8038",
+                      "templateHash": "3651532122518241859"
                     },
                     "name": "Azure Kubernetes Service (AKS) Managed Cluster Agent Pools",
                     "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Agent Pool."

--- a/avm/ptn/azd/aks/tests/e2e/max/main.test.bicep
+++ b/avm/ptn/azd/aks/tests/e2e/max/main.test.bicep
@@ -25,7 +25,7 @@ param aksClusterRoleAssignmentName string = newGuid()
 
 // Enforced location als not all regions have quota available
 #disable-next-line no-hardcoded-location
-var enforcedLocation = 'northeurope'
+var enforcedLocation = 'uksouth'
 
 // ============ //
 // Dependencies //

--- a/avm/ptn/azd/aks/version.json
+++ b/avm/ptn/azd/aks/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1",
+  "version": "0.2",
   "pathFilters": [
     "./main.json"
   ]


### PR DESCRIPTION
## Description

Fixes #5078 

Update to use newer API version for creating AKS managed clusters as the current one has been deprecated/retired.
Similarly, update to use newer Kubernetes version.

## Pipeline Reference

Manual deployment using `Test-ModuleLocally.ps1` passes:

![image](https://github.com/user-attachments/assets/83147e00-a0d9-4345-b2c9-431ecfe6f9de)


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
