### PR TITLE
fix: remove dependency for hciResourceProviderObjectId

### DIFF
--- a/avm/res/azure-stack-hci/logical-network/main.json
+++ b/avm/res/azure-stack-hci/logical-network/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "882640149062350351"
+      "version": "0.35.1.17967",
+      "templateHash": "369463873785242820"
     },
     "name": "Azure Stack HCI Logical Network",
     "description": "This module deploys an Azure Stack HCI Logical Network."

--- a/avm/res/azure-stack-hci/logical-network/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/azure-stack-hci/logical-network/tests/e2e/defaults/main.test.bicep
@@ -67,7 +67,6 @@ module nestedDependencies '../../../../../../../utilities/e2e-template-assets/mo
     arbDeploymentServicePrincipalSecret: arbDeploymentServicePrincipalSecret
     arbDeploymentSPObjectId: arbDeploymentSPObjectId
     deploymentUserPassword: localAdminAndDeploymentUserPass
-    hciResourceProviderObjectId: hciResourceProviderObjectId
     localAdminPassword: localAdminAndDeploymentUserPass
     location: enforcedLocation
   }

--- a/avm/res/azure-stack-hci/network-interface/main.json
+++ b/avm/res/azure-stack-hci/network-interface/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "2855794615987868353"
+      "version": "0.35.1.17967",
+      "templateHash": "15100144726254601129"
     },
     "name": "Azure Stack HCI Network Interface",
     "description": "This module deploys an Azure Stack HCI network interface."

--- a/avm/res/azure-stack-hci/network-interface/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/azure-stack-hci/network-interface/tests/e2e/defaults/main.test.bicep
@@ -67,7 +67,6 @@ module nestedDependencies '../../../../../../../utilities/e2e-template-assets/mo
     arbDeploymentServicePrincipalSecret: arbDeploymentServicePrincipalSecret
     arbDeploymentSPObjectId: arbDeploymentSPObjectId
     deploymentUserPassword: localAdminAndDeploymentUserPass
-    hciResourceProviderObjectId: hciResourceProviderObjectId
     localAdminPassword: localAdminAndDeploymentUserPass
     location: enforcedLocation
   }

--- a/avm/res/azure-stack-hci/virtual-hard-disk/main.json
+++ b/avm/res/azure-stack-hci/virtual-hard-disk/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "2087652594627682665"
+      "version": "0.35.1.17967",
+      "templateHash": "13278479909796100774"
     },
     "name": "Azure Stack HCI Virtual Hard Disk",
     "description": "This module deploys an Azure Stack HCI virtual hard disk."

--- a/avm/res/azure-stack-hci/virtual-hard-disk/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/azure-stack-hci/virtual-hard-disk/tests/e2e/defaults/main.test.bicep
@@ -69,7 +69,6 @@ module nestedDependencies '../../../../../../../utilities/e2e-template-assets/mo
     arbDeploymentServicePrincipalSecret: arbDeploymentServicePrincipalSecret
     arbDeploymentSPObjectId: arbDeploymentSPObjectId
     deploymentUserPassword: localAdminAndDeploymentUserPass
-    hciResourceProviderObjectId: hciResourceProviderObjectId
     localAdminPassword: localAdminAndDeploymentUserPass
     location: enforcedLocation
   }

--- a/avm/res/hybrid-container-service/provisioned-cluster-instance/main.json
+++ b/avm/res/hybrid-container-service/provisioned-cluster-instance/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "3751112123649509527"
+      "version": "0.35.1.17967",
+      "templateHash": "13787889442475501981"
     },
     "name": "Hybrid Container Service Provisioned Cluster Instance",
     "description": "Deploy a provisioned cluster instance."
@@ -737,8 +737,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "11097658599960058650"
+              "version": "0.35.1.17967",
+              "templateHash": "10780007379279172631"
             }
           },
           "parameters": {

--- a/avm/res/hybrid-container-service/provisioned-cluster-instance/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/hybrid-container-service/provisioned-cluster-instance/tests/e2e/defaults/main.test.bicep
@@ -67,7 +67,6 @@ module nestedDependencies '../../../../../../../utilities/e2e-template-assets/mo
     arbDeploymentServicePrincipalSecret: arbDeploymentServicePrincipalSecret
     arbDeploymentSPObjectId: arbDeploymentSPObjectId
     deploymentUserPassword: localAdminAndDeploymentUserPass
-    hciResourceProviderObjectId: hciResourceProviderObjectId
     localAdminPassword: localAdminAndDeploymentUserPass
     location: enforcedLocation
   }


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|      [![avm.res.azure-stack-hci.cluster](https://github.com/Infrastructure-as-code-Automation/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.cluster.yml/badge.svg?branch=hangxu%2Fimage2)](https://github.com/Infrastructure-as-code-Automation/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.cluster.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
