### PR TITLE
fix: Enabling multiple resource group config in failover groups at `avm/res/sql/server`

### DIFF
--- a/avm/res/sql/server/CHANGELOG.md
+++ b/avm/res/sql/server/CHANGELOG.md
@@ -11,7 +11,6 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 ### Breaking Changes
 
 - Renamed `partnerServers` array to `partnerServerResourceIds` in the failover group module to make it possible to use SQL servers from different resource groups.
-- None
 
 ## 0.19.1
 

--- a/avm/res/sql/server/CHANGELOG.md
+++ b/avm/res/sql/server/CHANGELOG.md
@@ -11,3 +11,14 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 ### Breaking Changes
 
 - None
+
+## 0.20.0
+
+### Changes
+
+- Renamed `partnerServers` array to `partnerServerResourceIds` in the failover group module to make it possible to use SQL servers from different resource groups.
+- `tags` parameters are now properly typed instead of using `object` type.
+
+### Breaking Changes
+
+- None

--- a/avm/res/sql/server/CHANGELOG.md
+++ b/avm/res/sql/server/CHANGELOG.md
@@ -2,22 +2,22 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/sql/server/CHANGELOG.md).
 
+## 0.20.0
+
+### Changes
+
+- `tags` parameters are now properly typed instead of using `object` type.
+
+### Breaking Changes
+
+- Renamed `partnerServers` array to `partnerServerResourceIds` in the failover group module to make it possible to use SQL servers from different resource groups.
+- None
+
 ## 0.19.1
 
 ### Changes
 
 - Initial version
-
-### Breaking Changes
-
-- None
-
-## 0.20.0
-
-### Changes
-
-- Renamed `partnerServers` array to `partnerServerResourceIds` in the failover group module to make it possible to use SQL servers from different resource groups.
-- `tags` parameters are now properly typed instead of using `object` type.
 
 ### Breaking Changes
 

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -721,8 +721,8 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           'ssfog-db1'
         ]
         name: 'ssfog-fg-geo'
