### PR TITLE
ci: [Test 03] Enforce test folder validation for pattern modules for defaults only

### DIFF
--- a/.github/workflows/avm.template.module.yml
+++ b/.github/workflows/avm.template.module.yml
@@ -47,172 +47,172 @@ jobs:
         with:
           modulePath: "${{ inputs.modulePath }}"
 
-  #########################
-  #   PSRule validation   #
-  #########################
-  job_psrule_test: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
-    name: "PSRule [${{ matrix.testCases.name }}]"
-    runs-on: ubuntu-latest
-    if: ${{ inputs.psRuleModuleTestFilePaths != '' && (fromJson(inputs.workflowInput)).staticValidation == 'true'  }}
-    strategy:
-      fail-fast: false
-      matrix:
-        testCases: ${{ fromJson(inputs.psRuleModuleTestFilePaths) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set environment
-        uses: ./.github/actions/templates/avm-setEnvironment
-      - name: "Run PSRule validation with [${{ matrix.testCases.path }}]"
-        uses: ./.github/actions/templates/avm-validateModulePSRule
-        with:
-          templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
-          subscriptionId: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
-          managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
-          psrulePath: "/utilities/pipelines/staticValidation/psrule" #'${{ github.workspace }}/avm'
-          psruleBaseline: "Azure.Default"
+  # #########################
+  # #   PSRule validation   #
+  # #########################
+  # job_psrule_test: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
+  #   name: "PSRule [${{ matrix.testCases.name }}]"
+  #   runs-on: ubuntu-latest
+  #   if: ${{ inputs.psRuleModuleTestFilePaths != '' && (fromJson(inputs.workflowInput)).staticValidation == 'true'  }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       testCases: ${{ fromJson(inputs.psRuleModuleTestFilePaths) }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Set environment
+  #       uses: ./.github/actions/templates/avm-setEnvironment
+  #     - name: "Run PSRule validation with [${{ matrix.testCases.path }}]"
+  #       uses: ./.github/actions/templates/avm-validateModulePSRule
+  #       with:
+  #         templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
+  #         subscriptionId: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+  #         managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
+  #         psrulePath: "/utilities/pipelines/staticValidation/psrule" #'${{ github.workspace }}/avm'
+  #         psruleBaseline: "Azure.Default"
 
-  job_psrule_test_waf_reliability: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
-    name: "PSRule - WAF Reliability [${{ matrix.testCases.name }}]"
-    runs-on: ubuntu-latest
-    if: ${{ inputs.psRuleModuleTestFilePaths != '' && (fromJson(inputs.workflowInput)).staticValidation == 'true'  }}
-    strategy:
-      fail-fast: false
-      matrix:
-        testCases: ${{ fromJson(inputs.psRuleModuleTestFilePaths) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set environment
-        uses: ./.github/actions/templates/avm-setEnvironment
-      - name: "Run PSRule validation with [${{ matrix.testCases.path }}]"
-        uses: ./.github/actions/templates/avm-validateModulePSRule
-        with:
-          templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
-          subscriptionId: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
-          managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
-          psrulePath: "/utilities/pipelines/staticValidation/psrule" #'${{ github.workspace }}/avm'
-          psruleBaseline: "Azure.Pillar.Reliability"
+  # job_psrule_test_waf_reliability: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
+  #   name: "PSRule - WAF Reliability [${{ matrix.testCases.name }}]"
+  #   runs-on: ubuntu-latest
+  #   if: ${{ inputs.psRuleModuleTestFilePaths != '' && (fromJson(inputs.workflowInput)).staticValidation == 'true'  }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       testCases: ${{ fromJson(inputs.psRuleModuleTestFilePaths) }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Set environment
+  #       uses: ./.github/actions/templates/avm-setEnvironment
+  #     - name: "Run PSRule validation with [${{ matrix.testCases.path }}]"
+  #       uses: ./.github/actions/templates/avm-validateModulePSRule
+  #       with:
+  #         templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
+  #         subscriptionId: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+  #         managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
+  #         psrulePath: "/utilities/pipelines/staticValidation/psrule" #'${{ github.workspace }}/avm'
+  #         psruleBaseline: "Azure.Pillar.Reliability"
 
-  job_psrule_test_waf_security_cb: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
-    name: "PSRule - WAF Security - AVM Custom Baseline [${{ matrix.testCases.name }}]"
-    runs-on: ubuntu-latest
-    if: ${{ inputs.psRuleModuleTestFilePaths != '' && (fromJson(inputs.workflowInput)).staticValidation == 'true'  }}
-    strategy:
-      fail-fast: false
-      matrix:
-        testCases: ${{ fromJson(inputs.psRuleModuleTestFilePaths) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set environment
-        uses: ./.github/actions/templates/avm-setEnvironment
-      - name: "Run PSRule validation with [${{ matrix.testCases.path }}]"
-        uses: ./.github/actions/templates/avm-validateModulePSRule
-        with:
-          templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
-          subscriptionId: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
-          managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
-          psrulePath: "/utilities/pipelines/staticValidation/psrule" #'${{ github.workspace }}/avm'
-          psruleBaseline: "CB.AVM.WAF.Security"
+  # job_psrule_test_waf_security_cb: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
+  #   name: "PSRule - WAF Security - AVM Custom Baseline [${{ matrix.testCases.name }}]"
+  #   runs-on: ubuntu-latest
+  #   if: ${{ inputs.psRuleModuleTestFilePaths != '' && (fromJson(inputs.workflowInput)).staticValidation == 'true'  }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       testCases: ${{ fromJson(inputs.psRuleModuleTestFilePaths) }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Set environment
+  #       uses: ./.github/actions/templates/avm-setEnvironment
+  #     - name: "Run PSRule validation with [${{ matrix.testCases.path }}]"
+  #       uses: ./.github/actions/templates/avm-validateModulePSRule
+  #       with:
+  #         templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
+  #         subscriptionId: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+  #         managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
+  #         psrulePath: "/utilities/pipelines/staticValidation/psrule" #'${{ github.workspace }}/avm'
+  #         psruleBaseline: "CB.AVM.WAF.Security"
 
-  job_psrule_test_waf_security: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
-    name: "PSRule - WAF Security [${{ matrix.testCases.name }}]"
-    runs-on: ubuntu-latest
-    if: ${{ inputs.psRuleModuleTestFilePaths != '' && (fromJson(inputs.workflowInput)).staticValidation == 'true'  }}
-    strategy:
-      fail-fast: false
-      matrix:
-        testCases: ${{ fromJson(inputs.psRuleModuleTestFilePaths) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set environment
-        uses: ./.github/actions/templates/avm-setEnvironment
-      - name: "Run PSRule validation with [${{ matrix.testCases.path }}]"
-        uses: ./.github/actions/templates/avm-validateModulePSRule
-        with:
-          templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
-          subscriptionId: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
-          managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
-          psrulePath: "/utilities/pipelines/staticValidation/psrule" #'${{ github.workspace }}/avm'
-          psruleBaseline: "Azure.Pillar.Security"
+  # job_psrule_test_waf_security: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
+  #   name: "PSRule - WAF Security [${{ matrix.testCases.name }}]"
+  #   runs-on: ubuntu-latest
+  #   if: ${{ inputs.psRuleModuleTestFilePaths != '' && (fromJson(inputs.workflowInput)).staticValidation == 'true'  }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       testCases: ${{ fromJson(inputs.psRuleModuleTestFilePaths) }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Set environment
+  #       uses: ./.github/actions/templates/avm-setEnvironment
+  #     - name: "Run PSRule validation with [${{ matrix.testCases.path }}]"
+  #       uses: ./.github/actions/templates/avm-validateModulePSRule
+  #       with:
+  #         templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
+  #         subscriptionId: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+  #         managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
+  #         psrulePath: "/utilities/pipelines/staticValidation/psrule" #'${{ github.workspace }}/avm'
+  #         psruleBaseline: "Azure.Pillar.Security"
 
-  #############################
-  #   Deployment validation   #
-  #############################
-  job_module_deploy_validation: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
-    name: "Deploy [${{ matrix.testCases.name}}]"
-    environment: avm-validation
-    runs-on: ubuntu-latest
-    if: |
-      !cancelled() &&
-      (fromJson(inputs.workflowInput)).deploymentValidation == 'true' &&
-      needs.job_module_static_validation.result != 'failure' &&
-      needs.job_psrule_test_waf_reliability.result != 'failure' &&
-      needs.job_psrule_test_waf_security_cb.result != 'failure'
-    needs:
-      - job_module_static_validation
-      - job_psrule_test_waf_reliability
-      - job_psrule_test_waf_security_cb
-    strategy:
-      fail-fast: false
-      matrix:
-        testCases: ${{ fromJson(inputs.moduleTestFilePaths) }}
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set environment
-        uses: ./.github/actions/templates/avm-setEnvironment
-        with:
-          removeDeployment: "${{ fromJson(inputs.workflowInput).removeDeployment }}"
-      - name: "Run deployment validation with test file [${{ matrix.testCases.path }}]"
-        uses: ./.github/actions/templates/avm-validateModuleDeployment
-        with:
-          modulePath: "${{ inputs.modulePath }}"
-          templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
-          deploymentMetadataLocation: "WestEurope"
-          subscriptionId: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
-          managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
-          removeDeployment: "${{ fromJson(inputs.workflowInput).removeDeployment }}"
-          customLocation: "${{ fromJson(inputs.workflowInput).customLocation }}"
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-          VALIDATE_CLIENT_ID: ${{ secrets.VALIDATE_CLIENT_ID }}
-          VALIDATE_SUBSCRIPTION_ID: ${{ secrets.VALIDATE_SUBSCRIPTION_ID }}
-          VALIDATE_TENANT_ID: ${{ secrets.VALIDATE_TENANT_ID }}
+  # #############################
+  # #   Deployment validation   #
+  # #############################
+  # job_module_deploy_validation: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
+  #   name: "Deploy [${{ matrix.testCases.name}}]"
+  #   environment: avm-validation
+  #   runs-on: ubuntu-latest
+  #   if: |
+  #     !cancelled() &&
+  #     (fromJson(inputs.workflowInput)).deploymentValidation == 'true' &&
+  #     needs.job_module_static_validation.result != 'failure' &&
+  #     needs.job_psrule_test_waf_reliability.result != 'failure' &&
+  #     needs.job_psrule_test_waf_security_cb.result != 'failure'
+  #   needs:
+  #     - job_module_static_validation
+  #     - job_psrule_test_waf_reliability
+  #     - job_psrule_test_waf_security_cb
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       testCases: ${{ fromJson(inputs.moduleTestFilePaths) }}
+  #   steps:
+  #     - name: "Checkout"
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Set environment
+  #       uses: ./.github/actions/templates/avm-setEnvironment
+  #       with:
+  #         removeDeployment: "${{ fromJson(inputs.workflowInput).removeDeployment }}"
+  #     - name: "Run deployment validation with test file [${{ matrix.testCases.path }}]"
+  #       uses: ./.github/actions/templates/avm-validateModuleDeployment
+  #       with:
+  #         modulePath: "${{ inputs.modulePath }}"
+  #         templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
+  #         deploymentMetadataLocation: "WestEurope"
+  #         subscriptionId: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+  #         managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
+  #         removeDeployment: "${{ fromJson(inputs.workflowInput).removeDeployment }}"
+  #         customLocation: "${{ fromJson(inputs.workflowInput).customLocation }}"
+  #       env:
+  #         AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+  #         VALIDATE_CLIENT_ID: ${{ secrets.VALIDATE_CLIENT_ID }}
+  #         VALIDATE_SUBSCRIPTION_ID: ${{ secrets.VALIDATE_SUBSCRIPTION_ID }}
+  #         VALIDATE_TENANT_ID: ${{ secrets.VALIDATE_TENANT_ID }}
 
-  ##################
-  #   Publishing   #
-  ##################
-  job_publish_module: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
-    name: "Publishing"
-    runs-on: ubuntu-latest
-    # Note: Below always() required in condition due to psrule jobs being skipped for ptn & utl modules not having defaults or waf-aligned folders
-    if: |
-      always() &&
-      needs.job_module_static_validation.result == 'success' &&
-      needs.job_module_deploy_validation.result == 'success' &&
-      github.ref == 'refs/heads/main' &&
-      github.repository	 == 'Azure/bicep-registry-modules'
-    needs:
-      - job_module_static_validation
-      - job_module_deploy_validation
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set environment
-        uses: ./.github/actions/templates/avm-setEnvironment
-      - name: "Publishing"
-        uses: ./.github/actions/templates/avm-publishModule
-        with:
-          templateFilePath: "${{ inputs.modulePath }}/main.bicep"
-        env:
-          PUBLISH_REGISTRY_SERVER: "${{ secrets.PUBLISH_REGISTRY_SERVER }}"
-          PUBLISH_CLIENT_ID: "${{ secrets.PUBLISH_CLIENT_ID }}"
-          PUBLISH_TENANT_ID: "${{ secrets.PUBLISH_TENANT_ID }}"
-          PUBLISH_SUBSCRIPTION_ID: "${{ secrets.PUBLISH_SUBSCRIPTION_ID }}"
+  # ##################
+  # #   Publishing   #
+  # ##################
+  # job_publish_module: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
+  #   name: "Publishing"
+  #   runs-on: ubuntu-latest
+  #   # Note: Below always() required in condition due to psrule jobs being skipped for ptn & utl modules not having defaults or waf-aligned folders
+  #   if: |
+  #     always() &&
+  #     needs.job_module_static_validation.result == 'success' &&
+  #     needs.job_module_deploy_validation.result == 'success' &&
+  #     github.ref == 'refs/heads/main' &&
+  #     github.repository	 == 'Azure/bicep-registry-modules'
+  #   needs:
+  #     - job_module_static_validation
+  #     - job_module_deploy_validation
+  #   steps:
+  #     - name: "Checkout"
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Set environment
+  #       uses: ./.github/actions/templates/avm-setEnvironment
+  #     - name: "Publishing"
+  #       uses: ./.github/actions/templates/avm-publishModule
+  #       with:
+  #         templateFilePath: "${{ inputs.modulePath }}/main.bicep"
+  #       env:
+  #         PUBLISH_REGISTRY_SERVER: "${{ secrets.PUBLISH_REGISTRY_SERVER }}"
+  #         PUBLISH_CLIENT_ID: "${{ secrets.PUBLISH_CLIENT_ID }}"
+  #         PUBLISH_TENANT_ID: "${{ secrets.PUBLISH_TENANT_ID }}"
+  #         PUBLISH_SUBSCRIPTION_ID: "${{ secrets.PUBLISH_SUBSCRIPTION_ID }}"

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -184,7 +184,7 @@ Describe 'File/folder tests' -Tag 'Modules' {
             $pathExisting | Should -Be $true
         }
 
-        It '[<moduleFolderName>] Module should contain a [` tests/e2e/*waf-aligned `] folder.' -TestCases ($topLevelModuleTestCases | Where-Object { $_.moduleType -eq 'res' }) {
+        It '[<moduleFolderName>] Module should contain a [` tests/e2e/*waf-aligned `] folder.' -TestCases ($topLevelModuleTestCases | Where-Object { $_.moduleType -ne 'utl' }) {
 
             param(
                 [string] $moduleFolderPath

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -194,7 +194,7 @@ Describe 'File/folder tests' -Tag 'Modules' {
             $wafAlignedFolder | Should -Not -BeNullOrEmpty
         }
 
-        It '[<moduleFolderName>] Module should contain a [` tests/e2e/*defaults `] folder.' -TestCases ($topLevelModuleTestCases | Where-Object { $_.moduleType -eq 'res' }) {
+        It '[<moduleFolderName>] Module should contain a [` tests/e2e/*defaults `] folder.' -TestCases ($topLevelModuleTestCases | Where-Object { $_.moduleType -ne 'utl' }) {
 
             param(
                 [string] $moduleFolderPath

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -184,7 +184,7 @@ Describe 'File/folder tests' -Tag 'Modules' {
             $pathExisting | Should -Be $true
         }
 
-        It '[<moduleFolderName>] Module should contain a [` tests/e2e/*waf-aligned `] folder.' -TestCases ($topLevelModuleTestCases | Where-Object { $_.moduleType -ne 'utl' }) {
+        It '[<moduleFolderName>] Module should contain a [` tests/e2e/*waf-aligned `] folder.' -TestCases ($topLevelModuleTestCases | Where-Object { $_.moduleType -eq 'res' }) {
 
             param(
                 [string] $moduleFolderPath
@@ -194,7 +194,7 @@ Describe 'File/folder tests' -Tag 'Modules' {
             $wafAlignedFolder | Should -Not -BeNullOrEmpty
         }
 
-        It '[<moduleFolderName>] Module should contain a [` tests/e2e/*defaults `] folder.' -TestCases ($topLevelModuleTestCases | Where-Object { $_.moduleType -eq 'res' }) {
+        It '[<moduleFolderName>] Module should contain a [` tests/e2e/*defaults `] folder.' -TestCases ($topLevelModuleTestCases | Where-Object { $_.moduleType -ne 'utl' }) {
 
             param(
                 [string] $moduleFolderPath

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -194,7 +194,7 @@ Describe 'File/folder tests' -Tag 'Modules' {
             $wafAlignedFolder | Should -Not -BeNullOrEmpty
         }
 
-        It '[<moduleFolderName>] Module should contain a [` tests/e2e/*defaults `] folder.' -TestCases ($topLevelModuleTestCases | Where-Object { $_.moduleType -ne 'utl' }) {
+        It '[<moduleFolderName>] Module should contain a [` tests/e2e/*defaults `] folder.' -TestCases ($topLevelModuleTestCases | Where-Object { $_.moduleType -eq 'res' }) {
 
             param(
                 [string] $moduleFolderPath


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.ptn.aca-lza.hosting-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.aca-lza.hosting-environment.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.aca-lza.hosting-environment.yml)
[![avm.ptn.ai-platform.baseline](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.ai-platform.baseline.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.ai-platform.baseline.yml)
[![avm.ptn.alz.empty](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.alz.empty.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.alz.empty.yml)
[![avm.ptn.app-service-lza.hosting-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app-service-lza.hosting-environment.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app-service-lza.hosting-environment.yml)
[![avm.ptn.app.container-job-toolkit.yml](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app.container-job-toolkit.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app.container-job-toolkit.yml)  
[![avm.ptn.authorization.pim-role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.pim-role-assignment.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.pim-role-assignment.yml)
[![avm.ptn.authorization.policy-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-assignment.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-assignment.yml)
[![avm.ptn.authorization.policy-exemption](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-exemption.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-exemption.yml)
[![avm.ptn.authorization.resource-role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.resource-role-assignment.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.resource-role-assignment.yml)
[![avm.ptn.authorization.role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-assignment.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-assignment.yml)
[![avm.ptn.authorization.role-definition](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-definition.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-definition.yml)
[![avm.ptn.azd.acr-container-app](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.acr-container-app.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.acr-container-app.yml)
[![avm.ptn.azd.aks-automatic-cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks-automatic-cluster.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks-automatic-cluster.yml)      
[![avm.ptn.azd.aks](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks.yml)
[![avm.ptn.azd.apim-api](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.apim-api.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.apim-api.yml)
[![avm.ptn.azd.container-app-upsert](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-app-upsert.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-app-upsert.yml)
[![avm.ptn.azd.container-apps-stack](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-apps-stack.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-apps-stack.yml)
[![avm.ptn.azd.insights-dashboard](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.insights-dashboard.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.insights-dashboard.yml)
[![avm.ptn.azd.ml-ai-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.ml-ai-environment.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.ml-ai-environment.yml)
[![avm.ptn.azd.ml-hub-dependencies](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.ml-hub-dependencies.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.ml-hub-dependencies.yml)
[![avm.ptn.azd.ml-project](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.ml-project.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.ml-project.yml)
[![avm.ptn.azd.monitoring](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.monitoring.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.monitoring.yml)
[![avm.ptn.data.private-analytical-workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.data.private-analytical-workspace.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.data.private-analytical-workspace.yml)
[![avm.ptn.deployment-script.import-image-to-acr](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.deployment-script.import-image-to-acr.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.deployment-script.import-image-to-acr.yml)
[![avm.ptn.dev-ops.cicd-agents-and-runners](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.dev-ops.cicd-agents-and-runners.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.dev-ops.cicd-agents-and-runners.yml)
[![avm.ptn.finops-toolkit.finops-hub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.finops-toolkit.finops-hub.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.finops-toolkit.finops-hub.yml)      
[![avm.ptn.lz.sub-vending](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml)
[![avm.ptn.mgmt-groups.subscription-placement](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.mgmt-groups.subscription-placement.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.mgmt-groups.subscription-placement.yml)
[![avm.ptn.network.hub-networking](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml)
[![avm.ptn.network.private-link-private-dns-zones](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.private-link-private-dns-zones.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.private-link-private-dns-zones.yml)
[![avm.ptn.policy-insights.remediation](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.policy-insights.remediation.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.policy-insights.remediation.yml)
[![avm.ptn.sa.conversation-knowledge-mining](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.conversation-knowledge-mining.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.conversation-knowledge-mining.yml)
[![avm.ptn.security.security-center](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.security.security-center.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.security.security-center.yml)
[![avm.ptn.virtual-machine-images.azure-image-builder](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml/badge.svg?branch=users%2Ferikag%2Ftest-ptn-def-only&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
