### PR TITLE
fix: CI - Changed Token-Replacement check to only check the current module, as opposed to all including cross-referenced modules

### DIFF
--- a/avm/res/storage/storage-account/main.bicep
+++ b/avm/res/storage/storage-account/main.bicep
@@ -317,7 +317,7 @@ var formattedRoleAssignments = [
 
 #disable-next-line no-deployments-resources
 resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
-  name: '46d3xbcp.res.storage-storageaccount.${replace('0.25.1', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
+  name: '46d3xbcp.res.storage-storageaccount.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'
     template: {

--- a/avm/res/storage/storage-account/main.bicep
+++ b/avm/res/storage/storage-account/main.bicep
@@ -317,7 +317,7 @@ var formattedRoleAssignments = [
 
 #disable-next-line no-deployments-resources
 resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
-  name: '46d3xbcp.res.storage-storageaccount.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
+  name: '46d3xbcp.res.storage-storageaccount.${replace('0.25.1', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'
     template: {

--- a/utilities/pipelines/publish/Publish-ModuleFromPathToPBR.ps1
+++ b/utilities/pipelines/publish/Publish-ModuleFromPathToPBR.ps1
@@ -89,7 +89,7 @@ function Publish-ModuleFromPathToPBR {
         $null = Convert-TokensInFileList @tokenConfiguration
 
         # Double-check that tokens are correctly replaced
-        $templateContent = bicep build $moduleBicepFilePath --stdout
+        $templateContent = Get-Content -Path $moduleBicepFilePath
         $incorrectLines = @()
         for ($index = 0; $index -lt $templateContent.Count; $index++) {
             if ($templateContent[$index] -match '\-\.\.-\-\.\.\-') {


### PR DESCRIPTION
## Description

- Changed Token-Replacement check to only check the current module, as opposed to all including cross-referenced modules
- This resolves an issue with a top-level module having a child that itself implements telemetry. During the current token replacement, this child is ignored as the token replacement happens in the main bicep file - not the JSON, nor linked files. The original solution was used in the early days to catch issues with incorrectly published cross-referenced modules that has since been ironed out. As such, we can savely pivot and only check the current template for a correct replacement.
- Tested locally using the failing storage account module. 

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
