### PR TITLE
fix: `res/signal-r-service/signal-r` Changelog fix

### DIFF
--- a/avm/res/signal-r-service/signal-r/CHANGELOG.md
+++ b/avm/res/signal-r-service/signal-r/CHANGELOG.md
@@ -11,6 +11,8 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ## Breaking Changes
 
+- None
+
 ## 0.8.0
 
 ### Changes

--- a/avm/res/signal-r-service/signal-r/CHANGELOG.md
+++ b/avm/res/signal-r-service/signal-r/CHANGELOG.md
@@ -9,7 +9,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 - Added 'HttpRequestLogs' option to `liveTraceCatagoriesToEnable` and `resourceLogConfigurationsToEnable` properties
 - Resource provider updates
 
-## Breaking Changes
+### Breaking Changes
 
 - None
 

--- a/avm/res/signal-r-service/signal-r/README.md
+++ b/avm/res/signal-r-service/signal-r/README.md
@@ -706,7 +706,7 @@ param tags = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`name`](#parameter-name) | string | The name of the SignalR Service resource. |
+| [`name`](#parameter-name) | string | The name of the SignalR service resource. |
 
 **Optional parameters**
 
@@ -736,7 +736,7 @@ param tags = {
 
 ### Parameter: `name`
 
-The name of the SignalR Service resource.
+The name of the SignalR service resource.
 
 - Required: Yes
 - Type: string

--- a/avm/res/signal-r-service/signal-r/main.bicep
+++ b/avm/res/signal-r-service/signal-r/main.bicep
@@ -8,7 +8,7 @@ metadata description = 'This module deploys a SignalR Service SignalR.'
 @description('Optional. The location for the resource.')
 param location string = resourceGroup().location
 
-@description('Required. The name of the SignalR Service resource.')
+@description('Required. The name of the SignalR service resource.')
 param name string
 
 @description('Optional. The kind of the service.')

--- a/avm/res/signal-r-service/signal-r/main.json
+++ b/avm/res/signal-r-service/signal-r/main.json
@@ -471,7 +471,7 @@
     "name": {
       "type": "string",
       "metadata": {
-        "description": "Required. The name of the SignalR Service resource."
+        "description": "Required. The name of the SignalR service resource."
       }
     },
     "kind": {


### PR DESCRIPTION
## Description

Fixes the malformed Changelog.

## Pipeline Reference

| Pipeline |
| -------- |
|   [![avm.res.signal-r-service.signal-r](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.signal-r.yml/badge.svg?branch=signal-r-changelog-fix)](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.signal-r.yml)       |

## Type of Change

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
