### PR TITLE
fix: links to changelogs

### DIFF
--- a/avm/ptn/aca-lza/hosting-environment/CHANGELOG.md
+++ b/avm/ptn/aca-lza/hosting-environment/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/aca-lza/hosting-environment/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/aca-lza/hosting-environment/CHANGELOG.md).
 
 ## 0.6.1
 

--- a/avm/ptn/ai-platform/baseline/CHANGELOG.md
+++ b/avm/ptn/ai-platform/baseline/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/ai-platform/baseline/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/ai-platform/baseline/CHANGELOG.md).
 
 ## 0.6.5
 

--- a/avm/ptn/alz/empty/CHANGELOG.md
+++ b/avm/ptn/alz/empty/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/alz/empty/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/alz/empty/CHANGELOG.md).
 
 ## 0.2.0
 

--- a/avm/ptn/app-service-lza/hosting-environment/CHANGELOG.md
+++ b/avm/ptn/app-service-lza/hosting-environment/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/app-service-lza/hosting-environment/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/app-service-lza/hosting-environment/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/ptn/app/container-job-toolkit/CHANGELOG.md
+++ b/avm/ptn/app/container-job-toolkit/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/app/container-job-toolkit/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/app/container-job-toolkit/CHANGELOG.md).
 
 ## 0.1.2
 

--- a/avm/ptn/authorization/pim-role-assignment/CHANGELOG.md
+++ b/avm/ptn/authorization/pim-role-assignment/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/pim-role-assignment/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/pim-role-assignment/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/ptn/authorization/policy-assignment/CHANGELOG.md
+++ b/avm/ptn/authorization/policy-assignment/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/policy-assignment/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/policy-assignment/CHANGELOG.md).
 
 ## 0.4.0
 

--- a/avm/ptn/authorization/policy-exemption/CHANGELOG.md
+++ b/avm/ptn/authorization/policy-exemption/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/policy-exemption/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/policy-exemption/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/ptn/authorization/resource-role-assignment/CHANGELOG.md
+++ b/avm/ptn/authorization/resource-role-assignment/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/resource-role-assignment/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/resource-role-assignment/CHANGELOG.md).
 
 ## 0.1.2
 

--- a/avm/ptn/authorization/role-assignment/CHANGELOG.md
+++ b/avm/ptn/authorization/role-assignment/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/role-assignment/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/role-assignment/CHANGELOG.md).
 
 ## 0.2.2
 

--- a/avm/ptn/authorization/role-definition/CHANGELOG.md
+++ b/avm/ptn/authorization/role-definition/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/role-definition/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/role-definition/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/ptn/azd/acr-container-app/CHANGELOG.md
+++ b/avm/ptn/azd/acr-container-app/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/acr-container-app/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/acr-container-app/CHANGELOG.md).
 
 ## 0.1.2
 

--- a/avm/ptn/azd/aks-automatic-cluster/CHANGELOG.md
+++ b/avm/ptn/azd/aks-automatic-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/aks-automatic-cluster/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/aks-automatic-cluster/CHANGELOG.md).
 
 ## 0.2.0
 

--- a/avm/ptn/azd/aks/CHANGELOG.md
+++ b/avm/ptn/azd/aks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/aks/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/aks/CHANGELOG.md).
 
 ## 0.2.0
 

--- a/avm/ptn/azd/apim-api/CHANGELOG.md
+++ b/avm/ptn/azd/apim-api/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/apim-api/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/apim-api/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/ptn/azd/container-app-upsert/CHANGELOG.md
+++ b/avm/ptn/azd/container-app-upsert/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/container-app-upsert/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/container-app-upsert/CHANGELOG.md).
 
 ## 0.1.2
 

--- a/avm/ptn/azd/container-apps-stack/CHANGELOG.md
+++ b/avm/ptn/azd/container-apps-stack/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/container-apps-stack/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/container-apps-stack/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/ptn/azd/insights-dashboard/CHANGELOG.md
+++ b/avm/ptn/azd/insights-dashboard/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/insights-dashboard/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/insights-dashboard/CHANGELOG.md).
 
 ## 0.1.2
 

--- a/avm/ptn/azd/ml-ai-environment/CHANGELOG.md
+++ b/avm/ptn/azd/ml-ai-environment/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/ml-ai-environment/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/ml-ai-environment/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/ptn/azd/ml-hub-dependencies/CHANGELOG.md
+++ b/avm/ptn/azd/ml-hub-dependencies/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/ml-hub-dependencies/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/ml-hub-dependencies/CHANGELOG.md).
 
 ## 0.2.0
 

--- a/avm/ptn/azd/ml-project/CHANGELOG.md
+++ b/avm/ptn/azd/ml-project/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/ml-project/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/ml-project/CHANGELOG.md).
 
 ## 0.1.3
 

--- a/avm/ptn/azd/monitoring/CHANGELOG.md
+++ b/avm/ptn/azd/monitoring/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/monitoring/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/monitoring/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/ptn/data/private-analytical-workspace/CHANGELOG.md
+++ b/avm/ptn/data/private-analytical-workspace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/data/private-analytical-workspace/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/data/private-analytical-workspace/CHANGELOG.md).
 
 ## 0.1.2
 

--- a/avm/ptn/deployment-script/import-image-to-acr/CHANGELOG.md
+++ b/avm/ptn/deployment-script/import-image-to-acr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/deployment-script/import-image-to-acr/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/deployment-script/import-image-to-acr/CHANGELOG.md).
 
 ## 0.4.4
 

--- a/avm/ptn/dev-ops/cicd-agents-and-runners/CHANGELOG.md
+++ b/avm/ptn/dev-ops/cicd-agents-and-runners/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/dev-ops/cicd-agents-and-runners/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/dev-ops/cicd-agents-and-runners/CHANGELOG.md).
 
 ## 0.2.3
 

