### PR TITLE
feat: Enable `Test-AzDeployment` to deal with 'diagnostic' returns

### DIFF
--- a/utilities/pipelines/e2eValidation/resourceDeployment/Test-TemplateDeployment.ps1
+++ b/utilities/pipelines/e2eValidation/resourceDeployment/Test-TemplateDeployment.ps1
@@ -180,6 +180,9 @@ function Test-TemplateDeployment {
         }
         if ($ValidationErrors -and ($res | ConvertTo-Json | ConvertFrom-Json -AsHashtable).Keys -Contains 'Code') {
             # Only contains a 'code' if there is an 'error code' attached
+            # Note: Ideally this would even show the `-Debug` information, but there seems to be no way of getting it in an automated fashion.
+            # So. errors that are rooted in a location conflict will continue to just show 'Conflict conflict: See inner error' without actually returning it.
+            # This comment is just here for reference if anybody else wants to tag a stab
             Write-Warning 'Errors found:' -Verbose
             Write-Warning ($res | ConvertTo-Json -Depth 10 | Out-String)
             Write-Error 'Template is not valid.'

--- a/utilities/pipelines/e2eValidation/resourceDeployment/Test-TemplateDeployment.ps1
+++ b/utilities/pipelines/e2eValidation/resourceDeployment/Test-TemplateDeployment.ps1
@@ -179,6 +179,7 @@ function Test-TemplateDeployment {
             }
         }
         if ($ValidationErrors -and ($res | ConvertTo-Json | ConvertFrom-Json -AsHashtable).Keys -Contains 'Code') {
+            # Only contains a 'code' if there is an 'error code' attached
             Write-Warning 'Errors found:' -Verbose
             Write-Warning ($res | ConvertTo-Json -Depth 10 | Out-String)
             Write-Error 'Template is not valid.'

--- a/utilities/pipelines/e2eValidation/resourceDeployment/Test-TemplateDeployment.ps1
+++ b/utilities/pipelines/e2eValidation/resourceDeployment/Test-TemplateDeployment.ps1
@@ -178,12 +178,13 @@ function Test-TemplateDeployment {
                 throw "[$deploymentScope] is a non-supported template scope"
             }
         }
-        if ($ValidationErrors) {
-            if ($res.Details) { Write-Warning ($res.Details | ConvertTo-Json -Depth 10 | Out-String) }
-            if ($res.Message) { Write-Warning $res.Message }
+        if ($ValidationErrors -and ($res | ConvertTo-Json | ConvertFrom-Json -AsHashtable).Keys -Contains 'Code') {
+            Write-Warning 'Errors found:' -Verbose
+            Write-Warning ($res | ConvertTo-Json -Depth 10 | Out-String)
             Write-Error 'Template is not valid.'
         } else {
             Write-Verbose 'Template is valid' -Verbose
+            Write-Verbose ($res | Out-String) -Verbose # May show diagnostic warnings
         }
     }
 


### PR DESCRIPTION
## Description

The function may now return `Diagnostic` information that is considere a warning. However, because the current implementation treats **any** return value as an error, these warnings are blocking. 
The updated implementation differentiates the two by only throwing an error if the return value contains a `code`.

This PR is a dependency for https://github.com/Azure/bicep-registry-modules/pull/5083 as that PR does return diagnostic warnings (false positives) and cannot get past the `Test-AzDeployment` stage without the fix

### Example output

```pwsh
PS C:\dev> $res = Test-AzSubscriptionDeployment @DeploymentInputs -Location $DeploymentMetadataLocation
# Using Bicep v0.35.1
# Calling Bicep with arguments: build "C:\dev\avm\res\web\site\tests\e2e\webAppLinux.max\main.test.bicep" --stdout
# C:\dev\avm\res\web\site\main.bicep(545,25) : Warning outputs-should-not-contain-secrets: Outputs should not contain secrets. Found possible secret: secure value 'slots[*].siteConfig.azureStorageAccounts.*.accessKey' [https://aka.ms/bicep/linter/outputs-should-not-contain-secrets]

# 14:16:04 - Template is valid.

# Diagnostics (2):
# (/subscriptions/<subId>/resourceGroups/dep-avmx-web.sites-wswalmax-rg/providers/Microsoft.Resources/deployments/x5ei2emr6nll2-test-wswalmax-init) A nested deployment got short-circuited and all its resources got skipped from validation. This is due to a nested template having a parameter that was not fully evaluated (e.g. contains a reference() function). Please see https://aka.ms/WhatIfEvalStopped for more guidance. (NestedDeploymentShortCircuited)
# (/subscriptions/<subId>resourceGroups/dep-avmx-web.sites-wswalmax-rg/providers/Microsoft.Resources/deployments/x5ei2emr6nll2-test-wswalmax-idem) A nested deployment got short-circuited and all its resources got skipped from validation. This is due to a nested template having a parameter that was not fully evaluated (e.g. contains a reference() function). Please see https://aka.ms/WhatIfEvalStopped for more guidance. (NestedDeploymentShortCircuited)

$res

# Diagnostics (2):
# (/subscriptions/<subId>/resourceGroups/dep-avmx-web.sites-wswalmax-rg/providers/Microsoft.Resources/deployments/x5ei2emr6nll2-test-wswalmax-init) A nested deployment got short-circuited and all its resources got skipped from validation. This is due to a nested template having a parameter that was not fully evaluated (e.g. contains a reference() function). Please see https://aka.ms/WhatIfEvalStopped for more guidance. (NestedDeploymentShortCircuited)
# (/subscriptions/<subId>resourceGroups/dep-avmx-web.sites-wswalmax-rg/providers/Microsoft.Resources/deployments/x5ei2emr6nll2-test-wswalmax-idem) A nested deployment got short-circuited and all its resources got skipped from validation. This is due to a nested template having a parameter that was not fully evaluated (e.g. contains a reference() function). Please see https://aka.ms/WhatIfEvalStopped for more guidance. (NestedDeploymentShortCircuited)
```

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|  [![avm.res.key-vault.vault](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml/badge.svg?branch=users%2Falsehr%2FdiagnosticsDuringTestAz&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml)        |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
