### PR TITLE
fix: cannot get plaintext token because of az update

### DIFF
--- a/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/hciHostDeploymentWithImage.bicep
+++ b/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/hciHostDeploymentWithImage.bicep
@@ -358,7 +358,6 @@ resource arc1 'Microsoft.Compute/virtualMachines/runCommands@2024-03-01' = {
       }
     ]
   }
-  dependsOn: [ad]
 }
 
 resource arc2 'Microsoft.Compute/virtualMachines/runCommands@2024-03-01' = {
@@ -418,7 +417,6 @@ resource arc2 'Microsoft.Compute/virtualMachines/runCommands@2024-03-01' = {
       }
     ]
   }
-  dependsOn: [ad]
 }
 
 output vnetSubnetResourceId string = vnet.properties.subnets[0].id

--- a/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/hciHostDeploymentWithImage.bicep
+++ b/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/hciHostDeploymentWithImage.bicep
@@ -358,6 +358,7 @@ resource arc1 'Microsoft.Compute/virtualMachines/runCommands@2024-03-01' = {
       }
     ]
   }
+  dependsOn: [ad]
 }
 
 resource arc2 'Microsoft.Compute/virtualMachines/runCommands@2024-03-01' = {
@@ -417,6 +418,7 @@ resource arc2 'Microsoft.Compute/virtualMachines/runCommands@2024-03-01' = {
       }
     ]
   }
+  dependsOn: [ad]
 }
 
 output vnetSubnetResourceId string = vnet.properties.subnets[0].id

--- a/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/scripts/provision-arc.ps1
+++ b/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/scripts/provision-arc.ps1
@@ -66,8 +66,7 @@ try {
         $credential = New-Object System.Management.Automation.PSCredential -ArgumentList $Using:ServicePrincipalId, $secureServicePrincipalSecret
         Connect-AzAccount -ServicePrincipal -Credential $credential -Subscription $Using:SubscriptionId -Tenant $Using:TenantId
         $secureToken = (Get-AzAccessToken -AsSecureString).Token
-        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureToken)
-        $token = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+        $token = [Net.NetworkCredential]::new('', $secureToken).Password
 
         $azcmagentPath = "$env:ProgramW6432\AzureConnectedMachineAgent\azcmagent.exe"
         & "$azcmagentPath" --version

--- a/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/scripts/provision-arc.ps1
+++ b/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/scripts/provision-arc.ps1
@@ -65,9 +65,9 @@ try {
         $secureServicePrincipalSecret = ConvertTo-SecureString $Using:ServicePrincipalSecret -AsPlainText -Force
         $credential = New-Object System.Management.Automation.PSCredential -ArgumentList $Using:ServicePrincipalId, $secureServicePrincipalSecret
         Connect-AzAccount -ServicePrincipal -Credential $credential -Subscription $Using:SubscriptionId -Tenant $Using:TenantId
-        $token = (Get-AzAccessToken).Token
-        # TODO: PowerShell 7
-        # $token = ConvertFrom-SecureString -SecureString ((Get-AzAccessToken -AsSecureString).Token) -AsPlainText
+        $secureToken = (Get-AzAccessToken -AsSecureString).Token
+        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureToken)
+        $token = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
 
         $azcmagentPath = "$env:ProgramW6432\AzureConnectedMachineAgent\azcmagent.exe"
         & "$azcmagentPath" --version

--- a/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/scripts/provision-arc.ps1
+++ b/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/scripts/provision-arc.ps1
@@ -94,7 +94,7 @@ try {
         Write-Output 'Waiting for Edge device resource to be ready'
         Start-Sleep -Seconds 600
         $waitInterval = 60
-        $maxWaitCount = 10
+        $maxWaitCount = 15
         $ready = $false
         for ($waitCount = 0; $job.JobState -ne 'Transferred' -and $waitCount -lt $maxWaitCount; $waitCount++) {
             Connect-AzAccount -ServicePrincipal -Credential $credential -Subscription $Using:SubscriptionId -Tenant $Using:TenantId | Out-Null


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.azure-stack-hci.cluster](https://github.com/Infrastructure-as-code-Automation/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.cluster.yml/badge.svg?branch=hangxu%2Fimage4)](https://github.com/Infrastructure-as-code-Automation/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.cluster.yml)     |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