--- a/avm/ptn/finops-toolkit/finops-hub/CHANGELOG.md
+++ b/avm/ptn/finops-toolkit/finops-hub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/finops-toolkit/finops-hub/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/finops-toolkit/finops-hub/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/ptn/lz/sub-vending/CHANGELOG.md
+++ b/avm/ptn/lz/sub-vending/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/lz/sub-vending/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/lz/sub-vending/CHANGELOG.md).
 
 ## 0.3.4
 

--- a/avm/ptn/mgmt-groups/subscription-placement/CHANGELOG.md
+++ b/avm/ptn/mgmt-groups/subscription-placement/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/mgmt-groups/subscription-placement/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/mgmt-groups/subscription-placement/CHANGELOG.md).
 
 ## 0.2.0
 

--- a/avm/ptn/network/hub-networking/CHANGELOG.md
+++ b/avm/ptn/network/hub-networking/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/network/hub-networking/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/network/hub-networking/CHANGELOG.md).
 
 ## 0.4.0
 

--- a/avm/ptn/network/private-link-private-dns-zones/CHANGELOG.md
+++ b/avm/ptn/network/private-link-private-dns-zones/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/network/private-link-private-dns-zones/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/network/private-link-private-dns-zones/CHANGELOG.md).
 
 ## 0.6.0
 

--- a/avm/ptn/policy-insights/remediation/CHANGELOG.md
+++ b/avm/ptn/policy-insights/remediation/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/policy-insights/remediation/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/policy-insights/remediation/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/ptn/sa/conversation-knowledge-mining/CHANGELOG.md
+++ b/avm/ptn/sa/conversation-knowledge-mining/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/sa/conversation-knowledge-mining/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/sa/conversation-knowledge-mining/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/ptn/sa/multi-agent-custom-automation-engine/CHANGELOG.md
+++ b/avm/ptn/sa/multi-agent-custom-automation-engine/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/sa/multi-agent-custom-automation-engine/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/sa/multi-agent-custom-automation-engine/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/ptn/security/security-center/CHANGELOG.md
+++ b/avm/ptn/security/security-center/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/security/security-center/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/security/security-center/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/ptn/subscription/service-health-alerts/CHANGELOG.md
+++ b/avm/ptn/subscription/service-health-alerts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/subscription/service-health-alerts/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/subscription/service-health-alerts/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/ptn/virtual-machine-images/azure-image-builder/CHANGELOG.md
+++ b/avm/ptn/virtual-machine-images/azure-image-builder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/ptn/virtual-machine-images/azure-image-builder/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/virtual-machine-images/azure-image-builder/CHANGELOG.md).
 
 ## 0.1.6
 

--- a/avm/res/aad/domain-service/CHANGELOG.md
+++ b/avm/res/aad/domain-service/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/aad/domain-service/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/aad/domain-service/CHANGELOG.md).
 
 ## 0.4.0
 

--- a/avm/res/alerts-management/action-rule/CHANGELOG.md
+++ b/avm/res/alerts-management/action-rule/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/alerts-management/action-rule/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/alerts-management/action-rule/CHANGELOG.md).
 
 ## 0.2.3
 

--- a/avm/res/analysis-services/server/CHANGELOG.md
+++ b/avm/res/analysis-services/server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/analysis-services/server/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/analysis-services/server/CHANGELOG.md).
 
 ## 0.3.3
 

--- a/avm/res/api-management/service/CHANGELOG.md
+++ b/avm/res/api-management/service/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/api-management/service/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/api-management/service/CHANGELOG.md).
 
 ## 0.9.1
 

--- a/avm/res/app-configuration/configuration-store/CHANGELOG.md
+++ b/avm/res/app-configuration/configuration-store/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/app-configuration/configuration-store/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/app-configuration/configuration-store/CHANGELOG.md).
 
 ## 0.6.3
 

--- a/avm/res/app/container-app/CHANGELOG.md
+++ b/avm/res/app/container-app/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/app/container-app/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/app/container-app/CHANGELOG.md).
 
 ## 0.17.0
 

--- a/avm/res/app/job/CHANGELOG.md
+++ b/avm/res/app/job/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/app/job/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/app/job/CHANGELOG.md).
 
 ## 0.6.0
 

--- a/avm/res/app/managed-environment/CHANGELOG.md
+++ b/avm/res/app/managed-environment/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/app/managed-environment/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/app/managed-environment/CHANGELOG.md).
 
 ## 0.11.2
 

--- a/avm/res/app/session-pool/CHANGELOG.md
+++ b/avm/res/app/session-pool/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/app/session-pool/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/app/session-pool/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/authorization/role-assignment/mg-scope/CHANGELOG.md
+++ b/avm/res/authorization/role-assignment/mg-scope/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/authorization/role-assignment/mg-scope/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/authorization/role-assignment/mg-scope/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/authorization/role-assignment/rg-scope/CHANGELOG.md
+++ b/avm/res/authorization/role-assignment/rg-scope/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/authorization/role-assignment/rg-scope/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/authorization/role-assignment/rg-scope/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/authorization/role-assignment/sub-scope/CHANGELOG.md
+++ b/avm/res/authorization/role-assignment/sub-scope/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/authorization/role-assignment/sub-scope/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/authorization/role-assignment/sub-scope/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/automation/automation-account/CHANGELOG.md
+++ b/avm/res/automation/automation-account/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/automation/automation-account/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/automation/automation-account/CHANGELOG.md).
 
 ## 0.14.1
 

--- a/avm/res/automation/automation-account/CHANGELOG.md
+++ b/avm/res/automation/automation-account/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/automation/automation-account/CHANGELOG.md).
+The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/automation/automation-account/CHANGELOG.md).
 
 ## 0.14.1
 

--- a/avm/res/azure-stack-hci/cluster/CHANGELOG.md
+++ b/avm/res/azure-stack-hci/cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/azure-stack-hci/cluster/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/azure-stack-hci/cluster/CHANGELOG.md).
 
 ## 0.1.8
 