-        partnerServers: [
-          '<secondaryServerName>'
+        partnerServerResourceIds: [
+          '<secondaryServerResourceId>'
         ]
         readWriteEndpoint: {
           failoverPolicy: 'Manual'
@@ -734,8 +734,8 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           'ssfog-db2'
         ]
         name: 'ssfog-fg-standby'
-        partnerServers: [
-          '<secondaryServerName>'
+        partnerServerResourceIds: [
+          '<secondaryServerResourceId>'
         ]
         readWriteEndpoint: {
           failoverPolicy: 'Automatic'
@@ -748,8 +748,8 @@ module server 'br/public:avm/res/sql/server:<version>' = {
           'ssfog-db3'
         ]
         name: 'ssfog-fg-readonly'
-        partnerServers: [
-          '<secondaryServerName>'
+        partnerServerResourceIds: [
+          '<secondaryServerResourceId>'
         ]
         readOnlyEndpoint: {
           failoverPolicy: 'Enabled'
@@ -831,8 +831,8 @@ module server 'br/public:avm/res/sql/server:<version>' = {
             "ssfog-db1"
           ],
           "name": "ssfog-fg-geo",
-          "partnerServers": [
-            "<secondaryServerName>"
+          "partnerServerResourceIds": [
+            "<secondaryServerResourceId>"
           ],
           "readWriteEndpoint": {
             "failoverPolicy": "Manual"
@@ -844,8 +844,8 @@ module server 'br/public:avm/res/sql/server:<version>' = {
             "ssfog-db2"
           ],
           "name": "ssfog-fg-standby",
-          "partnerServers": [
-            "<secondaryServerName>"
+          "partnerServerResourceIds": [
+            "<secondaryServerResourceId>"
           ],
           "readWriteEndpoint": {
             "failoverPolicy": "Automatic",
@@ -858,8 +858,8 @@ module server 'br/public:avm/res/sql/server:<version>' = {
             "ssfog-db3"
           ],
           "name": "ssfog-fg-readonly",
-          "partnerServers": [
-            "<secondaryServerName>"
+          "partnerServerResourceIds": [
+            "<secondaryServerResourceId>"
           ],
           "readOnlyEndpoint": {
             "failoverPolicy": "Enabled",
@@ -933,8 +933,8 @@ param failoverGroups = [
       'ssfog-db1'
     ]
     name: 'ssfog-fg-geo'
-    partnerServers: [
-      '<secondaryServerName>'
+    partnerServerResourceIds: [
+      '<secondaryServerResourceId>'
     ]
     readWriteEndpoint: {
       failoverPolicy: 'Manual'
@@ -946,8 +946,8 @@ param failoverGroups = [
       'ssfog-db2'
     ]
     name: 'ssfog-fg-standby'
-    partnerServers: [
-      '<secondaryServerName>'
+    partnerServerResourceIds: [
+      '<secondaryServerResourceId>'
     ]
     readWriteEndpoint: {
       failoverPolicy: 'Automatic'
@@ -960,8 +960,8 @@ param failoverGroups = [
       'ssfog-db3'
     ]
     name: 'ssfog-fg-readonly'
-    partnerServers: [
-      '<secondaryServerName>'
+    partnerServerResourceIds: [
+      '<secondaryServerResourceId>'
     ]
     readOnlyEndpoint: {
       failoverPolicy: 'Enabled'
@@ -3941,7 +3941,7 @@ The failover groups configuration.
 | :-- | :-- | :-- |
 | [`databases`](#parameter-failovergroupsdatabases) | array | List of databases in the failover group. |
 | [`name`](#parameter-failovergroupsname) | string | The name of the failover group. |
-| [`partnerServers`](#parameter-failovergroupspartnerservers) | array | List of the partner servers for the failover group. |
+| [`partnerServerResourceIds`](#parameter-failovergroupspartnerserverresourceids) | array | List of the partner server Resource Id for the failover group. |
 | [`readWriteEndpoint`](#parameter-failovergroupsreadwriteendpoint) | object | Read-write endpoint of the failover group instance. |
 | [`secondaryType`](#parameter-failovergroupssecondarytype) | string | Databases secondary type on partner server. |
 
@@ -3966,9 +3966,9 @@ The name of the failover group.
 - Required: Yes
 - Type: string
 
-### Parameter: `failoverGroups.partnerServers`
+### Parameter: `failoverGroups.partnerServerResourceIds`
 
-List of the partner servers for the failover group.
+List of the partner server Resource Id for the failover group.
 
 - Required: Yes
 - Type: array

--- a/avm/res/sql/server/audit-setting/main.json
+++ b/avm/res/sql/server/audit-setting/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "10207867872798857173"
+      "version": "0.36.177.2456",
+      "templateHash": "15087235755598672202"
     },
     "name": "Azure SQL Server Audit Settings",
     "description": "This module deploys an Azure SQL Server Audit Settings."
@@ -148,8 +148,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "16469435463567159258"
+              "version": "0.36.177.2456",
+              "templateHash": "9789204838235653449"
             }
           },
           "parameters": {

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "10140872033464442933"
+      "version": "0.36.177.2456",
+      "templateHash": "4683357092417411572"
     },
     "name": "SQL Server Database Long Term Backup Retention Policies",
     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."

--- a/avm/res/sql/server/database/backup-short-term-retention-policy/main.json
+++ b/avm/res/sql/server/database/backup-short-term-retention-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "9948442514033354219"
+      "version": "0.36.177.2456",
+      "templateHash": "15971526819734030405"
     },
     "name": "Azure SQL Server Database Short Term Backup Retention Policies",
     "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."

--- a/avm/res/sql/server/database/main.bicep
+++ b/avm/res/sql/server/database/main.bicep
@@ -129,7 +129,7 @@ param zoneRedundant bool = true
 // END OF DATABASE PROPERTIES
 
 @description('Optional. Tags of the resource.')
-param tags object?
+param tags resourceInput<'Microsoft.Sql/servers/database@2023-08-01'>.tags?
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
@@ -173,14 +173,14 @@ var identity = !empty(managedIdentities)
     }
   : null
 
-resource cMKKeyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId)) {
+resource cMKKeyVault 'Microsoft.KeyVault/vaults@2024-11-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId)) {
   name: last(split(customerManagedKey.?keyVaultResourceId!, '/'))
   scope: resourceGroup(
     split(customerManagedKey.?keyVaultResourceId!, '/')[2],
     split(customerManagedKey.?keyVaultResourceId!, '/')[4]
   )
 
-  resource cMKKey 'keys@2023-07-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId) && !empty(customerManagedKey.?keyName)) {
+  resource cMKKey 'keys@2024-11-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId) && !empty(customerManagedKey.?keyName)) {
     name: customerManagedKey.?keyName!
   }
 }
@@ -201,8 +201,8 @@ resource database 'Microsoft.Sql/servers/databases@2023-08-01' = {
     elasticPoolId: elasticPoolResourceId
     encryptionProtector: customerManagedKey != null
       ? !empty(customerManagedKey.?keyVersion)
-          ? '${cMKKeyVault::cMKKey.properties.keyUri}/${customerManagedKey!.?keyVersion}'
-          : cMKKeyVault::cMKKey.properties.keyUriWithVersion
+          ? '${cMKKeyVault::cMKKey.?properties.keyUri}/${customerManagedKey!.?keyVersion}'
+          : cMKKeyVault::cMKKey.?properties.keyUriWithVersion
       : null
     encryptionProtectorAutoRotation: customerManagedKey.?autoRotationEnabled
     federatedClientId: federatedClientId

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "13916745959726876819"
+      "version": "0.36.177.2456",
+      "templateHash": "12896402749829057992"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database."
@@ -621,10 +621,13 @@
     },
     "tags": {
       "type": "object",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Sql/servers/database@2023-08-01#properties/tags"
+        },
         "description": "Optional. Tags of the resource."
-      }
+      },
+      "nullable": true
     },
     "location": {
       "type": "string",
@@ -688,7 +691,7 @@
       "condition": "[and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName')))))]",
       "existing": true,
       "type": "Microsoft.KeyVault/vaults/keys",
-      "apiVersion": "2023-07-01",
+      "apiVersion": "2024-11-01",
       "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
       "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
       "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
@@ -703,7 +706,7 @@
       "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId')))]",
       "existing": true,
       "type": "Microsoft.KeyVault/vaults",
-      "apiVersion": "2023-07-01",
+      "apiVersion": "2024-11-01",
       "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
       "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
       "name": "[last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))]"
@@ -723,7 +726,7 @@
         "collation": "[parameters('collation')]",
         "createMode": "[parameters('createMode')]",
         "elasticPoolId": "[parameters('elasticPoolResourceId')]",
-        "encryptionProtector": "[if(not(equals(parameters('customerManagedKey'), null())), if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), reference('cMKKeyVault::cMKKey').keyUriWithVersion), null())]",
+        "encryptionProtector": "[if(not(equals(parameters('customerManagedKey'), null())), if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', tryGet(if(and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName'))))), reference('cMKKeyVault::cMKKey', '2024-11-01', 'full'), null()), 'properties', 'keyUri'), tryGet(parameters('customerManagedKey'), 'keyVersion')), tryGet(if(and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName'))))), reference('cMKKeyVault::cMKKey', '2024-11-01', 'full'), null()), 'properties', 'keyUriWithVersion')), null())]",
         "encryptionProtectorAutoRotation": "[tryGet(parameters('customerManagedKey'), 'autoRotationEnabled')]",
         "federatedClientId": "[parameters('federatedClientId')]",
         "freeLimitExhaustionBehavior": "[parameters('freeLimitExhaustionBehavior')]",
@@ -840,8 +843,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "9948442514033354219"
+              "version": "0.36.177.2456",
+              "templateHash": "15971526819734030405"
             },
             "name": "Azure SQL Server Database Short Term Backup Retention Policies",
             "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."
@@ -951,8 +954,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "10140872033464442933"
+              "version": "0.36.177.2456",
+              "templateHash": "4683357092417411572"
             },
             "name": "SQL Server Database Long Term Backup Retention Policies",
             "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."

--- a/avm/res/sql/server/elastic-pool/main.bicep
+++ b/avm/res/sql/server/elastic-pool/main.bicep
@@ -8,7 +8,7 @@ param name string
 param serverName string
 
 @description('Optional. Tags of the resource.')
-param tags object?
+param tags resourceInput<'Microsoft.Sql/servers/elasticPools@2023-08-01'>.tags?
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location

--- a/avm/res/sql/server/elastic-pool/main.json
+++ b/avm/res/sql/server/elastic-pool/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "13597336529535443631"
+      "version": "0.36.177.2456",
+      "templateHash": "17717615088622599892"
     },
     "name": "SQL Server Elastic Pool",
     "description": "This module deploys an Azure SQL Server Elastic Pool."
@@ -218,10 +218,13 @@
     },
     "tags": {
       "type": "object",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Sql/servers/elasticPools@2023-08-01#properties/tags"
+        },
         "description": "Optional. Tags of the resource."
-      }
+      },
+      "nullable": true
     },
     "location": {
       "type": "string",

--- a/avm/res/sql/server/encryption-protector/main.json
+++ b/avm/res/sql/server/encryption-protector/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "17490849737310265082"
+      "version": "0.36.177.2456",
+      "templateHash": "10711068673745163019"
     },
     "name": "Azure SQL Server Encryption Protector",
     "description": "This module deploys an Azure SQL Server Encryption Protector."

--- a/avm/res/sql/server/failover-group/README.md
+++ b/avm/res/sql/server/failover-group/README.md
@@ -22,7 +22,7 @@ This module deploys Azure SQL Server failover group.
 | :-- | :-- | :-- |
 | [`databases`](#parameter-databases) | array | List of databases in the failover group. |
 | [`name`](#parameter-name) | string | The name of the failover group. |
-| [`partnerServers`](#parameter-partnerservers) | array | List of the partner servers for the failover group. |
+| [`partnerServerResourceIds`](#parameter-partnerserverresourceids) | array | List of the partner server Resource Ids for the failover group. |
 | [`readWriteEndpoint`](#parameter-readwriteendpoint) | object | Read-write endpoint of the failover group instance. |
 | [`secondaryType`](#parameter-secondarytype) | string | Databases secondary type on partner server. |
 
@@ -53,9 +53,9 @@ The name of the failover group.
 - Required: Yes
 - Type: string
 
-### Parameter: `partnerServers`
+### Parameter: `partnerServerResourceIds`
 
-List of the partner servers for the failover group.
+List of the partner server Resource Ids for the failover group.
 
 - Required: Yes
 - Type: array

--- a/avm/res/sql/server/failover-group/main.bicep
+++ b/avm/res/sql/server/failover-group/main.bicep
@@ -10,8 +10,8 @@ param serverName string
 @description('Required. List of databases in the failover group.')
 param databases string[]
 
-@description('Required. List of the partner servers for the failover group.')
-param partnerServers string[]
+@description('Required. List of the partner server Resource Ids for the failover group.')
+param partnerServerResourceIds string[]
 
 @description('Optional. Read-only endpoint of the failover group instance.')
 param readOnlyEndpoint readOnlyEndpointType?
@@ -27,7 +27,7 @@ resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
 }
 
 @description('Optional. Tags of the resource.')
-param tags object?
+param tags resourceInput<'Microsoft.Sql/servers/failoverGroups@2023-08-01'>.tags?
 
 // https://stackoverflow.com/questions/78337117/azure-sql-failover-group-fails-on-second-run
 // https://github.com/Azure/bicep-types-az/issues/2153
@@ -39,8 +39,8 @@ resource failoverGroup 'Microsoft.Sql/servers/failoverGroups@2024-05-01-preview'
   properties: {
     databases: [for db in databases: resourceId('Microsoft.Sql/servers/databases', serverName, db)]
     partnerServers: [
-      for partnerServer in partnerServers: {
-        id: resourceId(resourceGroup().name, 'Microsoft.Sql/servers', partnerServer)
+      for partnerServerResourceId in partnerServerResourceIds: {
+        id: partnerServerResourceId
       }
     ]
     readOnlyEndpoint: !empty(readOnlyEndpoint)

--- a/avm/res/sql/server/failover-group/main.json
+++ b/avm/res/sql/server/failover-group/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "7002329445517579297"
+      "version": "0.36.177.2456",
+      "templateHash": "3984300491863960452"
     },
     "name": "Azure SQL Server failover group",
     "description": "This module deploys Azure SQL Server failover group."
@@ -86,13 +86,13 @@
         "description": "Required. List of databases in the failover group."
       }
     },
-    "partnerServers": {
+    "partnerServerResourceIds": {
       "type": "array",
       "items": {
         "type": "string"
       },
       "metadata": {
-        "description": "Required. List of the partner servers for the failover group."
+        "description": "Required. List of the partner server Resource Ids for the failover group."
       }
     },
     "readOnlyEndpoint": {
@@ -120,10 +120,13 @@
     },
     "tags": {
       "type": "object",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Sql/servers/failoverGroups@2023-08-01#properties/tags"
+        },
         "description": "Optional. Tags of the resource."
-      }
+      },
+      "nullable": true
     }
   },
   "resources": {
@@ -147,9 +150,9 @@
           },
           {
             "name": "partnerServers",
-            "count": "[length(parameters('partnerServers'))]",
+            "count": "[length(parameters('partnerServerResourceIds'))]",
             "input": {
-              "id": "[resourceId(resourceGroup().name, 'Microsoft.Sql/servers', parameters('partnerServers')[copyIndex('partnerServers')])]"
+              "id": "[parameters('partnerServerResourceIds')[copyIndex('partnerServers')]]"
             }
           }
         ],

--- a/avm/res/sql/server/firewall-rule/main.json
+++ b/avm/res/sql/server/firewall-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "4373974379110057634"
+      "version": "0.36.177.2456",
+      "templateHash": "1978120530795786079"
     },
     "name": "Azure SQL Server Firewall Rule",
     "description": "This module deploys an Azure SQL Server Firewall Rule."

--- a/avm/res/sql/server/key/main.json
+++ b/avm/res/sql/server/key/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "11129867292095349286"
+      "version": "0.36.177.2456",
+      "templateHash": "18390282185252943853"
     },
     "name": "Azure SQL Server Keys",
     "description": "This module deploys an Azure SQL Server Key."

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "8900848350284880182"
+      "version": "0.36.177.2456",
+      "templateHash": "7746364141016651743"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -257,10 +257,13 @@
         },
         "tags": {
           "type": "object",
-          "nullable": true,
           "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Sql/servers/databases@2023-08-01#properties/tags"
+            },
             "description": "Optional. Tags of the resource."
-          }
+          },
+          "nullable": true
         },
         "lock": {
           "$ref": "#/definitions/lockType",
@@ -949,13 +952,13 @@
             "description": "Required. List of databases in the failover group."
           }
         },
