### PR TITLE
feat: Add lock to 'sql/server/database' and 'sql/server/elasticPool' and add database CMK

### DIFF
--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -19,22 +19,22 @@ This module deploys an Azure SQL Server.
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
-| `Microsoft.KeyVault/vaults/secrets` | [2023-07-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2023-07-01/vaults/secrets) |
-| `Microsoft.Network/privateEndpoints` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-11-01/privateEndpoints) |
-| `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-11-01/privateEndpoints/privateDnsZoneGroups) |
-| `Microsoft.Sql/servers` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers) |
-| `Microsoft.Sql/servers/auditingSettings` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/auditingSettings) |
-| `Microsoft.Sql/servers/databases` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/databases) |
+| `Microsoft.KeyVault/vaults/secrets` | [2024-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2024-11-01/vaults/secrets) |
+| `Microsoft.Network/privateEndpoints` | [2024-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/privateEndpoints) |
+| `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2024-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/privateEndpoints/privateDnsZoneGroups) |
+| `Microsoft.Sql/servers` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers) |
+| `Microsoft.Sql/servers/auditingSettings` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/auditingSettings) |
+| `Microsoft.Sql/servers/databases` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/databases) |
 | `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
-| `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/databases/backupShortTermRetentionPolicies) |
-| `Microsoft.Sql/servers/elasticPools` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/elasticPools) |
-| `Microsoft.Sql/servers/encryptionProtector` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/encryptionProtector) |
+| `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/databases/backupShortTermRetentionPolicies) |
+| `Microsoft.Sql/servers/elasticPools` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/elasticPools) |
+| `Microsoft.Sql/servers/encryptionProtector` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/encryptionProtector) |
 | `Microsoft.Sql/servers/failoverGroups` | [2024-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2024-05-01-preview/servers/failoverGroups) |
-| `Microsoft.Sql/servers/firewallRules` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/firewallRules) |
-| `Microsoft.Sql/servers/keys` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/keys) |
-| `Microsoft.Sql/servers/securityAlertPolicies` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/securityAlertPolicies) |
-| `Microsoft.Sql/servers/virtualNetworkRules` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/virtualNetworkRules) |
-| `Microsoft.Sql/servers/vulnerabilityAssessments` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/vulnerabilityAssessments) |
+| `Microsoft.Sql/servers/firewallRules` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/firewallRules) |
+| `Microsoft.Sql/servers/keys` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/keys) |
+| `Microsoft.Sql/servers/securityAlertPolicies` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/securityAlertPolicies) |
+| `Microsoft.Sql/servers/virtualNetworkRules` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/virtualNetworkRules) |
+| `Microsoft.Sql/servers/vulnerabilityAssessments` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/vulnerabilityAssessments) |
 
 ## Usage examples
 
@@ -4980,7 +4980,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/res/network/private-endpoint:0.10.1` | Remote reference |
+| `br/public:avm/res/network/private-endpoint:0.11.0` | Remote reference |
 | `br/public:avm/utl/types/avm-common-types:0.5.1` | Remote reference |
 
 ## Notes

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -271,6 +271,29 @@ module server 'br/public:avm/res/sql/server:<version>' = {
       keyVaultResourceId: '<keyVaultResourceId>'
       keyVersion: '<keyVersion>'
     }
+    databases: [
+      {
+        availabilityZone: -1
+        customerManagedKey: {
+          autoRotationEnabled: true
+          keyName: '<keyName>'
+          keyVaultResourceId: '<keyVaultResourceId>'
+          keyVersion: '<keyVersion>'
+        }
+        managedIdentities: {
+          userAssignedResourceIds: [
+            '<databaseIdentityResourceId>'
+          ]
+        }
+        maxSizeBytes: 2147483648
+        name: 'sscmk-db'
+        sku: {
+          name: 'Basic'
+          tier: 'Basic'
+        }
+        zoneRedundant: false
+      }
+    ]
     managedIdentities: {
       systemAssigned: false
       userAssignedResourceIds: [
@@ -316,6 +339,31 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         "keyVersion": "<keyVersion>"
       }
     },