--- a/avm/res/azure-stack-hci/logical-network/CHANGELOG.md
+++ b/avm/res/azure-stack-hci/logical-network/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/azure-stack-hci/logical-network/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/azure-stack-hci/logical-network/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/res/azure-stack-hci/network-interface/CHANGELOG.md
+++ b/avm/res/azure-stack-hci/network-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/azure-stack-hci/network-interface/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/azure-stack-hci/network-interface/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/res/azure-stack-hci/virtual-hard-disk/CHANGELOG.md
+++ b/avm/res/azure-stack-hci/virtual-hard-disk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/azure-stack-hci/virtual-hard-disk/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/azure-stack-hci/virtual-hard-disk/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/batch/batch-account/CHANGELOG.md
+++ b/avm/res/batch/batch-account/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/batch/batch-account/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/batch/batch-account/CHANGELOG.md).
 
 ## 0.10.3
 

--- a/avm/res/cache/redis-enterprise/CHANGELOG.md
+++ b/avm/res/cache/redis-enterprise/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/cache/redis-enterprise/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cache/redis-enterprise/CHANGELOG.md).
 
 ## 0.2.0
 

--- a/avm/res/cache/redis/CHANGELOG.md
+++ b/avm/res/cache/redis/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/cache/redis/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cache/redis/CHANGELOG.md).
 
 ## 0.15.0
 

--- a/avm/res/cdn/profile/CHANGELOG.md
+++ b/avm/res/cdn/profile/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/CHANGELOG.md).
 
 ## 0.13.0
 

--- a/avm/res/cognitive-services/account/CHANGELOG.md
+++ b/avm/res/cognitive-services/account/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/cognitive-services/account/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cognitive-services/account/CHANGELOG.md).
 
 ## 0.11.0
 

--- a/avm/res/communication/communication-service/CHANGELOG.md
+++ b/avm/res/communication/communication-service/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/communication/communication-service/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/communication/communication-service/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/communication/email-service/CHANGELOG.md
+++ b/avm/res/communication/email-service/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/communication/email-service/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/communication/email-service/CHANGELOG.md).
 
 ## 0.3.3
 

--- a/avm/res/compute/availability-set/CHANGELOG.md
+++ b/avm/res/compute/availability-set/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/compute/availability-set/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/availability-set/CHANGELOG.md).
 
 ## 0.2.2
 

--- a/avm/res/compute/disk-encryption-set/CHANGELOG.md
+++ b/avm/res/compute/disk-encryption-set/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/compute/disk-encryption-set/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/disk-encryption-set/CHANGELOG.md).
 
 ## 0.4.1
 

--- a/avm/res/compute/disk/CHANGELOG.md
+++ b/avm/res/compute/disk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/compute/disk/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/disk/CHANGELOG.md).
 
 ## 0.4.3
 

--- a/avm/res/compute/gallery/CHANGELOG.md
+++ b/avm/res/compute/gallery/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/compute/gallery/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/gallery/CHANGELOG.md).
 
 ## 0.9.2
 

--- a/avm/res/compute/image/CHANGELOG.md
+++ b/avm/res/compute/image/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/compute/image/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/image/CHANGELOG.md).
 
 ## 0.3.2
 

--- a/avm/res/compute/proximity-placement-group/CHANGELOG.md
+++ b/avm/res/compute/proximity-placement-group/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/compute/proximity-placement-group/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/proximity-placement-group/CHANGELOG.md).
 
 ## 0.3.2
 

--- a/avm/res/compute/ssh-public-key/CHANGELOG.md
+++ b/avm/res/compute/ssh-public-key/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/compute/ssh-public-key/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/ssh-public-key/CHANGELOG.md).
 
 ## 0.4.3
 

--- a/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
+++ b/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md).
 
 ## 0.8.1
 

--- a/avm/res/compute/virtual-machine/CHANGELOG.md
+++ b/avm/res/compute/virtual-machine/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/compute/virtual-machine/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/virtual-machine/CHANGELOG.md).
 
 ## 0.15.0
 

--- a/avm/res/consumption/budget/CHANGELOG.md
+++ b/avm/res/consumption/budget/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/consumption/budget/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/consumption/budget/CHANGELOG.md).
 
 ## 0.3.7
 

--- a/avm/res/container-instance/container-group/CHANGELOG.md
+++ b/avm/res/container-instance/container-group/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/container-instance/container-group/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/container-instance/container-group/CHANGELOG.md).
 
 ## 0.6.0
 

--- a/avm/res/container-registry/registry/CHANGELOG.md
+++ b/avm/res/container-registry/registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/container-registry/registry/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/container-registry/registry/CHANGELOG.md).
 
 ## 0.9.1
 

--- a/avm/res/container-service/managed-cluster/CHANGELOG.md
+++ b/avm/res/container-service/managed-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/container-service/managed-cluster/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/container-service/managed-cluster/CHANGELOG.md).
 
 ## 0.9.0
 

--- a/avm/res/data-factory/factory/CHANGELOG.md
+++ b/avm/res/data-factory/factory/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/data-factory/factory/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/data-factory/factory/CHANGELOG.md).
 
 ## 0.10.2
 

--- a/avm/res/data-protection/backup-vault/CHANGELOG.md
+++ b/avm/res/data-protection/backup-vault/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/data-protection/backup-vault/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/data-protection/backup-vault/CHANGELOG.md).
 
 ## 0.12.0
 

--- a/avm/res/databricks/access-connector/CHANGELOG.md
+++ b/avm/res/databricks/access-connector/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/databricks/access-connector/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/databricks/access-connector/CHANGELOG.md).
 
 ## 0.4.2
 

--- a/avm/res/databricks/workspace/CHANGELOG.md
+++ b/avm/res/databricks/workspace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/databricks/workspace/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/databricks/workspace/CHANGELOG.md).
 
 ## 0.11.2
 

