### PR TITLE
fix: update command to add reviewers in Set-AvmGitHubPrLabels function

### DIFF
--- a/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
@@ -56,7 +56,7 @@ function Set-AvmGitHubPrLabels {
                 gh pr edit $pr.url --add-label 'Needs: Module Owner :mega:' --repo $Repo
                 # add team members as reviewers
                 $teamMembers | ForEach-Object {
-                    gh pr review $pr.url --add-reviewer $_ --repo $Repo
+                    gh pr edit $pr.url --add-reviewer $_ --repo $Repo
                 }
             }
 


### PR DESCRIPTION
## Description

fixed the wrong command, so that reviewers are added correctly to a PR

## Pipeline Reference



## Type of Change

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