+    "databases": {
+      "value": [
+        {
+          "availabilityZone": -1,
+          "customerManagedKey": {
+            "autoRotationEnabled": true,
+            "keyName": "<keyName>",
+            "keyVaultResourceId": "<keyVaultResourceId>",
+            "keyVersion": "<keyVersion>"
+          },
+          "managedIdentities": {
+            "userAssignedResourceIds": [
+              "<databaseIdentityResourceId>"
+            ]
+          },
+          "maxSizeBytes": 2147483648,
+          "name": "sscmk-db",
+          "sku": {
+            "name": "Basic",
+            "tier": "Basic"
+          },
+          "zoneRedundant": false
+        }
+      ]
+    },
     "managedIdentities": {
       "value": {
         "systemAssigned": false,
@@ -357,6 +405,29 @@ param customerManagedKey = {
   keyVaultResourceId: '<keyVaultResourceId>'
   keyVersion: '<keyVersion>'
 }
+param databases = [
+  {
+    availabilityZone: -1
+    customerManagedKey: {
+      autoRotationEnabled: true
+      keyName: '<keyName>'
+      keyVaultResourceId: '<keyVaultResourceId>'
+      keyVersion: '<keyVersion>'
+    }
+    managedIdentities: {
+      userAssignedResourceIds: [
+        '<databaseIdentityResourceId>'
+      ]
+    }
+    maxSizeBytes: 2147483648
+    name: 'sscmk-db'
+    sku: {
+      name: 'Basic'
+      tier: 'Basic'
+    }
+    zoneRedundant: false
+  }
+]
 param managedIdentities = {
   systemAssigned: false
   userAssignedResourceIds: [
@@ -1055,6 +1126,12 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           retentionDays: 14
         }
         collation: 'SQL_Latin1_General_CP1_CI_AS'
+        customerManagedKey: {
+          autoRotationEnabled: true
+          keyName: '<keyName>'
+          keyVaultResourceId: '<keyVaultResourceId>'
+          keyVersion: '<keyVersion>'
+        }
         diagnosticSettings: [
           {
             eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -1242,6 +1319,12 @@ module server 'br/public:avm/res/sql/server:<version>' = {
             "retentionDays": 14
           },
           "collation": "SQL_Latin1_General_CP1_CI_AS",
+          "customerManagedKey": {
+            "autoRotationEnabled": true,
+            "keyName": "<keyName>",
+            "keyVaultResourceId": "<keyVaultResourceId>",
+            "keyVersion": "<keyVersion>"
+          },
           "diagnosticSettings": [
             {
               "eventHubAuthorizationRuleResourceId": "<eventHubAuthorizationRuleResourceId>",
@@ -1445,6 +1528,12 @@ param databases = [
       retentionDays: 14
     }
     collation: 'SQL_Latin1_General_CP1_CI_AS'
+    customerManagedKey: {
+      autoRotationEnabled: true
+      keyName: '<keyName>'
+      keyVaultResourceId: '<keyVaultResourceId>'
+      keyVersion: '<keyVersion>'
+    }
     diagnosticSettings: [
       {
         eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -2671,10 +2760,9 @@ The databases to create in the server.
 | [`catalogCollation`](#parameter-databasescatalogcollation) | string | Collation of the metadata catalog. |
 | [`collation`](#parameter-databasescollation) | string | The collation of the database. |
 | [`createMode`](#parameter-databasescreatemode) | string | Specifies the mode of database creation. |
+| [`customerManagedKey`](#parameter-databasescustomermanagedkey) | object | The customer managed key definition for database TDE. |
 | [`diagnosticSettings`](#parameter-databasesdiagnosticsettings) | array | The diagnostic settings of the service. |
 | [`elasticPoolResourceId`](#parameter-databaseselasticpoolresourceid) | string | The resource identifier of the elastic pool containing this database. |
-| [`encryptionProtector`](#parameter-databasesencryptionprotector) | string | The azure key vault URI of the database if it's configured with per Database Customer Managed Keys. |
-| [`encryptionProtectorAutoRotation`](#parameter-databasesencryptionprotectorautorotation) | bool | The flag to enable or disable auto rotation of database encryption protector AKV key. |
 | [`federatedClientId`](#parameter-databasesfederatedclientid) | string | The Client id used for cross tenant per database CMK scenario. |
 | [`freeLimitExhaustionBehavior`](#parameter-databasesfreelimitexhaustionbehavior) | string | Specifies the behavior when monthly free limits are exhausted for the free database. |
 | [`highAvailabilityReplicaCount`](#parameter-databaseshighavailabilityreplicacount) | int | The number of secondary replicas associated with the database that are used to provide high availability. Not applicable to a Hyperscale database within an elastic pool. |
@@ -2866,6 +2954,63 @@ Specifies the mode of database creation.
   ]
   ```
 
+### Parameter: `databases.customerManagedKey`
+
+The customer managed key definition for database TDE.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`keyName`](#parameter-databasescustomermanagedkeykeyname) | string | The name of the customer managed key to use for encryption. |
+| [`keyVaultResourceId`](#parameter-databasescustomermanagedkeykeyvaultresourceid) | string | The resource ID of a key vault to reference a customer managed key for encryption from. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`autoRotationEnabled`](#parameter-databasescustomermanagedkeyautorotationenabled) | bool | Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used. |
+| [`keyVersion`](#parameter-databasescustomermanagedkeykeyversion) | string | The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting. |
+| [`userAssignedIdentityResourceId`](#parameter-databasescustomermanagedkeyuserassignedidentityresourceid) | string | User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use. |
+
+### Parameter: `databases.customerManagedKey.keyName`
+
+The name of the customer managed key to use for encryption.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `databases.customerManagedKey.keyVaultResourceId`
+
+The resource ID of a key vault to reference a customer managed key for encryption from.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `databases.customerManagedKey.autoRotationEnabled`
+
+Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used.
+
+- Required: No
+- Type: bool
+
+### Parameter: `databases.customerManagedKey.keyVersion`
+
+The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting.
+
+- Required: No
+- Type: string
+
+### Parameter: `databases.customerManagedKey.userAssignedIdentityResourceId`
+
+User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use.
+
+- Required: No
+- Type: string
+
 ### Parameter: `databases.diagnosticSettings`
 
 The diagnostic settings of the service.
@@ -3018,20 +3163,6 @@ The resource identifier of the elastic pool containing this database.
 
 - Required: No
 - Type: string
-
-### Parameter: `databases.encryptionProtector`
-
-The azure key vault URI of the database if it's configured with per Database Customer Managed Keys.
-
-- Required: No
-- Type: string
-
-### Parameter: `databases.encryptionProtectorAutoRotation`
-
-The flag to enable or disable auto rotation of database encryption protector AKV key.
-
-- Required: No
-- Type: bool
 
 ### Parameter: `databases.federatedClientId`
 

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -1066,6 +1066,10 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         ]
         elasticPoolResourceId: '<elasticPoolResourceId>'
         licenseType: 'LicenseIncluded'
+        lock: {
+          kind: 'CanNotDelete'
+          name: 'myCustomLockName'
+        }
         managedIdentities: {
           userAssignedResourceIds: [
             '<databaseIdentityResourceId>'
@@ -1083,6 +1087,10 @@ module server 'br/public:avm/res/sql/server:<version>' = {
     elasticPools: [
       {
         availabilityZone: -1
+        lock: {
+          kind: 'CanNotDelete'
+          name: 'myCustomLockName'
+        }
         name: 'sqlsmax-ep-001'
         sku: {
           capacity: 10
@@ -1245,6 +1253,10 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           ],
           "elasticPoolResourceId": "<elasticPoolResourceId>",
           "licenseType": "LicenseIncluded",
+          "lock": {
+            "kind": "CanNotDelete",
+            "name": "myCustomLockName"
+          },
           "managedIdentities": {
             "userAssignedResourceIds": [
               "<databaseIdentityResourceId>"
@@ -1264,6 +1276,10 @@ module server 'br/public:avm/res/sql/server:<version>' = {
       "value": [
         {
           "availabilityZone": -1,
+          "lock": {
+            "kind": "CanNotDelete",
+            "name": "myCustomLockName"
+          },
           "name": "sqlsmax-ep-001",
           "sku": {
             "capacity": 10,
@@ -1440,6 +1456,10 @@ param databases = [
     ]
     elasticPoolResourceId: '<elasticPoolResourceId>'
     licenseType: 'LicenseIncluded'
+    lock: {
+      kind: 'CanNotDelete'
+      name: 'myCustomLockName'
+    }
     managedIdentities: {
       userAssignedResourceIds: [
         '<databaseIdentityResourceId>'
@@ -1457,6 +1477,10 @@ param databases = [
 param elasticPools = [
   {
     availabilityZone: -1
+    lock: {
+      kind: 'CanNotDelete'
+      name: 'myCustomLockName'
+    }
     name: 'sqlsmax-ep-001'
     sku: {
       capacity: 10
@@ -2656,6 +2680,7 @@ The databases to create in the server.
 | [`highAvailabilityReplicaCount`](#parameter-databaseshighavailabilityreplicacount) | int | The number of secondary replicas associated with the database that are used to provide high availability. Not applicable to a Hyperscale database within an elastic pool. |
 | [`isLedgerOn`](#parameter-databasesisledgeron) | bool | Whether or not this database is a ledger database, which means all tables in the database are ledger tables. |
 | [`licenseType`](#parameter-databaseslicensetype) | string | The license type to apply for this database. |
+| [`lock`](#parameter-databaseslock) | object | The lock settings of the database. |
 | [`longTermRetentionBackupResourceId`](#parameter-databaseslongtermretentionbackupresourceid) | string | The resource identifier of the long term retention backup associated with create operation of this database. |
 | [`maintenanceConfigurationId`](#parameter-databasesmaintenanceconfigurationid) | string | Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur. |
 | [`managedIdentities`](#parameter-databasesmanagedidentities) | object | The managed identities for the database. |
@@ -3057,6 +3082,42 @@ The license type to apply for this database.
   ]
   ```
 
+### Parameter: `databases.lock`
+
+The lock settings of the database.
+
+- Required: No
+- Type: object
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`kind`](#parameter-databaseslockkind) | string | Specify the type of lock. |
+| [`name`](#parameter-databaseslockname) | string | Specify the name of lock. |
+
+### Parameter: `databases.lock.kind`
+
+Specify the type of lock.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'CanNotDelete'
+    'None'
+    'ReadOnly'
+  ]
+  ```
+
+### Parameter: `databases.lock.name`
+
+Specify the name of lock.
+
+- Required: No
+- Type: string
+
 ### Parameter: `databases.longTermRetentionBackupResourceId`
 
 The resource identifier of the long term retention backup associated with create operation of this database.
@@ -3333,6 +3394,7 @@ The Elastic Pools to create in the server.
 | [`autoPauseDelay`](#parameter-elasticpoolsautopausedelay) | int | Time in minutes after which elastic pool is automatically paused. A value of -1 means that automatic pause is disabled. |
 | [`highAvailabilityReplicaCount`](#parameter-elasticpoolshighavailabilityreplicacount) | int | The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools. |
 | [`licenseType`](#parameter-elasticpoolslicensetype) | string | The license type to apply for this elastic pool. |
+| [`lock`](#parameter-elasticpoolslock) | object | The lock settings of the elastic pool. |
 | [`maintenanceConfigurationId`](#parameter-elasticpoolsmaintenanceconfigurationid) | string | Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur. |
 | [`maxSizeBytes`](#parameter-elasticpoolsmaxsizebytes) | int | The storage limit for the database elastic pool in bytes. |
 | [`minCapacity`](#parameter-elasticpoolsmincapacity) | int | Minimal capacity that serverless pool will not shrink below, if not paused. |
@@ -3392,6 +3454,42 @@ The license type to apply for this elastic pool.
     'LicenseIncluded'
   ]
   ```
+
+### Parameter: `elasticPools.lock`
+
+The lock settings of the elastic pool.
+
+- Required: No
+- Type: object
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`kind`](#parameter-elasticpoolslockkind) | string | Specify the type of lock. |
+| [`name`](#parameter-elasticpoolslockname) | string | Specify the name of lock. |
+
+### Parameter: `elasticPools.lock.kind`
+
+Specify the type of lock.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'CanNotDelete'
+    'None'
+    'ReadOnly'
+  ]
+  ```
+
+### Parameter: `elasticPools.lock.name`
+
+Specify the name of lock.
+
+- Required: No
+- Type: string
 
 ### Parameter: `elasticPools.maintenanceConfigurationId`
 

--- a/avm/res/sql/server/audit-setting/README.md
+++ b/avm/res/sql/server/audit-setting/README.md
@@ -13,7 +13,7 @@ This module deploys an Azure SQL Server Audit Settings.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Sql/servers/auditingSettings` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/auditingSettings) |
+| `Microsoft.Sql/servers/auditingSettings` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/auditingSettings) |
 
 ## Parameters
 

--- a/avm/res/sql/server/audit-setting/main.bicep
+++ b/avm/res/sql/server/audit-setting/main.bicep
@@ -52,19 +52,6 @@ var primaryUserAssignedIdentityPrincipalId = filter(
   identity => identity.key == server.properties.primaryUserAssignedIdentityId
 )[0].value.principalId
 
-// module storageAccount_sbdc_rbac 'modules/nested_storageRoleAssignment.bicep' = if (isManagedIdentityInUse && !empty(storageAccountResourceId)) {
-//   name: '${server.name}-stau-rbac'
-//   scope: (isManagedIdentityInUse && !empty(storageAccountResourceId))
-//     ? resourceGroup(split(storageAccountResourceId!, '/')[2], split(storageAccountResourceId!, '/')[4])
-//     : resourceGroup()
-//   params: {
-//     storageAccountName: last(split(storageAccountResourceId!, '/'))
-//     managedIdentityPrincipalId: server.identity.type == 'UserAssigned'
-//       ? primaryUserAssignedIdentityPrincipalId
-//       : server.identity.principalId
-//   }
-// }
-
 // If storage account is in a different resource group
 module storageAccount_sbdc_rbac_rg 'modules/nested_storageRoleAssignment.bicep' = if (isManagedIdentityInUse && !empty(storageAccountResourceId) && split(
   storageAccountResourceId,

--- a/avm/res/sql/server/audit-setting/main.bicep
+++ b/avm/res/sql/server/audit-setting/main.bicep
@@ -79,7 +79,7 @@ resource auditSettings 'Microsoft.Sql/servers/auditingSettings@2023-08-01-previe
     retentionDays: retentionDays
     storageAccountAccessKey: !empty(storageAccountResourceId) && !isManagedIdentityInUse
       ? listKeys(storageAccountResourceId, '2019-06-01').keys[0].value
-      : any(null)
+      : null
     storageAccountSubscriptionId: !empty(storageAccountResourceId) ? split(storageAccountResourceId, '/')[2] : any(null)
     storageEndpoint: !empty(storageAccountResourceId)
       ? 'https://${last(split(storageAccountResourceId, '/'))}.blob.${environment().suffixes.storage}'

--- a/avm/res/sql/server/audit-setting/main.bicep
+++ b/avm/res/sql/server/audit-setting/main.bicep
@@ -42,7 +42,7 @@ param retentionDays int = 90
 @description('Optional. A blob storage to hold the auditing storage account.')
 param storageAccountResourceId string = ''
 
-resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: serverName
 }
 
@@ -52,20 +52,50 @@ var primaryUserAssignedIdentityPrincipalId = filter(
   identity => identity.key == server.properties.primaryUserAssignedIdentityId
 )[0].value.principalId
 
-module storageAccount_sbdc_rbac 'modules/nested_storageRoleAssignment.bicep' = if (isManagedIdentityInUse && !empty(storageAccountResourceId)) {
-  name: '${server.name}-stau-rbac'
-  scope: (isManagedIdentityInUse && !empty(storageAccountResourceId))
-    ? resourceGroup(split(storageAccountResourceId!, '/')[2], split(storageAccountResourceId!, '/')[4])
-    : resourceGroup()
+// module storageAccount_sbdc_rbac 'modules/nested_storageRoleAssignment.bicep' = if (isManagedIdentityInUse && !empty(storageAccountResourceId)) {
+//   name: '${server.name}-stau-rbac'
+//   scope: (isManagedIdentityInUse && !empty(storageAccountResourceId))
+//     ? resourceGroup(split(storageAccountResourceId!, '/')[2], split(storageAccountResourceId!, '/')[4])
+//     : resourceGroup()
+//   params: {
+//     storageAccountName: last(split(storageAccountResourceId!, '/'))
+//     managedIdentityPrincipalId: server.identity.type == 'UserAssigned'
+//       ? primaryUserAssignedIdentityPrincipalId
+//       : server.identity.principalId
+//   }
+// }
+
+// If storage account is in a different resource group
+module storageAccount_sbdc_rbac_rg 'modules/nested_storageRoleAssignment.bicep' = if (isManagedIdentityInUse && !empty(storageAccountResourceId) && split(
+  storageAccountResourceId,
+  '/'
+)[4] != resourceGroup().name) {
+  name: '${server.name}-stau-rbac-rg'
+  scope: resourceGroup(split(storageAccountResourceId, '/')[2], split(storageAccountResourceId, '/')[4])
   params: {
-    storageAccountName: last(split(storageAccountResourceId!, '/'))
+    storageAccountName: last(split(storageAccountResourceId, '/'))
     managedIdentityPrincipalId: server.identity.type == 'UserAssigned'
       ? primaryUserAssignedIdentityPrincipalId
       : server.identity.principalId
   }
 }
 
-resource auditSettings 'Microsoft.Sql/servers/auditingSettings@2023-08-01-preview' = {
+// If storage account is in the same resource group
+module storageAccount_sbdc_rbac 'modules/nested_storageRoleAssignment.bicep' = if (isManagedIdentityInUse && !empty(storageAccountResourceId) && split(
+  storageAccountResourceId,
+  '/'
+)[4] == resourceGroup().name) {
+  name: '${server.name}-stau-rbac'
+  scope: resourceGroup()
+  params: {
+    storageAccountName: last(split(storageAccountResourceId, '/'))
+    managedIdentityPrincipalId: server.identity.type == 'UserAssigned'
+      ? primaryUserAssignedIdentityPrincipalId
+      : server.identity.principalId
+  }
+}
+
+resource auditSettings 'Microsoft.Sql/servers/auditingSettings@2023-08-01' = {
   name: name
   parent: server
   properties: {

--- a/avm/res/sql/server/audit-setting/main.json
+++ b/avm/res/sql/server/audit-setting/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "4727925735892722326"
+      "version": "0.36.1.42791",
+      "templateHash": "18380400942025106313"
     },
     "name": "Azure SQL Server Audit Settings",
     "description": "This module deploys an Azure SQL Server Audit Settings."
@@ -103,12 +103,12 @@
     "server": {
       "existing": true,
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[parameters('serverName')]"
     },
     "auditSettings": {
       "type": "Microsoft.Sql/servers/auditingSettings",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
       "properties": {
         "state": "[parameters('state')]",
@@ -124,8 +124,63 @@
         "storageEndpoint": "[if(not(empty(parameters('storageAccountResourceId'))), format('https://{0}.blob.{1}', last(split(parameters('storageAccountResourceId'), '/')), environment().suffixes.storage), null())]"
       }
     },
+    "storageAccount_sbdc_rbac_rg": {
+      "condition": "[and(and(parameters('isManagedIdentityInUse'), not(empty(parameters('storageAccountResourceId')))), not(equals(split(parameters('storageAccountResourceId'), '/')[4], resourceGroup().name)))]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('{0}-stau-rbac-rg', parameters('serverName'))]",
+      "subscriptionId": "[split(parameters('storageAccountResourceId'), '/')[2]]",
+      "resourceGroup": "[split(parameters('storageAccountResourceId'), '/')[4]]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "storageAccountName": {
+            "value": "[last(split(parameters('storageAccountResourceId'), '/'))]"
+          },
+          "managedIdentityPrincipalId": "[if(equals(reference('server', '2023-08-01', 'full').identity.type, 'UserAssigned'), createObject('value', filter(items(reference('server', '2023-08-01', 'full').identity.userAssignedIdentities), lambda('identity', equals(lambdaVariables('identity').key, reference('server').primaryUserAssignedIdentityId)))[0].value.principalId), createObject('value', reference('server', '2023-08-01', 'full').identity.principalId))]"
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.36.1.42791",
+              "templateHash": "16469435463567159258"
+            }
+          },
+          "parameters": {
+            "storageAccountName": {
+              "type": "string"
+            },
+            "managedIdentityPrincipalId": {
+              "type": "string"
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[format('Microsoft.Storage/storageAccounts/{0}', parameters('storageAccountName'))]",
+              "name": "[guid(format('{0}-{1}-Storage-Blob-Data-Contributor', resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('managedIdentityPrincipalId')))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
+                "principalId": "[parameters('managedIdentityPrincipalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "server"
+      ]
+    },
     "storageAccount_sbdc_rbac": {
-      "condition": "[and(parameters('isManagedIdentityInUse'), not(empty(parameters('storageAccountResourceId'))))]",
+      "condition": "[and(and(parameters('isManagedIdentityInUse'), not(empty(parameters('storageAccountResourceId')))), equals(split(parameters('storageAccountResourceId'), '/')[4], resourceGroup().name))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
       "name": "[format('{0}-stau-rbac', parameters('serverName'))]",
@@ -138,7 +193,7 @@
           "storageAccountName": {
             "value": "[last(split(parameters('storageAccountResourceId'), '/'))]"
           },
-          "managedIdentityPrincipalId": "[if(equals(reference('server', '2023-08-01-preview', 'full').identity.type, 'UserAssigned'), createObject('value', filter(items(reference('server', '2023-08-01-preview', 'full').identity.userAssignedIdentities), lambda('identity', equals(lambdaVariables('identity').key, reference('server').primaryUserAssignedIdentityId)))[0].value.principalId), createObject('value', reference('server', '2023-08-01-preview', 'full').identity.principalId))]"
+          "managedIdentityPrincipalId": "[if(equals(reference('server', '2023-08-01', 'full').identity.type, 'UserAssigned'), createObject('value', filter(items(reference('server', '2023-08-01', 'full').identity.userAssignedIdentities), lambda('identity', equals(lambdaVariables('identity').key, reference('server').primaryUserAssignedIdentityId)))[0].value.principalId), createObject('value', reference('server', '2023-08-01', 'full').identity.principalId))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -146,8 +201,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "9873493969278157067"
+              "version": "0.36.1.42791",
+              "templateHash": "16469435463567159258"
             }
           },
           "parameters": {

--- a/avm/res/sql/server/audit-setting/main.json
+++ b/avm/res/sql/server/audit-setting/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "15469959027924260105"
+      "version": "0.35.1.17967",
+      "templateHash": "4727925735892722326"
     },
     "name": "Azure SQL Server Audit Settings",
     "description": "This module deploys an Azure SQL Server Audit Settings."
@@ -146,8 +146,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "11839727322069180104"
+              "version": "0.35.1.17967",
+              "templateHash": "9873493969278157067"
             }
           },
           "parameters": {

--- a/avm/res/sql/server/audit-setting/modules/nested_storageRoleAssignment.bicep
+++ b/avm/res/sql/server/audit-setting/modules/nested_storageRoleAssignment.bicep
@@ -1,7 +1,7 @@
 param storageAccountName string
 param managedIdentityPrincipalId string
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
   name: storageAccountName
 }
 

--- a/avm/res/sql/server/database/README.md
+++ b/avm/res/sql/server/database/README.md
@@ -15,9 +15,9 @@ This module deploys an Azure SQL Server Database.
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
-| `Microsoft.Sql/servers/databases` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/databases) |
+| `Microsoft.Sql/servers/databases` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/databases) |
 | `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
-| `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/databases/backupShortTermRetentionPolicies) |
+| `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/databases/backupShortTermRetentionPolicies) |
 
 ## Parameters
 

--- a/avm/res/sql/server/database/README.md
+++ b/avm/res/sql/server/database/README.md
@@ -13,6 +13,7 @@ This module deploys an Azure SQL Server Database.
 
 | Resource Type | API Version |
 | :-- | :-- |
+| `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.Sql/servers/databases` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/databases) |
 | `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
@@ -53,6 +54,7 @@ This module deploys an Azure SQL Server Database.
 | [`isLedgerOn`](#parameter-isledgeron) | bool | Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created. |
 | [`licenseType`](#parameter-licensetype) | string | The license type to apply for this database. |
 | [`location`](#parameter-location) | string | Location for all resources. |
+| [`lock`](#parameter-lock) | object | The lock settings of the databse. |
 | [`longTermRetentionBackupResourceId`](#parameter-longtermretentionbackupresourceid) | string | The resource identifier of the long term retention backup associated with create operation of this database. |
 | [`maintenanceConfigurationId`](#parameter-maintenanceconfigurationid) | string | Maintenance configuration ID assigned to the database. This configuration defines the period when the maintenance updates will occur. |
 | [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. |
@@ -474,6 +476,42 @@ Location for all resources.
 - Required: No
 - Type: string
 - Default: `[resourceGroup().location]`
+
+### Parameter: `lock`
+
+The lock settings of the databse.
+
+- Required: No
+- Type: object
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`kind`](#parameter-lockkind) | string | Specify the type of lock. |
+| [`name`](#parameter-lockname) | string | Specify the name of lock. |
+
+### Parameter: `lock.kind`
+
+Specify the type of lock.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'CanNotDelete'
+    'None'
+    'ReadOnly'
+  ]
+  ```
+
+### Parameter: `lock.name`
+
+Specify the name of lock.
+
+- Required: No
+- Type: string
 
 ### Parameter: `longTermRetentionBackupResourceId`
 

--- a/avm/res/sql/server/database/README.md
+++ b/avm/res/sql/server/database/README.md
@@ -44,10 +44,9 @@ This module deploys an Azure SQL Server Database.
 | [`catalogCollation`](#parameter-catalogcollation) | string | Collation of the metadata catalog. |
 | [`collation`](#parameter-collation) | string | The collation of the database. |
 | [`createMode`](#parameter-createmode) | string | Specifies the mode of database creation. |
+| [`customerManagedKey`](#parameter-customermanagedkey) | object | The customer managed key definition for database TDE. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
 | [`elasticPoolResourceId`](#parameter-elasticpoolresourceid) | string | The resource ID of the elastic pool containing this database. |
-| [`encryptionProtector`](#parameter-encryptionprotector) | string | The azure key vault URI of the database if it's configured with per Database Customer Managed Keys. |
-| [`encryptionProtectorAutoRotation`](#parameter-encryptionprotectorautorotation) | bool | The flag to enable or disable auto rotation of database encryption protector AKV key. |
 | [`federatedClientId`](#parameter-federatedclientid) | string | The Client id used for cross tenant per database CMK scenario. |
 | [`freeLimitExhaustionBehavior`](#parameter-freelimitexhaustionbehavior) | string | Specifies the behavior when monthly free limits are exhausted for the free database. |
 | [`highAvailabilityReplicaCount`](#parameter-highavailabilityreplicacount) | int | The number of readonly secondary replicas associated with the database. |
@@ -251,6 +250,63 @@ Specifies the mode of database creation.
   ]
   ```
 
+### Parameter: `customerManagedKey`
+
+The customer managed key definition for database TDE.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`keyName`](#parameter-customermanagedkeykeyname) | string | The name of the customer managed key to use for encryption. |
+| [`keyVaultResourceId`](#parameter-customermanagedkeykeyvaultresourceid) | string | The resource ID of a key vault to reference a customer managed key for encryption from. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`autoRotationEnabled`](#parameter-customermanagedkeyautorotationenabled) | bool | Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used. |
+| [`keyVersion`](#parameter-customermanagedkeykeyversion) | string | The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting. |
+| [`userAssignedIdentityResourceId`](#parameter-customermanagedkeyuserassignedidentityresourceid) | string | User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use. |
+
+### Parameter: `customerManagedKey.keyName`
+
+The name of the customer managed key to use for encryption.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `customerManagedKey.keyVaultResourceId`
+
+The resource ID of a key vault to reference a customer managed key for encryption from.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `customerManagedKey.autoRotationEnabled`
+
+Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used.
+
+- Required: No
+- Type: bool
+
+### Parameter: `customerManagedKey.keyVersion`
+
+The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting.
+
+- Required: No
+- Type: string
+
+### Parameter: `customerManagedKey.userAssignedIdentityResourceId`
+
+User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use.
+
+- Required: No
+- Type: string
+
 ### Parameter: `diagnosticSettings`
 
 The diagnostic settings of the service.
@@ -403,20 +459,6 @@ The resource ID of the elastic pool containing this database.
 
 - Required: No
 - Type: string
-
-### Parameter: `encryptionProtector`
-
-The azure key vault URI of the database if it's configured with per Database Customer Managed Keys.
-
-- Required: No
-- Type: string
-
-### Parameter: `encryptionProtectorAutoRotation`
-
-The flag to enable or disable auto rotation of database encryption protector AKV key.
-
-- Required: No
-- Type: bool
 
 ### Parameter: `federatedClientId`
 

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/main.bicep
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/main.bicep
@@ -25,10 +25,10 @@ param weekOfYear int = 1
 @description('Optional. Yearly retention in ISO 8601 duration format.')
 param yearlyRetention string?
 
-resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: serverName
 
-  resource database 'databases@2023-08-01-preview' existing = {
+  resource database 'databases@2023-08-01' existing = {
     name: databaseName
   }
 }

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "15078686386861189890"
+      "version": "0.35.1.17967",
+      "templateHash": "12746160659080715511"
     },
     "name": "SQL Server Database Long Term Backup Retention Policies",
     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "12746160659080715511"
+      "version": "0.36.1.42791",
+      "templateHash": "101116542806833061"
     },
     "name": "SQL Server Database Long Term Backup Retention Policies",
     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."
@@ -75,13 +75,13 @@
     "server::database": {
       "existing": true,
       "type": "Microsoft.Sql/servers/databases",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('databaseName'))]"
     },
     "server": {
       "existing": true,
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[parameters('serverName')]"
     },
     "backupLongTermRetentionPolicy": {

--- a/avm/res/sql/server/database/backup-short-term-retention-policy/README.md
+++ b/avm/res/sql/server/database/backup-short-term-retention-policy/README.md
@@ -12,7 +12,7 @@ This module deploys an Azure SQL Server Database Short-Term Backup Retention Pol
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/databases/backupShortTermRetentionPolicies) |
+| `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/databases/backupShortTermRetentionPolicies) |
 
 ## Parameters
 

--- a/avm/res/sql/server/database/backup-short-term-retention-policy/main.bicep
+++ b/avm/res/sql/server/database/backup-short-term-retention-policy/main.bicep
@@ -13,15 +13,15 @@ param diffBackupIntervalInHours int = 24
 @description('Optional. Poin-in-time retention in days.')
 param retentionDays int = 7
 
-resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: serverName
 
-  resource database 'databases@2023-08-01-preview' existing = {
+  resource database 'databases@2023-08-01' existing = {
     name: databaseName
   }
 }
 
-resource backupShortTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies@2023-08-01-preview' = {
+resource backupShortTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies@2023-08-01' = {
   name: 'default'
   parent: server::database
   properties: {

--- a/avm/res/sql/server/database/backup-short-term-retention-policy/main.json
+++ b/avm/res/sql/server/database/backup-short-term-retention-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "586417749840962852"
+      "version": "0.35.1.17967",
+      "templateHash": "16869585493743816680"
     },
     "name": "Azure SQL Server Database Short Term Backup Retention Policies",
     "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."

--- a/avm/res/sql/server/database/backup-short-term-retention-policy/main.json
+++ b/avm/res/sql/server/database/backup-short-term-retention-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "16869585493743816680"
+      "version": "0.36.1.42791",
+      "templateHash": "9948442514033354219"
     },
     "name": "Azure SQL Server Database Short Term Backup Retention Policies",
     "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."
@@ -41,10 +41,10 @@
   "resources": [
     {
       "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[format('{0}/{1}/{2}', parameters('serverName'), parameters('databaseName'), 'default')]",
       "properties": {
-        "diffBackupIntervalInHours": "[if(equals(reference(resourceId('Microsoft.Sql/servers/databases', parameters('serverName'), parameters('databaseName')), '2023-08-01-preview', 'full').sku.tier, 'Hyperscale'), null(), parameters('diffBackupIntervalInHours'))]",
+        "diffBackupIntervalInHours": "[if(equals(reference(resourceId('Microsoft.Sql/servers/databases', parameters('serverName'), parameters('databaseName')), '2023-08-01', 'full').sku.tier, 'Hyperscale'), null(), parameters('diffBackupIntervalInHours'))]",
         "retentionDays": "[parameters('retentionDays')]"
       }
     }

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -156,7 +156,7 @@ import { customerManagedKeyWithAutoRotateType } from 'br/public:avm/utl/types/av
 @description('Optional. The customer managed key definition for database TDE.')
 param customerManagedKey customerManagedKeyWithAutoRotateType?
 
-resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: serverName
 }
 
@@ -185,7 +185,7 @@ resource cMKKeyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = if (!empt
   }
 }
 
-resource database 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+resource database 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: name
   parent: server
   location: location
@@ -231,12 +231,6 @@ resource database 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
     sourceResourceId: sourceResourceId
     useFreeLimit: useFreeLimit
     zoneRedundant: zoneRedundant
-    // keys: [
-    //   {
-    //     databaseKeyType: ''
-    //     uri: ''
-    //   }
-    // ]
   }
 }
 

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -49,12 +49,6 @@ param createMode
 @description('Optional. The resource ID of the elastic pool containing this database.')
 param elasticPoolResourceId string?
 
-// @description('Optional. The azure key vault URI of the database if it\'s configured with per Database Customer Managed Keys.')
-// param encryptionProtector string?
-
-// @description('Optional. The flag to enable or disable auto rotation of database encryption protector AKV key.')
-// param encryptionProtectorAutoRotation bool?
-
 @description('Optional. The Client id used for cross tenant per database CMK scenario.')
 @minLength(36)
 @maxLength(36)

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -140,6 +140,10 @@ param tags object?
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+@description('Optional. The lock settings of the databse.')
+param lock lockType?
+
 import { diagnosticSettingFullType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
 @description('Optional. The diagnostic settings of the service.')
 param diagnosticSettings diagnosticSettingFullType[]?
@@ -244,6 +248,17 @@ resource database_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021
     scope: database
   }
 ]
+
+resource database_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(lock ?? {}) && lock.?kind != 'None') {
+  name: lock.?name ?? 'lock-${name}'
+  properties: {
+    level: lock.?kind ?? ''
+    notes: lock.?kind == 'CanNotDelete'
+      ? 'Cannot delete resource or child resources.'
+      : 'Cannot delete or modify the resource or child resources.'
+  }
+  scope: database
+}
 
 module database_backupShortTermRetentionPolicy 'backup-short-term-retention-policy/main.bicep' = if (!empty(backupShortTermRetentionPolicy)) {
   name: '${uniqueString(deployment().name, location)}-shBakRetPol'

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "15825153899458576874"
+      "version": "0.35.1.17967",
+      "templateHash": "469670230062149348"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database."
@@ -250,6 +250,36 @@
       },
       "metadata": {
         "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+        }
+      }
+    },
+    "lockType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specify the name of lock."
+          }
+        },
+        "kind": {
+          "type": "string",
+          "allowedValues": [
+            "CanNotDelete",
+            "None",
+            "ReadOnly"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specify the type of lock."
+          }
+        }
+      },
+      "metadata": {
+        "description": "An AVM-aligned type for a lock.",
         "__bicep_imported_from!": {
           "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
         }
@@ -591,6 +621,13 @@
         "description": "Optional. Location for all resources."
       }
     },
+    "lock": {
+      "$ref": "#/definitions/lockType",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The lock settings of the databse."
+      }
+    },
     "diagnosticSettings": {
       "type": "array",
       "items": {
@@ -719,6 +756,20 @@
         "database"
       ]
     },
+    "database_lock": {
+      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+      "type": "Microsoft.Authorization/locks",
+      "apiVersion": "2020-05-01",
+      "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', parameters('serverName'), parameters('name'))]",
+      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+      "properties": {
+        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+        "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+      },
+      "dependsOn": [
+        "database"
+      ]
+    },
     "database_backupShortTermRetentionPolicy": {
       "condition": "[not(empty(parameters('backupShortTermRetentionPolicy')))]",
       "type": "Microsoft.Resources/deployments",
@@ -749,8 +800,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "586417749840962852"
+              "version": "0.35.1.17967",
+              "templateHash": "16869585493743816680"
             },
             "name": "Azure SQL Server Database Short Term Backup Retention Policies",
             "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."
@@ -866,8 +917,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "15078686386861189890"
+              "version": "0.35.1.17967",
+              "templateHash": "12746160659080715511"
             },
             "name": "SQL Server Database Long Term Backup Retention Policies",
             "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.35.1.17967",
-      "templateHash": "469670230062149348"
+      "templateHash": "15632818564385347474"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database."
@@ -131,6 +131,50 @@
       "metadata": {
         "__bicep_export!": true,
         "description": "The long-term backup retention policy for the database."
+      }
+    },
+    "customerManagedKeyWithAutoRotateType": {
+      "type": "object",
+      "properties": {
+        "keyVaultResourceId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
+          }
+        },
+        "keyName": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the customer managed key to use for encryption."
+          }
+        },
+        "keyVersion": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting."
+          }
+        },
+        "autoRotationEnabled": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used."
+          }
+        },
+        "userAssignedIdentityResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use."
+          }
+        }
+      },
+      "metadata": {
+        "description": "An AVM-aligned type for a customer-managed key. To be used if the resource type supports auto-rotation of the customer-managed key.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+        }
       }
     },
     "diagnosticSettingFullType": {
@@ -389,20 +433,6 @@
         "description": "Optional. The resource ID of the elastic pool containing this database."
       }
     },
-    "encryptionProtector": {
-      "type": "string",
-      "nullable": true,
-      "metadata": {
-        "description": "Optional. The azure key vault URI of the database if it's configured with per Database Customer Managed Keys."
-      }
-    },
-    "encryptionProtectorAutoRotation": {
-      "type": "bool",
-      "nullable": true,
-      "metadata": {
-        "description": "Optional. The flag to enable or disable auto rotation of database encryption protector AKV key."
-      }
-    },
     "federatedClientId": {
       "type": "string",
       "nullable": true,
@@ -658,6 +688,13 @@
       "metadata": {
         "description": "Optional. The managed identity definition for this resource."
       }
+    },
+    "customerManagedKey": {
+      "$ref": "#/definitions/customerManagedKeyWithAutoRotateType",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The customer managed key definition for database TDE."
+      }
     }
   },
   "variables": {
@@ -665,11 +702,29 @@
     "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', null()), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]"
   },
   "resources": {
+    "cMKKeyVault::cMKKey": {
+      "condition": "[and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName')))))]",
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults/keys",
+      "apiVersion": "2023-07-01",
+      "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+      "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+      "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
+    },
     "server": {
       "existing": true,
       "type": "Microsoft.Sql/servers",
       "apiVersion": "2023-08-01-preview",
       "name": "[parameters('serverName')]"
+    },
+    "cMKKeyVault": {
+      "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId')))]",
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2023-07-01",
+      "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+      "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+      "name": "[last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))]"
     },
     "database": {
       "type": "Microsoft.Sql/servers/databases",
@@ -686,8 +741,8 @@
         "collation": "[parameters('collation')]",
         "createMode": "[parameters('createMode')]",
         "elasticPoolId": "[parameters('elasticPoolResourceId')]",
-        "encryptionProtector": "[parameters('encryptionProtector')]",
-        "encryptionProtectorAutoRotation": "[parameters('encryptionProtectorAutoRotation')]",
+        "encryptionProtector": "[if(not(equals(parameters('customerManagedKey'), null())), if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), reference('cMKKeyVault::cMKKey').keyUriWithVersion), null())]",
+        "encryptionProtectorAutoRotation": "[tryGet(parameters('customerManagedKey'), 'autoRotationEnabled')]",
         "federatedClientId": "[parameters('federatedClientId')]",
         "freeLimitExhaustionBehavior": "[parameters('freeLimitExhaustionBehavior')]",
         "highAvailabilityReplicaCount": "[parameters('highAvailabilityReplicaCount')]",
@@ -713,7 +768,10 @@
         "sourceResourceId": "[parameters('sourceResourceId')]",
         "useFreeLimit": "[parameters('useFreeLimit')]",
         "zoneRedundant": "[parameters('zoneRedundant')]"
-      }
+      },
+      "dependsOn": [
+        "cMKKeyVault::cMKKey"
+      ]
     },
     "database_diagnosticSettings": {
       "copy": {

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "15632818564385347474"
+      "version": "0.36.1.42791",
+      "templateHash": "15961431104919711857"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database."
@@ -714,7 +714,7 @@
     "server": {
       "existing": true,
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[parameters('serverName')]"
     },
     "cMKKeyVault": {
@@ -728,7 +728,7 @@
     },
     "database": {
       "type": "Microsoft.Sql/servers/databases",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -858,8 +858,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "16869585493743816680"
+              "version": "0.36.1.42791",
+              "templateHash": "9948442514033354219"
             },
             "name": "Azure SQL Server Database Short Term Backup Retention Policies",
             "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."
@@ -895,10 +895,10 @@
           "resources": [
             {
               "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}/{2}', parameters('serverName'), parameters('databaseName'), 'default')]",
               "properties": {
-                "diffBackupIntervalInHours": "[if(equals(reference(resourceId('Microsoft.Sql/servers/databases', parameters('serverName'), parameters('databaseName')), '2023-08-01-preview', 'full').sku.tier, 'Hyperscale'), null(), parameters('diffBackupIntervalInHours'))]",
+                "diffBackupIntervalInHours": "[if(equals(reference(resourceId('Microsoft.Sql/servers/databases', parameters('serverName'), parameters('databaseName')), '2023-08-01', 'full').sku.tier, 'Hyperscale'), null(), parameters('diffBackupIntervalInHours'))]",
                 "retentionDays": "[parameters('retentionDays')]"
               }
             }
@@ -975,8 +975,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "12746160659080715511"
+              "version": "0.36.1.42791",
+              "templateHash": "101116542806833061"
             },
             "name": "SQL Server Database Long Term Backup Retention Policies",
             "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."
@@ -1045,13 +1045,13 @@
             "server::database": {
               "existing": true,
               "type": "Microsoft.Sql/servers/databases",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('databaseName'))]"
             },
             "server": {
               "existing": true,
               "type": "Microsoft.Sql/servers",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[parameters('serverName')]"
             },
             "backupLongTermRetentionPolicy": {
@@ -1125,7 +1125,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('database', '2023-08-01-preview', 'full').location]"
+      "value": "[reference('database', '2023-08-01', 'full').location]"
     }
   }
 }

--- a/avm/res/sql/server/elastic-pool/README.md
+++ b/avm/res/sql/server/elastic-pool/README.md
@@ -14,7 +14,7 @@ This module deploys an Azure SQL Server Elastic Pool.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
-| `Microsoft.Sql/servers/elasticPools` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/elasticPools) |
+| `Microsoft.Sql/servers/elasticPools` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/elasticPools) |
 
 ## Parameters
 

--- a/avm/res/sql/server/elastic-pool/README.md
+++ b/avm/res/sql/server/elastic-pool/README.md
@@ -7,11 +7,13 @@ This module deploys an Azure SQL Server Elastic Pool.
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Cross-referenced modules](#Cross-referenced-modules)
 
 ## Resource Types
 
 | Resource Type | API Version |
 | :-- | :-- |
+| `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Sql/servers/elasticPools` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/elasticPools) |
 
 ## Parameters
@@ -37,6 +39,7 @@ This module deploys an Azure SQL Server Elastic Pool.
 | [`highAvailabilityReplicaCount`](#parameter-highavailabilityreplicacount) | int | The number of secondary replicas associated with the elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools. |
 | [`licenseType`](#parameter-licensetype) | string | The license type to apply for this elastic pool. |
 | [`location`](#parameter-location) | string | Location for all resources. |
+| [`lock`](#parameter-lock) | object | The lock settings of the elastic pool. |
 | [`maintenanceConfigurationId`](#parameter-maintenanceconfigurationid) | string | Maintenance configuration resource ID assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur. |
 | [`maxSizeBytes`](#parameter-maxsizebytes) | int | The storage limit for the database elastic pool in bytes. |
 | [`minCapacity`](#parameter-mincapacity) | int | Minimal capacity that serverless pool will not shrink below, if not paused. |
@@ -113,6 +116,42 @@ Location for all resources.
 - Required: No
 - Type: string
 - Default: `[resourceGroup().location]`
+
+### Parameter: `lock`
+
+The lock settings of the elastic pool.
+
+- Required: No
+- Type: object
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`kind`](#parameter-lockkind) | string | Specify the type of lock. |
+| [`name`](#parameter-lockname) | string | Specify the name of lock. |
+
+### Parameter: `lock.kind`
+
+Specify the type of lock.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'CanNotDelete'
+    'None'
+    'ReadOnly'
+  ]
+  ```
+
+### Parameter: `lock.name`
+
+Specify the name of lock.
+
+- Required: No
+- Type: string
 
 ### Parameter: `maintenanceConfigurationId`
 
@@ -305,3 +344,11 @@ Whether or not this elastic pool is zone redundant, which means the replicas of 
 | `name` | string | The name of the deployed Elastic Pool. |
 | `resourceGroupName` | string | The resource group of the deployed Elastic Pool. |
 | `resourceId` | string | The resource ID of the deployed Elastic Pool. |
+
+## Cross-referenced modules
+
+This section gives you an overview of all local-referenced module files (i.e., other modules that are referenced in this module) and all remote-referenced files (i.e., Bicep modules that are referenced from a Bicep Registry or Template Specs).
+
+| Reference | Type |
+| :-- | :-- |
+| `br/public:avm/utl/types/avm-common-types:0.5.1` | Remote reference |

--- a/avm/res/sql/server/elastic-pool/main.bicep
+++ b/avm/res/sql/server/elastic-pool/main.bicep
@@ -68,11 +68,11 @@ param preferredEnclaveType 'Default' | 'VBS' = 'Default'
 @description('Optional. Whether or not this elastic pool is zone redundant, which means the replicas of this elastic pool will be spread across multiple availability zones.')
 param zoneRedundant bool = true
 
-resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: serverName
 }
 
-resource elasticPool 'Microsoft.Sql/servers/elasticPools@2023-08-01-preview' = {
+resource elasticPool 'Microsoft.Sql/servers/elasticPools@2023-08-01' = {
   name: name
   location: location
   parent: server

--- a/avm/res/sql/server/elastic-pool/main.bicep
+++ b/avm/res/sql/server/elastic-pool/main.bicep
@@ -13,6 +13,10 @@ param tags object?
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+@description('Optional. The lock settings of the elastic pool.')
+param lock lockType?
+
 @description('Optional. The elastic pool SKU.')
 param sku skuType = {
   capacity: 2
@@ -93,6 +97,17 @@ resource elasticPool 'Microsoft.Sql/servers/elasticPools@2023-08-01-preview' = {
     preferredEnclaveType: preferredEnclaveType
     zoneRedundant: zoneRedundant
   }
+}
+
+resource elasticPool_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(lock ?? {}) && lock.?kind != 'None') {
+  name: lock.?name ?? 'lock-${name}'
+  properties: {
+    level: lock.?kind ?? ''
+    notes: lock.?kind == 'CanNotDelete'
+      ? 'Cannot delete resource or child resources.'
+      : 'Cannot delete or modify the resource or child resources.'
+  }
+  scope: elasticPool
 }
 
 @description('The name of the deployed Elastic Pool.')

--- a/avm/res/sql/server/elastic-pool/main.json
+++ b/avm/res/sql/server/elastic-pool/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "6480963111257796466"
+      "version": "0.35.1.17967",
+      "templateHash": "15665151450501314299"
     },
     "name": "SQL Server Elastic Pool",
     "description": "This module deploys an Azure SQL Server Elastic Pool."
@@ -96,6 +96,36 @@
         "__bicep_export!": true,
         "description": "The elastic pool SKU."
       }
+    },
+    "lockType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specify the name of lock."
+          }
+        },
+        "kind": {
+          "type": "string",
+          "allowedValues": [
+            "CanNotDelete",
+            "None",
+            "ReadOnly"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specify the type of lock."
+          }
+        }
+      },
+      "metadata": {
+        "description": "An AVM-aligned type for a lock.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+        }
+      }
     }
   },
   "parameters": {
@@ -123,6 +153,13 @@
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "Optional. Location for all resources."
+      }
+    },
+    "lock": {
+      "$ref": "#/definitions/lockType",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The lock settings of the elastic pool."
       }
     },
     "sku": {
@@ -250,6 +287,20 @@
         "preferredEnclaveType": "[parameters('preferredEnclaveType')]",
         "zoneRedundant": "[parameters('zoneRedundant')]"
       }
+    },
+    "elasticPool_lock": {
+      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+      "type": "Microsoft.Authorization/locks",
+      "apiVersion": "2020-05-01",
+      "scope": "[format('Microsoft.Sql/servers/{0}/elasticPools/{1}', parameters('serverName'), parameters('name'))]",
+      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+      "properties": {
+        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+        "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+      },
+      "dependsOn": [
+        "elasticPool"
+      ]
     }
   },
   "outputs": {

--- a/avm/res/sql/server/elastic-pool/main.json
+++ b/avm/res/sql/server/elastic-pool/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "15665151450501314299"
+      "version": "0.36.1.42791",
+      "templateHash": "8266622523187177483"
     },
     "name": "SQL Server Elastic Pool",
     "description": "This module deploys an Azure SQL Server Elastic Pool."
@@ -265,12 +265,12 @@
     "server": {
       "existing": true,
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[parameters('serverName')]"
     },
     "elasticPool": {
       "type": "Microsoft.Sql/servers/elasticPools",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -330,7 +330,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('elasticPool', '2023-08-01-preview', 'full').location]"
+      "value": "[reference('elasticPool', '2023-08-01', 'full').location]"
     }
   }
 }

--- a/avm/res/sql/server/encryption-protector/README.md
+++ b/avm/res/sql/server/encryption-protector/README.md
@@ -12,7 +12,7 @@ This module deploys an Azure SQL Server Encryption Protector.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Sql/servers/encryptionProtector` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/encryptionProtector) |
+| `Microsoft.Sql/servers/encryptionProtector` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/encryptionProtector) |
 
 ## Parameters
 

--- a/avm/res/sql/server/encryption-protector/main.bicep
+++ b/avm/res/sql/server/encryption-protector/main.bicep
@@ -17,11 +17,11 @@ param autoRotationEnabled bool = true
 ])
 param serverKeyType string = 'ServiceManaged'
 
-resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource sqlServer 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: sqlServerName
 }
 
-resource encryptionProtector 'Microsoft.Sql/servers/encryptionProtector@2023-08-01-preview' = {
+resource encryptionProtector 'Microsoft.Sql/servers/encryptionProtector@2023-08-01' = {
   name: 'current'
   parent: sqlServer
   properties: {

--- a/avm/res/sql/server/encryption-protector/main.json
+++ b/avm/res/sql/server/encryption-protector/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "13156357596009101804"
+      "version": "0.35.1.17967",
+      "templateHash": "7021740352606247353"
     },
     "name": "Azure SQL Server Encryption Protector",
     "description": "This module deploys an Azure SQL Server Encryption Protector."

--- a/avm/res/sql/server/encryption-protector/main.json
+++ b/avm/res/sql/server/encryption-protector/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "7021740352606247353"
+      "version": "0.36.1.42791",
+      "templateHash": "17490849737310265082"
     },
     "name": "Azure SQL Server Encryption Protector",
     "description": "This module deploys an Azure SQL Server Encryption Protector."
@@ -45,7 +45,7 @@
   "resources": [
     {
       "type": "Microsoft.Sql/servers/encryptionProtector",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[format('{0}/{1}', parameters('sqlServerName'), 'current')]",
       "properties": {
         "serverKeyType": "[parameters('serverKeyType')]",

--- a/avm/res/sql/server/failover-group/main.bicep
+++ b/avm/res/sql/server/failover-group/main.bicep
@@ -22,7 +22,7 @@ param readWriteEndpoint readWriteEndpointType
 @description('Required. Databases secondary type on partner server.')
 param secondaryType 'Geo' | 'Standby'
 
-resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: serverName
 }
 

--- a/avm/res/sql/server/failover-group/main.json
+++ b/avm/res/sql/server/failover-group/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "16705539934522968897"
+      "version": "0.35.1.17967",
+      "templateHash": "15947051067826269286"
     },
     "name": "Azure SQL Server failover group",
     "description": "This module deploys Azure SQL Server failover group."

--- a/avm/res/sql/server/failover-group/main.json
+++ b/avm/res/sql/server/failover-group/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "15947051067826269286"
+      "version": "0.36.1.42791",
+      "templateHash": "7002329445517579297"
     },
     "name": "Azure SQL Server failover group",
     "description": "This module deploys Azure SQL Server failover group."
@@ -130,7 +130,7 @@
     "server": {
       "existing": true,
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[parameters('serverName')]"
     },
     "failoverGroup": {

--- a/avm/res/sql/server/firewall-rule/README.md
+++ b/avm/res/sql/server/firewall-rule/README.md
@@ -12,7 +12,7 @@ This module deploys an Azure SQL Server Firewall Rule.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Sql/servers/firewallRules` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/firewallRules) |
+| `Microsoft.Sql/servers/firewallRules` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/firewallRules) |
 
 ## Parameters
 

--- a/avm/res/sql/server/firewall-rule/main.bicep
+++ b/avm/res/sql/server/firewall-rule/main.bicep
@@ -13,11 +13,11 @@ param startIpAddress string = '0.0.0.0'
 @description('Conditional. The name of the parent SQL Server. Required if the template is used in a standalone deployment.')
 param serverName string
 
-resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: serverName
 }
 
-resource firewallRule 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = {
+resource firewallRule 'Microsoft.Sql/servers/firewallRules@2023-08-01' = {
   name: name
   parent: server
   properties: {

--- a/avm/res/sql/server/firewall-rule/main.json
+++ b/avm/res/sql/server/firewall-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "7080187876883566683"
+      "version": "0.36.1.42791",
+      "templateHash": "4373974379110057634"
     },
     "name": "Azure SQL Server Firewall Rule",
     "description": "This module deploys an Azure SQL Server Firewall Rule."
@@ -41,7 +41,7 @@
   "resources": [
     {
       "type": "Microsoft.Sql/servers/firewallRules",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
       "properties": {
         "endIpAddress": "[parameters('endIpAddress')]",

--- a/avm/res/sql/server/firewall-rule/main.json
+++ b/avm/res/sql/server/firewall-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "7783790094003665329"
+      "version": "0.35.1.17967",
+      "templateHash": "7080187876883566683"
     },
     "name": "Azure SQL Server Firewall Rule",
     "description": "This module deploys an Azure SQL Server Firewall Rule."

--- a/avm/res/sql/server/key/README.md
+++ b/avm/res/sql/server/key/README.md
@@ -12,7 +12,7 @@ This module deploys an Azure SQL Server Key.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Sql/servers/keys` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/keys) |
+| `Microsoft.Sql/servers/keys` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/keys) |
 
 ## Parameters
 

--- a/avm/res/sql/server/key/main.bicep
+++ b/avm/res/sql/server/key/main.bicep
@@ -25,11 +25,11 @@ var serverKeyName = empty(uri)
   ? 'ServiceManaged'
   : '${split(splittedKeyUri[2], '.')[0]}_${splittedKeyUri[4]}_${splittedKeyUri[5]}'
 
-resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: serverName
 }
 
-resource key 'Microsoft.Sql/servers/keys@2023-08-01-preview' = {
+resource key 'Microsoft.Sql/servers/keys@2023-08-01' = {
   name: name ?? serverKeyName
   parent: server
   properties: {

--- a/avm/res/sql/server/key/main.json
+++ b/avm/res/sql/server/key/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "9797257758598562244"
+      "version": "0.35.1.17967",
+      "templateHash": "6714566924594913670"
     },
     "name": "Azure SQL Server Keys",
     "description": "This module deploys an Azure SQL Server Key."

--- a/avm/res/sql/server/key/main.json
+++ b/avm/res/sql/server/key/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "6714566924594913670"
+      "version": "0.36.1.42791",
+      "templateHash": "11129867292095349286"
     },
     "name": "Azure SQL Server Keys",
     "description": "This module deploys an Azure SQL Server Key."
@@ -52,12 +52,12 @@
     "server": {
       "existing": true,
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[parameters('serverName')]"
     },
     "key": {
       "type": "Microsoft.Sql/servers/keys",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[format('{0}/{1}', parameters('serverName'), coalesce(parameters('name'), variables('serverKeyName')))]",
       "properties": {
         "serverKeyType": "[parameters('serverKeyType')]",

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -290,8 +290,7 @@ module server_databases 'database/main.bicep' = [
       collation: database.?collation
       createMode: database.?createMode
       elasticPoolResourceId: database.?elasticPoolResourceId
-      encryptionProtector: database.?encryptionProtector
-      encryptionProtectorAutoRotation: database.?encryptionProtectorAutoRotation
+      customerManagedKey: database.?customerManagedKey
       federatedClientId: database.?federatedClientId
       freeLimitExhaustionBehavior: database.?freeLimitExhaustionBehavior
       highAvailabilityReplicaCount: database.?highAvailabilityReplicaCount
@@ -754,11 +753,8 @@ type databaseType = {
   @description('Optional. The resource identifier of the elastic pool containing this database.')
   elasticPoolResourceId: string?
 
-  @description('Optional. The azure key vault URI of the database if it\'s configured with per Database Customer Managed Keys.')
-  encryptionProtector: string?
-
-  @description('Optional. The flag to enable or disable auto rotation of database encryption protector AKV key.')
-  encryptionProtectorAutoRotation: bool?
+  @description('Optional. The customer managed key definition for database TDE.')
+  customerManagedKey: customerManagedKeyWithAutoRotateType?
 
   @description('Optional. The Client id used for cross tenant per database CMK scenario.')
   @minLength(36)

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -216,7 +216,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource server 'Microsoft.Sql/servers@2023-08-01-preview' = {
+resource server 'Microsoft.Sql/servers@2023-08-01' = {
   location: location
   name: name
   tags: tags
@@ -357,7 +357,7 @@ module server_elasticPools 'elastic-pool/main.bicep' = [
   }
 ]
 
-module server_privateEndpoints 'br/public:avm/res/network/private-endpoint:0.10.1' = [
+module server_privateEndpoints 'br/public:avm/res/network/private-endpoint:0.11.0' = [
   for (privateEndpoint, index) in (privateEndpoints ?? []): {
     name: '${uniqueString(deployment().name, location)}-server-PrivateEndpoint-${index}'
     scope: resourceGroup(

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -297,6 +297,7 @@ module server_databases 'database/main.bicep' = [
       highAvailabilityReplicaCount: database.?highAvailabilityReplicaCount
       isLedgerOn: database.?isLedgerOn
       licenseType: database.?licenseType
+      lock: database.?lock
       longTermRetentionBackupResourceId: database.?longTermRetentionBackupResourceId
       maintenanceConfigurationId: database.?maintenanceConfigurationId
       manualCutover: database.?manualCutover
@@ -346,6 +347,7 @@ module server_elasticPools 'elastic-pool/main.bicep' = [
       availabilityZone: elasticPool.?availabilityZone
       highAvailabilityReplicaCount: elasticPool.?highAvailabilityReplicaCount
       licenseType: elasticPool.?licenseType
+      lock: elasticPool.?lock
       maintenanceConfigurationId: elasticPool.?maintenanceConfigurationId
       maxSizeBytes: elasticPool.?maxSizeBytes
       minCapacity: elasticPool.?minCapacity
@@ -715,6 +717,9 @@ type databaseType = {
   @description('Optional. Tags of the resource.')
   tags: object?
 
+  @description('Optional. The lock settings of the database.')
+  lock: lockType?
+
   @description('Optional. The managed identities for the database.')
   managedIdentities: managedIdentityOnlyUserAssignedType?
 
@@ -852,6 +857,9 @@ type elasticPoolType = {
 
   @description('Optional. Tags of the resource.')
   tags: object?
+
+  @description('Optional. The lock settings of the elastic pool.')
+  lock: lockType?
 
   @description('Optional. The elastic pool SKU.')
   sku: skuType?

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "17469013701936746633"
+      "version": "0.36.1.42791",
+      "templateHash": "12810467141935447786"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -2214,7 +2214,7 @@
     },
     "server": {
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -2420,8 +2420,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "15632818564385347474"
+              "version": "0.36.1.42791",
+              "templateHash": "15961431104919711857"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database."
@@ -3129,7 +3129,7 @@
             "server": {
               "existing": true,
               "type": "Microsoft.Sql/servers",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[parameters('serverName')]"
             },
             "cMKKeyVault": {
@@ -3143,7 +3143,7 @@
             },
             "database": {
               "type": "Microsoft.Sql/servers/databases",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
@@ -3273,8 +3273,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.35.1.17967",
-                      "templateHash": "16869585493743816680"
+                      "version": "0.36.1.42791",
+                      "templateHash": "9948442514033354219"
                     },
                     "name": "Azure SQL Server Database Short Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."
@@ -3310,10 +3310,10 @@
                   "resources": [
                     {
                       "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
-                      "apiVersion": "2023-08-01-preview",
+                      "apiVersion": "2023-08-01",
                       "name": "[format('{0}/{1}/{2}', parameters('serverName'), parameters('databaseName'), 'default')]",
                       "properties": {
-                        "diffBackupIntervalInHours": "[if(equals(reference(resourceId('Microsoft.Sql/servers/databases', parameters('serverName'), parameters('databaseName')), '2023-08-01-preview', 'full').sku.tier, 'Hyperscale'), null(), parameters('diffBackupIntervalInHours'))]",
+                        "diffBackupIntervalInHours": "[if(equals(reference(resourceId('Microsoft.Sql/servers/databases', parameters('serverName'), parameters('databaseName')), '2023-08-01', 'full').sku.tier, 'Hyperscale'), null(), parameters('diffBackupIntervalInHours'))]",
                         "retentionDays": "[parameters('retentionDays')]"
                       }
                     }
@@ -3390,8 +3390,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.35.1.17967",
-                      "templateHash": "12746160659080715511"
+                      "version": "0.36.1.42791",
+                      "templateHash": "101116542806833061"
                     },
                     "name": "SQL Server Database Long Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."
@@ -3460,13 +3460,13 @@
                     "server::database": {
                       "existing": true,
                       "type": "Microsoft.Sql/servers/databases",
-                      "apiVersion": "2023-08-01-preview",
+                      "apiVersion": "2023-08-01",
                       "name": "[format('{0}/{1}', parameters('serverName'), parameters('databaseName'))]"
                     },
                     "server": {
                       "existing": true,
                       "type": "Microsoft.Sql/servers",
-                      "apiVersion": "2023-08-01-preview",
+                      "apiVersion": "2023-08-01",
                       "name": "[parameters('serverName')]"
                     },
                     "backupLongTermRetentionPolicy": {
@@ -3540,7 +3540,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('database', '2023-08-01-preview', 'full').location]"
+              "value": "[reference('database', '2023-08-01', 'full').location]"
             }
           }
         }
@@ -3620,8 +3620,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "15665151450501314299"
+              "version": "0.36.1.42791",
+              "templateHash": "8266622523187177483"
             },
             "name": "SQL Server Elastic Pool",
             "description": "This module deploys an Azure SQL Server Elastic Pool."
@@ -3880,12 +3880,12 @@
             "server": {
               "existing": true,
               "type": "Microsoft.Sql/servers",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[parameters('serverName')]"
             },
             "elasticPool": {
               "type": "Microsoft.Sql/servers/elasticPools",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
@@ -3945,7 +3945,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('elasticPool', '2023-08-01-preview', 'full').location]"
+              "value": "[reference('elasticPool', '2023-08-01', 'full').location]"
             }
           }
         }
@@ -4016,8 +4016,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "15954548978129725136"
+              "version": "0.34.44.8038",
+              "templateHash": "12389807800450456797"
             },
             "name": "Private Endpoints",
             "description": "This module deploys a Private Endpoint."
@@ -4426,7 +4426,7 @@
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2024-03-01",
-              "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.10.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.11.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -4444,7 +4444,7 @@
             },
             "privateEndpoint": {
               "type": "Microsoft.Network/privateEndpoints",
-              "apiVersion": "2023-11-01",
+              "apiVersion": "2024-05-01",
               "name": "[parameters('name')]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
@@ -4532,8 +4532,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "5440815542537978381"
+                      "version": "0.34.44.8038",
+                      "templateHash": "13997305779829540948"
                     },
                     "name": "Private Endpoint Private DNS Zone Groups",
                     "description": "This module deploys a Private Endpoint Private DNS Zone Group."
@@ -4605,12 +4605,12 @@
                     "privateEndpoint": {
                       "existing": true,
                       "type": "Microsoft.Network/privateEndpoints",
-                      "apiVersion": "2023-11-01",
+                      "apiVersion": "2024-05-01",
                       "name": "[parameters('privateEndpointName')]"
                     },
                     "privateDnsZoneGroup": {
                       "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
-                      "apiVersion": "2023-11-01",
+                      "apiVersion": "2024-05-01",
                       "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
                       "properties": {
                         "privateDnsZoneConfigs": "[variables('privateDnsZoneConfigsVar')]"
@@ -4674,7 +4674,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('privateEndpoint', '2023-11-01', 'full').location]"
+              "value": "[reference('privateEndpoint', '2024-05-01', 'full').location]"
             },
             "customDnsConfigs": {
               "type": "array",
@@ -4744,8 +4744,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "7080187876883566683"
+              "version": "0.36.1.42791",
+              "templateHash": "4373974379110057634"
             },
             "name": "Azure SQL Server Firewall Rule",
             "description": "This module deploys an Azure SQL Server Firewall Rule."
@@ -4781,7 +4781,7 @@
           "resources": [
             {
               "type": "Microsoft.Sql/servers/firewallRules",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
               "properties": {
                 "endIpAddress": "[parameters('endIpAddress')]",
@@ -4851,8 +4851,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "16868479675279800432"
+              "version": "0.36.1.42791",
+              "templateHash": "4329943834463874399"
             },
             "name": "Azure SQL Server Virtual Network Rules",
             "description": "This module deploys an Azure SQL Server Virtual Network Rule."
@@ -4887,7 +4887,7 @@
           "resources": [
             {
               "type": "Microsoft.Sql/servers/virtualNetworkRules",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
               "properties": {
                 "ignoreMissingVnetServiceEndpoint": "[parameters('ignoreMissingVnetServiceEndpoint')]",
@@ -4973,8 +4973,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "15966111454725303120"
+              "version": "0.36.1.42791",
+              "templateHash": "15348652978067640813"
             },
             "name": "Azure SQL Server Security Alert Policies",
             "description": "This module deploys an Azure SQL Server Security Alert Policy."
@@ -5064,12 +5064,12 @@
             "server": {
               "existing": true,
               "type": "Microsoft.Sql/servers",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[parameters('serverName')]"
             },
             "securityAlertPolicy": {
               "type": "Microsoft.Sql/servers/securityAlertPolicies",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
               "properties": {
                 "disabledAlerts": "[parameters('disabledAlerts')]",
@@ -5148,8 +5148,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "15149956056568585521"
+              "version": "0.36.1.42791",
+              "templateHash": "2856119284131810417"
             },
             "name": "Azure SQL Server Vulnerability Assessments",
             "description": "This module deploys an Azure SQL Server Vulnerability Assessment."
@@ -5237,12 +5237,12 @@
             "server": {
               "existing": true,
               "type": "Microsoft.Sql/servers",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[parameters('serverName')]"
             },
             "vulnerabilityAssessment": {
               "type": "Microsoft.Sql/servers/vulnerabilityAssessments",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
               "properties": {
                 "storageContainerPath": "[format('https://{0}.blob.{1}/vulnerability-assessment/', last(split(parameters('storageAccountResourceId'), '/')), environment().suffixes.storage)]",
@@ -5267,7 +5267,7 @@
                     "value": "[last(split(parameters('storageAccountResourceId'), '/'))]"
                   },
                   "managedInstanceIdentityPrincipalId": {
-                    "value": "[reference('server', '2023-08-01-preview', 'full').identity.principalId]"
+                    "value": "[reference('server', '2023-08-01', 'full').identity.principalId]"
                   }
                 },
                 "template": {
@@ -5276,8 +5276,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.35.1.17967",
-                      "templateHash": "10761590804435613868"
+                      "version": "0.36.1.42791",
+                      "templateHash": "16708437053172304191"
                     }
                   },
                   "parameters": {
@@ -5372,8 +5372,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "6714566924594913670"
+              "version": "0.36.1.42791",
+              "templateHash": "11129867292095349286"
             },
             "name": "Azure SQL Server Keys",
             "description": "This module deploys an Azure SQL Server Key."
@@ -5419,12 +5419,12 @@
             "server": {
               "existing": true,
               "type": "Microsoft.Sql/servers",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[parameters('serverName')]"
             },
             "key": {
               "type": "Microsoft.Sql/servers/keys",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}', parameters('serverName'), coalesce(parameters('name'), variables('serverKeyName')))]",
               "properties": {
                 "serverKeyType": "[parameters('serverKeyType')]",
@@ -5490,8 +5490,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "6714566924594913670"
+              "version": "0.36.1.42791",
+              "templateHash": "11129867292095349286"
             },
             "name": "Azure SQL Server Keys",
             "description": "This module deploys an Azure SQL Server Key."
@@ -5537,12 +5537,12 @@
             "server": {
               "existing": true,
               "type": "Microsoft.Sql/servers",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[parameters('serverName')]"
             },
             "key": {
               "type": "Microsoft.Sql/servers/keys",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}', parameters('serverName'), coalesce(parameters('name'), variables('serverKeyName')))]",
               "properties": {
                 "serverKeyType": "[parameters('serverKeyType')]",
@@ -5610,8 +5610,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "7021740352606247353"
+              "version": "0.36.1.42791",
+              "templateHash": "17490849737310265082"
             },
             "name": "Azure SQL Server Encryption Protector",
             "description": "This module deploys an Azure SQL Server Encryption Protector."
@@ -5651,7 +5651,7 @@
           "resources": [
             {
               "type": "Microsoft.Sql/servers/encryptionProtector",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}', parameters('sqlServerName'), 'current')]",
               "properties": {
                 "serverKeyType": "[parameters('serverKeyType')]",
@@ -5742,8 +5742,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "4727925735892722326"
+              "version": "0.36.1.42791",
+              "templateHash": "18380400942025106313"
             },
             "name": "Azure SQL Server Audit Settings",
             "description": "This module deploys an Azure SQL Server Audit Settings."
@@ -5840,12 +5840,12 @@
             "server": {
               "existing": true,
               "type": "Microsoft.Sql/servers",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[parameters('serverName')]"
             },
             "auditSettings": {
               "type": "Microsoft.Sql/servers/auditingSettings",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
               "properties": {
                 "state": "[parameters('state')]",
@@ -5861,8 +5861,63 @@
                 "storageEndpoint": "[if(not(empty(parameters('storageAccountResourceId'))), format('https://{0}.blob.{1}', last(split(parameters('storageAccountResourceId'), '/')), environment().suffixes.storage), null())]"
               }
             },
+            "storageAccount_sbdc_rbac_rg": {
+              "condition": "[and(and(parameters('isManagedIdentityInUse'), not(empty(parameters('storageAccountResourceId')))), not(equals(split(parameters('storageAccountResourceId'), '/')[4], resourceGroup().name)))]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-stau-rbac-rg', parameters('serverName'))]",
+              "subscriptionId": "[split(parameters('storageAccountResourceId'), '/')[2]]",
+              "resourceGroup": "[split(parameters('storageAccountResourceId'), '/')[4]]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "storageAccountName": {
+                    "value": "[last(split(parameters('storageAccountResourceId'), '/'))]"
+                  },
+                  "managedIdentityPrincipalId": "[if(equals(reference('server', '2023-08-01', 'full').identity.type, 'UserAssigned'), createObject('value', filter(items(reference('server', '2023-08-01', 'full').identity.userAssignedIdentities), lambda('identity', equals(lambdaVariables('identity').key, reference('server').primaryUserAssignedIdentityId)))[0].value.principalId), createObject('value', reference('server', '2023-08-01', 'full').identity.principalId))]"
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.36.1.42791",
+                      "templateHash": "16469435463567159258"
+                    }
+                  },
+                  "parameters": {
+                    "storageAccountName": {
+                      "type": "string"
+                    },
+                    "managedIdentityPrincipalId": {
+                      "type": "string"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.Storage/storageAccounts/{0}', parameters('storageAccountName'))]",
+                      "name": "[guid(format('{0}-{1}-Storage-Blob-Data-Contributor', resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('managedIdentityPrincipalId')))]",
+                      "properties": {
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
+                        "principalId": "[parameters('managedIdentityPrincipalId')]",
+                        "principalType": "ServicePrincipal"
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "server"
+              ]
+            },
             "storageAccount_sbdc_rbac": {
-              "condition": "[and(parameters('isManagedIdentityInUse'), not(empty(parameters('storageAccountResourceId'))))]",
+              "condition": "[and(and(parameters('isManagedIdentityInUse'), not(empty(parameters('storageAccountResourceId')))), equals(split(parameters('storageAccountResourceId'), '/')[4], resourceGroup().name))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
               "name": "[format('{0}-stau-rbac', parameters('serverName'))]",
@@ -5875,7 +5930,7 @@
                   "storageAccountName": {
                     "value": "[last(split(parameters('storageAccountResourceId'), '/'))]"
                   },
-                  "managedIdentityPrincipalId": "[if(equals(reference('server', '2023-08-01-preview', 'full').identity.type, 'UserAssigned'), createObject('value', filter(items(reference('server', '2023-08-01-preview', 'full').identity.userAssignedIdentities), lambda('identity', equals(lambdaVariables('identity').key, reference('server').primaryUserAssignedIdentityId)))[0].value.principalId), createObject('value', reference('server', '2023-08-01-preview', 'full').identity.principalId))]"
+                  "managedIdentityPrincipalId": "[if(equals(reference('server', '2023-08-01', 'full').identity.type, 'UserAssigned'), createObject('value', filter(items(reference('server', '2023-08-01', 'full').identity.userAssignedIdentities), lambda('identity', equals(lambdaVariables('identity').key, reference('server').primaryUserAssignedIdentityId)))[0].value.principalId), createObject('value', reference('server', '2023-08-01', 'full').identity.principalId))]"
                 },
                 "template": {
                   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -5883,8 +5938,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.35.1.17967",
-                      "templateHash": "9873493969278157067"
+                      "version": "0.36.1.42791",
+                      "templateHash": "16469435463567159258"
                     }
                   },
                   "parameters": {
@@ -5971,8 +6026,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "1586204151956272516"
+              "version": "0.36.1.42791",
+              "templateHash": "18255389690016246128"
             }
           },
           "definitions": {
@@ -6050,7 +6105,7 @@
             "keyVault": {
               "existing": true,
               "type": "Microsoft.KeyVault/vaults",
-              "apiVersion": "2022-07-01",
+              "apiVersion": "2024-11-01",
               "name": "[parameters('keyVaultName')]"
             },
             "secrets": {
@@ -6059,7 +6114,7 @@
                 "count": "[length(parameters('secretsToSet'))]"
               },
               "type": "Microsoft.KeyVault/vaults/secrets",
-              "apiVersion": "2023-07-01",
+              "apiVersion": "2024-11-01",
               "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretsToSet')[copyIndex()].name)]",
               "properties": {
                 "value": "[parameters('secretsToSet')[copyIndex()].value]"
@@ -6137,8 +6192,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "15947051067826269286"
+              "version": "0.36.1.42791",
+              "templateHash": "7002329445517579297"
             },
             "name": "Azure SQL Server failover group",
             "description": "This module deploys Azure SQL Server failover group."
@@ -6262,7 +6317,7 @@
             "server": {
               "existing": true,
               "type": "Microsoft.Sql/servers",
-              "apiVersion": "2023-08-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[parameters('serverName')]"
             },
             "failoverGroup": {
@@ -6357,14 +6412,14 @@
       "metadata": {
         "description": "The principal ID of the system assigned identity."
       },
-      "value": "[tryGet(tryGet(reference('server', '2023-08-01-preview', 'full'), 'identity'), 'principalId')]"
+      "value": "[tryGet(tryGet(reference('server', '2023-08-01', 'full'), 'identity'), 'principalId')]"
     },
     "location": {
       "type": "string",
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('server', '2023-08-01-preview', 'full').location]"
+      "value": "[reference('server', '2023-08-01', 'full').location]"
     },
     "exportedSecrets": {
       "$ref": "#/definitions/secretsOutputType",

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "17728755673974169411"
+      "version": "0.35.1.17967",
+      "templateHash": "11410857118353437789"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -260,6 +260,13 @@
           "nullable": true,
           "metadata": {
             "description": "Optional. Tags of the resource."
+          }
+        },
+        "lock": {
+          "$ref": "#/definitions/lockType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The lock settings of the database."
           }
         },
         "managedIdentities": {
@@ -597,6 +604,13 @@
           "nullable": true,
           "metadata": {
             "description": "Optional. Tags of the resource."
+          }
+        },
+        "lock": {
+          "$ref": "#/definitions/lockType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The lock settings of the elastic pool."
           }
         },
         "sku": {
@@ -2336,6 +2350,9 @@
           "licenseType": {
             "value": "[tryGet(coalesce(parameters('databases'), createArray())[copyIndex()], 'licenseType')]"
           },
+          "lock": {
+            "value": "[tryGet(coalesce(parameters('databases'), createArray())[copyIndex()], 'lock')]"
+          },
           "longTermRetentionBackupResourceId": {
             "value": "[tryGet(coalesce(parameters('databases'), createArray())[copyIndex()], 'longTermRetentionBackupResourceId')]"
           },
@@ -2413,8 +2430,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "15825153899458576874"
+              "version": "0.35.1.17967",
+              "templateHash": "469670230062149348"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database."
@@ -2658,6 +2675,36 @@
               },
               "metadata": {
                 "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            },
+            "lockType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the name of lock."
+                  }
+                },
+                "kind": {
+                  "type": "string",
+                  "allowedValues": [
+                    "CanNotDelete",
+                    "None",
+                    "ReadOnly"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the type of lock."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a lock.",
                 "__bicep_imported_from!": {
                   "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
                 }
@@ -2999,6 +3046,13 @@
                 "description": "Optional. Location for all resources."
               }
             },
+            "lock": {
+              "$ref": "#/definitions/lockType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The lock settings of the databse."
+              }
+            },
             "diagnosticSettings": {
               "type": "array",
               "items": {
@@ -3127,6 +3181,20 @@
                 "database"
               ]
             },
+            "database_lock": {
+              "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+              "type": "Microsoft.Authorization/locks",
+              "apiVersion": "2020-05-01",
+              "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', parameters('serverName'), parameters('name'))]",
+              "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+              "properties": {
+                "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+              },
+              "dependsOn": [
+                "database"
+              ]
+            },
             "database_backupShortTermRetentionPolicy": {
               "condition": "[not(empty(parameters('backupShortTermRetentionPolicy')))]",
               "type": "Microsoft.Resources/deployments",
@@ -3157,8 +3225,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.34.44.8038",
-                      "templateHash": "586417749840962852"
+                      "version": "0.35.1.17967",
+                      "templateHash": "16869585493743816680"
                     },
                     "name": "Azure SQL Server Database Short Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."
@@ -3274,8 +3342,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.34.44.8038",
-                      "templateHash": "15078686386861189890"
+                      "version": "0.35.1.17967",
+                      "templateHash": "12746160659080715511"
                     },
                     "name": "SQL Server Database Long Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."
@@ -3475,6 +3543,9 @@
           "licenseType": {
             "value": "[tryGet(coalesce(parameters('elasticPools'), createArray())[copyIndex()], 'licenseType')]"
           },
+          "lock": {
+            "value": "[tryGet(coalesce(parameters('elasticPools'), createArray())[copyIndex()], 'lock')]"
+          },
           "maintenanceConfigurationId": {
             "value": "[tryGet(coalesce(parameters('elasticPools'), createArray())[copyIndex()], 'maintenanceConfigurationId')]"
           },
@@ -3501,8 +3572,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "6480963111257796466"
+              "version": "0.35.1.17967",
+              "templateHash": "15665151450501314299"
             },
             "name": "SQL Server Elastic Pool",
             "description": "This module deploys an Azure SQL Server Elastic Pool."
@@ -3592,6 +3663,36 @@
                 "__bicep_export!": true,
                 "description": "The elastic pool SKU."
               }
+            },
+            "lockType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the name of lock."
+                  }
+                },
+                "kind": {
+                  "type": "string",
+                  "allowedValues": [
+                    "CanNotDelete",
+                    "None",
+                    "ReadOnly"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the type of lock."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a lock.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
             }
           },
           "parameters": {
@@ -3619,6 +3720,13 @@
               "defaultValue": "[resourceGroup().location]",
               "metadata": {
                 "description": "Optional. Location for all resources."
+              }
+            },
+            "lock": {
+              "$ref": "#/definitions/lockType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The lock settings of the elastic pool."
               }
             },
             "sku": {
@@ -3746,6 +3854,20 @@
                 "preferredEnclaveType": "[parameters('preferredEnclaveType')]",
                 "zoneRedundant": "[parameters('zoneRedundant')]"
               }
+            },
+            "elasticPool_lock": {
+              "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+              "type": "Microsoft.Authorization/locks",
+              "apiVersion": "2020-05-01",
+              "scope": "[format('Microsoft.Sql/servers/{0}/elasticPools/{1}', parameters('serverName'), parameters('name'))]",
+              "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+              "properties": {
+                "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+              },
+              "dependsOn": [
+                "elasticPool"
+              ]
             }
           },
           "outputs": {
@@ -4574,8 +4696,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "7783790094003665329"
+              "version": "0.35.1.17967",
+              "templateHash": "7080187876883566683"
             },
             "name": "Azure SQL Server Firewall Rule",
             "description": "This module deploys an Azure SQL Server Firewall Rule."
@@ -4681,8 +4803,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "5983453570514916999"
+              "version": "0.35.1.17967",
+              "templateHash": "16868479675279800432"
             },
             "name": "Azure SQL Server Virtual Network Rules",
             "description": "This module deploys an Azure SQL Server Virtual Network Rule."
@@ -4803,8 +4925,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "5426873131651303318"
+              "version": "0.35.1.17967",
+              "templateHash": "15966111454725303120"
             },
             "name": "Azure SQL Server Security Alert Policies",
             "description": "This module deploys an Azure SQL Server Security Alert Policy."
@@ -4978,8 +5100,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "15940284955382664780"
+              "version": "0.35.1.17967",
+              "templateHash": "15149956056568585521"
             },
             "name": "Azure SQL Server Vulnerability Assessments",
             "description": "This module deploys an Azure SQL Server Vulnerability Assessment."
@@ -5106,8 +5228,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.34.44.8038",
-                      "templateHash": "16931034564891209519"
+                      "version": "0.35.1.17967",
+                      "templateHash": "10761590804435613868"
                     }
                   },
                   "parameters": {
@@ -5202,8 +5324,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "9797257758598562244"
+              "version": "0.35.1.17967",
+              "templateHash": "6714566924594913670"
             },
             "name": "Azure SQL Server Keys",
             "description": "This module deploys an Azure SQL Server Key."
@@ -5320,8 +5442,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "9797257758598562244"
+              "version": "0.35.1.17967",
+              "templateHash": "6714566924594913670"
             },
             "name": "Azure SQL Server Keys",
             "description": "This module deploys an Azure SQL Server Key."
@@ -5440,8 +5562,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "13156357596009101804"
+              "version": "0.35.1.17967",
+              "templateHash": "7021740352606247353"
             },
             "name": "Azure SQL Server Encryption Protector",
             "description": "This module deploys an Azure SQL Server Encryption Protector."
@@ -5572,8 +5694,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "15469959027924260105"
+              "version": "0.35.1.17967",
+              "templateHash": "4727925735892722326"
             },
             "name": "Azure SQL Server Audit Settings",
             "description": "This module deploys an Azure SQL Server Audit Settings."
@@ -5713,8 +5835,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.34.44.8038",
-                      "templateHash": "11839727322069180104"
+                      "version": "0.35.1.17967",
+                      "templateHash": "9873493969278157067"
                     }
                   },
                   "parameters": {
@@ -5801,8 +5923,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "12919538841236982879"
+              "version": "0.35.1.17967",
+              "templateHash": "1586204151956272516"
             }
           },
           "definitions": {
@@ -5967,8 +6089,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "16705539934522968897"
+              "version": "0.35.1.17967",
+              "templateHash": "15947051067826269286"
             },
             "name": "Azure SQL Server failover group",
             "description": "This module deploys Azure SQL Server failover group."

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.35.1.17967",
-      "templateHash": "11410857118353437789"
+      "templateHash": "17469013701936746633"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -342,18 +342,11 @@
             "description": "Optional. The resource identifier of the elastic pool containing this database."
           }
         },
-        "encryptionProtector": {
-          "type": "string",
+        "customerManagedKey": {
+          "$ref": "#/definitions/customerManagedKeyWithAutoRotateType",
           "nullable": true,
           "metadata": {
-            "description": "Optional. The azure key vault URI of the database if it's configured with per Database Customer Managed Keys."
-          }
-        },
-        "encryptionProtectorAutoRotation": {
-          "type": "bool",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The flag to enable or disable auto rotation of database encryption protector AKV key."
+            "description": "Optional. The customer managed key definition for database TDE."
           }
         },
         "federatedClientId": {
@@ -2329,11 +2322,8 @@
           "elasticPoolResourceId": {
             "value": "[tryGet(coalesce(parameters('databases'), createArray())[copyIndex()], 'elasticPoolResourceId')]"
           },
-          "encryptionProtector": {
-            "value": "[tryGet(coalesce(parameters('databases'), createArray())[copyIndex()], 'encryptionProtector')]"
-          },
-          "encryptionProtectorAutoRotation": {
-            "value": "[tryGet(coalesce(parameters('databases'), createArray())[copyIndex()], 'encryptionProtectorAutoRotation')]"
+          "customerManagedKey": {
+            "value": "[tryGet(coalesce(parameters('databases'), createArray())[copyIndex()], 'customerManagedKey')]"
           },
           "federatedClientId": {
             "value": "[tryGet(coalesce(parameters('databases'), createArray())[copyIndex()], 'federatedClientId')]"
@@ -2431,7 +2421,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.35.1.17967",
-              "templateHash": "469670230062149348"
+              "templateHash": "15632818564385347474"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database."
@@ -2556,6 +2546,50 @@
               "metadata": {
                 "__bicep_export!": true,
                 "description": "The long-term backup retention policy for the database."
+              }
+            },
+            "customerManagedKeyWithAutoRotateType": {
+              "type": "object",
+              "properties": {
+                "keyVaultResourceId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
+                  }
+                },
+                "keyName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the customer managed key to use for encryption."
+                  }
+                },
+                "keyVersion": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting."
+                  }
+                },
+                "autoRotationEnabled": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used."
+                  }
+                },
+                "userAssignedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a customer-managed key. To be used if the resource type supports auto-rotation of the customer-managed key.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
               }
             },
             "diagnosticSettingFullType": {
@@ -2814,20 +2848,6 @@
                 "description": "Optional. The resource ID of the elastic pool containing this database."
               }
             },
-            "encryptionProtector": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. The azure key vault URI of the database if it's configured with per Database Customer Managed Keys."
-              }
-            },
-            "encryptionProtectorAutoRotation": {
-              "type": "bool",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. The flag to enable or disable auto rotation of database encryption protector AKV key."
-              }
-            },
             "federatedClientId": {
               "type": "string",
               "nullable": true,
@@ -3083,6 +3103,13 @@
               "metadata": {
                 "description": "Optional. The managed identity definition for this resource."
               }
+            },
+            "customerManagedKey": {
+              "$ref": "#/definitions/customerManagedKeyWithAutoRotateType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The customer managed key definition for database TDE."
+              }
             }
           },
           "variables": {
@@ -3090,11 +3117,29 @@
             "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', null()), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]"
           },
           "resources": {
+            "cMKKeyVault::cMKKey": {
+              "condition": "[and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName')))))]",
+              "existing": true,
+              "type": "Microsoft.KeyVault/vaults/keys",
+              "apiVersion": "2023-07-01",
+              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+              "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
+            },
             "server": {
               "existing": true,
               "type": "Microsoft.Sql/servers",
               "apiVersion": "2023-08-01-preview",
               "name": "[parameters('serverName')]"
+            },
+            "cMKKeyVault": {
+              "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId')))]",
+              "existing": true,
+              "type": "Microsoft.KeyVault/vaults",
+              "apiVersion": "2023-07-01",
+              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+              "name": "[last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))]"
             },
             "database": {
               "type": "Microsoft.Sql/servers/databases",
@@ -3111,8 +3156,8 @@
                 "collation": "[parameters('collation')]",
                 "createMode": "[parameters('createMode')]",
                 "elasticPoolId": "[parameters('elasticPoolResourceId')]",
-                "encryptionProtector": "[parameters('encryptionProtector')]",
-                "encryptionProtectorAutoRotation": "[parameters('encryptionProtectorAutoRotation')]",
+                "encryptionProtector": "[if(not(equals(parameters('customerManagedKey'), null())), if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), reference('cMKKeyVault::cMKKey').keyUriWithVersion), null())]",
+                "encryptionProtectorAutoRotation": "[tryGet(parameters('customerManagedKey'), 'autoRotationEnabled')]",
                 "federatedClientId": "[parameters('federatedClientId')]",
                 "freeLimitExhaustionBehavior": "[parameters('freeLimitExhaustionBehavior')]",
                 "highAvailabilityReplicaCount": "[parameters('highAvailabilityReplicaCount')]",
@@ -3138,7 +3183,10 @@
                 "sourceResourceId": "[parameters('sourceResourceId')]",
                 "useFreeLimit": "[parameters('useFreeLimit')]",
                 "zoneRedundant": "[parameters('zoneRedundant')]"
-              }
+              },
+              "dependsOn": [
+                "cMKKeyVault::cMKKey"
+              ]
             },
             "database_diagnosticSettings": {
               "copy": {

--- a/avm/res/sql/server/modules/keyVaultExport.bicep
+++ b/avm/res/sql/server/modules/keyVaultExport.bicep
@@ -13,11 +13,11 @@ param secretsToSet secretToSetType[]
 //   Resources   //
 // ============= //
 
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
   name: keyVaultName
 }
 
-resource secrets 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = [
+resource secrets 'Microsoft.KeyVault/vaults/secrets@2024-11-01' = [
   for secret in secretsToSet: {
     name: secret.name
     parent: keyVault

--- a/avm/res/sql/server/security-alert-policy/README.md
+++ b/avm/res/sql/server/security-alert-policy/README.md
@@ -12,7 +12,7 @@ This module deploys an Azure SQL Server Security Alert Policy.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Sql/servers/securityAlertPolicies` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/securityAlertPolicies) |
+| `Microsoft.Sql/servers/securityAlertPolicies` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/securityAlertPolicies) |
 
 ## Parameters
 

--- a/avm/res/sql/server/security-alert-policy/main.bicep
+++ b/avm/res/sql/server/security-alert-policy/main.bicep
@@ -41,11 +41,11 @@ param storageEndpoint string?
 @description('Conditional. The name of the parent SQL Server. Required if the template is used in a standalone deployment.')
 param serverName string
 
-resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: serverName
 }
 
-resource securityAlertPolicy 'Microsoft.Sql/servers/securityAlertPolicies@2023-08-01-preview' = {
+resource securityAlertPolicy 'Microsoft.Sql/servers/securityAlertPolicies@2023-08-01' = {
   name: name
   parent: server
   properties: {

--- a/avm/res/sql/server/security-alert-policy/main.json
+++ b/avm/res/sql/server/security-alert-policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "5426873131651303318"
+      "version": "0.35.1.17967",
+      "templateHash": "15966111454725303120"
     },
     "name": "Azure SQL Server Security Alert Policies",
     "description": "This module deploys an Azure SQL Server Security Alert Policy."

--- a/avm/res/sql/server/security-alert-policy/main.json
+++ b/avm/res/sql/server/security-alert-policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "15966111454725303120"
+      "version": "0.36.1.42791",
+      "templateHash": "15348652978067640813"
     },
     "name": "Azure SQL Server Security Alert Policies",
     "description": "This module deploys an Azure SQL Server Security Alert Policy."
@@ -96,12 +96,12 @@
     "server": {
       "existing": true,
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[parameters('serverName')]"
     },
     "securityAlertPolicy": {
       "type": "Microsoft.Sql/servers/securityAlertPolicies",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
       "properties": {
         "disabledAlerts": "[parameters('disabledAlerts')]",

--- a/avm/res/sql/server/tests/e2e/cmk/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/cmk/dependencies.bicep
@@ -100,7 +100,7 @@ output keyVaultDatabaseEncryptionKeyUrl string = keyVault::dbKey.properties.keyU
 @description('The name of the created Server Encryption Key.')
 output keyVaultKeyName string = keyVault::key.name
 
-@description('The URL of the created Database Encryption Key.')
+@description('The name of the created Database Encryption Key.')
 output keyVaultDatabaseKeyName string = keyVault::dbKey.name
 
 @description('The name of the created Key Vault.')

--- a/avm/res/sql/server/tests/e2e/cmk/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/cmk/dependencies.bicep
@@ -1,6 +1,9 @@
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
+@description('Required. The name of the Managed Identity for the database to create.')
+param databaseIdentityName string
+
 @description('Optional. The location to deploy resources to.')
 param location string = resourceGroup().location
 
@@ -9,6 +12,11 @@ param keyVaultName string
 
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
   name: managedIdentityName
+  location: location
+}
+
+resource dbManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: databaseIdentityName
   location: location
 }
 
@@ -35,6 +43,13 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
       kty: 'RSA'
     }
   }
+
+  resource dbKey 'keys@2022-07-01' = {
+    name: 'keyDatabaseEncryptionKey'
+    properties: {
+      kty: 'RSA'
+    }
+  }
 }
 
 resource keyPermissions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
@@ -50,17 +65,43 @@ resource keyPermissions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
 }
 