--- a/avm/res/db-for-my-sql/flexible-server/CHANGELOG.md
+++ b/avm/res/db-for-my-sql/flexible-server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/db-for-my-sql/flexible-server/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/db-for-my-sql/flexible-server/CHANGELOG.md).
 
 ## 0.8.0
 

--- a/avm/res/db-for-postgre-sql/flexible-server/CHANGELOG.md
+++ b/avm/res/db-for-postgre-sql/flexible-server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/db-for-postgre-sql/flexible-server/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/db-for-postgre-sql/flexible-server/CHANGELOG.md).
 
 ## 0.12.0
 

--- a/avm/res/desktop-virtualization/application-group/CHANGELOG.md
+++ b/avm/res/desktop-virtualization/application-group/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/desktop-virtualization/application-group/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/desktop-virtualization/application-group/CHANGELOG.md).
 
 ## 0.3.3
 

--- a/avm/res/desktop-virtualization/host-pool/CHANGELOG.md
+++ b/avm/res/desktop-virtualization/host-pool/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/desktop-virtualization/host-pool/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/desktop-virtualization/host-pool/CHANGELOG.md).
 
 ## 0.6.0
 

--- a/avm/res/desktop-virtualization/scaling-plan/CHANGELOG.md
+++ b/avm/res/desktop-virtualization/scaling-plan/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/desktop-virtualization/scaling-plan/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/desktop-virtualization/scaling-plan/CHANGELOG.md).
 
 ## 0.3.2
 

--- a/avm/res/desktop-virtualization/workspace/CHANGELOG.md
+++ b/avm/res/desktop-virtualization/workspace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/desktop-virtualization/workspace/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/desktop-virtualization/workspace/CHANGELOG.md).
 
 ## 0.8.0
 

--- a/avm/res/dev-center/network-connection/CHANGELOG.md
+++ b/avm/res/dev-center/network-connection/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/dev-center/network-connection/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/dev-center/network-connection/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/dev-center/project/CHANGELOG.md
+++ b/avm/res/dev-center/project/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/dev-center/project/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/dev-center/project/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/dev-ops-infrastructure/pool/CHANGELOG.md
+++ b/avm/res/dev-ops-infrastructure/pool/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/dev-ops-infrastructure/pool/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/dev-ops-infrastructure/pool/CHANGELOG.md).
 
 ## 0.5.0
 

--- a/avm/res/dev-test-lab/lab/CHANGELOG.md
+++ b/avm/res/dev-test-lab/lab/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/dev-test-lab/lab/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/dev-test-lab/lab/CHANGELOG.md).
 
 ## 0.4.2
 

--- a/avm/res/digital-twins/digital-twins-instance/CHANGELOG.md
+++ b/avm/res/digital-twins/digital-twins-instance/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/digital-twins/digital-twins-instance/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/digital-twins/digital-twins-instance/CHANGELOG.md).
 
 ## 0.4.1
 

--- a/avm/res/document-db/database-account/CHANGELOG.md
+++ b/avm/res/document-db/database-account/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/document-db/database-account/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/document-db/database-account/CHANGELOG.md).
 
 ## 0.15.0
 

--- a/avm/res/document-db/mongo-cluster/CHANGELOG.md
+++ b/avm/res/document-db/mongo-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/document-db/mongo-cluster/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/document-db/mongo-cluster/CHANGELOG.md).
 
 ## 0.4.0
 

--- a/avm/res/elastic-san/elastic-san/CHANGELOG.md
+++ b/avm/res/elastic-san/elastic-san/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/elastic-san/elastic-san/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/elastic-san/elastic-san/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/event-grid/domain/CHANGELOG.md
+++ b/avm/res/event-grid/domain/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/event-grid/domain/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/event-grid/domain/CHANGELOG.md).
 
 ## 0.8.2
 

--- a/avm/res/event-grid/namespace/CHANGELOG.md
+++ b/avm/res/event-grid/namespace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/event-grid/namespace/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/event-grid/namespace/CHANGELOG.md).
 
 ## 0.7.2
 

--- a/avm/res/event-grid/system-topic/CHANGELOG.md
+++ b/avm/res/event-grid/system-topic/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/event-grid/system-topic/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/event-grid/system-topic/CHANGELOG.md).
 
 ## 0.6.3
 

--- a/avm/res/event-grid/topic/CHANGELOG.md
+++ b/avm/res/event-grid/topic/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/event-grid/topic/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/event-grid/topic/CHANGELOG.md).
 
 ## 0.9.0
 

--- a/avm/res/event-hub/namespace/CHANGELOG.md
+++ b/avm/res/event-hub/namespace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/event-hub/namespace/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/event-hub/namespace/CHANGELOG.md).
 
 ## 0.12.1
 

--- a/avm/res/fabric/capacity/CHANGELOG.md
+++ b/avm/res/fabric/capacity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/fabric/capacity/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/fabric/capacity/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/res/health-bot/health-bot/CHANGELOG.md
+++ b/avm/res/health-bot/health-bot/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/health-bot/health-bot/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/health-bot/health-bot/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/healthcare-apis/workspace/CHANGELOG.md
+++ b/avm/res/healthcare-apis/workspace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/healthcare-apis/workspace/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/healthcare-apis/workspace/CHANGELOG.md).
 
 ## 0.4.3
 

--- a/avm/res/hybrid-compute/gateway/CHANGELOG.md
+++ b/avm/res/hybrid-compute/gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/hybrid-compute/gateway/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/hybrid-compute/gateway/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/hybrid-compute/license/CHANGELOG.md
+++ b/avm/res/hybrid-compute/license/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/hybrid-compute/license/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/hybrid-compute/license/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/hybrid-compute/machine/CHANGELOG.md
+++ b/avm/res/hybrid-compute/machine/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/hybrid-compute/machine/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/hybrid-compute/machine/CHANGELOG.md).
 
 ## 0.4.1
 

