### PR TITLE
fix: CI for new modules and Changelogs

### DIFF
--- a/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
+++ b/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
@@ -204,6 +204,7 @@ Get any template (main.json) files in the given folder path that would qualify f
 .DESCRIPTION
 Get any template (main.json) files in the given folder path that would qualify for publishing.
 Uses Head^-1 to check for changed files and filters them by the module path & path filter of the version.json
+Note: This logic does not return new files that were added, but only files that were modified. Therefore, it is not suitable for new modules that have not been published before.
 
 .PARAMETER ModuleFolderPath
 Mandatory. The path to the module to check for changed files in.

--- a/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
+++ b/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
@@ -204,7 +204,6 @@ Get any template (main.json) files in the given folder path that would qualify f
 .DESCRIPTION
 Get any template (main.json) files in the given folder path that would qualify for publishing.
 Uses Head^-1 to check for changed files and filters them by the module path & path filter of the version.json
-Note: This logic does not return new files that were added, but only files that were modified. Therefore, it is not suitable for new modules that have not been published before.
 
 .PARAMETER ModuleFolderPath
 Mandatory. The path to the module to check for changed files in.

--- a/utilities/pipelines/sharedScripts/Get-PublishedModuleVersionsList.ps1
+++ b/utilities/pipelines/sharedScripts/Get-PublishedModuleVersionsList.ps1
@@ -14,7 +14,7 @@ Mandatory. The module name of the module. (e.g., `vault/key-vault`, `network/vir
 .EXAMPLE
 Get-PublishedModuleVersionsList -ModuleType 'res' -ModuleName 'vault/key-vault'
 
-Returns the module versions for module `avm/res/vault/key-vault`. E.g., `@(0.1.0, 0.1.1, (...))`
+Returns the module versions for module `avm/res/vault/key-vault`. E.g., `@(0.1.0, 0.1.1, (...))`, `@()`
 
 #>
 
@@ -31,21 +31,26 @@ function Get-PublishedModuleVersionsList {
     )
 
     $tagListUrl = 'https://mcr.microsoft.com/v2/bicep/avm/{0}/{1}/tags/list' -f $ModuleType, $ModuleName
-    Write-Verbose "Getting available tags at '$tagListUrl'..." -Verbose
-    try {
-        $tagListResponse = Invoke-RestMethod -Uri $tagListUrl
-    } catch {
-        if (Test-McrConnection) {
-            Write-Verbose "MCR connection test passed. New modules don't have a published version."
-            return $null
+    for ($i = 0; $i -lt 5; $i++) {
+        try {
+            Write-Verbose "Getting available tags at '$tagListUrl' (attempt $($i + 1))..." -Verbose
+            $tagListResponse = Invoke-RestMethod -Uri $tagListUrl
+            $publishedTags = $tagListResponse.tags | Sort-Object { [Version]$_ } -Culture 'en-US'
+            Write-Verbose "  Found tags: $($publishedTags -join ', ')" -Verbose
+            return $publishedTags
+        } catch {
+            if ($i -eq 4) {
+                if (Test-McrConnection) {
+                    Write-Verbose "MCR connection test passed. New modules don't have a published version."
+                    return @()
+                }
+                Write-Error 'Failed to get tags from MCR ($tagListUrl) after 5 attempts. Please check your network connection and try again.'
+                Write-Error "Error message: $($_.Exception.Message)"
+                throw $_.Exception
+            }
+            Start-Sleep -Seconds 5
         }
-        Write-Error "Error occurred while accessing URL: $tagListUrl"
-        Write-Error "Error message: $($_.Exception.Message)"
-        throw $_.Exception
     }
-    $publishedTags = $tagListResponse.tags | Sort-Object { [Version]$_ } -Culture 'en-US'
-    Write-Verbose "  Found tags: $($publishedTags -join ', ')" -Verbose
-    return $publishedTags
 }
 
 <#

--- a/utilities/pipelines/sharedScripts/Get-PublishedModuleVersionsList.ps1
+++ b/utilities/pipelines/sharedScripts/Get-PublishedModuleVersionsList.ps1
@@ -37,7 +37,7 @@ function Get-PublishedModuleVersionsList {
     } catch {
         if (Test-McrConnection) {
             Write-Verbose "MCR connection test passed. New modules don't have a published version."
-            return '0.1.0'
+            return $null
         }
         Write-Error "Error occurred while accessing URL: $tagListUrl"
         Write-Error "Error message: $($_.Exception.Message)"

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -1554,12 +1554,12 @@ Describe 'Module tests' -Tag 'Module' {
                 # the module will be published. Use the new version
                 $expectedModuleVersion = Get-ModuleTargetVersion -ModuleFolderPath $moduleFolderPath
             } else {
-                # the module will not be published. Use the current version
+                # the module will not be published (in that case use the current version), or is a new module without a version
                 Write-Verbose 'A new version will not be published. Use the current version.' -Verbose
                 $publishedVersions = Get-PublishedModuleVersionsList -ModuleType $moduleType -ModuleName ($moduleFolderName -replace '\\', '/')
                 # the last version in the array is the latest published version
-                Write-Verbose "Latest published version is [$($publishedVersions[-1])]." -Verbose
-                $expectedModuleVersion = $publishedVersions[-1]
+                $expectedModuleVersion = $publishedVersions -is [Array] -and $publishedVersions.Count -gt 0 ? $publishedVersions[-1] : $publishedVersions
+                Write-Verbose "Latest published version is [$($expectedModuleVersion)]." -Verbose
             }
 
             $sections = $changelogContent | Where-Object { $_ -match '^##\s+' }

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -1551,7 +1551,7 @@ Describe 'Module tests' -Tag 'Module' {
             $changelogContent | Should -Not -BeNullOrEmpty -Because 'CHANGELOG.md file not found or uncomplete.'
 
             $moduleTargetVersion = Get-ModuleTargetVersion -ModuleFolderPath $moduleFolderPath
-            if ((Get-ModulesToPublish -ModuleFolderPath $moduleFolderPath) -ge 1 -or $moduleTargetVersion -eq '0.1') {
+            if ((Get-ModulesToPublish -ModuleFolderPath $moduleFolderPath) -ge 1 -or $moduleTargetVersion -eq '0.1.0') {
                 # the module will be published
                 $expectedModuleVersion = $moduleTargetVersion
             } else {
@@ -1562,9 +1562,6 @@ Describe 'Module tests' -Tag 'Module' {
                 if ($publishedVersions.Count -gt 0) {
                     # more than one version have been published
                     $expectedModuleVersion = $publishedVersions[-1]
-                } elseif ($publishedVersions.Count -eq 0) {
-                    # no version has been published yet
-                    $expectedModuleVersion = '0.1.0'
                 } else {
                     # only one version has been published
                     $expectedModuleVersion = $publishedVersions

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -1551,23 +1551,14 @@ Describe 'Module tests' -Tag 'Module' {
             $changelogContent | Should -Not -BeNullOrEmpty -Because 'CHANGELOG.md file not found or uncomplete.'
 
             $moduleTargetVersion = Get-ModuleTargetVersion -ModuleFolderPath $moduleFolderPath
+            # the second condition is for local testing only, as, after committing to GitHub, the first condition picks up the version
             if ((Get-ModulesToPublish -ModuleFolderPath $moduleFolderPath) -ge 1 -or $moduleTargetVersion -eq '0.1.0') {
-                # the module will be published
+                # The module will be published
                 $expectedModuleVersion = $moduleTargetVersion
             } else {
-                Write-Verbose 'The module will not be published (in that case use the current version), or is a new module without a version.' -Verbose
-                $publishedVersions = @(Get-PublishedModuleVersionsList -ModuleType $moduleType -ModuleName ($moduleFolderName -replace '\\', '/'))
-
-                # the last version in the array is the latest published version
-                if ($publishedVersions.Count -gt 0) {
-                    # more than one version have been published
-                    $expectedModuleVersion = $publishedVersions[-1]
-                } else {
-                    # only one version has been published
-                    $expectedModuleVersion = $publishedVersions
-                }
-                # $expectedModuleVersion = $publishedVersions -is [Array] -and $publishedVersions.Count -gt 0 ? $publishedVersions[-1] : $publishedVersions
-                Write-Verbose "Latest published version is [$($expectedModuleVersion)]." -Verbose
+                # Since the module is not being published, we can stop here. The version in the changelog is checked in another test.
+                Set-ItResult -Skipped -Because 'the module is not going to be published and the version number remains unchanged.'
+                return
             }
 
             $sections = $changelogContent | Where-Object { $_ -match '^##\s+' }


### PR DESCRIPTION
## Description

New modules don't have published versions. Instead of getting the latest version, assume 0.1.0 is the current version.

Closes #5489 

## Pipeline Reference

| Pipeline |
| -------- |
|  [![avm.res.signal-r-service.signal-r](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.signal-r.yml/badge.svg?branch=get-published-module-tags-fix)](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.signal-r.yml)        |

Tested with a new module, a changed module (that will be published) and an unchanged module.

## Type of Change

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