+resource dbKeyPermissions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid('msi-${keyVault::dbKey.id}-${location}-${dbManagedIdentity.id}-Key-Vault-Crypto-Service-Encryption-User-RoleAssignment')
+  scope: keyVault::dbKey
+  properties: {
+    principalId: dbManagedIdentity.properties.principalId
+    // Key Vault Crypto Service Encryption User
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      'e147488a-f6f5-4113-8e2d-b22465e65bf6'
+    )
+    principalType: 'ServicePrincipal'
+  }
+}
+
 @description('The principal ID of the created managed identity.')
 output managedIdentityPrincipalId string = managedIdentity.properties.principalId
 
 @description('The resource ID of the created managed identity.')
 output managedIdentityResourceId string = managedIdentity.id
 
-@description('The URL of the created Key Vault Encryption Key.')
+@description('The principal ID of the created database managed identity.')
+output databaseIdentityPrincipalId string = dbManagedIdentity.properties.principalId
+
+@description('The resource ID of the created database managed identity.')
+output databaseIdentityResourceId string = dbManagedIdentity.id
+
+@description('The URL of the created Server Encryption Key.')
 output keyVaultEncryptionKeyUrl string = keyVault::key.properties.keyUriWithVersion
 
-@description('The name of the created Key Vault Encryption Key.')
+@description('The URL of the created Database Encryption Key.')
+output keyVaultDatabaseEncryptionKeyUrl string = keyVault::dbKey.properties.keyUriWithVersion
+
+@description('The name of the created Server Encryption Key.')
 output keyVaultKeyName string = keyVault::key.name
