### PR TITLE
fix: ProximityPlacementGroup - Renamed plural `zones` parameter to singular `availabilityZone` and added allowed set

### DIFF
--- a/avm/res/compute/proximity-placement-group/CHANGELOG.md
+++ b/avm/res/compute/proximity-placement-group/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/proximity-placement-group/CHANGELOG.md).
 
+## 0.4.0
+
+### Changes
+
+- None
+
+### Breaking Changes
+
+- Renamed `zones` parameter to `availabilityZones`
+- Added allowed set `[1,2,3]` to `availabilityZones` parameter. I.e., zones **must** be provided as integers, not strings
+
 ## 0.3.2
 
 ### Changes

--- a/avm/res/compute/proximity-placement-group/CHANGELOG.md
+++ b/avm/res/compute/proximity-placement-group/CHANGELOG.md
@@ -10,8 +10,9 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Breaking Changes
 
-- Renamed `zones` parameter to `availabilityZones`
-- Added allowed set `[1,2,3]` to `availabilityZones` parameter. I.e., zones **must** be provided as integers, not strings
+- Renamed `zones` parameter to singular `availabilityZone`
+- Changed type of `availabilityZone` to singular integer without a default as the resource is zone-redundant, not zonal. As a result, users **must** define a zone upon deployment, but can opt out by providing a value of -1
+- Added allowed set `[-1,1,2,3]` to `availabilityZone` parameter
 
 ## 0.3.2
 

