### PR TITLE
feat: Add `connectionPolicy` to 'avm/res/sql/server'

### DIFF
--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -24,8 +24,9 @@ This module deploys an Azure SQL Server.
 | `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2024-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/privateEndpoints/privateDnsZoneGroups) |
 | `Microsoft.Sql/servers` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers) |
 | `Microsoft.Sql/servers/auditingSettings` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/auditingSettings) |
+| `Microsoft.Sql/servers/connectionPolicies` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/connectionPolicies) |
 | `Microsoft.Sql/servers/databases` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/databases) |
-| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
+| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/databases/backupLongTermRetentionPolicies) |
 | `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/databases/backupShortTermRetentionPolicies) |
 | `Microsoft.Sql/servers/elasticPools` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/elasticPools) |
 | `Microsoft.Sql/servers/encryptionProtector` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/encryptionProtector) |
@@ -1007,7 +1008,7 @@ module server 'br/public:avm/res/sql/server:<version>' = {
     secretsExportConfiguration: {
       keyVaultResourceId: '<keyVaultResourceId>'
       sqlAdminPasswordSecretName: 'adminLoginPasswordKey'
-      sqlAzureConnectionStringSercretName: 'sqlConnectionStringKey'
+      sqlAzureConnectionStringSecretName: 'sqlConnectionStringKey'
     }
   }
 }
@@ -1052,7 +1053,7 @@ module server 'br/public:avm/res/sql/server:<version>' = {
       "value": {
         "keyVaultResourceId": "<keyVaultResourceId>",
         "sqlAdminPasswordSecretName": "adminLoginPasswordKey",
-        "sqlAzureConnectionStringSercretName": "sqlConnectionStringKey"
+        "sqlAzureConnectionStringSecretName": "sqlConnectionStringKey"
       }
     }
   }
@@ -1085,7 +1086,7 @@ param location = '<location>'
 param secretsExportConfiguration = {
   keyVaultResourceId: '<keyVaultResourceId>'
   sqlAdminPasswordSecretName: 'adminLoginPasswordKey'
-  sqlAzureConnectionStringSercretName: 'sqlConnectionStringKey'
+  sqlAzureConnectionStringSecretName: 'sqlConnectionStringKey'
 }
 ```
 
@@ -2021,6 +2022,7 @@ module server 'br/public:avm/res/sql/server:<version>' = {
       sid: '<sid>'
       tenantId: '<tenantId>'
     }
+    connectionPolicy: 'Redirect'
     customerManagedKey: {
       autoRotationEnabled: true
       keyName: '<keyName>'
@@ -2156,6 +2158,9 @@ module server 'br/public:avm/res/sql/server:<version>' = {
         "sid": "<sid>",
         "tenantId": "<tenantId>"
       }
+    },
+    "connectionPolicy": {
+      "value": "Redirect"
     },
     "customerManagedKey": {
       "value": {
@@ -2311,6 +2316,7 @@ param administrators = {
   sid: '<sid>'
   tenantId: '<tenantId>'
 }
+param connectionPolicy = 'Redirect'
 param customerManagedKey = {
   autoRotationEnabled: true
   keyName: '<keyName>'
@@ -2444,6 +2450,7 @@ param vulnerabilityAssessmentsObj = {
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`auditSettings`](#parameter-auditsettings) | object | The audit settings configuration. If you want to disable auditing, set the parmaeter to an empty object. |
+| [`connectionPolicy`](#parameter-connectionpolicy) | string | SQL logical server connection policy. |
 | [`customerManagedKey`](#parameter-customermanagedkey) | object | The customer managed key definition for server TDE. |
 | [`databases`](#parameter-databases) | array | The databases to create in the server. |
 | [`elasticPools`](#parameter-elasticpools) | array | The Elastic Pools to create in the server. |
@@ -2679,6 +2686,22 @@ Specifies the identifier key of the auditing storage account.
 - Required: No
 - Type: string
 
+### Parameter: `connectionPolicy`
+
+SQL logical server connection policy.
+
+- Required: No
+- Type: string
+- Default: `'Default'`
+- Allowed:
+  ```Bicep
+  [
+    'Default'
+    'Proxy'
+    'Redirect'
+  ]
+  ```
+
 ### Parameter: `customerManagedKey`
 
 The customer managed key definition for server TDE.
@@ -2834,33 +2857,10 @@ The long term backup retention policy for the database.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`backupStorageAccessTier`](#parameter-databasesbackuplongtermretentionpolicybackupstorageaccesstier) | string | The BackupStorageAccessTier for the LTR backups. |
-| [`makeBackupsImmutable`](#parameter-databasesbackuplongtermretentionpolicymakebackupsimmutable) | bool | The setting whether to make LTR backups immutable. |
 | [`monthlyRetention`](#parameter-databasesbackuplongtermretentionpolicymonthlyretention) | string | Monthly retention in ISO 8601 duration format. |
 | [`weeklyRetention`](#parameter-databasesbackuplongtermretentionpolicyweeklyretention) | string | Weekly retention in ISO 8601 duration format. |
 | [`weekOfYear`](#parameter-databasesbackuplongtermretentionpolicyweekofyear) | int | Week of year backup to keep for yearly retention. |
 | [`yearlyRetention`](#parameter-databasesbackuplongtermretentionpolicyyearlyretention) | string | Yearly retention in ISO 8601 duration format. |
-
-### Parameter: `databases.backupLongTermRetentionPolicy.backupStorageAccessTier`
-
-The BackupStorageAccessTier for the LTR backups.
-
-- Required: No
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'Archive'
-    'Hot'
-  ]
-  ```
-
-### Parameter: `databases.backupLongTermRetentionPolicy.makeBackupsImmutable`
-
-The setting whether to make LTR backups immutable.
-
-- Required: No
-- Type: bool
 
 ### Parameter: `databases.backupLongTermRetentionPolicy.monthlyRetention`
 