--- a/avm/res/hybrid-container-service/provisioned-cluster-instance/CHANGELOG.md
+++ b/avm/res/hybrid-container-service/provisioned-cluster-instance/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/hybrid-container-service/provisioned-cluster-instance/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/hybrid-container-service/provisioned-cluster-instance/CHANGELOG.md).
 
 ## 0.2.1
 

--- a/avm/res/insights/action-group/CHANGELOG.md
+++ b/avm/res/insights/action-group/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/insights/action-group/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/action-group/CHANGELOG.md).
 
 ## 0.7.0
 

--- a/avm/res/insights/activity-log-alert/CHANGELOG.md
+++ b/avm/res/insights/activity-log-alert/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/insights/activity-log-alert/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/activity-log-alert/CHANGELOG.md).
 
 ## 0.4.0
 

--- a/avm/res/insights/component/CHANGELOG.md
+++ b/avm/res/insights/component/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/insights/component/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/component/CHANGELOG.md).
 
 ## 0.6.0
 

--- a/avm/res/insights/data-collection-endpoint/CHANGELOG.md
+++ b/avm/res/insights/data-collection-endpoint/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/insights/data-collection-endpoint/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/data-collection-endpoint/CHANGELOG.md).
 
 ## 0.5.0
 

--- a/avm/res/insights/data-collection-rule/CHANGELOG.md
+++ b/avm/res/insights/data-collection-rule/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/insights/data-collection-rule/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/data-collection-rule/CHANGELOG.md).
 
 ## 0.6.0
 

--- a/avm/res/insights/diagnostic-setting/CHANGELOG.md
+++ b/avm/res/insights/diagnostic-setting/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/insights/diagnostic-setting/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/diagnostic-setting/CHANGELOG.md).
 
 ## 0.1.4
 

--- a/avm/res/insights/metric-alert/CHANGELOG.md
+++ b/avm/res/insights/metric-alert/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/insights/metric-alert/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/metric-alert/CHANGELOG.md).
 
 ## 0.4.0
 

--- a/avm/res/insights/private-link-scope/CHANGELOG.md
+++ b/avm/res/insights/private-link-scope/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/insights/private-link-scope/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/private-link-scope/CHANGELOG.md).
 
 ## 0.7.1
 

--- a/avm/res/insights/scheduled-query-rule/CHANGELOG.md
+++ b/avm/res/insights/scheduled-query-rule/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/insights/scheduled-query-rule/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/scheduled-query-rule/CHANGELOG.md).
 
 ## 0.5.1
 

--- a/avm/res/insights/webtest/CHANGELOG.md
+++ b/avm/res/insights/webtest/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/insights/webtest/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/webtest/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/key-vault/vault/CHANGELOG.md
+++ b/avm/res/key-vault/vault/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/key-vault/vault/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/key-vault/vault/CHANGELOG.md).
 
 ## 0.13.0
 

--- a/avm/res/kubernetes-configuration/extension/CHANGELOG.md
+++ b/avm/res/kubernetes-configuration/extension/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/kubernetes-configuration/extension/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/kubernetes-configuration/extension/CHANGELOG.md).
 
 ## 0.3.6
 

--- a/avm/res/kubernetes-configuration/flux-configuration/CHANGELOG.md
+++ b/avm/res/kubernetes-configuration/flux-configuration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/kubernetes-configuration/flux-configuration/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/kubernetes-configuration/flux-configuration/CHANGELOG.md).
 
 ## 0.3.5
 

--- a/avm/res/kubernetes/connected-cluster/CHANGELOG.md
+++ b/avm/res/kubernetes/connected-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/kubernetes/connected-cluster/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/kubernetes/connected-cluster/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/res/kusto/cluster/CHANGELOG.md
+++ b/avm/res/kusto/cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/kusto/cluster/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/kusto/cluster/CHANGELOG.md).
 
 ## 0.7.2
 

--- a/avm/res/load-test-service/load-test/CHANGELOG.md
+++ b/avm/res/load-test-service/load-test/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/load-test-service/load-test/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/load-test-service/load-test/CHANGELOG.md).
 
 ## 0.4.2
 

--- a/avm/res/logic/workflow/CHANGELOG.md
+++ b/avm/res/logic/workflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/logic/workflow/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/logic/workflow/CHANGELOG.md).
 
 ## 0.5.2
 

--- a/avm/res/machine-learning-services/workspace/CHANGELOG.md
+++ b/avm/res/machine-learning-services/workspace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/machine-learning-services/workspace/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/machine-learning-services/workspace/CHANGELOG.md).
 
 ## 0.12.1
 

--- a/avm/res/maintenance/configuration-assignment/CHANGELOG.md
+++ b/avm/res/maintenance/configuration-assignment/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/maintenance/configuration-assignment/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/maintenance/configuration-assignment/CHANGELOG.md).
 
 ## 0.2.0
 

--- a/avm/res/maintenance/maintenance-configuration/CHANGELOG.md
+++ b/avm/res/maintenance/maintenance-configuration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/maintenance/maintenance-configuration/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/maintenance/maintenance-configuration/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md
+++ b/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md).
 
 ## 0.4.1
 

--- a/avm/res/managed-services/registration-definition/CHANGELOG.md
+++ b/avm/res/managed-services/registration-definition/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/managed-services/registration-definition/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-services/registration-definition/CHANGELOG.md).
 
 ## 0.1.2
 

--- a/avm/res/management/management-group/CHANGELOG.md
+++ b/avm/res/management/management-group/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/management/management-group/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/management/management-group/CHANGELOG.md).
 
 ## 0.1.2
 

--- a/avm/res/maps/account/CHANGELOG.md
+++ b/avm/res/maps/account/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/maps/account/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/maps/account/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/net-app/net-app-account/CHANGELOG.md
+++ b/avm/res/net-app/net-app-account/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/net-app/net-app-account/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/net-app/net-app-account/CHANGELOG.md).
 
 ## 0.10.0
 