+
+@description('The URL of the created Database Encryption Key.')
+output keyVaultDatabaseKeyName string = keyVault::dbKey.name
 
 @description('The name of the created Key Vault.')
 output keyVaultName string = keyVault.name

--- a/avm/res/sql/server/tests/e2e/max/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/max/main.test.bicep
@@ -170,12 +170,18 @@ module testDeployment '../../../main.bicep' = [
             kind: 'CanNotDelete'
             name: 'myCustomLockName'
           }
+          customerManagedKey: {
+            keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
+            keyName: nestedDependencies.outputs.databaseKeyVaultKeyName
+            keyVersion: last(split(nestedDependencies.outputs.databaseKeyVaultEncryptionKeyUrl, '/'))
+            autoRotationEnabled: true
+          }
         }
       ]
       customerManagedKey: {
         keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
-        keyName: nestedDependencies.outputs.keyVaultKeyName
-        keyVersion: last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))
+        keyName: nestedDependencies.outputs.serverKeyVaultKeyName
+        keyVersion: last(split(nestedDependencies.outputs.serverKeyVaultEncryptionKeyUrl, '/'))
         autoRotationEnabled: true
       }
       firewallRules: [

--- a/avm/res/sql/server/tests/e2e/max/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/max/main.test.bicep
@@ -127,6 +127,10 @@ module testDeployment '../../../main.bicep' = [
             capacity: 10
           }
           availabilityZone: -1
+          lock: {
+            kind: 'CanNotDelete'
+            name: 'myCustomLockName'
+          }
         }
       ]
       databases: [
@@ -162,6 +166,10 @@ module testDeployment '../../../main.bicep' = [
             monthlyRetention: 'P6M'
           }
           availabilityZone: -1
+          lock: {
+            kind: 'CanNotDelete'
+            name: 'myCustomLockName'
+          }
         }
       ]
       customerManagedKey: {

--- a/avm/res/sql/server/version.json
+++ b/avm/res/sql/server/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.16"
+  "version": "0.17"
 }