-        "partnerServers": {
+        "partnerServerResourceIds": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "metadata": {
-            "description": "Required. List of the partner servers for the failover group."
+            "description": "Required. List of the partner server Resource Id for the failover group."
           }
         },
         "readOnlyEndpoint": {
@@ -1952,10 +1955,13 @@
     },
     "tags": {
       "type": "object",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Sql/servers@2023-08-01#properties/tags"
+        },
         "description": "Optional. Tags of the resource."
-      }
+      },
+      "nullable": true
     },
     "enableTelemetry": {
       "type": "bool",
@@ -2184,7 +2190,7 @@
       "condition": "[and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName')))))]",
       "existing": true,
       "type": "Microsoft.KeyVault/vaults/keys",
-      "apiVersion": "2023-07-01",
+      "apiVersion": "2024-11-01",
       "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
       "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
       "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
@@ -2193,7 +2199,7 @@
       "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId')))]",
       "existing": true,
       "type": "Microsoft.KeyVault/vaults",
-      "apiVersion": "2023-07-01",
+      "apiVersion": "2024-11-01",
       "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
       "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
       "name": "[last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))]"
@@ -2231,7 +2237,7 @@
         "administrators": "[union(createObject('administratorType', 'ActiveDirectory'), coalesce(parameters('administrators'), createObject()))]",
         "federatedClientId": "[parameters('federatedClientId')]",
         "isIPv6Enabled": "[parameters('isIPv6Enabled')]",
-        "keyId": "[if(not(equals(parameters('customerManagedKey'), null())), if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), reference('cMKKeyVault::cMKKey').keyUriWithVersion), null())]",
+        "keyId": "[if(not(equals(parameters('customerManagedKey'), null())), if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', tryGet(if(and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName'))))), reference('cMKKeyVault::cMKKey', '2024-11-01', 'full'), null()), 'properties', 'keyUri'), tryGet(parameters('customerManagedKey'), 'keyVersion')), tryGet(if(and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName'))))), reference('cMKKeyVault::cMKKey', '2024-11-01', 'full'), null()), 'properties', 'keyUriWithVersion')), null())]",
         "version": "12.0",
         "minimalTlsVersion": "[parameters('minimalTlsVersion')]",
         "primaryUserAssignedIdentityId": "[parameters('primaryUserAssignedIdentityResourceId')]",
@@ -2437,8 +2443,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "13916745959726876819"
+              "version": "0.36.177.2456",
+              "templateHash": "12896402749829057992"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database."
@@ -3053,10 +3059,13 @@
             },
             "tags": {
               "type": "object",
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Sql/servers/database@2023-08-01#properties/tags"
+                },
                 "description": "Optional. Tags of the resource."