--- a/avm/res/network/application-gateway-web-application-firewall-policy/CHANGELOG.md
+++ b/avm/res/network/application-gateway-web-application-firewall-policy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/application-gateway-web-application-firewall-policy/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/application-gateway-web-application-firewall-policy/CHANGELOG.md).
 
 ## 0.2.0
 

--- a/avm/res/network/application-gateway/CHANGELOG.md
+++ b/avm/res/network/application-gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/application-gateway/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/application-gateway/CHANGELOG.md).
 
 ## 0.6.0
 

--- a/avm/res/network/application-security-group/CHANGELOG.md
+++ b/avm/res/network/application-security-group/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/application-security-group/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/application-security-group/CHANGELOG.md).
 
 ## 0.2.1
 

--- a/avm/res/network/azure-firewall/CHANGELOG.md
+++ b/avm/res/network/azure-firewall/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/azure-firewall/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/azure-firewall/CHANGELOG.md).
 
 ## 0.7.1
 

--- a/avm/res/network/bastion-host/CHANGELOG.md
+++ b/avm/res/network/bastion-host/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/bastion-host/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/bastion-host/CHANGELOG.md).
 
 ## 0.6.1
 

--- a/avm/res/network/connection/CHANGELOG.md
+++ b/avm/res/network/connection/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/connection/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/connection/CHANGELOG.md).
 
 ## 0.1.5
 

--- a/avm/res/network/ddos-protection-plan/CHANGELOG.md
+++ b/avm/res/network/ddos-protection-plan/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/ddos-protection-plan/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/ddos-protection-plan/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/network/dns-forwarding-ruleset/CHANGELOG.md
+++ b/avm/res/network/dns-forwarding-ruleset/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/dns-forwarding-ruleset/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/dns-forwarding-ruleset/CHANGELOG.md).
 
 ## 0.5.2
 

--- a/avm/res/network/dns-resolver/CHANGELOG.md
+++ b/avm/res/network/dns-resolver/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/dns-resolver/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/dns-resolver/CHANGELOG.md).
 
 ## 0.5.4
 

--- a/avm/res/network/dns-zone/CHANGELOG.md
+++ b/avm/res/network/dns-zone/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/dns-zone/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/dns-zone/CHANGELOG.md).
 
 ## 0.5.3
 

--- a/avm/res/network/express-route-circuit/CHANGELOG.md
+++ b/avm/res/network/express-route-circuit/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/express-route-circuit/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/express-route-circuit/CHANGELOG.md).
 
 ## 0.6.0
 

--- a/avm/res/network/express-route-gateway/CHANGELOG.md
+++ b/avm/res/network/express-route-gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/express-route-gateway/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/express-route-gateway/CHANGELOG.md).
 
 ## 0.7.0
 

--- a/avm/res/network/express-route-port/CHANGELOG.md
+++ b/avm/res/network/express-route-port/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/express-route-port/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/express-route-port/CHANGELOG.md).
 
 ## 0.3.0
 

--- a/avm/res/network/firewall-policy/CHANGELOG.md
+++ b/avm/res/network/firewall-policy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/firewall-policy/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/firewall-policy/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/network/front-door-web-application-firewall-policy/CHANGELOG.md
+++ b/avm/res/network/front-door-web-application-firewall-policy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/front-door-web-application-firewall-policy/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/front-door-web-application-firewall-policy/CHANGELOG.md).
 
 ## 0.3.2
 

--- a/avm/res/network/front-door/CHANGELOG.md
+++ b/avm/res/network/front-door/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/front-door/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/front-door/CHANGELOG.md).
 
 ## 0.3.2
 

--- a/avm/res/network/ip-group/CHANGELOG.md
+++ b/avm/res/network/ip-group/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/ip-group/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/ip-group/CHANGELOG.md).
 
 ## 0.3.0
 

--- a/avm/res/network/load-balancer/CHANGELOG.md
+++ b/avm/res/network/load-balancer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/load-balancer/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/load-balancer/CHANGELOG.md).
 
 ## 0.4.2
 

--- a/avm/res/network/local-network-gateway/CHANGELOG.md
+++ b/avm/res/network/local-network-gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/local-network-gateway/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/local-network-gateway/CHANGELOG.md).
 
 ## 0.3.0
 

--- a/avm/res/network/nat-gateway/CHANGELOG.md
+++ b/avm/res/network/nat-gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/nat-gateway/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/nat-gateway/CHANGELOG.md).
 
 ## 1.4.0
 

--- a/avm/res/network/network-interface/CHANGELOG.md
+++ b/avm/res/network/network-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/network-interface/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/network-interface/CHANGELOG.md).
 
 ## 0.5.2
 

--- a/avm/res/network/network-manager/CHANGELOG.md
+++ b/avm/res/network/network-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/network-manager/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/network-manager/CHANGELOG.md).
 
 ## 0.5.2
 

--- a/avm/res/network/network-security-group/CHANGELOG.md
+++ b/avm/res/network/network-security-group/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/network-security-group/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/network-security-group/CHANGELOG.md).
 
 ## 0.5.1
 

--- a/avm/res/network/network-security-perimeter/CHANGELOG.md
+++ b/avm/res/network/network-security-perimeter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/network-security-perimeter/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/network-security-perimeter/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/network/network-watcher/CHANGELOG.md
+++ b/avm/res/network/network-watcher/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/network-watcher/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/network-watcher/CHANGELOG.md).
 
 ## 0.4.1
 

--- a/avm/res/network/p2s-vpn-gateway/CHANGELOG.md
+++ b/avm/res/network/p2s-vpn-gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/p2s-vpn-gateway/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/p2s-vpn-gateway/CHANGELOG.md).
 
 ## 0.1.2
 