--- a/avm/res/sql/server/database/README.md
+++ b/avm/res/sql/server/database/README.md
@@ -16,7 +16,7 @@ This module deploys an Azure SQL Server Database.
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 | `Microsoft.Sql/servers/databases` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/databases) |
-| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
+| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/databases/backupLongTermRetentionPolicies) |
 | `Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/databases/backupShortTermRetentionPolicies) |
 
 ## Parameters
@@ -127,33 +127,10 @@ The long term backup retention policy to create for the database.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`backupStorageAccessTier`](#parameter-backuplongtermretentionpolicybackupstorageaccesstier) | string | The BackupStorageAccessTier for the LTR backups. |
-| [`makeBackupsImmutable`](#parameter-backuplongtermretentionpolicymakebackupsimmutable) | bool | The setting whether to make LTR backups immutable. |
 | [`monthlyRetention`](#parameter-backuplongtermretentionpolicymonthlyretention) | string | Monthly retention in ISO 8601 duration format. |
 | [`weeklyRetention`](#parameter-backuplongtermretentionpolicyweeklyretention) | string | Weekly retention in ISO 8601 duration format. |
 | [`weekOfYear`](#parameter-backuplongtermretentionpolicyweekofyear) | int | Week of year backup to keep for yearly retention. |
 | [`yearlyRetention`](#parameter-backuplongtermretentionpolicyyearlyretention) | string | Yearly retention in ISO 8601 duration format. |
-
-### Parameter: `backupLongTermRetentionPolicy.backupStorageAccessTier`
-
-The BackupStorageAccessTier for the LTR backups.
-
-- Required: No
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'Archive'
-    'Hot'
-  ]
-  ```
-
-### Parameter: `backupLongTermRetentionPolicy.makeBackupsImmutable`
-
-The setting whether to make LTR backups immutable.
-
-- Required: No
-- Type: bool
 
 ### Parameter: `backupLongTermRetentionPolicy.monthlyRetention`
 

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/README.md
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/README.md
@@ -12,7 +12,7 @@ This module deploys an Azure SQL Server Database Long-Term Backup Retention Poli
 
 | Resource Type | API Version |
 | :-- | :-- |
-| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-05-01-preview/servers/databases/backupLongTermRetentionPolicies) |
+| `Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies` | [2023-08-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Sql/2023-08-01/servers/databases/backupLongTermRetentionPolicies) |
 
 ## Parameters
 
