### PR TITLE
feat: VSCode - adds warning for referenced rp and module versions

### DIFF
--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -16,6 +16,9 @@
         },
         "no-unused-params": {
           "level": "warning"
+        },
+        "no-unused-vars": {
+          "level": "warning"
         }
       }
     }

--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -1,12 +1,23 @@
 // This is a Bicep configuration file. It can be used to control how Bicep operates and to customize validation settings for the Bicep linter. The linter uses these settings when evaluating your Bicep files for best practices.
 // For further information, please refer to the official documentation at: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-config
 {
-    "experimentalFeaturesEnabled": {
-        "publishSource": true
-    },
-    "analyzers": {
-        "core": {
-            "rules": {}
+  "experimentalFeaturesEnabled": {
+    "publishSource": true
+  },
+  "analyzers": {
+    "core": {
+      "rules": {
+        "use-recent-api-versions": {
+          "level": "warning"
+        },
+        "use-recent-module-versions": {
+          "level": "warning",
+          "message": "The module version is outdated. Please consider updating to the latest version."
+        },
+        "no-unused-params": {
+          "level": "warning"
         }
+      }
     }
+  }
 }


### PR DESCRIPTION
## Description

Adds warning to Visual Studio Code, if a newer version of a referenced Resource Provider or AVM exists.

## Pipeline Reference

| Pipeline |
| -------- |
|          |

## Type of Change

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [s] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