--- a/avm/res/network/private-dns-zone/CHANGELOG.md
+++ b/avm/res/network/private-dns-zone/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/private-dns-zone/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/private-dns-zone/CHANGELOG.md).
 
 ## 0.7.1
 

--- a/avm/res/network/private-endpoint/CHANGELOG.md
+++ b/avm/res/network/private-endpoint/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/private-endpoint/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/private-endpoint/CHANGELOG.md).
 
 ## 0.11.0
 

--- a/avm/res/network/private-link-service/CHANGELOG.md
+++ b/avm/res/network/private-link-service/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/private-link-service/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/private-link-service/CHANGELOG.md).
 
 ## 0.3.0
 

--- a/avm/res/network/public-ip-address/CHANGELOG.md
+++ b/avm/res/network/public-ip-address/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/public-ip-address/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/public-ip-address/CHANGELOG.md).
 
 ## 0.8.0
 

--- a/avm/res/network/public-ip-prefix/CHANGELOG.md
+++ b/avm/res/network/public-ip-prefix/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/public-ip-prefix/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/public-ip-prefix/CHANGELOG.md).
 
 ## 0.6.0
 

--- a/avm/res/network/route-table/CHANGELOG.md
+++ b/avm/res/network/route-table/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/route-table/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/route-table/CHANGELOG.md).
 
 ## 0.4.1
 

--- a/avm/res/network/service-endpoint-policy/CHANGELOG.md
+++ b/avm/res/network/service-endpoint-policy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/service-endpoint-policy/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/service-endpoint-policy/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/network/trafficmanagerprofile/CHANGELOG.md
+++ b/avm/res/network/trafficmanagerprofile/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/trafficmanagerprofile/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/trafficmanagerprofile/CHANGELOG.md).
 
 ## 0.3.0
 

--- a/avm/res/network/virtual-hub/CHANGELOG.md
+++ b/avm/res/network/virtual-hub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-hub/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-hub/CHANGELOG.md).
 
 ## 0.4.0
 

--- a/avm/res/network/virtual-network-gateway/CHANGELOG.md
+++ b/avm/res/network/virtual-network-gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-network-gateway/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-network-gateway/CHANGELOG.md).
 
 ## 0.7.0
 

--- a/avm/res/network/virtual-network/CHANGELOG.md
+++ b/avm/res/network/virtual-network/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-network/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-network/CHANGELOG.md).
 
 ## 0.7.0
 

--- a/avm/res/network/virtual-network/subnet/CHANGELOG.md
+++ b/avm/res/network/virtual-network/subnet/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-network/subnet/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-network/subnet/CHANGELOG.md).
 
 ## 0.1.2
 

--- a/avm/res/network/virtual-wan/CHANGELOG.md
+++ b/avm/res/network/virtual-wan/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-wan/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-wan/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/network/vpn-gateway/CHANGELOG.md
+++ b/avm/res/network/vpn-gateway/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/vpn-gateway/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/vpn-gateway/CHANGELOG.md).
 
 ## 0.2.0
 

--- a/avm/res/network/vpn-server-configuration/CHANGELOG.md
+++ b/avm/res/network/vpn-server-configuration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/vpn-server-configuration/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/vpn-server-configuration/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/res/network/vpn-site/CHANGELOG.md
+++ b/avm/res/network/vpn-site/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/network/vpn-site/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/vpn-site/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/operational-insights/workspace/CHANGELOG.md
+++ b/avm/res/operational-insights/workspace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/operational-insights/workspace/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/operational-insights/workspace/CHANGELOG.md).
 
 ## 0.11.2
 

--- a/avm/res/operations-management/solution/CHANGELOG.md
+++ b/avm/res/operations-management/solution/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/operations-management/solution/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/operations-management/solution/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/portal/dashboard/CHANGELOG.md
+++ b/avm/res/portal/dashboard/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/portal/dashboard/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/portal/dashboard/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/power-bi-dedicated/capacity/CHANGELOG.md
+++ b/avm/res/power-bi-dedicated/capacity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/power-bi-dedicated/capacity/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/power-bi-dedicated/capacity/CHANGELOG.md).
 
 ## 0.2.1
 

--- a/avm/res/purview/account/CHANGELOG.md
+++ b/avm/res/purview/account/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/purview/account/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/purview/account/CHANGELOG.md).
 
 ## 0.9.1
 

--- a/avm/res/recovery-services/vault/CHANGELOG.md
+++ b/avm/res/recovery-services/vault/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/recovery-services/vault/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/recovery-services/vault/CHANGELOG.md).
 
 ## 0.9.1
 

--- a/avm/res/relay/namespace/CHANGELOG.md
+++ b/avm/res/relay/namespace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/relay/namespace/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/relay/namespace/CHANGELOG.md).
 
 ## 0.7.2
 

--- a/avm/res/resource-graph/query/CHANGELOG.md
+++ b/avm/res/resource-graph/query/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/resource-graph/query/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/resource-graph/query/CHANGELOG.md).
 
 ## 0.3.1
 

--- a/avm/res/resources/deployment-script/CHANGELOG.md
+++ b/avm/res/resources/deployment-script/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/resources/deployment-script/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/resources/deployment-script/CHANGELOG.md).
 
 ## 0.5.1
 

--- a/avm/res/resources/resource-group/CHANGELOG.md
+++ b/avm/res/resources/resource-group/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/resources/resource-group/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/resources/resource-group/CHANGELOG.md).
 
 ## 0.4.1
 

--- a/avm/res/search/search-service/CHANGELOG.md
+++ b/avm/res/search/search-service/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/search/search-service/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/search/search-service/CHANGELOG.md).
 
 ## 0.10.0
 