-              }
+              },
+              "nullable": true
             },
             "location": {
               "type": "string",
@@ -3120,7 +3129,7 @@
               "condition": "[and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName')))))]",
               "existing": true,
               "type": "Microsoft.KeyVault/vaults/keys",
-              "apiVersion": "2023-07-01",
+              "apiVersion": "2024-11-01",
               "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
               "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
               "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
@@ -3135,7 +3144,7 @@
               "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId')))]",
               "existing": true,
               "type": "Microsoft.KeyVault/vaults",
-              "apiVersion": "2023-07-01",
+              "apiVersion": "2024-11-01",
               "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
               "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
               "name": "[last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))]"
@@ -3155,7 +3164,7 @@
                 "collation": "[parameters('collation')]",
                 "createMode": "[parameters('createMode')]",
                 "elasticPoolId": "[parameters('elasticPoolResourceId')]",
-                "encryptionProtector": "[if(not(equals(parameters('customerManagedKey'), null())), if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), reference('cMKKeyVault::cMKKey').keyUriWithVersion), null())]",
+                "encryptionProtector": "[if(not(equals(parameters('customerManagedKey'), null())), if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', tryGet(if(and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName'))))), reference('cMKKeyVault::cMKKey', '2024-11-01', 'full'), null()), 'properties', 'keyUri'), tryGet(parameters('customerManagedKey'), 'keyVersion')), tryGet(if(and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName'))))), reference('cMKKeyVault::cMKKey', '2024-11-01', 'full'), null()), 'properties', 'keyUriWithVersion')), null())]",
                 "encryptionProtectorAutoRotation": "[tryGet(parameters('customerManagedKey'), 'autoRotationEnabled')]",
                 "federatedClientId": "[parameters('federatedClientId')]",
                 "freeLimitExhaustionBehavior": "[parameters('freeLimitExhaustionBehavior')]",
@@ -3272,8 +3281,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "9948442514033354219"
+                      "version": "0.36.177.2456",
+                      "templateHash": "15971526819734030405"
                     },
                     "name": "Azure SQL Server Database Short Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."
