### PR TITLE
feat: Update API version for IP Groups to latest API version `2024-05-01`

### DIFF
--- a/avm/res/network/ip-group/README.md
+++ b/avm/res/network/ip-group/README.md
@@ -17,7 +17,7 @@ This module deploys an IP Group.
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Network/ipGroups` | [2023-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-04-01/ipGroups) |
+| `Microsoft.Network/ipGroups` | [2024-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/ipGroups) |
 
 ## Usage examples
 

--- a/avm/res/network/ip-group/main.bicep
+++ b/avm/res/network/ip-group/main.bicep
@@ -73,7 +73,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource ipGroup 'Microsoft.Network/ipGroups@2023-04-01' = {
+resource ipGroup 'Microsoft.Network/ipGroups@2024-05-01' = {
   name: name
   location: location
   tags: tags

--- a/avm/res/network/ip-group/main.json
+++ b/avm/res/network/ip-group/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "8471825539906571393"
+      "version": "0.35.1.17967",
+      "templateHash": "5366931574985794833"
     },
     "name": "IP Groups",
     "description": "This module deploys an IP Group."
@@ -212,7 +212,7 @@
     },
     "ipGroup": {
       "type": "Microsoft.Network/ipGroups",
-      "apiVersion": "2023-04-01",
+      "apiVersion": "2024-05-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -284,7 +284,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('ipGroup', '2023-04-01', 'full').location]"
+      "value": "[reference('ipGroup', '2024-05-01', 'full').location]"
     }
   }
 }

--- a/avm/res/network/ip-group/version.json
+++ b/avm/res/network/ip-group/version.json
@@ -1,7 +1,7 @@
 {
-    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.2",
-    "pathFilters": [
-        "./main.json"
-    ]
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.3",
+  "pathFilters": [
+    "./main.json"
+  ]
 }


### PR DESCRIPTION
## Description

- Updated the Networks - IP Groups to the latest API version

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.network.ip-group](https://github.com/ahmadabdalla/bicep-registry-modules/actions/workflows/avm.res.network.ip-group.yml/badge.svg)](https://github.com/ahmadabdalla/bicep-registry-modules/actions/workflows/avm.res.network.ip-group.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
