### PR TITLE
feat: add support for policy versioning on assignments

### DIFF
--- a/avm/ptn/authorization/policy-assignment/README.md
+++ b/avm/ptn/authorization/policy-assignment/README.md
@@ -14,7 +14,7 @@ This module deploys a Policy Assignment at a Management Group, Subscription or R
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Authorization/policyAssignments` | [2022-06-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-06-01/policyAssignments) |
+| `Microsoft.Authorization/policyAssignments` | [2025-01-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2025-01-01/policyAssignments) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
 
 ## Usage examples
@@ -138,6 +138,7 @@ module policyAssignment 'br/public:avm/ptn/authorization/policy-assignment:<vers
     additionalSubscriptionIDsToAssignRbacTo: [
       '<subscriptionId>'
     ]
+    definitionVersion: '1.0.0-preview'
     description: '[Description] Policy Assignment at the management group scope'
     displayName: '[Display Name] Policy Assignment at the management group scope'
     enforcementMode: 'DoNotEnforce'
@@ -240,6 +241,9 @@ module policyAssignment 'br/public:avm/ptn/authorization/policy-assignment:<vers
       "value": [
         "<subscriptionId>"
       ]
+    },
+    "definitionVersion": {
+      "value": "1.0.0-preview"
     },
     "description": {
       "value": "[Description] Policy Assignment at the management group scope"
@@ -358,6 +362,7 @@ param additionalResourceGroupResourceIDsToAssignRbacTo = [
 param additionalSubscriptionIDsToAssignRbacTo = [
   '<subscriptionId>'
 ]
+param definitionVersion = '1.0.0-preview'
 param description = '[Description] Policy Assignment at the management group scope'
 param displayName = '[Display Name] Policy Assignment at the management group scope'
 param enforcementMode = 'DoNotEnforce'
@@ -534,6 +539,7 @@ module policyAssignment 'br/public:avm/ptn/authorization/policy-assignment:<vers
     name: 'apargmax001'
     policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
     // Non-required parameters
+    definitionVersion: '1.0.0-preview'
     description: '[Description] Policy Assignment at the resource group scope'
     displayName: '[Display Name] Policy Assignment at the resource group scope'
     enforcementMode: 'DoNotEnforce'
@@ -624,6 +630,9 @@ module policyAssignment 'br/public:avm/ptn/authorization/policy-assignment:<vers
       "value": "/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611"
     },
     // Non-required parameters
+    "definitionVersion": {
+      "value": "1.0.0-preview"
+    },
     "description": {
       "value": "[Description] Policy Assignment at the resource group scope"
     },
@@ -738,6 +747,7 @@ using 'br/public:avm/ptn/authorization/policy-assignment:<version>'
 param name = 'apargmax001'
 param policyDefinitionId = '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
 // Non-required parameters
+param definitionVersion = '1.0.0-preview'
 param description = '[Description] Policy Assignment at the resource group scope'
 param displayName = '[Display Name] Policy Assignment at the resource group scope'
 param enforcementMode = 'DoNotEnforce'
@@ -917,6 +927,7 @@ module policyAssignment 'br/public:avm/ptn/authorization/policy-assignment:<vers
     name: 'apasubmax001'
     policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
     // Non-required parameters
+    definitionVersion: '1.0.0-preview'
     description: '[Description] Policy Assignment at the subscription scope'
     displayName: '[Display Name] Policy Assignment at the subscription scope'
     enforcementMode: 'DoNotEnforce'
@@ -1006,6 +1017,9 @@ module policyAssignment 'br/public:avm/ptn/authorization/policy-assignment:<vers
       "value": "/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611"
     },
     // Non-required parameters
+    "definitionVersion": {
+      "value": "1.0.0-preview"
+    },
     "description": {
       "value": "[Description] Policy Assignment at the subscription scope"
     },
@@ -1117,6 +1131,7 @@ using 'br/public:avm/ptn/authorization/policy-assignment:<version>'
 param name = 'apasubmax001'
 param policyDefinitionId = '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
 // Non-required parameters
+param definitionVersion = '1.0.0-preview'
 param description = '[Description] Policy Assignment at the subscription scope'
 param displayName = '[Display Name] Policy Assignment at the subscription scope'
 param enforcementMode = 'DoNotEnforce'
@@ -1203,6 +1218,7 @@ param userAssignedIdentityId = '<userAssignedIdentityId>'
 | [`additionalManagementGroupsIDsToAssignRbacTo`](#parameter-additionalmanagementgroupsidstoassignrbacto) | array | An array of additional management group IDs to assign RBAC to for the policy assignment if it has an identity. |
 | [`additionalResourceGroupResourceIDsToAssignRbacTo`](#parameter-additionalresourcegroupresourceidstoassignrbacto) | array | An array of additional Resource Group Resource IDs to assign RBAC to for the policy assignment if it has an identity, only supported for Management Group Policy Assignments. |
 | [`additionalSubscriptionIDsToAssignRbacTo`](#parameter-additionalsubscriptionidstoassignrbacto) | array | An array of additional Subscription IDs to assign RBAC to for the policy assignment if it has an identity, only supported for Management Group Policy Assignments. |
+| [`definitionVersion`](#parameter-definitionversion) | string | The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview |
 | [`description`](#parameter-description) | string | This message will be part of response in case of policy violation. |
 | [`displayName`](#parameter-displayname) | string | The display name of the policy assignment. Maximum length is 128 characters. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
@@ -1258,6 +1274,13 @@ An array of additional Subscription IDs to assign RBAC to for the policy assignm
 - Required: No
 - Type: array
 - Default: `[]`
+
+### Parameter: `definitionVersion`
+
+The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview
+
+- Required: No
+- Type: string
 
 ### Parameter: `description`
 

--- a/avm/ptn/authorization/policy-assignment/README.md
+++ b/avm/ptn/authorization/policy-assignment/README.md
@@ -138,7 +138,7 @@ module policyAssignment 'br/public:avm/ptn/authorization/policy-assignment:<vers
     additionalSubscriptionIDsToAssignRbacTo: [
       '<subscriptionId>'
     ]
-    definitionVersion: '1.0.0-preview'
+    definitionVersion: '1.*.*-preview'
     description: '[Description] Policy Assignment at the management group scope'
     displayName: '[Display Name] Policy Assignment at the management group scope'
     enforcementMode: 'DoNotEnforce'
@@ -243,7 +243,7 @@ module policyAssignment 'br/public:avm/ptn/authorization/policy-assignment:<vers
       ]
     },
     "definitionVersion": {
-      "value": "1.0.0-preview"
+      "value": "1.*.*-preview"
     },
     "description": {
       "value": "[Description] Policy Assignment at the management group scope"
@@ -362,7 +362,7 @@ param additionalResourceGroupResourceIDsToAssignRbacTo = [
 param additionalSubscriptionIDsToAssignRbacTo = [
   '<subscriptionId>'
 ]
-param definitionVersion = '1.0.0-preview'
+param definitionVersion = '1.*.*-preview'
 param description = '[Description] Policy Assignment at the management group scope'
 param displayName = '[Display Name] Policy Assignment at the management group scope'
 param enforcementMode = 'DoNotEnforce'
@@ -539,7 +539,7 @@ module policyAssignment 'br/public:avm/ptn/authorization/policy-assignment:<vers
     name: 'apargmax001'
     policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
     // Non-required parameters
-    definitionVersion: '1.0.0-preview'
+    definitionVersion: '1.*.*-preview'
     description: '[Description] Policy Assignment at the resource group scope'
     displayName: '[Display Name] Policy Assignment at the resource group scope'
     enforcementMode: 'DoNotEnforce'
@@ -631,7 +631,7 @@ module policyAssignment 'br/public:avm/ptn/authorization/policy-assignment:<vers
     },
     // Non-required parameters
     "definitionVersion": {
-      "value": "1.0.0-preview"
+      "value": "1.*.*-preview"
     },
     "description": {
       "value": "[Description] Policy Assignment at the resource group scope"
@@ -747,7 +747,7 @@ using 'br/public:avm/ptn/authorization/policy-assignment:<version>'
 param name = 'apargmax001'
 param policyDefinitionId = '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
 // Non-required parameters
-param definitionVersion = '1.0.0-preview'
+param definitionVersion = '1.*.*-preview'
 param description = '[Description] Policy Assignment at the resource group scope'
 param displayName = '[Display Name] Policy Assignment at the resource group scope'
 param enforcementMode = 'DoNotEnforce'
@@ -927,7 +927,7 @@ module policyAssignment 'br/public:avm/ptn/authorization/policy-assignment:<vers
     name: 'apasubmax001'
     policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
     // Non-required parameters
-    definitionVersion: '1.0.0-preview'
+    definitionVersion: '1.*.*-preview'
     description: '[Description] Policy Assignment at the subscription scope'
     displayName: '[Display Name] Policy Assignment at the subscription scope'
     enforcementMode: 'DoNotEnforce'
@@ -1018,7 +1018,7 @@ module policyAssignment 'br/public:avm/ptn/authorization/policy-assignment:<vers
     },
     // Non-required parameters
     "definitionVersion": {
-      "value": "1.0.0-preview"
+      "value": "1.*.*-preview"
     },
     "description": {
       "value": "[Description] Policy Assignment at the subscription scope"
@@ -1131,7 +1131,7 @@ using 'br/public:avm/ptn/authorization/policy-assignment:<version>'
 param name = 'apasubmax001'
 param policyDefinitionId = '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
 // Non-required parameters
-param definitionVersion = '1.0.0-preview'
+param definitionVersion = '1.*.*-preview'
 param description = '[Description] Policy Assignment at the subscription scope'
 param displayName = '[Display Name] Policy Assignment at the subscription scope'
 param enforcementMode = 'DoNotEnforce'

--- a/avm/ptn/authorization/policy-assignment/README.md
+++ b/avm/ptn/authorization/policy-assignment/README.md
@@ -1218,7 +1218,7 @@ param userAssignedIdentityId = '<userAssignedIdentityId>'
 | [`additionalManagementGroupsIDsToAssignRbacTo`](#parameter-additionalmanagementgroupsidstoassignrbacto) | array | An array of additional management group IDs to assign RBAC to for the policy assignment if it has an identity. |
 | [`additionalResourceGroupResourceIDsToAssignRbacTo`](#parameter-additionalresourcegroupresourceidstoassignrbacto) | array | An array of additional Resource Group Resource IDs to assign RBAC to for the policy assignment if it has an identity, only supported for Management Group Policy Assignments. |
 | [`additionalSubscriptionIDsToAssignRbacTo`](#parameter-additionalsubscriptionidstoassignrbacto) | array | An array of additional Subscription IDs to assign RBAC to for the policy assignment if it has an identity, only supported for Management Group Policy Assignments. |
-| [`definitionVersion`](#parameter-definitionversion) | string | The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview |
+| [`definitionVersion`](#parameter-definitionversion) | string | The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview. |
 | [`description`](#parameter-description) | string | This message will be part of response in case of policy violation. |
 | [`displayName`](#parameter-displayname) | string | The display name of the policy assignment. Maximum length is 128 characters. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
@@ -1277,7 +1277,7 @@ An array of additional Subscription IDs to assign RBAC to for the policy assignm
 
 ### Parameter: `definitionVersion`
 
-The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview
+The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview.
 
 - Required: No
 - Type: string

--- a/avm/ptn/authorization/policy-assignment/main.bicep
+++ b/avm/ptn/authorization/policy-assignment/main.bicep
@@ -76,6 +76,9 @@ param overrides array = []
 @sys.description('Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location.')
 param resourceSelectors array = []
 
+@sys.description('Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview')
+param definitionVersion string?
+
 @sys.description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
 
@@ -121,6 +124,7 @@ module policyAssignment_mg 'modules/management-group.bicep' = if (empty(subscrip
     location: location
     overrides: !empty(overrides) ? overrides : []
     resourceSelectors: !empty(resourceSelectors) ? resourceSelectors : []
+    definitionVersion: definitionVersion
     additionalManagementGroupsIDsToAssignRbacTo: additionalManagementGroupsIDsToAssignRbacTo
     additionalSubscriptionIDsToAssignRbacTo: additionalSubscriptionIDsToAssignRbacTo
     additionalResourceGroupResourceIDsToAssignRbacTo: additionalResourceGroupResourceIDsToAssignRbacTo
@@ -149,6 +153,7 @@ module policyAssignment_sub 'modules/subscription.bicep' = if (!empty(subscripti
     location: location
     overrides: !empty(overrides) ? overrides : []
     resourceSelectors: !empty(resourceSelectors) ? resourceSelectors : []
+    definitionVersion: definitionVersion
   }
 }
 
@@ -172,6 +177,7 @@ module policyAssignment_rg 'modules/resource-group.bicep' = if (!empty(resourceG
     location: location
     overrides: !empty(overrides) ? overrides : []
     resourceSelectors: !empty(resourceSelectors) ? resourceSelectors : []
+    definitionVersion: definitionVersion
   }
 }
 

--- a/avm/ptn/authorization/policy-assignment/main.bicep
+++ b/avm/ptn/authorization/policy-assignment/main.bicep
@@ -76,7 +76,7 @@ param overrides array = []
 @sys.description('Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location.')
 param resourceSelectors array = []
 
-@sys.description('Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview')
+@sys.description('Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview.')
 param definitionVersion string?
 
 @sys.description('Optional. Enable/Disable usage telemetry for module.')

--- a/avm/ptn/authorization/policy-assignment/main.json
+++ b/avm/ptn/authorization/policy-assignment/main.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+  "languageVersion": "2.0",
   "contentVersion": "1.0.0.0",
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "18206582420908895315"
+      "version": "0.36.1.42791",
+      "templateHash": "2126672396764471077"
     },
     "name": "Policy Assignments (All scopes)",
     "description": "This module deploys a Policy Assignment at a Management Group, Subscription or Resource Group scope."
@@ -166,6 +167,13 @@
         "description": "Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location."
       }
     },
+    "definitionVersion": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview"
+      }
+    },
     "enableTelemetry": {
       "type": "bool",
       "defaultValue": true,
@@ -174,8 +182,8 @@
       }
     }
   },
-  "resources": [
-    {
+  "resources": {
+    "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2024-03-01",
@@ -196,7 +204,7 @@
         }
       }
     },
-    {
+    "policyAssignment_mg": {
       "condition": "[and(empty(parameters('subscriptionId')), empty(parameters('resourceGroupName')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
@@ -236,6 +244,9 @@
           },
           "overrides": "[if(not(empty(parameters('overrides'))), createObject('value', parameters('overrides')), createObject('value', createArray()))]",
           "resourceSelectors": "[if(not(empty(parameters('resourceSelectors'))), createObject('value', parameters('resourceSelectors')), createObject('value', createArray()))]",
+          "definitionVersion": {
+            "value": "[parameters('definitionVersion')]"
+          },
           "additionalManagementGroupsIDsToAssignRbacTo": {
             "value": "[parameters('additionalManagementGroupsIDsToAssignRbacTo')]"
           },
@@ -248,12 +259,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "10678509985815740940"
+              "version": "0.36.1.42791",
+              "templateHash": "10783625542125225559"
             },
             "name": "Policy Assignments (Management Group scope)",
             "description": "This module deploys a Policy Assignment at a Management Group scope."
@@ -393,16 +405,23 @@
               "metadata": {
                 "description": "Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location."
               }
+            },
+            "definitionVersion": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview"
+              }
             }
           },
           "variables": {
             "identityVar": "[if(equals(parameters('identity'), 'SystemAssigned'), createObject('type', parameters('identity')), if(equals(parameters('identity'), 'UserAssigned'), createObject('type', parameters('identity'), 'userAssignedIdentities', createObject(format('{0}', parameters('userAssignedIdentityId')), createObject())), null()))]",
             "finalArrayOfManagementGroupsToAssignRbacTo": "[if(equals(parameters('identity'), 'SystemAssigned'), union(parameters('additionalManagementGroupsIDsToAssignRbacTo'), createArray(managementGroup().name)), createArray())]"
           },
-          "resources": [
-            {
+          "resources": {
+            "policyAssignment": {
               "type": "Microsoft.Authorization/policyAssignments",
-              "apiVersion": "2022-06-01",
+              "apiVersion": "2025-01-01",
               "name": "[parameters('name')]",
               "location": "[parameters('location')]",
               "properties": {
@@ -415,11 +434,12 @@
                 "enforcementMode": "[parameters('enforcementMode')]",
                 "notScopes": "[if(not(empty(parameters('notScopes'))), parameters('notScopes'), createArray())]",
                 "overrides": "[if(not(empty(parameters('overrides'))), parameters('overrides'), createArray())]",
-                "resourceSelectors": "[if(not(empty(parameters('resourceSelectors'))), parameters('resourceSelectors'), createArray())]"
+                "resourceSelectors": "[if(not(empty(parameters('resourceSelectors'))), parameters('resourceSelectors'), createArray())]",
+                "definitionVersion": "[parameters('definitionVersion')]"
               },
               "identity": "[variables('identityVar')]"
             },
-            {
+            "managementGroupRoleAssignments": {
               "copy": {
                 "name": "managementGroupRoleAssignments",
                 "count": "[length(parameters('roleDefinitionIds'))]"
@@ -439,7 +459,7 @@
                     "value": "[parameters('name')]"
                   },
                   "policyAssignmentIdentityId": {
-                    "value": "[reference(extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policyAssignments', parameters('name')), '2022-06-01', 'full').identity.principalId]"
+                    "value": "[reference('policyAssignment', '2025-01-01', 'full').identity.principalId]"
                   },
                   "roleDefinitionId": {
                     "value": "[parameters('roleDefinitionIds')[copyIndex()]]"
@@ -454,8 +474,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.32.4.45862",
-                      "templateHash": "9631038445585845349"
+                      "version": "0.36.1.42791",
+                      "templateHash": "16132708231319273822"
                     }
                   },
                   "parameters": {
@@ -526,8 +546,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.32.4.45862",
-                              "templateHash": "9140403539470176881"
+                              "version": "0.36.1.42791",
+                              "templateHash": "18359218032794714355"
                             }
                           },
                           "parameters": {
@@ -577,10 +597,10 @@
                 }
               },
               "dependsOn": [
-                "[extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policyAssignments', parameters('name'))]"
+                "policyAssignment"
               ]
             },
-            {
+            "additionalSubscriptionRoleAssignments": {
               "copy": {
                 "name": "additionalSubscriptionRoleAssignments",
                 "count": "[length(parameters('roleDefinitionIds'))]"
@@ -600,7 +620,7 @@
                     "value": "[parameters('name')]"
                   },
                   "policyAssignmentIdentityId": {
-                    "value": "[reference(extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policyAssignments', parameters('name')), '2022-06-01', 'full').identity.principalId]"
+                    "value": "[reference('policyAssignment', '2025-01-01', 'full').identity.principalId]"
                   },
                   "roleDefinitionId": {
                     "value": "[parameters('roleDefinitionIds')[copyIndex()]]"
@@ -615,8 +635,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.32.4.45862",
-                      "templateHash": "5868976721767457523"
+                      "version": "0.36.1.42791",
+                      "templateHash": "13456700536070272376"
                     }
                   },
                   "parameters": {
@@ -687,8 +707,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.32.4.45862",
-                              "templateHash": "1856107527131838082"
+                              "version": "0.36.1.42791",
+                              "templateHash": "283263530432177648"
                             }
                           },
                           "parameters": {
@@ -738,10 +758,10 @@
                 }
               },
               "dependsOn": [
-                "[extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policyAssignments', parameters('name'))]"
+                "policyAssignment"
               ]
             },
-            {
+            "additionalResourceGroupRoleAssignments": {
               "copy": {
                 "name": "additionalResourceGroupRoleAssignments",
                 "count": "[length(parameters('roleDefinitionIds'))]"
@@ -761,7 +781,7 @@
                     "value": "[parameters('name')]"
                   },
                   "policyAssignmentIdentityId": {
-                    "value": "[reference(extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policyAssignments', parameters('name')), '2022-06-01', 'full').identity.principalId]"
+                    "value": "[reference('policyAssignment', '2025-01-01', 'full').identity.principalId]"
                   },
                   "roleDefinitionId": {
                     "value": "[parameters('roleDefinitionIds')[copyIndex()]]"
@@ -776,8 +796,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.32.4.45862",
-                      "templateHash": "12514251766635911763"
+                      "version": "0.36.1.42791",
+                      "templateHash": "1587977627296299534"
                     }
                   },
                   "parameters": {
@@ -848,8 +868,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.32.4.45862",
-                              "templateHash": "11358116386111113340"
+                              "version": "0.36.1.42791",
+                              "templateHash": "17794491056080423713"
                             }
                           },
                           "parameters": {
@@ -899,10 +919,10 @@
                 }
               },
               "dependsOn": [
-                "[extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policyAssignments', parameters('name'))]"
+                "policyAssignment"
               ]
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",
@@ -916,7 +936,7 @@
               "metadata": {
                 "description": "Policy Assignment principal ID."
               },
-              "value": "[coalesce(tryGet(tryGet(reference(extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policyAssignments', parameters('name')), '2022-06-01', 'full'), 'identity'), 'principalId'), '')]"
+              "value": "[coalesce(tryGet(tryGet(reference('policyAssignment', '2025-01-01', 'full'), 'identity'), 'principalId'), '')]"
             },
             "resourceId": {
               "type": "string",
@@ -930,13 +950,13 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference(extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policyAssignments', parameters('name')), '2022-06-01', 'full').location]"
+              "value": "[reference('policyAssignment', '2025-01-01', 'full').location]"
             }
           }
         }
       }
     },
-    {
+    "policyAssignment_sub": {
       "condition": "[and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
@@ -978,16 +998,20 @@
             "value": "[parameters('location')]"
           },
           "overrides": "[if(not(empty(parameters('overrides'))), createObject('value', parameters('overrides')), createObject('value', createArray()))]",
-          "resourceSelectors": "[if(not(empty(parameters('resourceSelectors'))), createObject('value', parameters('resourceSelectors')), createObject('value', createArray()))]"
+          "resourceSelectors": "[if(not(empty(parameters('resourceSelectors'))), createObject('value', parameters('resourceSelectors')), createObject('value', createArray()))]",
+          "definitionVersion": {
+            "value": "[parameters('definitionVersion')]"
+          }
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "2523227409976507857"
+              "version": "0.36.1.42791",
+              "templateHash": "14101605250654342468"
             },
             "name": "Policy Assignments (Subscription scope)",
             "description": "This module deploys a Policy Assignment at a Subscription scope."
@@ -1107,6 +1131,13 @@
                 "description": "Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location."
               }
             },
+            "definitionVersion": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview"
+              }
+            },
             "subscriptionId": {
               "type": "string",
               "defaultValue": "[subscription().subscriptionId]",
@@ -1118,10 +1149,10 @@
           "variables": {
             "identityVar": "[if(equals(parameters('identity'), 'SystemAssigned'), createObject('type', parameters('identity')), if(equals(parameters('identity'), 'UserAssigned'), createObject('type', parameters('identity'), 'userAssignedIdentities', createObject(format('{0}', parameters('userAssignedIdentityId')), createObject())), null()))]"
           },
-          "resources": [
-            {
+          "resources": {
+            "policyAssignment": {
               "type": "Microsoft.Authorization/policyAssignments",
-              "apiVersion": "2022-06-01",
+              "apiVersion": "2025-01-01",
               "name": "[parameters('name')]",
               "location": "[parameters('location')]",
               "properties": {
@@ -1134,11 +1165,12 @@
                 "enforcementMode": "[parameters('enforcementMode')]",
                 "notScopes": "[if(not(empty(parameters('notScopes'))), parameters('notScopes'), createArray())]",
                 "overrides": "[if(not(empty(parameters('overrides'))), parameters('overrides'), createArray())]",
-                "resourceSelectors": "[if(not(empty(parameters('resourceSelectors'))), parameters('resourceSelectors'), createArray())]"
+                "resourceSelectors": "[if(not(empty(parameters('resourceSelectors'))), parameters('resourceSelectors'), createArray())]",
+                "definitionVersion": "[parameters('definitionVersion')]"
               },
               "identity": "[variables('identityVar')]"
             },
-            {
+            "roleAssignment": {
               "copy": {
                 "name": "roleAssignment",
                 "count": "[length(parameters('roleDefinitionIds'))]"
@@ -1149,14 +1181,14 @@
               "name": "[guid(parameters('subscriptionId'), parameters('roleDefinitionIds')[copyIndex()], parameters('location'), parameters('name'))]",
               "properties": {
                 "roleDefinitionId": "[parameters('roleDefinitionIds')[copyIndex()]]",
-                "principalId": "[reference(subscriptionResourceId('Microsoft.Authorization/policyAssignments', parameters('name')), '2022-06-01', 'full').identity.principalId]",
+                "principalId": "[reference('policyAssignment', '2025-01-01', 'full').identity.principalId]",
                 "principalType": "ServicePrincipal"
               },
               "dependsOn": [
-                "[subscriptionResourceId('Microsoft.Authorization/policyAssignments', parameters('name'))]"
+                "policyAssignment"
               ]
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",
@@ -1170,7 +1202,7 @@
               "metadata": {
                 "description": "Policy Assignment principal ID."
               },
-              "value": "[coalesce(tryGet(tryGet(reference(subscriptionResourceId('Microsoft.Authorization/policyAssignments', parameters('name')), '2022-06-01', 'full'), 'identity'), 'principalId'), '')]"
+              "value": "[coalesce(tryGet(tryGet(reference('policyAssignment', '2025-01-01', 'full'), 'identity'), 'principalId'), '')]"
             },
             "resourceId": {
               "type": "string",
@@ -1184,13 +1216,13 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference(subscriptionResourceId('Microsoft.Authorization/policyAssignments', parameters('name')), '2022-06-01', 'full').location]"
+              "value": "[reference('policyAssignment', '2025-01-01', 'full').location]"
             }
           }
         }
       }
     },
-    {
+    "policyAssignment_rg": {
       "condition": "[and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId'))))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
@@ -1232,16 +1264,20 @@
             "value": "[parameters('location')]"
           },
           "overrides": "[if(not(empty(parameters('overrides'))), createObject('value', parameters('overrides')), createObject('value', createArray()))]",
-          "resourceSelectors": "[if(not(empty(parameters('resourceSelectors'))), createObject('value', parameters('resourceSelectors')), createObject('value', createArray()))]"
+          "resourceSelectors": "[if(not(empty(parameters('resourceSelectors'))), createObject('value', parameters('resourceSelectors')), createObject('value', createArray()))]",
+          "definitionVersion": {
+            "value": "[parameters('definitionVersion')]"
+          }
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.32.4.45862",
-              "templateHash": "3323049503112762784"
+              "version": "0.36.1.42791",
+              "templateHash": "13003023420704428336"
             },
             "name": "Policy Assignments (Resource Group scope)",
             "description": "This module deploys a Policy Assignment at a Resource Group scope."
@@ -1361,6 +1397,13 @@
                 "description": "Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location."
               }
             },
+            "definitionVersion": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview"
+              }
+            },
             "subscriptionId": {
               "type": "string",
               "defaultValue": "[subscription().subscriptionId]",
@@ -1379,10 +1422,10 @@
           "variables": {
             "identityVar": "[if(equals(parameters('identity'), 'SystemAssigned'), createObject('type', parameters('identity')), if(equals(parameters('identity'), 'UserAssigned'), createObject('type', parameters('identity'), 'userAssignedIdentities', createObject(format('{0}', parameters('userAssignedIdentityId')), createObject())), null()))]"
           },
-          "resources": [
-            {
+          "resources": {
+            "policyAssignment": {
               "type": "Microsoft.Authorization/policyAssignments",
-              "apiVersion": "2022-06-01",
+              "apiVersion": "2025-01-01",
               "name": "[parameters('name')]",
               "location": "[parameters('location')]",
               "properties": {
@@ -1395,11 +1438,12 @@
                 "enforcementMode": "[parameters('enforcementMode')]",
                 "notScopes": "[if(not(empty(parameters('notScopes'))), parameters('notScopes'), createArray())]",
                 "overrides": "[if(not(empty(parameters('overrides'))), parameters('overrides'), createArray())]",
-                "resourceSelectors": "[if(not(empty(parameters('resourceSelectors'))), parameters('resourceSelectors'), createArray())]"
+                "resourceSelectors": "[if(not(empty(parameters('resourceSelectors'))), parameters('resourceSelectors'), createArray())]",
+                "definitionVersion": "[parameters('definitionVersion')]"
               },
               "identity": "[variables('identityVar')]"
             },
-            {
+            "roleAssignment": {
               "copy": {
                 "name": "roleAssignment",
                 "count": "[length(parameters('roleDefinitionIds'))]"
@@ -1410,14 +1454,14 @@
               "name": "[guid(parameters('subscriptionId'), parameters('resourceGroupName'), parameters('roleDefinitionIds')[copyIndex()], parameters('location'), parameters('name'))]",
               "properties": {
                 "roleDefinitionId": "[parameters('roleDefinitionIds')[copyIndex()]]",
-                "principalId": "[reference(resourceId('Microsoft.Authorization/policyAssignments', parameters('name')), '2022-06-01', 'full').identity.principalId]",
+                "principalId": "[reference('policyAssignment', '2025-01-01', 'full').identity.principalId]",
                 "principalType": "ServicePrincipal"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Authorization/policyAssignments', parameters('name'))]"
+                "policyAssignment"
               ]
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",
@@ -1431,7 +1475,7 @@
               "metadata": {
                 "description": "Policy Assignment principal ID."
               },
-              "value": "[coalesce(tryGet(tryGet(reference(resourceId('Microsoft.Authorization/policyAssignments', parameters('name')), '2022-06-01', 'full'), 'identity'), 'principalId'), '')]"
+              "value": "[coalesce(tryGet(tryGet(reference('policyAssignment', '2025-01-01', 'full'), 'identity'), 'principalId'), '')]"
             },
             "resourceId": {
               "type": "string",
@@ -1452,41 +1496,41 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference(resourceId('Microsoft.Authorization/policyAssignments', parameters('name')), '2022-06-01', 'full').location]"
+              "value": "[reference('policyAssignment', '2025-01-01', 'full').location]"
             }
           }
         }
       }
     }
-  ],
+  },
   "outputs": {
     "name": {
       "type": "string",
       "metadata": {
         "description": "Policy Assignment Name."
       },
-      "value": "[if(and(empty(parameters('subscriptionId')), empty(parameters('resourceGroupName'))), reference(extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', parameters('managementGroupId')), 'Microsoft.Resources/deployments', format('{0}-PolicyAssignment-MG-Module', uniqueString(deployment().name, parameters('location')))), '2022-09-01').outputs.name.value, if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId(parameters('subscriptionId'), 'Microsoft.Resources/deployments', format('{0}-PolicyAssignment-Sub-Module', uniqueString(deployment().name, parameters('location')))), '2022-09-01').outputs.name.value, reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('subscriptionId'), parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-PolicyAssignment-RG-Module', uniqueString(deployment().name, parameters('location')))), '2022-09-01').outputs.name.value))]"
+      "value": "[if(and(empty(parameters('subscriptionId')), empty(parameters('resourceGroupName'))), reference('policyAssignment_mg').outputs.name.value, if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference('policyAssignment_sub').outputs.name.value, reference('policyAssignment_rg').outputs.name.value))]"
     },
     "principalId": {
       "type": "string",
       "metadata": {
         "description": "Policy Assignment principal ID."
       },
-      "value": "[if(and(empty(parameters('subscriptionId')), empty(parameters('resourceGroupName'))), reference(extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', parameters('managementGroupId')), 'Microsoft.Resources/deployments', format('{0}-PolicyAssignment-MG-Module', uniqueString(deployment().name, parameters('location')))), '2022-09-01').outputs.principalId.value, if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId(parameters('subscriptionId'), 'Microsoft.Resources/deployments', format('{0}-PolicyAssignment-Sub-Module', uniqueString(deployment().name, parameters('location')))), '2022-09-01').outputs.principalId.value, reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('subscriptionId'), parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-PolicyAssignment-RG-Module', uniqueString(deployment().name, parameters('location')))), '2022-09-01').outputs.principalId.value))]"
+      "value": "[if(and(empty(parameters('subscriptionId')), empty(parameters('resourceGroupName'))), reference('policyAssignment_mg').outputs.principalId.value, if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference('policyAssignment_sub').outputs.principalId.value, reference('policyAssignment_rg').outputs.principalId.value))]"
     },
     "resourceId": {
       "type": "string",
       "metadata": {
         "description": "Policy Assignment resource ID."
       },
-      "value": "[if(and(empty(parameters('subscriptionId')), empty(parameters('resourceGroupName'))), reference(extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', parameters('managementGroupId')), 'Microsoft.Resources/deployments', format('{0}-PolicyAssignment-MG-Module', uniqueString(deployment().name, parameters('location')))), '2022-09-01').outputs.resourceId.value, if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId(parameters('subscriptionId'), 'Microsoft.Resources/deployments', format('{0}-PolicyAssignment-Sub-Module', uniqueString(deployment().name, parameters('location')))), '2022-09-01').outputs.resourceId.value, reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('subscriptionId'), parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-PolicyAssignment-RG-Module', uniqueString(deployment().name, parameters('location')))), '2022-09-01').outputs.resourceId.value))]"
+      "value": "[if(and(empty(parameters('subscriptionId')), empty(parameters('resourceGroupName'))), reference('policyAssignment_mg').outputs.resourceId.value, if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference('policyAssignment_sub').outputs.resourceId.value, reference('policyAssignment_rg').outputs.resourceId.value))]"
     },
     "location": {
       "type": "string",
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[if(and(empty(parameters('subscriptionId')), empty(parameters('resourceGroupName'))), reference(extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', parameters('managementGroupId')), 'Microsoft.Resources/deployments', format('{0}-PolicyAssignment-MG-Module', uniqueString(deployment().name, parameters('location')))), '2022-09-01').outputs.location.value, if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId(parameters('subscriptionId'), 'Microsoft.Resources/deployments', format('{0}-PolicyAssignment-Sub-Module', uniqueString(deployment().name, parameters('location')))), '2022-09-01').outputs.location.value, reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('subscriptionId'), parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-PolicyAssignment-RG-Module', uniqueString(deployment().name, parameters('location')))), '2022-09-01').outputs.location.value))]"
+      "value": "[if(and(empty(parameters('subscriptionId')), empty(parameters('resourceGroupName'))), reference('policyAssignment_mg').outputs.location.value, if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference('policyAssignment_sub').outputs.location.value, reference('policyAssignment_rg').outputs.location.value))]"
     }
   }
 }

--- a/avm/ptn/authorization/policy-assignment/main.json
+++ b/avm/ptn/authorization/policy-assignment/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.1.42791",
-      "templateHash": "2126672396764471077"
+      "templateHash": "3232583895512445117"
     },
     "name": "Policy Assignments (All scopes)",
     "description": "This module deploys a Policy Assignment at a Management Group, Subscription or Resource Group scope."
@@ -171,7 +171,7 @@
       "type": "string",
       "nullable": true,
       "metadata": {
-        "description": "Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview"
+        "description": "Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview."
       }
     },
     "enableTelemetry": {
@@ -265,7 +265,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.36.1.42791",
-              "templateHash": "10783625542125225559"
+              "templateHash": "16571041331828455729"
             },
             "name": "Policy Assignments (Management Group scope)",
             "description": "This module deploys a Policy Assignment at a Management Group scope."
@@ -410,7 +410,7 @@
               "type": "string",
               "nullable": true,
               "metadata": {
-                "description": "Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview"
+                "description": "Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview."
               }
             }
           },
@@ -1011,7 +1011,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.36.1.42791",
-              "templateHash": "14101605250654342468"
+              "templateHash": "1309214929264356674"
             },
             "name": "Policy Assignments (Subscription scope)",
             "description": "This module deploys a Policy Assignment at a Subscription scope."
@@ -1135,7 +1135,7 @@
               "type": "string",
               "nullable": true,
               "metadata": {
-                "description": "Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview"
+                "description": "Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview."
               }
             },
             "subscriptionId": {
@@ -1277,7 +1277,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.36.1.42791",
-              "templateHash": "13003023420704428336"
+              "templateHash": "11388691241992820794"
             },
             "name": "Policy Assignments (Resource Group scope)",
             "description": "This module deploys a Policy Assignment at a Resource Group scope."
@@ -1401,7 +1401,7 @@
               "type": "string",
               "nullable": true,
               "metadata": {
-                "description": "Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview"
+                "description": "Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview."
               }
             },
             "subscriptionId": {

--- a/avm/ptn/authorization/policy-assignment/modules/management-group.bicep
+++ b/avm/ptn/authorization/policy-assignment/modules/management-group.bicep
@@ -68,7 +68,7 @@ param overrides array = []
 @sys.description('Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location.')
 param resourceSelectors array = []
 
-@sys.description('Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview')
+@sys.description('Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview.')
 param definitionVersion string?
 
 var identityVar = identity == 'SystemAssigned'

--- a/avm/ptn/authorization/policy-assignment/modules/management-group.bicep
+++ b/avm/ptn/authorization/policy-assignment/modules/management-group.bicep
@@ -68,6 +68,9 @@ param overrides array = []
 @sys.description('Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location.')
 param resourceSelectors array = []
 
+@sys.description('Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview')
+param definitionVersion string?
+
 var identityVar = identity == 'SystemAssigned'
   ? {
       type: identity
@@ -85,7 +88,7 @@ var finalArrayOfManagementGroupsToAssignRbacTo = identity == 'SystemAssigned'
   ? union(additionalManagementGroupsIDsToAssignRbacTo, [managementGroup().name])
   : []
 
-resource policyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
+resource policyAssignment 'Microsoft.Authorization/policyAssignments@2025-01-01' = {
   name: name
   location: location
   properties: {
@@ -99,6 +102,7 @@ resource policyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01'
     notScopes: !empty(notScopes) ? notScopes : []
     overrides: !empty(overrides) ? overrides : []
     resourceSelectors: !empty(resourceSelectors) ? resourceSelectors : []
+    definitionVersion: definitionVersion
   }
   identity: identityVar
 }

--- a/avm/ptn/authorization/policy-assignment/modules/resource-group.bicep
+++ b/avm/ptn/authorization/policy-assignment/modules/resource-group.bicep
@@ -59,7 +59,7 @@ param overrides array = []
 @sys.description('Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location.')
 param resourceSelectors array = []
 
-@sys.description('Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview')
+@sys.description('Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview.')
 param definitionVersion string?
 
 @sys.description('Optional. The Target Scope for the Policy. The subscription ID of the subscription for the policy assignment. If not provided, will use the current scope for deployment.')

--- a/avm/ptn/authorization/policy-assignment/modules/resource-group.bicep
+++ b/avm/ptn/authorization/policy-assignment/modules/resource-group.bicep
@@ -59,6 +59,9 @@ param overrides array = []
 @sys.description('Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location.')
 param resourceSelectors array = []
 
+@sys.description('Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview')
+param definitionVersion string?
+
 @sys.description('Optional. The Target Scope for the Policy. The subscription ID of the subscription for the policy assignment. If not provided, will use the current scope for deployment.')
 param subscriptionId string = subscription().subscriptionId
 
@@ -78,7 +81,7 @@ var identityVar = identity == 'SystemAssigned'
         }
       : null
 
-resource policyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
+resource policyAssignment 'Microsoft.Authorization/policyAssignments@2025-01-01' = {
   name: name
   location: location
   properties: {
@@ -92,6 +95,7 @@ resource policyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01'
     notScopes: !empty(notScopes) ? notScopes : []
     overrides: !empty(overrides) ? overrides : []
     resourceSelectors: !empty(resourceSelectors) ? resourceSelectors : []
+    definitionVersion: definitionVersion
   }
   identity: identityVar
 }

--- a/avm/ptn/authorization/policy-assignment/modules/subscription.bicep
+++ b/avm/ptn/authorization/policy-assignment/modules/subscription.bicep
@@ -59,7 +59,7 @@ param overrides array = []
 @sys.description('Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location.')
 param resourceSelectors array = []
 
-@sys.description('Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview')
+@sys.description('Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview.')
 param definitionVersion string?
 
 @sys.description('Optional. The Target Scope for the Policy. The subscription ID of the subscription for the policy assignment. If not provided, will use the current scope for deployment.')

--- a/avm/ptn/authorization/policy-assignment/modules/subscription.bicep
+++ b/avm/ptn/authorization/policy-assignment/modules/subscription.bicep
@@ -59,6 +59,9 @@ param overrides array = []
 @sys.description('Optional. The resource selector list to filter policies by resource properties. Facilitates safe deployment practices (SDP) by enabling gradual roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location.')
 param resourceSelectors array = []
 
+@sys.description('Optional. The policy definition version to use for the policy assignment. If not specified, the latest version of the policy definition will be used. For more information on policy assignment definition versions see https://learn.microsoft.com/azure/governance/policy/concepts/assignment-structure#policy-definition-id-and-version-preview')
+param definitionVersion string?
+
 @sys.description('Optional. The Target Scope for the Policy. The subscription ID of the subscription for the policy assignment. If not provided, will use the current scope for deployment.')
 param subscriptionId string = subscription().subscriptionId
 
@@ -75,7 +78,7 @@ var identityVar = identity == 'SystemAssigned'
         }
       : null
 
-resource policyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
+resource policyAssignment 'Microsoft.Authorization/policyAssignments@2025-01-01' = {
   name: name
   location: location
   properties: {
@@ -89,6 +92,7 @@ resource policyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01'
     notScopes: !empty(notScopes) ? notScopes : []
     overrides: !empty(overrides) ? overrides : []
     resourceSelectors: !empty(resourceSelectors) ? resourceSelectors : []
+    definitionVersion: definitionVersion
   }
   identity: identityVar
 }

--- a/avm/ptn/authorization/policy-assignment/tests/e2e/mg.max/main.test.bicep
+++ b/avm/ptn/authorization/policy-assignment/tests/e2e/mg.max/main.test.bicep
@@ -50,6 +50,7 @@ module testDeployment '../../../main.bicep' = {
     name: '${namePrefix}${serviceShort}001'
     //Configure Azure Defender for SQL agents on virtual machines
     policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
+    definitionVersion: '1.0.0-preview'
     description: '[Description] Policy Assignment at the management group scope'
     displayName: '[Display Name] Policy Assignment at the management group scope'
     enforcementMode: 'DoNotEnforce'

--- a/avm/ptn/authorization/policy-assignment/tests/e2e/mg.max/main.test.bicep
+++ b/avm/ptn/authorization/policy-assignment/tests/e2e/mg.max/main.test.bicep
@@ -50,7 +50,7 @@ module testDeployment '../../../main.bicep' = {
     name: '${namePrefix}${serviceShort}001'
     //Configure Azure Defender for SQL agents on virtual machines
     policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
-    definitionVersion: '1.0.0-preview'
+    definitionVersion: '1.*.*-preview'
     description: '[Description] Policy Assignment at the management group scope'
     displayName: '[Display Name] Policy Assignment at the management group scope'
     enforcementMode: 'DoNotEnforce'

--- a/avm/ptn/authorization/policy-assignment/tests/e2e/rg.max/main.test.bicep
+++ b/avm/ptn/authorization/policy-assignment/tests/e2e/rg.max/main.test.bicep
@@ -42,7 +42,7 @@ module nestedDependencies 'dependencies.bicep' = {
   name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
   params: {
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
-    keyVaultName: 'dep-${namePrefix}-kv-${serviceShort}'
+    keyVaultName: 'dep-${namePrefix}-kvlt-${serviceShort}'
     location: resourceLocation
   }
   dependsOn: [

--- a/avm/ptn/authorization/policy-assignment/tests/e2e/rg.max/main.test.bicep
+++ b/avm/ptn/authorization/policy-assignment/tests/e2e/rg.max/main.test.bicep
@@ -60,7 +60,7 @@ module testDeployment '../../../main.bicep' = {
     name: '${namePrefix}${serviceShort}001'
     //Configure Azure Defender for SQL agents on virtual machines
     policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
-    definitionVersion: '1.0.0-preview'
+    definitionVersion: '1.*.*-preview'
     description: '[Description] Policy Assignment at the resource group scope'
     displayName: '[Display Name] Policy Assignment at the resource group scope'
     enforcementMode: 'DoNotEnforce'

--- a/avm/ptn/authorization/policy-assignment/tests/e2e/rg.max/main.test.bicep
+++ b/avm/ptn/authorization/policy-assignment/tests/e2e/rg.max/main.test.bicep
@@ -60,6 +60,7 @@ module testDeployment '../../../main.bicep' = {
     name: '${namePrefix}${serviceShort}001'
     //Configure Azure Defender for SQL agents on virtual machines
     policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
+    definitionVersion: '1.0.0-preview'
     description: '[Description] Policy Assignment at the resource group scope'
     displayName: '[Display Name] Policy Assignment at the resource group scope'
     enforcementMode: 'DoNotEnforce'

--- a/avm/ptn/authorization/policy-assignment/tests/e2e/sub.max/main.test.bicep
+++ b/avm/ptn/authorization/policy-assignment/tests/e2e/sub.max/main.test.bicep
@@ -59,7 +59,7 @@ module testDeployment '../../../main.bicep' = {
     name: '${namePrefix}${serviceShort}001'
     //Configure Azure Defender for SQL agents on virtual machines
     policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
-    definitionVersion: '1.0.0-preview'
+    definitionVersion: '1.*.*-preview'
     description: '[Description] Policy Assignment at the subscription scope'
     displayName: '[Display Name] Policy Assignment at the subscription scope'
     enforcementMode: 'DoNotEnforce'

--- a/avm/ptn/authorization/policy-assignment/tests/e2e/sub.max/main.test.bicep
+++ b/avm/ptn/authorization/policy-assignment/tests/e2e/sub.max/main.test.bicep
@@ -59,6 +59,7 @@ module testDeployment '../../../main.bicep' = {
     name: '${namePrefix}${serviceShort}001'
     //Configure Azure Defender for SQL agents on virtual machines
     policyDefinitionId: '/providers/Microsoft.Authorization/policySetDefinitions/39a366e6-fdde-4f41-bbf8-3757f46d1611'
+    definitionVersion: '1.0.0-preview'
     description: '[Description] Policy Assignment at the subscription scope'
     displayName: '[Display Name] Policy Assignment at the subscription scope'
     enforcementMode: 'DoNotEnforce'

--- a/avm/ptn/authorization/policy-assignment/version.json
+++ b/avm/ptn/authorization/policy-assignment/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.3"
+  "version": "0.4"
 }


### PR DESCRIPTION
## Description

Add support for policy versioning on assignments

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|      [![avm.ptn.authorization.policy-assignment](https://github.com/jtracey93/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-assignment.yml/badge.svg?branch=feat%2Fadd-policy-versioning-support)](https://github.com/jtracey93/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-assignment.yml)    |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