--- a/avm/res/compute/proximity-placement-group/README.md
+++ b/avm/res/compute/proximity-placement-group/README.md
@@ -45,6 +45,7 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
   name: 'proximityPlacementGroupDeployment'
   params: {
     // Required parameters
+    availabilityZone: -1
     name: 'cppgmin001'
     // Non-required parameters
     location: '<location>'
@@ -65,6 +66,9 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "availabilityZone": {
+      "value": -1
+    },
     "name": {
       "value": "cppgmin001"
     },
@@ -87,6 +91,7 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
 using 'br/public:avm/res/compute/proximity-placement-group:<version>'
 
 // Required parameters
+param availabilityZone = -1
 param name = 'cppgmin001'
 // Non-required parameters
 param location = '<location>'
@@ -109,11 +114,9 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
   name: 'proximityPlacementGroupDeployment'
   params: {
     // Required parameters
+    availabilityZone: 1
     name: 'cppgmax001'
     // Non-required parameters
-    availabilityZones: [
-      1
-    ]
     colocationStatus: {
       code: 'ColocationStatus/Aligned'
       displayStatus: 'Aligned'
@@ -173,15 +176,13 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "availabilityZone": {
+      "value": 1
+    },
     "name": {
       "value": "cppgmax001"
     },
     // Non-required parameters
-    "availabilityZones": {
-      "value": [
-        1
-      ]
-    },
     "colocationStatus": {
       "value": {
         "code": "ColocationStatus/Aligned",
@@ -253,11 +254,9 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
 using 'br/public:avm/res/compute/proximity-placement-group:<version>'
 
 // Required parameters
+param availabilityZone = 1
 param name = 'cppgmax001'
 // Non-required parameters
-param availabilityZones = [
-  1
-]
 param colocationStatus = {
   code: 'ColocationStatus/Aligned'
   displayStatus: 'Aligned'
@@ -319,11 +318,9 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
   name: 'proximityPlacementGroupDeployment'
   params: {
     // Required parameters
+    availabilityZone: 1
     name: 'cppgwaf001'
     // Non-required parameters
-    availabilityZones: [
-      1
-    ]
     colocationStatus: {
       code: 'ColocationStatus/Aligned'
       displayStatus: 'Aligned'
@@ -360,15 +357,13 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "availabilityZone": {
+      "value": 1
+    },
     "name": {
       "value": "cppgwaf001"
     },
     // Non-required parameters
-    "availabilityZones": {
-      "value": [
-        1
-      ]
-    },
     "colocationStatus": {
       "value": {
         "code": "ColocationStatus/Aligned",
@@ -413,11 +408,9 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
 using 'br/public:avm/res/compute/proximity-placement-group:<version>'
 
 // Required parameters
+param availabilityZone = 1
 param name = 'cppgwaf001'
 // Non-required parameters
-param availabilityZones = [
-  1
-]
 param colocationStatus = {
   code: 'ColocationStatus/Aligned'
   displayStatus: 'Aligned'
@@ -448,13 +441,13 @@ param type = 'Standard'
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`availabilityZone`](#parameter-availabilityzone) | int | Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone numbers here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones). |
 | [`name`](#parameter-name) | string | The name of the proximity placement group that is being created. |
 
 **Optional parameters**
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`availabilityZones`](#parameter-availabilityzones) | array | Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created. |
 | [`colocationStatus`](#parameter-colocationstatus) | object | Describes colocation status of the Proximity Placement Group. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`intent`](#parameter-intent) | object | Specifies the user intent of the proximity placement group. |
@@ -464,35 +457,28 @@ param type = 'Standard'
 | [`tags`](#parameter-tags) | object | Tags of the proximity placement group resource. |
 | [`type`](#parameter-type) | string | Specifies the type of the proximity placement group. |
 
+### Parameter: `availabilityZone`
+
+Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone numbers here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones).
+
+- Required: Yes
+- Type: int
+- Allowed:
+  ```Bicep
+  [
+    -1
+    1
+    2
+    3
+  ]
+  ```
+
 ### Parameter: `name`
 
 The name of the proximity placement group that is being created.
 
 - Required: Yes
 - Type: string
-
-### Parameter: `availabilityZones`
-
-Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created.
-
-- Required: No
-- Type: array
-- Default:
-  ```Bicep
-  [
-    1
-    2
-    3
-  ]
-  ```
-- Allowed:
-  ```Bicep
-  [
-    1
-    2
-    3
-  ]
-  ```
 
 ### Parameter: `colocationStatus`
 

--- a/avm/res/compute/proximity-placement-group/README.md
+++ b/avm/res/compute/proximity-placement-group/README.md
@@ -111,6 +111,9 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
     // Required parameters
     name: 'cppgmax001'
     // Non-required parameters
+    availabilityZones: [
+      1
+    ]
     colocationStatus: {
       code: 'ColocationStatus/Aligned'
       displayStatus: 'Aligned'
@@ -153,9 +156,6 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
       TagB: 'Tags for sale'
     }
     type: 'Standard'
-    zones: [
-      '1'
-    ]
   }
 }
 ```
@@ -177,6 +177,11 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
       "value": "cppgmax001"
     },
     // Non-required parameters
+    "availabilityZones": {
+      "value": [
+        1
+      ]
+    },
     "colocationStatus": {
       "value": {
         "code": "ColocationStatus/Aligned",
@@ -232,11 +237,6 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
     },
     "type": {
       "value": "Standard"
-    },
-    "zones": {
-      "value": [
-        "1"
-      ]
     }
   }
 }
@@ -255,6 +255,9 @@ using 'br/public:avm/res/compute/proximity-placement-group:<version>'
 // Required parameters
 param name = 'cppgmax001'
 // Non-required parameters
+param availabilityZones = [
+  1
+]
 param colocationStatus = {
   code: 'ColocationStatus/Aligned'
   displayStatus: 'Aligned'
@@ -297,9 +300,6 @@ param tags = {
   TagB: 'Tags for sale'
 }
 param type = 'Standard'
-param zones = [
-  '1'
-]
 ```
 
 </details>
@@ -321,6 +321,9 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
     // Required parameters
     name: 'cppgwaf001'
     // Non-required parameters
+    availabilityZones: [
+      1
+    ]
     colocationStatus: {
       code: 'ColocationStatus/Aligned'
       displayStatus: 'Aligned'
@@ -340,9 +343,6 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
       TagB: 'Tags for sale'
     }
     type: 'Standard'
-    zones: [
-      '1'
-    ]
   }
 }
 ```
@@ -364,6 +364,11 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
       "value": "cppgwaf001"
     },
     // Non-required parameters
+    "availabilityZones": {
+      "value": [
+        1
+      ]
+    },
     "colocationStatus": {
       "value": {
         "code": "ColocationStatus/Aligned",
@@ -392,11 +397,6 @@ module proximityPlacementGroup 'br/public:avm/res/compute/proximity-placement-gr
     },
     "type": {
       "value": "Standard"
-    },
-    "zones": {
-      "value": [
-        "1"
-      ]
     }
   }
 }
@@ -415,6 +415,9 @@ using 'br/public:avm/res/compute/proximity-placement-group:<version>'
 // Required parameters
 param name = 'cppgwaf001'
 // Non-required parameters
+param availabilityZones = [
+  1
+]
 param colocationStatus = {
   code: 'ColocationStatus/Aligned'
   displayStatus: 'Aligned'
@@ -434,9 +437,6 @@ param tags = {
   TagB: 'Tags for sale'
 }
 param type = 'Standard'
-param zones = [
-  '1'
-]
 ```
 
 </details>
@@ -454,6 +454,7 @@ param zones = [
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`availabilityZones`](#parameter-availabilityzones) | array | Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created. |
 | [`colocationStatus`](#parameter-colocationstatus) | object | Describes colocation status of the Proximity Placement Group. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`intent`](#parameter-intent) | object | Specifies the user intent of the proximity placement group. |
@@ -462,7 +463,6 @@ param zones = [
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Tags of the proximity placement group resource. |
 | [`type`](#parameter-type) | string | Specifies the type of the proximity placement group. |
-| [`zones`](#parameter-zones) | array | Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created. |
 
 ### Parameter: `name`
 
@@ -470,6 +470,29 @@ The name of the proximity placement group that is being created.
 
 - Required: Yes
 - Type: string
+
+### Parameter: `availabilityZones`
+
+Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created.
+
+- Required: No
+- Type: array
+- Default:
+  ```Bicep
+  [
+    1
+    2
+    3
+  ]
+  ```
+- Allowed:
+  ```Bicep
+  [
+    1
+    2
+    3
+  ]
+  ```
 
 ### Parameter: `colocationStatus`
 
@@ -661,13 +684,6 @@ Specifies the type of the proximity placement group.
     'Ultra'
   ]
   ```
-
-### Parameter: `zones`
-
-Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created.
-
-- Required: No
-- Type: array
 
 ## Outputs
 

--- a/avm/res/compute/proximity-placement-group/main.bicep
+++ b/avm/res/compute/proximity-placement-group/main.bicep
@@ -25,13 +25,14 @@ param roleAssignments roleAssignmentType[]?
 @description('Optional. Tags of the proximity placement group resource.')
 param tags object?
 
-@description('Optional. Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created.')
+@description('Required. Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone numbers here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones).')
 @allowed([
+  -1
   1
   2
   3
 ])
-param availabilityZones int[] = [1, 2, 3]
+param availabilityZone int
 
 @description('Optional. Describes colocation status of the Proximity Placement Group.')
 param colocationStatus object?
@@ -90,7 +91,7 @@ resource proximityPlacementGroup 'Microsoft.Compute/proximityPlacementGroups@202
   name: name
   location: location
   tags: tags
-  zones: map(availabilityZones, zone => '${zone}')
+  zones: availabilityZone != -1 ? array(string(availabilityZone)) : null // If expecting an array
   properties: {
     proximityPlacementGroupType: type
     colocationStatus: colocationStatus

--- a/avm/res/compute/proximity-placement-group/main.bicep
+++ b/avm/res/compute/proximity-placement-group/main.bicep
@@ -26,7 +26,12 @@ param roleAssignments roleAssignmentType[]?
 param tags object?
 
 @description('Optional. Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created.')
-param zones array?
+@allowed([
+  1
+  2
+  3
+])
+param availabilityZones int[] = [1, 2, 3]
 
 @description('Optional. Describes colocation status of the Proximity Placement Group.')
 param colocationStatus object?
@@ -85,7 +90,7 @@ resource proximityPlacementGroup 'Microsoft.Compute/proximityPlacementGroups@202
   name: name
   location: location
   tags: tags
-  zones: zones
+  zones: map(availabilityZones, zone => '${zone}')
   properties: {
     proximityPlacementGroupType: type
     colocationStatus: colocationStatus

--- a/avm/res/compute/proximity-placement-group/main.json
+++ b/avm/res/compute/proximity-placement-group/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.177.2456",
-      "templateHash": "9164094872946704611"
+      "templateHash": "3940421282476160298"
     },
     "name": "Proximity Placement Groups",
     "description": "This module deploys a Proximity Placement Group."
@@ -167,23 +167,16 @@
         "description": "Optional. Tags of the proximity placement group resource."
       }
     },
-    "availabilityZones": {
-      "type": "array",
-      "items": {
-        "type": "int"
-      },
-      "defaultValue": [
-        1,
-        2,
-        3
-      ],
+    "availabilityZone": {
+      "type": "int",
       "allowedValues": [
+        -1,
         1,
         2,
         3
       ],
       "metadata": {
-        "description": "Optional. Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created."
+        "description": "Required. Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone numbers here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones)."
       }
     },
     "colocationStatus": {
@@ -251,7 +244,7 @@
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
-      "zones": "[map(parameters('availabilityZones'), lambda('zone', format('{0}', lambdaVariables('zone'))))]",
+      "zones": "[if(not(equals(parameters('availabilityZone'), -1)), array(string(parameters('availabilityZone'))), null())]",
       "properties": {
         "proximityPlacementGroupType": "[parameters('type')]",
         "colocationStatus": "[parameters('colocationStatus')]",

--- a/avm/res/compute/proximity-placement-group/main.json
+++ b/avm/res/compute/proximity-placement-group/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "4166602537893111543"
+      "version": "0.36.177.2456",
+      "templateHash": "9164094872946704611"
     },
     "name": "Proximity Placement Groups",
     "description": "This module deploys a Proximity Placement Group."
@@ -167,9 +167,21 @@
         "description": "Optional. Tags of the proximity placement group resource."
       }
     },
-    "zones": {
+    "availabilityZones": {
       "type": "array",
-      "nullable": true,
+      "items": {
+        "type": "int"
+      },
+      "defaultValue": [
+        1,
+        2,
+        3
+      ],
+      "allowedValues": [
+        1,
+        2,
+        3
+      ],
       "metadata": {
         "description": "Optional. Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the proximity placement group can be created."
       }
@@ -239,7 +251,7 @@
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
-      "zones": "[parameters('zones')]",
+      "zones": "[map(parameters('availabilityZones'), lambda('zone', format('{0}', lambdaVariables('zone'))))]",
       "properties": {
         "proximityPlacementGroupType": "[parameters('type')]",
         "colocationStatus": "[parameters('colocationStatus')]",

--- a/avm/res/compute/proximity-placement-group/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/compute/proximity-placement-group/tests/e2e/defaults/main.test.bicep
@@ -43,6 +43,7 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: resourceLocation
+      availabilityZone: -1
     }
   }
 ]

--- a/avm/res/compute/proximity-placement-group/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/proximity-placement-group/tests/e2e/max/main.test.bicep
@@ -78,8 +78,8 @@ module testDeployment '../../../main.bicep' = [
           principalType: 'ServicePrincipal'
         }
       ]
-      zones: [
-        '1'
+      availabilityZones: [
+        1
       ]
       type: 'Standard'
       tags: {

--- a/avm/res/compute/proximity-placement-group/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/proximity-placement-group/tests/e2e/max/main.test.bicep
@@ -78,9 +78,7 @@ module testDeployment '../../../main.bicep' = [
           principalType: 'ServicePrincipal'
         }
       ]
-      availabilityZones: [
-        1
-      ]
+      availabilityZone: 1
       type: 'Standard'
       tags: {
         'hidden-title': 'This is visible in the resource name'

--- a/avm/res/compute/proximity-placement-group/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/compute/proximity-placement-group/tests/e2e/waf-aligned/main.test.bicep
@@ -43,8 +43,8 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: resourceLocation
-      zones: [
-        '1'
+      availabilityZones: [
+        1
       ]
       type: 'Standard'
       tags: {

--- a/avm/res/compute/proximity-placement-group/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/compute/proximity-placement-group/tests/e2e/waf-aligned/main.test.bicep
@@ -43,9 +43,7 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: resourceLocation
-      availabilityZones: [
-        1
-      ]
+      availabilityZone: 1
       type: 'Standard'
       tags: {
         'hidden-title': 'This is visible in the resource name'

--- a/avm/res/compute/proximity-placement-group/version.json
+++ b/avm/res/compute/proximity-placement-group/version.json
@@ -1,4 +1,4 @@
 {
-    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.3"
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.4"
 }


### PR DESCRIPTION
## Description

- Renamed `zones` parameter to singular `availabilityZone`
- Changed type of `availabilityZone` to singular integer without a default as the resource is zone-redundant, not zonal. As a result, users **must** define a zone upon deployment, but can opt out by providing a value of -1
- Added allowed set `[-1,1,2,3]` to `availabilityZone` parameter

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.compute.proximity-placement-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.proximity-placement-group.yml/badge.svg?branch=users%2Falsehr%2FcomputeProximityPlacementGroupZones&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.proximity-placement-group.yml)     |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
