### PR TITLE
fix: Compute-Disk - Changed `availabilityZone` allowed set

### DIFF
--- a/avm/res/compute/disk/CHANGELOG.md
+++ b/avm/res/compute/disk/CHANGELOG.md
@@ -10,7 +10,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Breaking Changes
 
-- Changed allowed set from `[0,1,2,3]` to `[-1,1,2,3]`. `-1` works in the same way as the previous `0` to specify that no zone is to be set
+- Changed `availabilityZones` allowed set from `[0,1,2,3]` to `[-1,1,2,3]`. `-1` works in the same way as the previous `0` to specify that no zone is to be set
 
 ## 0.4.3
 

--- a/avm/res/compute/disk/CHANGELOG.md
+++ b/avm/res/compute/disk/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/disk/CHANGELOG.md).
 
+## 0.5.0
+
+### Changes
+
+- None
+
+### Breaking Changes
+
+- Changed allowed set from `[0,1,2,3]` to `[-1,1,2,3]`. `-1` works in the same way as the previous `0` to specify that no zone is to be set
+
 ## 0.4.3
 
 ### Changes

--- a/avm/res/compute/disk/README.md
+++ b/avm/res/compute/disk/README.md
@@ -47,7 +47,7 @@ module disk 'br/public:avm/res/compute/disk:<version>' = {
   name: 'diskDeployment'
   params: {
     // Required parameters
-    availabilityZone: 0
+    availabilityZone: -1
     name: 'cdmin001'
     sku: 'Standard_LRS'
     // Non-required parameters
@@ -71,7 +71,7 @@ module disk 'br/public:avm/res/compute/disk:<version>' = {
   "parameters": {
     // Required parameters
     "availabilityZone": {
-      "value": 0
+      "value": -1
     },
     "name": {
       "value": "cdmin001"
@@ -101,7 +101,7 @@ module disk 'br/public:avm/res/compute/disk:<version>' = {
 using 'br/public:avm/res/compute/disk:<version>'
 
 // Required parameters
-param availabilityZone = 0
+param availabilityZone = -1
 param name = 'cdmin001'
 param sku = 'Standard_LRS'
 // Non-required parameters
@@ -126,7 +126,7 @@ module disk 'br/public:avm/res/compute/disk:<version>' = {
   name: 'diskDeployment'
   params: {
     // Required parameters
-    availabilityZone: 0
+    availabilityZone: -1
     name: 'cdimg001'
     sku: 'Standard_LRS'
     // Non-required parameters
@@ -151,7 +151,7 @@ module disk 'br/public:avm/res/compute/disk:<version>' = {
   "parameters": {
     // Required parameters
     "availabilityZone": {
-      "value": 0
+      "value": -1
     },
     "name": {
       "value": "cdimg001"
@@ -184,7 +184,7 @@ module disk 'br/public:avm/res/compute/disk:<version>' = {
 using 'br/public:avm/res/compute/disk:<version>'
 
 // Required parameters
-param availabilityZone = 0
+param availabilityZone = -1
 param name = 'cdimg001'
 param sku = 'Standard_LRS'
 // Non-required parameters
@@ -210,7 +210,7 @@ module disk 'br/public:avm/res/compute/disk:<version>' = {
   name: 'diskDeployment'
   params: {
     // Required parameters
-    availabilityZone: 0
+    availabilityZone: -1
     name: 'cdimp001'
     sku: 'Standard_LRS'
     // Non-required parameters
@@ -236,7 +236,7 @@ module disk 'br/public:avm/res/compute/disk:<version>' = {
   "parameters": {
     // Required parameters
     "availabilityZone": {
-      "value": 0
+      "value": -1
     },
     "name": {
       "value": "cdimp001"
@@ -272,7 +272,7 @@ module disk 'br/public:avm/res/compute/disk:<version>' = {
 using 'br/public:avm/res/compute/disk:<version>'
 
 // Required parameters
-param availabilityZone = 0
+param availabilityZone = -1
 param name = 'cdimp001'
 param sku = 'Standard_LRS'
 // Non-required parameters
@@ -620,7 +620,7 @@ param tags = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`availabilityZone`](#parameter-availabilityzone) | int | If set to 1, 2 or 3, the availability zone is hardcoded to that value. If zero, then availability zones are not used. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones). |
+| [`availabilityZone`](#parameter-availabilityzone) | int | If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone numbers here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones). |
 | [`name`](#parameter-name) | string | The name of the disk that is being created. |
 | [`sku`](#parameter-sku) | string | The disks sku name. Can be . |
 
@@ -663,14 +663,14 @@ param tags = {
 
 ### Parameter: `availabilityZone`
 
-If set to 1, 2 or 3, the availability zone is hardcoded to that value. If zero, then availability zones are not used. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).
+If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone numbers here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones).
 
 - Required: Yes
 - Type: int
 - Allowed:
   ```Bicep
   [
-    0
+    -1
     1
     2
     3

--- a/avm/res/compute/disk/main.bicep
+++ b/avm/res/compute/disk/main.bicep
@@ -123,9 +123,9 @@ param publicNetworkAccess string = 'Disabled'
 @description('Optional. True if the image from which the OS disk is created supports accelerated networking.')
 param acceleratedNetwork bool = false
 
-@description('Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If zero, then availability zones are not used. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones).')
+@description('Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone numbers here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones).')
 @allowed([
-  0
+  -1
   1
   2
   3
@@ -256,7 +256,7 @@ resource disk 'Microsoft.Compute/disks@2023-10-02' = {
         }
       : {}
   }
-  zones: availabilityZone != 0 ? array(string(availabilityZone)) : null
+  zones: availabilityZone != -1 ? array(string(availabilityZone)) : null
 }
 
 resource disk_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(lock ?? {}) && lock.?kind != 'None') {

--- a/avm/res/compute/disk/main.json
+++ b/avm/res/compute/disk/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "5228212360415586573"
+      "version": "0.36.177.2456",
+      "templateHash": "18204160603102381854"
     },
     "name": "Compute Disks",
     "description": "This module deploys a Compute Disk"
@@ -342,13 +342,13 @@
     "availabilityZone": {
       "type": "int",
       "allowedValues": [
-        0,
+        -1,
         1,
         2,
         3
       ],
       "metadata": {
-        "description": "Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If zero, then availability zones are not used. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone.To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones) and [Distribute VMs and disks across availability zones](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-high-availability#distribute-vms-and-disks-across-availability-zones)."
+        "description": "Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone numbers here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones)."
       }
     },
     "lock": {
@@ -459,7 +459,7 @@
         "publicNetworkAccess": "[parameters('publicNetworkAccess')]",
         "supportedCapabilities": "[if(not(empty(parameters('osType'))), createObject('acceleratedNetwork', parameters('acceleratedNetwork'), 'architecture', if(not(empty(parameters('architecture'))), parameters('architecture'), null())), createObject())]"
       },
-      "zones": "[if(not(equals(parameters('availabilityZone'), 0)), array(string(parameters('availabilityZone'))), null())]"
+      "zones": "[if(not(equals(parameters('availabilityZone'), -1)), array(string(parameters('availabilityZone'))), null())]"
     },
     "disk_lock": {
       "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",

--- a/avm/res/compute/disk/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/compute/disk/tests/e2e/defaults/main.test.bicep
@@ -43,7 +43,7 @@ module testDeployment '../../../main.bicep' = [
       name: '${namePrefix}-${serviceShort}001'
       location: resourceLocation
       sku: 'Standard_LRS'
-      availabilityZone: 0
+      availabilityZone: -1
       diskSizeGB: 1
     }
   }

--- a/avm/res/compute/disk/tests/e2e/image/main.test.bicep
+++ b/avm/res/compute/disk/tests/e2e/image/main.test.bicep
@@ -52,7 +52,7 @@ module testDeployment '../../../main.bicep' = [
       name: '${namePrefix}-${serviceShort}001'
       location: resourceLocation
       sku: 'Standard_LRS'
-      availabilityZone: 0
+      availabilityZone: -1
       createOption: 'FromImage'
       imageReferenceId: '${subscription().id}/Providers/Microsoft.Compute/Locations/westeurope/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2022-datacenter-azure-edition/Versions/20348.2340.240303'
     }

--- a/avm/res/compute/disk/tests/e2e/import/main.test.bicep
+++ b/avm/res/compute/disk/tests/e2e/import/main.test.bicep
@@ -59,7 +59,7 @@ module testDeployment '../../../main.bicep' = [
       name: '${namePrefix}-${serviceShort}001'
       location: resourceLocation
       sku: 'Standard_LRS'
-      availabilityZone: 0
+      availabilityZone: -1
       createOption: 'Import'
       sourceUri: nestedDependencies.outputs.vhdUri
       storageAccountId: nestedDependencies.outputs.storageAccountResourceId

--- a/avm/res/compute/disk/version.json
+++ b/avm/res/compute/disk/version.json
@@ -1,4 +1,4 @@
 {
-    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.4"
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.5"
 }


### PR DESCRIPTION
## Description

- Changed `availabilityZones` allowed set from `[0,1,2,3]` to `[-1,1,2,3]`. `-1` works in the same way as the previous `0` to specify that no zone is to be set

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.compute.disk](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk.yml/badge.svg?branch=users%2Falsehr%2FcomputeDiskZone&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