@@ -3383,8 +3392,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "10140872033464442933"
+                      "version": "0.36.177.2456",
+                      "templateHash": "4683357092417411572"
                     },
                     "name": "SQL Server Database Long Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."
@@ -3593,8 +3602,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "13597336529535443631"
+              "version": "0.36.177.2456",
+              "templateHash": "17717615088622599892"
             },
             "name": "SQL Server Elastic Pool",
             "description": "This module deploys an Azure SQL Server Elastic Pool."
@@ -3806,10 +3815,13 @@
             },
             "tags": {
               "type": "object",
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Sql/servers/elasticPools@2023-08-01#properties/tags"
+                },
                 "description": "Optional. Tags of the resource."
-              }
+              },
+              "nullable": true
             },
             "location": {
               "type": "string",
@@ -4849,8 +4861,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "4373974379110057634"
+              "version": "0.36.177.2456",
+              "templateHash": "1978120530795786079"
             },
             "name": "Azure SQL Server Firewall Rule",
             "description": "This module deploys an Azure SQL Server Firewall Rule."
@@ -4956,8 +4968,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "4329943834463874399"
+              "version": "0.36.177.2456",
+              "templateHash": "3011136361984958720"
             },
             "name": "Azure SQL Server Virtual Network Rules",
             "description": "This module deploys an Azure SQL Server Virtual Network Rule."