--- a/avm/res/security-insights/data-connector/CHANGELOG.md
+++ b/avm/res/security-insights/data-connector/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/security-insights/data-connector/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/security-insights/data-connector/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/security-insights/setting/CHANGELOG.md
+++ b/avm/res/security-insights/setting/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/security-insights/setting/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/security-insights/setting/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/service-bus/namespace/CHANGELOG.md
+++ b/avm/res/service-bus/namespace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/service-bus/namespace/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/service-bus/namespace/CHANGELOG.md).
 
 ## 0.14.1
 

--- a/avm/res/service-fabric/cluster/CHANGELOG.md
+++ b/avm/res/service-fabric/cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/service-fabric/cluster/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/service-fabric/cluster/CHANGELOG.md).
 
 ## 0.5.1
 

--- a/avm/res/service-networking/traffic-controller/CHANGELOG.md
+++ b/avm/res/service-networking/traffic-controller/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/service-networking/traffic-controller/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/service-networking/traffic-controller/CHANGELOG.md).
 
 ## 0.1.1
 

--- a/avm/res/signal-r-service/signal-r/CHANGELOG.md
+++ b/avm/res/signal-r-service/signal-r/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/signal-r-service/signal-r/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/signal-r-service/signal-r/CHANGELOG.md).
 
 ## 0.8.0
 

--- a/avm/res/signal-r-service/web-pub-sub/CHANGELOG.md
+++ b/avm/res/signal-r-service/web-pub-sub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/signal-r-service/web-pub-sub/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/signal-r-service/web-pub-sub/CHANGELOG.md).
 
 ## 0.7.0
 

--- a/avm/res/sql/instance-pool/CHANGELOG.md
+++ b/avm/res/sql/instance-pool/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/sql/instance-pool/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/sql/instance-pool/CHANGELOG.md).
 
 ## 0.1.2
 

--- a/avm/res/sql/managed-instance/CHANGELOG.md
+++ b/avm/res/sql/managed-instance/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/sql/managed-instance/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/sql/managed-instance/CHANGELOG.md).
 
 ## 0.3.0
 

--- a/avm/res/sql/server/CHANGELOG.md
+++ b/avm/res/sql/server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/sql/server/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/sql/server/CHANGELOG.md).
 
 ## 0.19.1
 

--- a/avm/res/storage/storage-account/CHANGELOG.md
+++ b/avm/res/storage/storage-account/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/storage/storage-account/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/storage/storage-account/CHANGELOG.md).
 
 ## 0.22.1
 

--- a/avm/res/storage/storage-account/blob-service/container/CHANGELOG.md
+++ b/avm/res/storage/storage-account/blob-service/container/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/storage/storage-account/blob-service/container/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/storage/storage-account/blob-service/container/CHANGELOG.md).
 
 ## 0.1.0
 

--- a/avm/res/synapse/private-link-hub/CHANGELOG.md
+++ b/avm/res/synapse/private-link-hub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/synapse/private-link-hub/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/synapse/private-link-hub/CHANGELOG.md).
 
 ## 0.6.4
 

--- a/avm/res/synapse/workspace/CHANGELOG.md
+++ b/avm/res/synapse/workspace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/synapse/workspace/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/synapse/workspace/CHANGELOG.md).
 
 ## 0.13.0
 

--- a/avm/res/virtual-machine-images/image-template/CHANGELOG.md
+++ b/avm/res/virtual-machine-images/image-template/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/virtual-machine-images/image-template/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/virtual-machine-images/image-template/CHANGELOG.md).
 
 ## 0.5.2
 

--- a/avm/res/web/connection/CHANGELOG.md
+++ b/avm/res/web/connection/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/web/connection/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/web/connection/CHANGELOG.md).
 
 ## 0.4.2
 

--- a/avm/res/web/hosting-environment/CHANGELOG.md
+++ b/avm/res/web/hosting-environment/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/web/hosting-environment/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/web/hosting-environment/CHANGELOG.md).
 
 ## 0.4.0
 

--- a/avm/res/web/serverfarm/CHANGELOG.md
+++ b/avm/res/web/serverfarm/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/web/serverfarm/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/web/serverfarm/CHANGELOG.md).
 
 ## 0.4.1
 

--- a/avm/res/web/site/CHANGELOG.md
+++ b/avm/res/web/site/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/web/site/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/web/site/CHANGELOG.md).
 
 ## 0.16.0
 

--- a/avm/res/web/static-site/CHANGELOG.md
+++ b/avm/res/web/static-site/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/web/static-site/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/web/static-site/CHANGELOG.md).
 
 ## 0.9.0
 

--- a/avm/utl/types/avm-common-types/CHANGELOG.md
+++ b/avm/utl/types/avm-common-types/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/utl/types/avm-common-types/CHANGELOG.md).
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utl/types/avm-common-types/CHANGELOG.md).
 
 ## 0.6.0
 

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -1534,7 +1534,7 @@ Describe 'Module tests' -Tag 'Module' {
             $changelogContent[1] | Should -BeNullOrEmpty -Because "the changelog's second line should be empty"
 
             # The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/res/aad/domain-service/CHANGELOG.md).
-            $linkToLatestVersionChangelog = 'The latest version of the changelog can be found [here](/Azure/bicep-registry-modules/blob/main/avm/{0}/{1}/Changelog.md).' -f $moduleType, $moduleFolderName
+            $linkToLatestVersionChangelog = 'The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/{0}/{1}/Changelog.md).' -f $moduleType, $moduleFolderName
             $changelogContent[2] | Should -Be $linkToLatestVersionChangelog -Because ('the changelog must contain a link to the latest version {0}' -f $linkToLatestVersionChangelog)
             $changelogContent[3] | Should -BeNullOrEmpty -Because "the changelog's forth line should be empty"
         }


### PR DESCRIPTION
## Description

The header links to the changelogs were broken.

## Pipeline Reference

| Pipeline |
| -------- |
|   [![avm.res.azure-stack-hci.network-interface](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.network-interface.yml/badge.svg?branch=changlog-link-fix)](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.network-interface.yml)       |

## Type of Change

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
