### PR TITLE
feat: Alerts-Management - Added `schedule` to max test

### DIFF
--- a/avm/res/alerts-management/action-rule/README.md
+++ b/avm/res/alerts-management/action-rule/README.md
@@ -232,6 +232,11 @@ module actionRule 'br/public:avm/res/alerts-management/action-rule:<version>' = 
         roleDefinitionIdOrName: '<roleDefinitionIdOrName>'
       }
     ]
+    schedule: {
+      effectiveFrom: '2026-01-01T00:00:00'
+      effectiveUntil: '2027-12-31T23:59:59'
+      timeZone: 'Eastern Standard Time'
+    }
     scopes: [
       '<id>'
     ]
@@ -396,6 +401,13 @@ module actionRule 'br/public:avm/res/alerts-management/action-rule:<version>' = 
         }
       ]
     },
+    "schedule": {
+      "value": {
+        "effectiveFrom": "2026-01-01T00:00:00",
+        "effectiveUntil": "2027-12-31T23:59:59",
+        "timeZone": "Eastern Standard Time"
+      }
+    },
     "scopes": {
       "value": [
         "<id>"
@@ -546,6 +558,11 @@ param roleAssignments = [
     roleDefinitionIdOrName: '<roleDefinitionIdOrName>'
   }
 ]
+param schedule = {
+  effectiveFrom: '2026-01-01T00:00:00'
+  effectiveUntil: '2027-12-31T23:59:59'
+  timeZone: 'Eastern Standard Time'
+}
 param scopes = [
   '<id>'
 ]

--- a/avm/res/alerts-management/action-rule/main.json
+++ b/avm/res/alerts-management/action-rule/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "9440630980565289166"
+      "version": "0.35.1.17967",
+      "templateHash": "14879341739605245920"
     },
     "name": "Action Rules",
     "description": "This module deploys an Alert Processing Rule."

--- a/avm/res/alerts-management/action-rule/tests/e2e/max/main.test.bicep
+++ b/avm/res/alerts-management/action-rule/tests/e2e/max/main.test.bicep
@@ -157,6 +157,11 @@ module testDeployment '../../../main.bicep' = [
           actionType: 'AddActionGroups'
         }
       ]
+      schedule: {
+        effectiveFrom: '2026-01-01T00:00:00'
+        effectiveUntil: '2027-12-31T23:59:59'
+        timeZone: 'Eastern Standard Time'
+      }
       roleAssignments: [
         {
           name: 'a66da6bc-b3ee-484e-9bdb-9294938bb327'


### PR DESCRIPTION
## Description

As per the linked issue, I added the schedule as a test to the max test to validate if the deployment works now - which it appears to be.

Closes #1952

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.res.alerts-management.action-rule](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.alerts-management.action-rule.yml/badge.svg?branch=users%2Falsehr%2FalertRuleScheduleTest&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.alerts-management.action-rule.yml)       |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