@@ -27,8 +27,6 @@ This module deploys an Azure SQL Server Database Long-Term Backup Retention Poli
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`backupStorageAccessTier`](#parameter-backupstorageaccesstier) | string | The BackupStorageAccessTier for the LTR backups. |
-| [`makeBackupsImmutable`](#parameter-makebackupsimmutable) | bool | The setting whether to make LTR backups immutable. |
 | [`monthlyRetention`](#parameter-monthlyretention) | string | Monthly retention in ISO 8601 duration format. |
 | [`weeklyRetention`](#parameter-weeklyretention) | string | Weekly retention in ISO 8601 duration format. |
 | [`weekOfYear`](#parameter-weekofyear) | int | Week of year backup to keep for yearly retention. |
@@ -47,27 +45,6 @@ The name of the parent SQL Server.
 
 - Required: Yes
 - Type: string
-
-### Parameter: `backupStorageAccessTier`
-
-The BackupStorageAccessTier for the LTR backups.
-
-- Required: No
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'Archive'
-    'Hot'
-  ]
-  ```
-
-### Parameter: `makeBackupsImmutable`
-
-The setting whether to make LTR backups immutable.
-
-- Required: No
-- Type: bool
 
 ### Parameter: `monthlyRetention`
 

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/main.bicep
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/main.bicep
@@ -7,12 +7,6 @@ param serverName string
 @description('Required. The name of the parent database.')
 param databaseName string
 
-@description('Optional. The BackupStorageAccessTier for the LTR backups.')
-param backupStorageAccessTier 'Archive' | 'Hot'?
-
-@description('Optional. The setting whether to make LTR backups immutable.')
-param makeBackupsImmutable bool?
-
 @description('Optional. Monthly retention in ISO 8601 duration format.')
 param monthlyRetention string?
 
@@ -33,12 +27,10 @@ resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   }
 }
 
-resource backupLongTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@2023-05-01-preview' = {
+resource backupLongTermRetentionPolicy 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@2023-08-01' = {
   name: 'default'
   parent: server::database
   properties: {
-    backupStorageAccessTier: backupStorageAccessTier
-    makeBackupsImmutable: makeBackupsImmutable
     monthlyRetention: monthlyRetention
     weeklyRetention: weeklyRetention
     weekOfYear: weekOfYear

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.1.42791",
-      "templateHash": "101116542806833061"
+      "templateHash": "10140872033464442933"
     },
     "name": "SQL Server Database Long Term Backup Retention Policies",
     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."
@@ -22,24 +22,6 @@
       "type": "string",
       "metadata": {
         "description": "Required. The name of the parent database."
-      }
-    },
-    "backupStorageAccessTier": {
-      "type": "string",
-      "allowedValues": [
-        "Archive",
-        "Hot"
-      ],
-      "nullable": true,
-      "metadata": {
-        "description": "Optional. The BackupStorageAccessTier for the LTR backups."
-      }
-    },
-    "makeBackupsImmutable": {
-      "type": "bool",
-      "nullable": true,
-      "metadata": {
-        "description": "Optional. The setting whether to make LTR backups immutable."
       }
     },
     "monthlyRetention": {
@@ -86,11 +68,9 @@
     },
     "backupLongTermRetentionPolicy": {
       "type": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies",
-      "apiVersion": "2023-05-01-preview",
+      "apiVersion": "2023-08-01",
       "name": "[format('{0}/{1}/{2}', parameters('serverName'), parameters('databaseName'), 'default')]",
       "properties": {
-        "backupStorageAccessTier": "[parameters('backupStorageAccessTier')]",
-        "makeBackupsImmutable": "[parameters('makeBackupsImmutable')]",
         "monthlyRetention": "[parameters('monthlyRetention')]",
         "weeklyRetention": "[parameters('weeklyRetention')]",
         "weekOfYear": "[parameters('weekOfYear')]",

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -289,8 +289,6 @@ module database_backupLongTermRetentionPolicy 'backup-long-term-retention-policy
   params: {
     serverName: serverName
     databaseName: database.name
-    backupStorageAccessTier: backupLongTermRetentionPolicy.?backupStorageAccessTier
-    makeBackupsImmutable: backupLongTermRetentionPolicy.?makeBackupsImmutable
     weeklyRetention: backupLongTermRetentionPolicy.?weeklyRetention
     monthlyRetention: backupLongTermRetentionPolicy.?monthlyRetention
     yearlyRetention: backupLongTermRetentionPolicy.?yearlyRetention
@@ -350,12 +348,6 @@ type shortTermBackupRetentionPolicyType = {
 @export()
 @description('The long-term backup retention policy for the database.')
 type longTermBackupRetentionPolicyType = {
-  @description('Optional. The BackupStorageAccessTier for the LTR backups.')
-  backupStorageAccessTier: 'Archive' | 'Hot'?
-
-  @description('Optional. The setting whether to make LTR backups immutable.')
-  makeBackupsImmutable: bool?
-
   @description('Optional. Monthly retention in ISO 8601 duration format.')
   monthlyRetention: string?
 

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.1.42791",
-      "templateHash": "15961431104919711857"
+      "templateHash": "13916745959726876819"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database."
@@ -81,24 +81,6 @@
     "longTermBackupRetentionPolicyType": {
       "type": "object",
       "properties": {
-        "backupStorageAccessTier": {
-          "type": "string",
-          "allowedValues": [
-            "Archive",
-            "Hot"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The BackupStorageAccessTier for the LTR backups."
-          }
-        },
-        "makeBackupsImmutable": {
-          "type": "bool",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The setting whether to make LTR backups immutable."
-          }
-        },
         "monthlyRetention": {
           "type": "string",
           "nullable": true,
@@ -949,12 +931,6 @@
           "databaseName": {
             "value": "[parameters('name')]"
           },
-          "backupStorageAccessTier": {
-            "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'backupStorageAccessTier')]"
-          },
-          "makeBackupsImmutable": {
-            "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'makeBackupsImmutable')]"
-          },
           "weeklyRetention": {
             "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'weeklyRetention')]"
           },
@@ -976,7 +952,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.36.1.42791",
-              "templateHash": "101116542806833061"
+              "templateHash": "10140872033464442933"
             },
             "name": "SQL Server Database Long Term Backup Retention Policies",
             "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."
@@ -992,24 +968,6 @@
               "type": "string",
               "metadata": {
                 "description": "Required. The name of the parent database."
-              }
-            },
-            "backupStorageAccessTier": {
-              "type": "string",
-              "allowedValues": [
-                "Archive",
-                "Hot"
-              ],
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. The BackupStorageAccessTier for the LTR backups."
-              }
-            },
-            "makeBackupsImmutable": {
-              "type": "bool",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. The setting whether to make LTR backups immutable."
               }
             },
             "monthlyRetention": {
@@ -1056,11 +1014,9 @@
             },
             "backupLongTermRetentionPolicy": {
               "type": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies",
-              "apiVersion": "2023-05-01-preview",
+              "apiVersion": "2023-08-01",
               "name": "[format('{0}/{1}/{2}', parameters('serverName'), parameters('databaseName'), 'default')]",
               "properties": {
-                "backupStorageAccessTier": "[parameters('backupStorageAccessTier')]",
-                "makeBackupsImmutable": "[parameters('makeBackupsImmutable')]",
                 "monthlyRetention": "[parameters('monthlyRetention')]",
                 "weeklyRetention": "[parameters('weeklyRetention')]",
                 "weekOfYear": "[parameters('weekOfYear')]",

--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -101,6 +101,14 @@ param publicNetworkAccess string = ''
 ])
 param restrictOutboundNetworkAccess string?
 
+@description('Optional. SQL logical server connection policy.')
+@allowed([
+  'Default'
+  'Redirect'
+  'Proxy'
+])
+param connectionPolicy string = 'Default'
+
 var formattedUserAssignedIdentities = reduce(
   map((managedIdentities.?userAssignedResourceIds ?? []), (id) => { '${id}': {} }),
   {},
@@ -567,6 +575,14 @@ module failover_groups 'failover-group/main.bicep' = [
     ]
   }
 ]
+
+resource server_connection_policy 'Microsoft.Sql/servers/connectionPolicies@2023-08-01' = {
+  name: 'default'
+  parent: server
+  properties: {
+    connectionType: connectionPolicy
+  }
+}
 
 @description('The name of the deployed SQL server.')
 output name string = server.name

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.1.42791",
-      "templateHash": "441156217882584740"
+      "templateHash": "7337014448560608719"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -1359,24 +1359,6 @@
     "longTermBackupRetentionPolicyType": {
       "type": "object",
       "properties": {
-        "backupStorageAccessTier": {
-          "type": "string",
-          "allowedValues": [
-            "Archive",
-            "Hot"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The BackupStorageAccessTier for the LTR backups."
-          }
-        },
-        "makeBackupsImmutable": {
-          "type": "bool",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The setting whether to make LTR backups immutable."
-          }
-        },
         "monthlyRetention": {
           "type": "string",
           "nullable": true,
@@ -2113,6 +2095,18 @@
         "description": "Optional. Whether or not to restrict outbound network access for this server."
       }
     },
+    "connectionPolicy": {
+      "type": "string",
+      "defaultValue": "Default",
+      "allowedValues": [
+        "Default",
+        "Redirect",
+        "Proxy"
+      ],
+      "metadata": {
+        "description": "Optional. SQL logical server connection policy."
+      }
+    },
     "vulnerabilityAssessmentsObj": {
       "$ref": "#/definitions/vulnerabilityAssessmentType",
       "nullable": true,
@@ -2272,6 +2266,17 @@
         "server"
       ]
     },
+    "server_connection_policy": {
+      "type": "Microsoft.Sql/servers/connectionPolicies",
+      "apiVersion": "2023-08-01",
+      "name": "[format('{0}/{1}', parameters('name'), 'default')]",
+      "properties": {
+        "connectionType": "[parameters('connectionPolicy')]"
+      },
+      "dependsOn": [
+        "server"
+      ]
+    },
     "server_databases": {
       "copy": {
         "name": "server_databases",
@@ -2421,7 +2426,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.36.1.42791",
-              "templateHash": "15961431104919711857"
+              "templateHash": "13916745959726876819"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database."
@@ -2496,24 +2501,6 @@
             "longTermBackupRetentionPolicyType": {
               "type": "object",
               "properties": {
-                "backupStorageAccessTier": {
-                  "type": "string",
-                  "allowedValues": [
-                    "Archive",
-                    "Hot"
-                  ],
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The BackupStorageAccessTier for the LTR backups."
-                  }
-                },
-                "makeBackupsImmutable": {
-                  "type": "bool",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. The setting whether to make LTR backups immutable."
-                  }
-                },
                 "monthlyRetention": {
                   "type": "string",
                   "nullable": true,
@@ -3364,12 +3351,6 @@
                   "databaseName": {
                     "value": "[parameters('name')]"
                   },
-                  "backupStorageAccessTier": {
-                    "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'backupStorageAccessTier')]"
-                  },
-                  "makeBackupsImmutable": {
-                    "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'makeBackupsImmutable')]"
-                  },
                   "weeklyRetention": {
                     "value": "[tryGet(parameters('backupLongTermRetentionPolicy'), 'weeklyRetention')]"
                   },
@@ -3391,7 +3372,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.36.1.42791",
-                      "templateHash": "101116542806833061"
+                      "templateHash": "10140872033464442933"
                     },
                     "name": "SQL Server Database Long Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."
@@ -3407,24 +3388,6 @@
                       "type": "string",
                       "metadata": {
                         "description": "Required. The name of the parent database."
-                      }
-                    },
-                    "backupStorageAccessTier": {
-                      "type": "string",
-                      "allowedValues": [
-                        "Archive",
-                        "Hot"
-                      ],
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. The BackupStorageAccessTier for the LTR backups."
-                      }
-                    },
-                    "makeBackupsImmutable": {
-                      "type": "bool",
-                      "nullable": true,
-                      "metadata": {
-                        "description": "Optional. The setting whether to make LTR backups immutable."
                       }
                     },
                     "monthlyRetention": {
@@ -3471,11 +3434,9 @@
                     },
                     "backupLongTermRetentionPolicy": {
                       "type": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies",
-                      "apiVersion": "2023-05-01-preview",
+                      "apiVersion": "2023-08-01",
                       "name": "[format('{0}/{1}/{2}', parameters('serverName'), parameters('databaseName'), 'default')]",
                       "properties": {
-                        "backupStorageAccessTier": "[parameters('backupStorageAccessTier')]",
-                        "makeBackupsImmutable": "[parameters('makeBackupsImmutable')]",
                         "monthlyRetention": "[parameters('monthlyRetention')]",
                         "weeklyRetention": "[parameters('weeklyRetention')]",
                         "weekOfYear": "[parameters('weekOfYear')]",

--- a/avm/res/sql/server/tests/e2e/admin/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/admin/dependencies.bicep
@@ -4,7 +4,7 @@ param managedIdentityName string
 @description('Optional. The location to deploy resources to.')
 param location string = resourceGroup().location
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }

--- a/avm/res/sql/server/tests/e2e/admin/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/admin/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/sql/server/tests/e2e/audit/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/audit/dependencies.bicep
@@ -4,7 +4,7 @@ param storageAccountName string
 @description('Optional. The location to deploy resources to.')
 param location string = resourceGroup().location
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   name: storageAccountName
   location: location
   sku: {

--- a/avm/res/sql/server/tests/e2e/audit/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/audit/main.test.bicep
@@ -30,7 +30,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/sql/server/tests/e2e/cmk/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/cmk/dependencies.bicep
@@ -10,17 +10,17 @@ param location string = resourceGroup().location
 @description('Required. The name of the Key Vault to create.')
 param keyVaultName string
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
 
-resource dbManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource dbManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: databaseIdentityName
   location: location
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
   name: keyVaultName
   location: location
   properties: {
@@ -37,14 +37,14 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     accessPolicies: []
   }
 
-  resource key 'keys@2022-07-01' = {
+  resource key 'keys@2024-11-01' = {
     name: 'keyServerEncryptionKey'
     properties: {
       kty: 'RSA'
     }
   }
 
-  resource dbKey 'keys@2022-07-01' = {
+  resource dbKey 'keys@2024-11-01' = {
     name: 'keyDatabaseEncryptionKey'
     properties: {
       kty: 'RSA'

--- a/avm/res/sql/server/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/defaults/main.test.bicep
@@ -17,10 +17,6 @@ param resourceLocation string = deployment().location
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'ssmin'
 
-@description('Optional. The password to leverage for the login.')
-@secure()
-param password string = newGuid()
-
 @description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
 param namePrefix string = '#_namePrefix_#'
 
@@ -30,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/sql/server/tests/e2e/elasticPool/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/elasticPool/main.test.bicep
@@ -30,7 +30,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/sql/server/tests/e2e/failover-group/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/failover-group/dependencies.bicep
@@ -8,7 +8,7 @@ param location string = resourceGroup().location
 @secure()
 param password string = newGuid()
 
-resource server 'Microsoft.Sql/servers@2021-11-01' = {
+resource server 'Microsoft.Sql/servers@2023-08-01' = {
   name: serverName
   location: location
   properties: {

--- a/avm/res/sql/server/tests/e2e/failover-group/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/failover-group/main.test.bicep
@@ -32,7 +32,7 @@ var locationSecondary = 'southeastasia'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: locationPrimary
 }

--- a/avm/res/sql/server/tests/e2e/kvSecrets/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/kvSecrets/dependencies.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 @description('Required. The name of the keyVault to create.')
 param keyVaultName string
 
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
   name: keyVaultName
   location: location
   properties: {

--- a/avm/res/sql/server/tests/e2e/kvSecrets/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/kvSecrets/main.test.bicep
@@ -30,7 +30,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -61,7 +61,7 @@ module testDeployment '../../../main.bicep' = [
       secretsExportConfiguration: {
         keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
         sqlAdminPasswordSecretName: 'adminLoginPasswordKey'
-        sqlAzureConnectionStringSercretName: 'sqlConnectionStringKey'
+        sqlAzureConnectionStringSecretName: 'sqlConnectionStringKey'
       }
       databases: [
         {

--- a/avm/res/sql/server/tests/e2e/max/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/max/dependencies.bicep
@@ -15,17 +15,17 @@ param keyVaultName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource serverIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource serverIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: serverIdentityName
   location: location
 }
 
-resource databaseIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource databaseIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: databaseIdentityName
   location: location
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-07-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -43,11 +43,11 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   }
 }
 
-resource privateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+resource privateDNSZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
   name: 'privatelink${environment().suffixes.sqlServerHostname}'
   location: 'global'
 
-  resource virtualNetworkLinks 'virtualNetworkLinks@2020-06-01' = {
+  resource virtualNetworkLinks 'virtualNetworkLinks@2024-06-01' = {
     name: '${virtualNetwork.name}-vnetlink'
     location: 'global'
     properties: {
@@ -59,7 +59,7 @@ resource privateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
   }
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
   name: keyVaultName
   location: location
   properties: {
@@ -76,14 +76,14 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     accessPolicies: []
   }
 
-  resource serverKey 'keys@2022-07-01' = {
+  resource serverKey 'keys@2024-11-01' = {
     name: 'serverKeyEncryptionKey'
     properties: {
       kty: 'RSA'
     }
   }
 
-  resource databaseKey 'keys@2022-07-01' = {
+  resource databaseKey 'keys@2024-11-01' = {
     name: 'databaseKeyEncryptionKey'
     properties: {
       kty: 'RSA'

--- a/avm/res/sql/server/tests/e2e/secondary/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/secondary/dependencies.bicep
@@ -8,7 +8,7 @@ param location string = resourceGroup().location
 @secure()
 param password string = newGuid()
 
-resource server 'Microsoft.Sql/servers@2021-11-01' = {
+resource server 'Microsoft.Sql/servers@2023-08-01' = {
   name: serverName
   location: location
   properties: {
@@ -16,7 +16,7 @@ resource server 'Microsoft.Sql/servers@2021-11-01' = {
     administratorLoginPassword: password
   }
 
-  resource database 'databases@2021-11-01' = {
+  resource database 'databases@2023-08-01' = {
     name: 'db1'
     location: location
     sku: {

--- a/avm/res/sql/server/tests/e2e/vulnAssm/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/vulnAssm/dependencies.bicep
@@ -7,12 +7,12 @@ param storageAccountName string
 @description('Optional. The location to deploy resources to.')
 param location string = resourceGroup().location
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   name: storageAccountName
   location: location
   sku: {

--- a/avm/res/sql/server/tests/e2e/vulnAssm/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/vulnAssm/main.test.bicep
@@ -30,7 +30,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/sql/server/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/waf-aligned/dependencies.bicep
@@ -12,12 +12,12 @@ param keyVaultName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-07-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -35,11 +35,11 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   }
 }
 
-resource privateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+resource privateDNSZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
   name: 'privatelink${environment().suffixes.sqlServerHostname}'
   location: 'global'
 
-  resource virtualNetworkLinks 'virtualNetworkLinks@2020-06-01' = {
+  resource virtualNetworkLinks 'virtualNetworkLinks@2024-06-01' = {
     name: '${virtualNetwork.name}-vnetlink'
     location: 'global'
     properties: {
@@ -51,7 +51,7 @@ resource privateDNSZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
   }
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
   name: keyVaultName
   location: location
   properties: {
@@ -68,7 +68,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     accessPolicies: []
   }
 
-  resource key 'keys@2022-07-01' = {
+  resource key 'keys@2024-11-01' = {
     name: 'keyEncryptionKey'
     properties: {
       kty: 'RSA'

--- a/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/waf-aligned/main.test.bicep
@@ -30,7 +30,7 @@ param baseTime string = utcNow('u')
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: enforcedLocation
 }
@@ -179,6 +179,7 @@ module testDeployment '../../../main.bicep' = [
         }
       ]
       restrictOutboundNetworkAccess: 'Disabled'
+      connectionPolicy: 'Redirect'
       tags: {
         'hidden-title': 'This is visible in the resource name'
         Environment: 'Non-Prod'

--- a/avm/res/sql/server/version.json
+++ b/avm/res/sql/server/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.18"
+  "version": "0.19"
 }


### PR DESCRIPTION
## Description

This PR adds a new 'connectionPolicy' parameter to 'avm/res/sql/server' module.

Further changes:
* Adding new `connectionPolicy` to WAF test
* Updating long-term-retention-policy API: pls note: this is a breaking change as the latest API removed 2 params
* Also updating all API versions in the test files

Fixes #5399 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.sql.server](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg?branch=api)](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml)   |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