--- a/avm/res/sql/server/virtual-network-rule/README.md
+++ b/avm/res/sql/server/virtual-network-rule/README.md
@@ -12,7 +12,7 @@ This module deploys an Azure SQL Server Virtual Network Rule.
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Sql/servers/virtualNetworkRules` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/virtualNetworkRules) |
+| `Microsoft.Sql/servers/virtualNetworkRules` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/virtualNetworkRules) |
 
 ## Parameters
 

--- a/avm/res/sql/server/virtual-network-rule/main.bicep
+++ b/avm/res/sql/server/virtual-network-rule/main.bicep
@@ -13,11 +13,11 @@ param virtualNetworkSubnetResourceId string
 @description('Conditional. The name of the parent SQL Server. Required if the template is used in a standalone deployment.')
 param serverName string
 
-resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: serverName
 }
 
-resource virtualNetworkRule 'Microsoft.Sql/servers/virtualNetworkRules@2023-08-01-preview' = {
+resource virtualNetworkRule 'Microsoft.Sql/servers/virtualNetworkRules@2023-08-01' = {
   name: name
   parent: server
   properties: {

--- a/avm/res/sql/server/virtual-network-rule/main.json
+++ b/avm/res/sql/server/virtual-network-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "16868479675279800432"
+      "version": "0.36.1.42791",
+      "templateHash": "4329943834463874399"
     },
     "name": "Azure SQL Server Virtual Network Rules",
     "description": "This module deploys an Azure SQL Server Virtual Network Rule."
@@ -40,7 +40,7 @@
   "resources": [
     {
       "type": "Microsoft.Sql/servers/virtualNetworkRules",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
       "properties": {
         "ignoreMissingVnetServiceEndpoint": "[parameters('ignoreMissingVnetServiceEndpoint')]",

--- a/avm/res/sql/server/virtual-network-rule/main.json
+++ b/avm/res/sql/server/virtual-network-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "5983453570514916999"
+      "version": "0.35.1.17967",
+      "templateHash": "16868479675279800432"
     },
     "name": "Azure SQL Server Virtual Network Rules",
     "description": "This module deploys an Azure SQL Server Virtual Network Rule."

--- a/avm/res/sql/server/vulnerability-assessment/README.md
+++ b/avm/res/sql/server/vulnerability-assessment/README.md
@@ -13,7 +13,7 @@ This module deploys an Azure SQL Server Vulnerability Assessment.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Sql/servers/vulnerabilityAssessments` | [2023-08-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01-preview/servers/vulnerabilityAssessments) |
+| `Microsoft.Sql/servers/vulnerabilityAssessments` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/vulnerabilityAssessments) |
 
 ## Parameters
 