@@ -5078,8 +5090,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "15348652978067640813"
+              "version": "0.36.177.2456",
+              "templateHash": "5044173542671495897"
             },
             "name": "Azure SQL Server Security Alert Policies",
             "description": "This module deploys an Azure SQL Server Security Alert Policy."
@@ -5253,8 +5265,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "2856119284131810417"
+              "version": "0.36.177.2456",
+              "templateHash": "9146279544254115816"
             },
             "name": "Azure SQL Server Vulnerability Assessments",
             "description": "This module deploys an Azure SQL Server Vulnerability Assessment."
@@ -5381,8 +5393,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "16708437053172304191"
+                      "version": "0.36.177.2456",
+                      "templateHash": "17896260506837363606"
                     }
                   },
                   "parameters": {
@@ -5477,8 +5489,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "11129867292095349286"
+              "version": "0.36.177.2456",
+              "templateHash": "18390282185252943853"
             },
             "name": "Azure SQL Server Keys",
             "description": "This module deploys an Azure SQL Server Key."
@@ -5581,12 +5593,12 @@
             "value": "[parameters('name')]"
           },
           "name": {
-            "value": "[format('{0}_{1}_{2}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'), if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), tryGet(parameters('customerManagedKey'), 'keyVersion'), last(split(reference('cMKKeyVault::cMKKey').keyUriWithVersion, '/'))))]"
+            "value": "[format('{0}_{1}_{2}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'), if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), tryGet(parameters('customerManagedKey'), 'keyVersion'), last(split(coalesce(tryGet(if(and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName'))))), reference('cMKKeyVault::cMKKey', '2024-11-01', 'full'), null()), 'properties', 'keyUriWithVersion'), ''), '/'))))]"
           },
           "serverKeyType": {
             "value": "AzureKeyVault"
           },
