### PR TITLE
feat: ActionGroup - Added support for `incidentReceivers` property

### DIFF
--- a/avm/res/insights/action-group/CHANGELOG.md
+++ b/avm/res/insights/action-group/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/action-group/CHANGELOG.md).
 
+## 0.8.0
+
+### Changes
+
+- Added support for `incidentReceivers` property.
+
+### Breaking Changes
+
+- None
+
 ## 0.7.0
 
 ### Changes

--- a/avm/res/insights/action-group/README.md
+++ b/avm/res/insights/action-group/README.md
@@ -129,6 +129,19 @@ module actionGroup 'br/public:avm/res/insights/action-group:<version>' = {
         useCommonAlertSchema: true
       }
     ]
+    incidentReceivers: [
+      {
+        connection: {
+          id: 'TestConnectionId'
+          name: 'TestConnectionName'
+        }
+        incidentManagementService: 'TestIndentManagementService'
+        mappings: {
+          customizedProperty: 'TestCustomProperty'
+        }
+        name: 'TestName'
+      }
+    ]
     location: 'global'
     lock: {
       kind: 'CanNotDelete'
@@ -200,6 +213,21 @@ module actionGroup 'br/public:avm/res/insights/action-group:<version>' = {
           "emailAddress": "test.user2@testcompany.com",
           "name": "TestUser2",
           "useCommonAlertSchema": true
+        }
+      ]
+    },
+    "incidentReceivers": {
+      "value": [
+        {
+          "connection": {
+            "id": "TestConnectionId",
+            "name": "TestConnectionName"
+          },
+          "incidentManagementService": "TestIndentManagementService",
+          "mappings": {
+            "customizedProperty": "TestCustomProperty"
+          },
+          "name": "TestName"
         }
       ]
     },
@@ -277,6 +305,19 @@ param emailReceivers = [
     emailAddress: 'test.user2@testcompany.com'
     name: 'TestUser2'
     useCommonAlertSchema: true
+  }
+]
+param incidentReceivers = [
+  {
+    connection: {
+      id: 'TestConnectionId'
+      name: 'TestConnectionName'
+    }
+    incidentManagementService: 'TestIndentManagementService'
+    mappings: {
+      customizedProperty: 'TestCustomProperty'
+    }
+    name: 'TestName'
   }
 ]
 param location = 'global'