--- a/avm/res/sql/server/vulnerability-assessment/main.bicep
+++ b/avm/res/sql/server/vulnerability-assessment/main.bicep
@@ -23,7 +23,7 @@ param useStorageAccountAccessKey bool = false
 @description('Optional. Create the Storage Blob Data Contributor role assignment on the storage account. Note, the role assignment must not already exist on the storage account.')
 param createStorageRoleAssignment bool = true
 
-resource server 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: serverName
 }
 
@@ -37,7 +37,7 @@ module storageAccount_sbdc_rbac 'modules/nested_storageRoleAssignment.bicep' = i
   }
 }
 
-resource vulnerabilityAssessment 'Microsoft.Sql/servers/vulnerabilityAssessments@2023-08-01-preview' = {
+resource vulnerabilityAssessment 'Microsoft.Sql/servers/vulnerabilityAssessments@2023-08-01' = {
   name: name
   parent: server
   properties: {

--- a/avm/res/sql/server/vulnerability-assessment/main.json
+++ b/avm/res/sql/server/vulnerability-assessment/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "15940284955382664780"
+      "version": "0.35.1.17967",
+      "templateHash": "15149956056568585521"
     },
     "name": "Azure SQL Server Vulnerability Assessments",
     "description": "This module deploys an Azure SQL Server Vulnerability Assessment."
@@ -133,8 +133,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "16931034564891209519"
+              "version": "0.35.1.17967",
+              "templateHash": "10761590804435613868"
             }
           },
           "parameters": {

--- a/avm/res/sql/server/vulnerability-assessment/main.json
+++ b/avm/res/sql/server/vulnerability-assessment/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "15149956056568585521"
+      "version": "0.36.1.42791",
+      "templateHash": "2856119284131810417"
     },
     "name": "Azure SQL Server Vulnerability Assessments",
     "description": "This module deploys an Azure SQL Server Vulnerability Assessment."