-          "uri": "[if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), createObject('value', format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion'))), createObject('value', reference('cMKKeyVault::cMKKey').keyUriWithVersion))]"
+          "uri": "[if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), createObject('value', format('{0}/{1}', tryGet(if(and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName'))))), reference('cMKKeyVault::cMKKey', '2024-11-01', 'full'), null()), 'properties', 'keyUri'), tryGet(parameters('customerManagedKey'), 'keyVersion'))), createObject('value', tryGet(if(and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName'))))), reference('cMKKeyVault::cMKKey', '2024-11-01', 'full'), null()), 'properties', 'keyUriWithVersion')))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -5595,8 +5607,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "11129867292095349286"
+              "version": "0.36.177.2456",
+              "templateHash": "18390282185252943853"
             },
             "name": "Azure SQL Server Keys",
             "description": "This module deploys an Azure SQL Server Key."
@@ -5700,7 +5712,7 @@
             "value": "[parameters('name')]"
           },
           "serverKeyName": {
-            "value": "[reference('cmk_key').outputs.name.value]"
+            "value": "[coalesce(tryGet(if(not(equals(parameters('customerManagedKey'), null())), reference('cmk_key'), null()), 'outputs', 'name', 'value'), '')]"
           },
           "serverKeyType": {
             "value": "AzureKeyVault"
@@ -5715,8 +5727,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "17490849737310265082"
+              "version": "0.36.177.2456",
+              "templateHash": "10711068673745163019"
             },
             "name": "Azure SQL Server Encryption Protector",
             "description": "This module deploys an Azure SQL Server Encryption Protector."
@@ -5847,8 +5859,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "10207867872798857173"
+              "version": "0.36.177.2456",
+              "templateHash": "15087235755598672202"
             },
             "name": "Azure SQL Server Audit Settings",
             "description": "This module deploys an Azure SQL Server Audit Settings."
@@ -5990,8 +6002,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "16469435463567159258"
+                      "version": "0.36.177.2456",
+                      "templateHash": "9789204838235653449"
                     }
                   },
                   "parameters": {
@@ -6078,8 +6090,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "18255389690016246128"
+              "version": "0.36.177.2456",
+              "templateHash": "15876875108926400759"
             }
           },
           "definitions": {
@@ -6224,8 +6236,8 @@
           "databases": {
             "value": "[coalesce(parameters('failoverGroups'), createArray())[copyIndex()].databases]"
           },
-          "partnerServers": {
-            "value": "[coalesce(parameters('failoverGroups'), createArray())[copyIndex()].partnerServers]"
+          "partnerServerResourceIds": {
+            "value": "[coalesce(parameters('failoverGroups'), createArray())[copyIndex()].partnerServerResourceIds]"
           },
           "readOnlyEndpoint": {
             "value": "[tryGet(coalesce(parameters('failoverGroups'), createArray())[copyIndex()], 'readOnlyEndpoint')]"
@@ -6244,8 +6256,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "7002329445517579297"
+              "version": "0.36.177.2456",
+              "templateHash": "3984300491863960452"
             },
             "name": "Azure SQL Server failover group",
             "description": "This module deploys Azure SQL Server failover group."
@@ -6325,13 +6337,13 @@
                 "description": "Required. List of databases in the failover group."
               }
             },
-            "partnerServers": {
+            "partnerServerResourceIds": {
               "type": "array",
               "items": {
                 "type": "string"
               },
               "metadata": {
-                "description": "Required. List of the partner servers for the failover group."
+                "description": "Required. List of the partner server Resource Ids for the failover group."
               }
             },
             "readOnlyEndpoint": {
@@ -6359,10 +6371,13 @@
             },
             "tags": {
               "type": "object",
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Sql/servers/failoverGroups@2023-08-01#properties/tags"
+                },
                 "description": "Optional. Tags of the resource."
-              }
+              },
+              "nullable": true
             }
           },
           "resources": {
@@ -6386,9 +6401,9 @@
                   },
                   {
                     "name": "partnerServers",
-                    "count": "[length(parameters('partnerServers'))]",
+                    "count": "[length(parameters('partnerServerResourceIds'))]",
                     "input": {
-                      "id": "[resourceId(resourceGroup().name, 'Microsoft.Sql/servers', parameters('partnerServers')[copyIndex('partnerServers')])]"
+                      "id": "[parameters('partnerServerResourceIds')[copyIndex('partnerServers')]]"
                     }
                   }
                 ],
@@ -6478,7 +6493,7 @@
       "metadata": {
         "description": "A hashtable of references to the secrets exported to the provided Key Vault. The key of each reference is each secret's name."
       },
