### PR TITLE
fix: res/storage/storage-account - Corrected spelling of 'secondaryAccessKey' and updated version to 0.22

### DIFF
--- a/avm/res/storage/storage-account/README.md
+++ b/avm/res/storage/storage-account/README.md
@@ -4851,8 +4851,8 @@ Tags of the resource.
 | `privateEndpoints` | array | The private endpoints of the Storage Account. |
 | `resourceGroupName` | string | The resource group of the deployed storage account. |
 | `resourceId` | string | The resource ID of the deployed storage account. |
+| `secondaryAccessKey` | securestring | The secondary access key of the storage account. |
 | `secondaryConnectionString` | securestring | The secondary connection string of the storage account. |
-| `secondayAccessKey` | securestring | The secondary access key of the storage account. |
 | `serviceEndpoints` | object | All service endpoints of the deployed storage account, Note Standard_LRS and Standard_ZRS accounts only have a blob service endpoint. |
 | `systemAssignedMIPrincipalId` | string | The principal ID of the system assigned identity. |
 

--- a/avm/res/storage/storage-account/main.bicep
+++ b/avm/res/storage/storage-account/main.bicep
@@ -737,7 +737,7 @@ output primaryAccessKey string = storageAccount.listKeys().keys[0].value
 
 @secure()
 @description('The secondary access key of the storage account.')
-output secondayAccessKey string = storageAccount.listKeys().keys[1].value
+output secondaryAccessKey string = storageAccount.listKeys().keys[1].value
 
 @secure()
 @description('The primary connection string of the storage account.')

--- a/avm/res/storage/storage-account/main.json
+++ b/avm/res/storage/storage-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.1.42791",
-      "templateHash": "11420853700547056365"
+      "templateHash": "2002035157037571974"
     },
     "name": "Storage Accounts",
     "description": "This module deploys a Storage Account."
@@ -5672,7 +5672,7 @@
       },
       "value": "[listKeys('storageAccount', '2024-01-01').keys[0].value]"
     },
-    "secondayAccessKey": {
+    "secondaryAccessKey": {
       "type": "securestring",
       "metadata": {
         "description": "The secondary access key of the storage account."

--- a/avm/res/storage/storage-account/version.json
+++ b/avm/res/storage/storage-account/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.21"
+  "version": "0.22"
 }


### PR DESCRIPTION
## Description
fix: Corrected spelling of 'secondaryAccessKey' and updated version to 0.22

Fixes #5438
Closes #5438

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Fixes #456
Closes #123
Closes #456
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.storage.storage-account](https://github.com/ktremain/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml/badge.svg?branch=kt%2F5438-typo_fix)](https://github.com/ktremain/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