@@ -94,12 +94,12 @@
     "server": {
       "existing": true,
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[parameters('serverName')]"
     },
     "vulnerabilityAssessment": {
       "type": "Microsoft.Sql/servers/vulnerabilityAssessments",
-      "apiVersion": "2023-08-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[format('{0}/{1}', parameters('serverName'), parameters('name'))]",
       "properties": {
         "storageContainerPath": "[format('https://{0}.blob.{1}/vulnerability-assessment/', last(split(parameters('storageAccountResourceId'), '/')), environment().suffixes.storage)]",
@@ -124,7 +124,7 @@
             "value": "[last(split(parameters('storageAccountResourceId'), '/'))]"
           },
           "managedInstanceIdentityPrincipalId": {
-            "value": "[reference('server', '2023-08-01-preview', 'full').identity.principalId]"
+            "value": "[reference('server', '2023-08-01', 'full').identity.principalId]"
           }
         },
         "template": {
@@ -133,8 +133,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "10761590804435613868"
+              "version": "0.36.1.42791",
+              "templateHash": "16708437053172304191"
             }
           },
           "parameters": {

--- a/avm/res/sql/server/vulnerability-assessment/modules/nested_storageRoleAssignment.bicep
+++ b/avm/res/sql/server/vulnerability-assessment/modules/nested_storageRoleAssignment.bicep
@@ -1,7 +1,7 @@
 param storageAccountName string
 param managedInstanceIdentityPrincipalId string
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
   name: storageAccountName
 }
 
@@ -10,7 +10,10 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid('${storageAccount.id}-${managedInstanceIdentityPrincipalId}-Storage-Blob-Data-Contributor')
   scope: storageAccount
   properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+    )
     principalId: managedInstanceIdentityPrincipalId
     principalType: 'ServicePrincipal'
   }


### PR DESCRIPTION
## Description

This PR adds 2 changes: 

1. Standard lock functionality to `sql/server/database` and `sql/server/elasticPool` module 
2. Extends the database module with standard CMK functionality

Fixes #5301 
Fixes #2369 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.sql.server](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg?branch=5301)](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml)   |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
