### PR TITLE
fix: make default test pass CI criteria at `avm/res/sql/server`

### DIFF
--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -385,8 +385,12 @@ module server 'br/public:avm/res/sql/server:<version>' = {
     // Required parameters
     name: 'ssmin001'
     // Non-required parameters
-    administratorLogin: 'adminUserName'
-    administratorLoginPassword: '<administratorLoginPassword>'
+    administrators: {
+      azureADOnlyAuthentication: true
+      login: '<login>'
+      principalType: 'Application'
+      sid: '<sid>'
+    }
     location: '<location>'
   }
 }
@@ -409,11 +413,13 @@ module server 'br/public:avm/res/sql/server:<version>' = {
       "value": "ssmin001"
     },
     // Non-required parameters
-    "administratorLogin": {
-      "value": "adminUserName"
-    },
-    "administratorLoginPassword": {
-      "value": "<administratorLoginPassword>"
+    "administrators": {
+      "value": {
+        "azureADOnlyAuthentication": true,
+        "login": "<login>",
+        "principalType": "Application",
+        "sid": "<sid>"
+      }
     },
     "location": {
       "value": "<location>"
@@ -435,8 +441,12 @@ using 'br/public:avm/res/sql/server:<version>'
 // Required parameters
 param name = 'ssmin001'
 // Non-required parameters
-param administratorLogin = 'adminUserName'
-param administratorLoginPassword = '<administratorLoginPassword>'
+param administrators = {
+  azureADOnlyAuthentication: true
+  login: '<login>'
+  principalType: 'Application'
+  sid: '<sid>'
+}
 param location = '<location>'
 ```
 

--- a/avm/res/sql/server/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/defaults/main.test.bicep
@@ -47,8 +47,12 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: resourceLocation
-      administratorLogin: 'adminUserName'
-      administratorLoginPassword: password
+      administrators: {
+        azureADOnlyAuthentication: true
+        login: deployer().objectId
+        sid: deployer().objectId
+        principalType: 'Application'
+      }
     }
   }
 ]

--- a/utilities/pipelines/staticValidation/psrule/.ps-rule/min-suppress.Rule.yaml
+++ b/utilities/pipelines/staticValidation/psrule/.ps-rule/min-suppress.Rule.yaml
@@ -54,6 +54,8 @@ spec:
     - Azure.SQLMI.MaintenanceWindow # Excluded as it requires user input
     # Application Gateway
     - Azure.AppGw.UseHTTPS # Excluded as it requires user input and additional configuration
+    # SQL Server
+    - Azure.SQL.VAScan # Excluded as it requires user input and additional configuration
   if:
     name: "."
     contains:


### PR DESCRIPTION
## Description

See [details](https://github.com/Azure/bicep-registry-modules/pull/5006#issuecomment-2888223777)


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.sql.server](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg?branch=sql-ps-rule-fix)](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