-      "value": "[if(not(equals(parameters('secretsExportConfiguration'), null())), toObject(reference('secretsExport').outputs.secretsSet.value, lambda('secret', last(split(lambdaVariables('secret').secretResourceId, '/'))), lambda('secret', lambdaVariables('secret'))), createObject())]"
+      "value": "[if(not(equals(parameters('secretsExportConfiguration'), null())), toObject(coalesce(tryGet(tryGet(tryGet(if(not(equals(parameters('secretsExportConfiguration'), null())), reference('secretsExport'), null()), 'outputs'), 'secretsSet'), 'value'), createArray()), lambda('secret', last(split(lambdaVariables('secret').secretResourceId, '/'))), lambda('secret', lambdaVariables('secret'))), createObject())]"
     },
     "privateEndpoints": {
       "type": "array",

--- a/avm/res/sql/server/security-alert-policy/main.json
+++ b/avm/res/sql/server/security-alert-policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "15348652978067640813"
+      "version": "0.36.177.2456",
+      "templateHash": "5044173542671495897"
     },
     "name": "Azure SQL Server Security Alert Policies",
     "description": "This module deploys an Azure SQL Server Security Alert Policy."

--- a/avm/res/sql/server/tests/e2e/failover-group/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/failover-group/dependencies.bicep
@@ -19,4 +19,6 @@ resource server 'Microsoft.Sql/servers@2023-08-01' = {
 
 @description('The name of the deployed secondary server.')
 output secondaryServerName string = server.name
+
+@description('The resource Id of the deployed secondary server.')
 output secondaryServerResourceId string = server.id

--- a/avm/res/sql/server/tests/e2e/failover-group/dependencies.bicep
+++ b/avm/res/sql/server/tests/e2e/failover-group/dependencies.bicep
@@ -19,3 +19,4 @@ resource server 'Microsoft.Sql/servers@2023-08-01' = {
 
 @description('The name of the deployed secondary server.')
 output secondaryServerName string = server.name
+output secondaryServerResourceId string = server.id

--- a/avm/res/sql/server/tests/e2e/failover-group/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/failover-group/main.test.bicep
@@ -101,8 +101,8 @@ module testDeployment '../../../main.bicep' = [
           databases: [
             '${namePrefix}-${serviceShort}-db1'
           ]
-          partnerServers: [
-            nestedDependencies.outputs.secondaryServerName
+          partnerServerResourceIds: [
+            nestedDependencies.outputs.secondaryServerResourceId
           ]
           readWriteEndpoint: {
             failoverPolicy: 'Manual'
@@ -115,8 +115,8 @@ module testDeployment '../../../main.bicep' = [
           databases: [
             '${namePrefix}-${serviceShort}-db2'
           ]
-          partnerServers: [
-            nestedDependencies.outputs.secondaryServerName
+          partnerServerResourceIds: [
+            nestedDependencies.outputs.secondaryServerResourceId
           ]
           readWriteEndpoint: {
             failoverPolicy: 'Automatic'
@@ -130,8 +130,8 @@ module testDeployment '../../../main.bicep' = [
           databases: [
             '${namePrefix}-${serviceShort}-db3'
           ]
-          partnerServers: [
-            nestedDependencies.outputs.secondaryServerName
+          partnerServerResourceIds: [
+            nestedDependencies.outputs.secondaryServerResourceId
           ]
           readWriteEndpoint: {
             failoverPolicy: 'Manual'

--- a/avm/res/sql/server/version.json
+++ b/avm/res/sql/server/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.19"
+  "version": "0.20"
 }

--- a/avm/res/sql/server/virtual-network-rule/main.json
+++ b/avm/res/sql/server/virtual-network-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "4329943834463874399"
+      "version": "0.36.177.2456",
+      "templateHash": "3011136361984958720"
     },
     "name": "Azure SQL Server Virtual Network Rules",
     "description": "This module deploys an Azure SQL Server Virtual Network Rule."

--- a/avm/res/sql/server/vulnerability-assessment/main.json
+++ b/avm/res/sql/server/vulnerability-assessment/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "2856119284131810417"
+      "version": "0.36.177.2456",
+      "templateHash": "9146279544254115816"
     },
     "name": "Azure SQL Server Vulnerability Assessments",
     "description": "This module deploys an Azure SQL Server Vulnerability Assessment."
@@ -133,8 +133,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "16708437053172304191"
+              "version": "0.36.177.2456",
+              "templateHash": "17896260506837363606"
             }
           },
           "parameters": {


### PR DESCRIPTION
## Description

This PR enables for failover cluster members to be in a different resource groups. `partnerServers` array has been renamed to `partnerServerResourceIds` in the failover group module to make it possible to use SQL servers from different resource groups.

Also adding proper types to `tags` and updating to latest bicep.

Fixes #5560 

## Pipeline Reference

| Pipeline |
| -------- |
|     [![avm.res.sql.server](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg?branch=5560)](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml)  |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