@@ -427,6 +468,7 @@ param tags = {
 | [`enabled`](#parameter-enabled) | bool | Indicates whether this action group is enabled. If an action group is not enabled, then none of its receivers will receive communications. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`eventHubReceivers`](#parameter-eventhubreceivers) | array | The list of Event Hub receivers that are part of this action group. |
+| [`incidentReceivers`](#parameter-incidentreceivers) | array | The list of incident receivers that are part of this action group. |
 | [`itsmReceivers`](#parameter-itsmreceivers) | array | The list of ITSM receivers that are part of this action group. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
@@ -505,6 +547,13 @@ Enable/Disable usage telemetry for module.
 ### Parameter: `eventHubReceivers`
 
 The list of Event Hub receivers that are part of this action group.
+
+- Required: No
+- Type: array
+
+### Parameter: `incidentReceivers`
+
+The list of incident receivers that are part of this action group.
 
 - Required: No
 - Type: array

--- a/avm/res/insights/action-group/README.md
+++ b/avm/res/insights/action-group/README.md
@@ -242,21 +242,6 @@ module actionGroup 'br/public:avm/res/insights/action-group:<version>' = {
         }
       ]
     },
-    "incidentReceivers": {
-      "value": [
-        {
-          "connection": {
-            "id": "0",
-            "name": "MyConnectionName"
-          },
-          "incidentManagementService": "ServiceNow",
-          "mappings": {
-            "CustomProperty": "Allowed"
-          },
-          "name": "MyIncidentReceiver"
-        }
-      ]
-    },
     "tags": {
       "value": {
         "Environment": "Non-Prod",
@@ -291,20 +276,6 @@ param emailReceivers = [
   {
     emailAddress: 'test.user2@testcompany.com'
     name: 'TestUser2'
-    useCommonAlertSchema: true
-  }
-]
-param incidentReceivers = [
-  {
-    connection: {
-      id: 'TestId',
-      name: 'TestName'
-    },
-    incidentManagementService: 'TestIncidentReceiverManagementService',
-    mappings: {
-      CustomProperty: 'TestCustomProperty'
-    },
-    name: 'TestIncidentReceiver'
     useCommonAlertSchema: true
   }
 ]
@@ -456,7 +427,6 @@ param tags = {
 | [`enabled`](#parameter-enabled) | bool | Indicates whether this action group is enabled. If an action group is not enabled, then none of its receivers will receive communications. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`eventHubReceivers`](#parameter-eventhubreceivers) | array | The list of Event Hub receivers that are part of this action group. |
-| [`incidentReceivers`](#parameter-incidentreceivers) | array | The list of incident receivers that are part of this action group. | 
 | [`itsmReceivers`](#parameter-itsmreceivers) | array | The list of ITSM receivers that are part of this action group. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
@@ -535,13 +505,6 @@ Enable/Disable usage telemetry for module.
 ### Parameter: `eventHubReceivers`
 
 The list of Event Hub receivers that are part of this action group.
-
-- Required: No
-- Type: array
-
-### Parameter: `incidentReceivers`
-
-The list of incident receivers that are part of this action group.
 
 - Required: No
 - Type: array
@@ -734,7 +697,7 @@ The list of webhook receivers that are part of this action group.
 
 - Required: No
 - Type: array
-  
+
 ## Outputs
 
 | Output | Type | Description |

--- a/avm/res/insights/action-group/README.md
+++ b/avm/res/insights/action-group/README.md
@@ -242,6 +242,21 @@ module actionGroup 'br/public:avm/res/insights/action-group:<version>' = {
         }
       ]
     },
+    "incidentReceivers": {
+      "value": [
+        {
+          "connection": {
+            "id": "0",
+            "name": "MyConnectionName"
+          },
+          "incidentManagementService": "ServiceNow",
+          "mappings": {
+            "CustomProperty": "Allowed"
+          },
+          "name": "MyIncidentReceiver"
+        }
+      ]
+    },
     "tags": {
       "value": {
         "Environment": "Non-Prod",
@@ -277,6 +292,19 @@ param emailReceivers = [
     emailAddress: 'test.user2@testcompany.com'
     name: 'TestUser2'
     useCommonAlertSchema: true
+  }
+]
+param incidentReceivers: [
+  {
+    connection: {
+      id: 'TestId',
+      name: 'TestConnectionName'
+    },
+    incidentManagementService: 'ServiceNow',
+    mappings: {
+      CustomProperty: 'CustomPropertyValue'
+    },
+    name: 'MyIncidentReceiver'
   }
 ]
 param location = 'global'
@@ -436,6 +464,7 @@ param tags = {
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`voiceReceivers`](#parameter-voicereceivers) | array | The list of voice receivers that are part of this action group. |
 | [`webhookReceivers`](#parameter-webhookreceivers) | array | The list of webhook receivers that are part of this action group. |
+| [`incidentReceivers`](#parameter-incidentreceivers) | array | The list of incident receivers that are part of this action group. | 
 
 ### Parameter: `groupShortName`
 
@@ -694,6 +723,13 @@ The list of voice receivers that are part of this action group.
 ### Parameter: `webhookReceivers`
 
 The list of webhook receivers that are part of this action group.
+
+- Required: No
+- Type: array
+  
+### Parameter: `incidentReceivers`
+
+The list of incident receivers that are part of this action group.
 
 - Required: No
 - Type: array

--- a/avm/res/insights/action-group/README.md
+++ b/avm/res/insights/action-group/README.md
@@ -294,17 +294,18 @@ param emailReceivers = [
     useCommonAlertSchema: true
   }
 ]
-param incidentReceivers: [
+param incidentReceivers = [
   {
     connection: {
       id: 'TestId',
-      name: 'TestConnectionName'
+      name: 'TestName'
     },
-    incidentManagementService: 'ServiceNow',
+    incidentManagementService: 'TestIncidentReceiverManagementService',
     mappings: {
-      CustomProperty: 'CustomPropertyValue'
+      CustomProperty: 'TestCustomProperty'
     },
-    name: 'MyIncidentReceiver'
+    name: 'TestIncidentReceiver'
+    useCommonAlertSchema: true
   }
 ]
 param location = 'global'
@@ -455,6 +456,7 @@ param tags = {
 | [`enabled`](#parameter-enabled) | bool | Indicates whether this action group is enabled. If an action group is not enabled, then none of its receivers will receive communications. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`eventHubReceivers`](#parameter-eventhubreceivers) | array | The list of Event Hub receivers that are part of this action group. |
+| [`incidentReceivers`](#parameter-incidentreceivers) | array | The list of incident receivers that are part of this action group. | 
 | [`itsmReceivers`](#parameter-itsmreceivers) | array | The list of ITSM receivers that are part of this action group. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
@@ -464,7 +466,6 @@ param tags = {
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`voiceReceivers`](#parameter-voicereceivers) | array | The list of voice receivers that are part of this action group. |
 | [`webhookReceivers`](#parameter-webhookreceivers) | array | The list of webhook receivers that are part of this action group. |
-| [`incidentReceivers`](#parameter-incidentreceivers) | array | The list of incident receivers that are part of this action group. | 
 
 ### Parameter: `groupShortName`
 
@@ -534,6 +535,13 @@ Enable/Disable usage telemetry for module.
 ### Parameter: `eventHubReceivers`
 
 The list of Event Hub receivers that are part of this action group.
+
+- Required: No
+- Type: array
+
+### Parameter: `incidentReceivers`
+
+The list of incident receivers that are part of this action group.
 
 - Required: No
 - Type: array
@@ -727,13 +735,6 @@ The list of webhook receivers that are part of this action group.
 - Required: No
 - Type: array
   
-### Parameter: `incidentReceivers`
-
-The list of incident receivers that are part of this action group.
-
-- Required: No
-- Type: array
-
 ## Outputs
 
 | Output | Type | Description |

--- a/avm/res/insights/action-group/main.bicep
+++ b/avm/res/insights/action-group/main.bicep
@@ -51,6 +51,9 @@ param azureFunctionReceivers array?
 @description('Optional. The list of ARM role receivers that are part of this action group. Roles are Azure RBAC roles and only built-in roles are supported.')
 param armRoleReceivers array?
 
+@description('Optional. The list of incident receivers that are part of this action group.')
+param incidentReceivers array?
+
 @description('Optional. Tags of the resource.')
 param tags object?
 
@@ -122,6 +125,7 @@ resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
     logicAppReceivers: logicAppReceivers
     azureFunctionReceivers: azureFunctionReceivers
     armRoleReceivers: armRoleReceivers
+    incidentReceivers: incidentReceivers
   }
 }
 

--- a/avm/res/insights/action-group/main.bicep
+++ b/avm/res/insights/action-group/main.bicep
@@ -52,7 +52,7 @@ param azureFunctionReceivers array?
 param armRoleReceivers array?
 
 @description('Optional. The list of incident receivers that are part of this action group.')
-param incidentReceivers array?
+param incidentReceivers resourceInput<'Microsoft.Insights/actionGroups@2023-01-01'>.properties.incidentReceivers?
 
 @description('Optional. Tags of the resource.')
 param tags object?

--- a/avm/res/insights/action-group/main.bicep
+++ b/avm/res/insights/action-group/main.bicep
@@ -52,7 +52,7 @@ param azureFunctionReceivers array?
 param armRoleReceivers array?
 
 @description('Optional. The list of incident receivers that are part of this action group.')
-param incidentReceivers resourceInput<'Microsoft.Insights/actionGroups@2023-01-01'>.properties.incidentReceivers?
+param incidentReceivers resourceInput<'Microsoft.Insights/actionGroups@2024-10-01-preview'>.properties.incidentReceivers?
 
 @description('Optional. Tags of the resource.')
 param tags object?

--- a/avm/res/insights/action-group/main.json
+++ b/avm/res/insights/action-group/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "9527555062791455599"
+      "version": "0.36.177.2456",
+      "templateHash": "9573193223020654189"
     },
     "name": "Action Groups",
     "description": "This module deploys an Action Group."
@@ -234,10 +234,13 @@
     },
     "incidentReceivers": {
       "type": "array",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Insights/actionGroups@2024-10-01-preview#properties/properties/properties/incidentReceivers"
+        },
         "description": "Optional. The list of incident receivers that are part of this action group."
-      }
+      },
+      "nullable": true
     },
     "tags": {
       "type": "object",

--- a/avm/res/insights/action-group/main.json
+++ b/avm/res/insights/action-group/main.json
@@ -317,7 +317,7 @@
         "voiceReceivers": "[parameters('voiceReceivers')]",
         "logicAppReceivers": "[parameters('logicAppReceivers')]",
         "azureFunctionReceivers": "[parameters('azureFunctionReceivers')]",
-        "armRoleReceivers": "[parameters('armRoleReceivers')]"
+        "armRoleReceivers": "[parameters('armRoleReceivers')]",
         "incidentReceivers": "[parameters('incidentReceivers')]"
       }
     },

--- a/avm/res/insights/action-group/main.json
+++ b/avm/res/insights/action-group/main.json
@@ -232,6 +232,13 @@
         "description": "Optional. The list of ARM role receivers that are part of this action group. Roles are Azure RBAC roles and only built-in roles are supported."
       }
     },
+    "incidentReceivers": {
+      "type": "array",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The list of incident receivers that are part of this action group."
+      }
+    },
     "tags": {
       "type": "object",
       "nullable": true,
@@ -311,6 +318,7 @@
         "logicAppReceivers": "[parameters('logicAppReceivers')]",
         "azureFunctionReceivers": "[parameters('azureFunctionReceivers')]",
         "armRoleReceivers": "[parameters('armRoleReceivers')]"
+        "incidentReceivers": "[parameters('incidentReceivers')]"
       }
     },
     "actionGroup_lock": {

--- a/avm/res/insights/action-group/tests/e2e/max/main.test.bicep
+++ b/avm/res/insights/action-group/tests/e2e/max/main.test.bicep
@@ -67,8 +67,15 @@ module testDeployment '../../../main.bicep' = [
       ]
       incidentReceivers: [
         {
-          name: 'TestIncidentReceiver'
-          useCommonAlertSchema: true
+          connection: {
+            id: 'TestConnectionId'
+            name: 'TestConnectionName'
+          }
+          incidentManagementService: 'TestIndentManagementService'
+          mappings: {
+            customizedProperty: 'TestCustomProperty'
+          }
+          name: 'TestName'
         }
       ]
       lock: {

--- a/avm/res/insights/action-group/tests/e2e/max/main.test.bicep
+++ b/avm/res/insights/action-group/tests/e2e/max/main.test.bicep
@@ -65,6 +65,12 @@ module testDeployment '../../../main.bicep' = [
           useCommonAlertSchema: true
         }
       ]
+      incidentReceivers: [
+        {
+          name: 'TestIncidentReceiver'
+          useCommonAlertSchema: true
+        }
+      ]
       lock: {
         kind: 'CanNotDelete'
         name: 'myCustomLockName'

--- a/avm/res/insights/action-group/version.json
+++ b/avm/res/insights/action-group/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.7"
+  "version": "0.8"
 }


### PR DESCRIPTION
## Description

Fixes #5541

[ActionGroups](https://learn.microsoft.com/en-us/azure/templates/microsoft.insights/actiongroups?pivots=deployment-language-bicep) allow the usage of incidentReceivers in both the regular Azure Resource and the ARM json format. This PR adds that capability to the azure module.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|          |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
