### PR TITLE
fix: VirtualMachine - Renamed `zone` parameter and updated allowed set 

### DIFF
--- a/avm/res/compute/virtual-machine/CHANGELOG.md
+++ b/avm/res/compute/virtual-machine/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/virtual-machine/CHANGELOG.md).
 
+## 0.16.0
+
+### Changes
+
+- None
+
+### Breaking Changes
+
+- Renamed `zone` parameter to `availabilityZone`
+- Changed 'availabilityZone' allowed set from [0,1,2,3] to [-1,1,2,3]. -1 works in the same way as the previous 0 to specify that no zone is to be set
+
 ## 0.15.1
 
 ### Changes

--- a/avm/res/compute/virtual-machine/README.md
+++ b/avm/res/compute/virtual-machine/README.md
@@ -68,6 +68,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'localAdminUser'
+    availabilityZone: -1
     imageReference: {
       offer: '0001-com-ubuntu-server-jammy'
       publisher: 'Canonical'
@@ -102,7 +103,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     }
     osType: 'Linux'
     vmSize: 'Standard_D2s_v3'
-    zone: 0
     // Non-required parameters
     configurationProfile: '/providers/Microsoft.Automanage/bestPractices/AzureBestPracticesProduction'
     disablePasswordAuthentication: true
@@ -132,6 +132,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     // Required parameters
     "adminUsername": {
       "value": "localAdminUser"
+    },
+    "availabilityZone": {
+      "value": -1
     },
     "imageReference": {
       "value": {
@@ -179,9 +182,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "vmSize": {
       "value": "Standard_D2s_v3"
     },
-    "zone": {
-      "value": 0
-    },
     // Non-required parameters
     "configurationProfile": {
       "value": "/providers/Microsoft.Automanage/bestPractices/AzureBestPracticesProduction"
@@ -216,6 +216,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'localAdminUser'
+param availabilityZone = -1
 param imageReference = {
   offer: '0001-com-ubuntu-server-jammy'
   publisher: 'Canonical'
@@ -250,7 +251,6 @@ param osDisk = {
 }
 param osType = 'Linux'
 param vmSize = 'Standard_D2s_v3'
-param zone = 0
 // Non-required parameters
 param configurationProfile = '/providers/Microsoft.Automanage/bestPractices/AzureBestPracticesProduction'
 param disablePasswordAuthentication = true
@@ -281,6 +281,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'localAdminUser'
+    availabilityZone: -1
     imageReference: {
       offer: '0001-com-ubuntu-server-jammy'
       publisher: 'Canonical'
@@ -308,7 +309,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     }
     osType: 'Linux'
     vmSize: 'Standard_D2s_v3'
-    zone: 0
     // Non-required parameters
     disablePasswordAuthentication: true
     location: '<location>'
@@ -337,6 +337,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     // Required parameters
     "adminUsername": {
       "value": "localAdminUser"
+    },
+    "availabilityZone": {
+      "value": -1
     },
     "imageReference": {
       "value": {
@@ -377,9 +380,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "vmSize": {
       "value": "Standard_D2s_v3"
     },
-    "zone": {
-      "value": 0
-    },
     // Non-required parameters
     "disablePasswordAuthentication": {
       "value": true
@@ -411,6 +411,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'localAdminUser'
+param availabilityZone = -1
 param imageReference = {
   offer: '0001-com-ubuntu-server-jammy'
   publisher: 'Canonical'
@@ -438,7 +439,6 @@ param osDisk = {
 }
 param osType = 'Linux'
 param vmSize = 'Standard_D2s_v3'
-param zone = 0
 // Non-required parameters
 param disablePasswordAuthentication = true
 param location = '<location>'
@@ -468,6 +468,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'localAdministrator'
+    availabilityZone: 1
     imageReference: {
       offer: '0001-com-ubuntu-server-focal'
       publisher: 'Canonical'
@@ -586,7 +587,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     }
     osType: 'Linux'
     vmSize: 'Standard_D2s_v3'
-    zone: 1
     // Non-required parameters
     backupPolicyName: '<backupPolicyName>'
     backupVaultName: '<backupVaultName>'
@@ -768,6 +768,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "adminUsername": {
       "value": "localAdministrator"
     },
+    "availabilityZone": {
+      "value": 1
+    },
     "imageReference": {
       "value": {
         "offer": "0001-com-ubuntu-server-focal",
@@ -897,9 +900,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     },
     "vmSize": {
       "value": "Standard_D2s_v3"
-    },
-    "zone": {
-      "value": 1
     },
     // Non-required parameters
     "backupPolicyName": {
@@ -1126,6 +1126,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'localAdministrator'
+param availabilityZone = 1
 param imageReference = {
   offer: '0001-com-ubuntu-server-focal'
   publisher: 'Canonical'
@@ -1244,7 +1245,6 @@ param osDisk = {
 }
 param osType = 'Linux'
 param vmSize = 'Standard_D2s_v3'
-param zone = 1
 // Non-required parameters
 param backupPolicyName = '<backupPolicyName>'
 param backupVaultName = '<backupVaultName>'
@@ -1426,6 +1426,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'VMAdmin'
+    availabilityZone: 2
     imageReference: {
       offer: 'WindowsServer'
       publisher: 'MicrosoftWindowsServer'
@@ -1516,7 +1517,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     }
     osType: 'Windows'
     vmSize: 'Standard_D2s_v3'
-    zone: 2
     // Non-required parameters
     adminPassword: '<adminPassword>'
     backupPolicyName: '<backupPolicyName>'
@@ -1703,6 +1703,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "adminUsername": {
       "value": "VMAdmin"
     },
+    "availabilityZone": {
+      "value": 2
+    },
     "imageReference": {
       "value": {
         "offer": "WindowsServer",
@@ -1804,9 +1807,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     },
     "vmSize": {
       "value": "Standard_D2s_v3"
-    },
-    "zone": {
-      "value": 2
     },
     // Non-required parameters
     "adminPassword": {
@@ -2040,6 +2040,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'VMAdmin'
+param availabilityZone = 2
 param imageReference = {
   offer: 'WindowsServer'
   publisher: 'MicrosoftWindowsServer'
@@ -2130,7 +2131,6 @@ param osDisk = {
 }
 param osType = 'Windows'
 param vmSize = 'Standard_D2s_v3'
-param zone = 2
 // Non-required parameters
 param adminPassword = '<adminPassword>'
 param backupPolicyName = '<backupPolicyName>'
@@ -2317,6 +2317,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'localAdminUser'
+    availabilityZone: -1
     imageReference: {
       offer: 'WindowsServer'
       publisher: 'MicrosoftWindowsServer'
@@ -2344,7 +2345,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     }
     osType: 'Windows'
     vmSize: 'Standard_D2s_v3'
-    zone: 0
     // Non-required parameters
     adminPassword: '<adminPassword>'
     location: '<location>'
@@ -2367,6 +2367,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     // Required parameters
     "adminUsername": {
       "value": "localAdminUser"
+    },
+    "availabilityZone": {
+      "value": -1
     },
     "imageReference": {
       "value": {
@@ -2407,9 +2410,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "vmSize": {
       "value": "Standard_D2s_v3"
     },
-    "zone": {
-      "value": 0
-    },
     // Non-required parameters
     "adminPassword": {
       "value": "<adminPassword>"
@@ -2433,6 +2433,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'localAdminUser'
+param availabilityZone = -1
 param imageReference = {
   offer: 'WindowsServer'
   publisher: 'MicrosoftWindowsServer'
@@ -2460,7 +2461,6 @@ param osDisk = {
 }
 param osType = 'Windows'
 param vmSize = 'Standard_D2s_v3'
-param zone = 0
 // Non-required parameters
 param adminPassword = '<adminPassword>'
 param location = '<location>'
@@ -2484,6 +2484,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'localAdminUser'
+    availabilityZone: 1
     imageReference: {
       offer: 'WindowsServer'
       publisher: 'MicrosoftWindowsServer'
@@ -2511,7 +2512,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     }
     osType: 'Windows'
     vmSize: 'Standard_D2s_v3'
-    zone: 1
     // Non-required parameters
     adminPassword: '<adminPassword>'
     dataDisks: [
@@ -2556,6 +2556,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "adminUsername": {
       "value": "localAdminUser"
     },
+    "availabilityZone": {
+      "value": 1
+    },
     "imageReference": {
       "value": {
         "offer": "WindowsServer",
@@ -2594,9 +2597,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     },
     "vmSize": {
       "value": "Standard_D2s_v3"
-    },
-    "zone": {
-      "value": 1
     },
     // Non-required parameters
     "adminPassword": {
@@ -2646,6 +2646,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'localAdminUser'
+param availabilityZone = 1
 param imageReference = {
   offer: 'WindowsServer'
   publisher: 'MicrosoftWindowsServer'
@@ -2673,7 +2674,6 @@ param osDisk = {
 }
 param osType = 'Windows'
 param vmSize = 'Standard_D2s_v3'
-param zone = 1
 // Non-required parameters
 param adminPassword = '<adminPassword>'
 param dataDisks = [
@@ -2718,6 +2718,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'localAdminUser'
+    availabilityZone: -1
     imageReference: {
       offer: 'WindowsServer'
       publisher: 'MicrosoftWindowsServer'
@@ -2749,7 +2750,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     }
     osType: 'Windows'
     vmSize: 'Standard_D2s_v3'
-    zone: 0
     // Non-required parameters
     adminPassword: '<adminPassword>'
     extensionGuestConfigurationExtension: {
@@ -2802,6 +2802,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "adminUsername": {
       "value": "localAdminUser"
     },
+    "availabilityZone": {
+      "value": -1
+    },
     "imageReference": {
       "value": {
         "offer": "WindowsServer",
@@ -2844,9 +2847,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     },
     "vmSize": {
       "value": "Standard_D2s_v3"
-    },
-    "zone": {
-      "value": 0
     },
     // Non-required parameters
     "adminPassword": {
@@ -2906,6 +2906,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'localAdminUser'
+param availabilityZone = -1
 param imageReference = {
   offer: 'WindowsServer'
   publisher: 'MicrosoftWindowsServer'
@@ -2937,7 +2938,6 @@ param osDisk = {
 }
 param osType = 'Windows'
 param vmSize = 'Standard_D2s_v3'
-param zone = 0
 // Non-required parameters
 param adminPassword = '<adminPassword>'
 param extensionGuestConfigurationExtension = {
@@ -2990,6 +2990,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'localAdminUser'
+    availabilityZone: -1
     imageReference: {
       offer: 'WindowsServer'
       publisher: 'MicrosoftWindowsServer'
@@ -3017,7 +3018,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     }
     osType: 'Windows'
     vmSize: 'Standard_D2s_v3'
-    zone: 0
     // Non-required parameters
     adminPassword: '<adminPassword>'
     extensionAadJoinConfig: {
@@ -3064,6 +3064,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "adminUsername": {
       "value": "localAdminUser"
     },
+    "availabilityZone": {
+      "value": -1
+    },
     "imageReference": {
       "value": {
         "offer": "WindowsServer",
@@ -3102,9 +3105,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     },
     "vmSize": {
       "value": "Standard_D2s_v3"
-    },
-    "zone": {
-      "value": 0
     },
     // Non-required parameters
     "adminPassword": {
@@ -3158,6 +3158,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'localAdminUser'
+param availabilityZone = -1
 param imageReference = {
   offer: 'WindowsServer'
   publisher: 'MicrosoftWindowsServer'
@@ -3185,7 +3186,6 @@ param osDisk = {
 }
 param osType = 'Windows'
 param vmSize = 'Standard_D2s_v3'
-param zone = 0
 // Non-required parameters
 param adminPassword = '<adminPassword>'
 param extensionAadJoinConfig = {
@@ -3232,6 +3232,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'VMAdmin'
+    availabilityZone: 2
     imageReference: {
       offer: 'WindowsServer'
       publisher: 'MicrosoftWindowsServer'
@@ -3346,7 +3347,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     }
     osType: 'Windows'
     vmSize: 'Standard_D2s_v3'
-    zone: 2
     // Non-required parameters
     additionalUnattendContent: [
       {
@@ -3573,6 +3573,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "adminUsername": {
       "value": "VMAdmin"
     },
+    "availabilityZone": {
+      "value": 2
+    },
     "imageReference": {
       "value": {
         "offer": "WindowsServer",
@@ -3698,9 +3701,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     },
     "vmSize": {
       "value": "Standard_D2s_v3"
-    },
-    "zone": {
-      "value": 2
     },
     // Non-required parameters
     "additionalUnattendContent": {
@@ -3978,6 +3978,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'VMAdmin'
+param availabilityZone = 2
 param imageReference = {
   offer: 'WindowsServer'
   publisher: 'MicrosoftWindowsServer'
@@ -4092,7 +4093,6 @@ param osDisk = {
 }
 param osType = 'Windows'
 param vmSize = 'Standard_D2s_v3'
-param zone = 2
 // Non-required parameters
 param additionalUnattendContent = [
   {
@@ -4319,6 +4319,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'localAdminUser'
+    availabilityZone: -1
     imageReference: {
       offer: 'WindowsServer'
       publisher: 'MicrosoftWindowsServer'
@@ -4346,7 +4347,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     }
     osType: 'Windows'
     vmSize: 'Standard_NV6ads_A10_v5'
-    zone: 0
     // Non-required parameters
     adminPassword: '<adminPassword>'
     extensionNvidiaGpuDriverWindows: {
@@ -4373,6 +4373,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     // Required parameters
     "adminUsername": {
       "value": "localAdminUser"
+    },
+    "availabilityZone": {
+      "value": -1
     },
     "imageReference": {
       "value": {
@@ -4413,9 +4416,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "vmSize": {
       "value": "Standard_NV6ads_A10_v5"
     },
-    "zone": {
-      "value": 0
-    },
     // Non-required parameters
     "adminPassword": {
       "value": "<adminPassword>"
@@ -4447,6 +4447,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'localAdminUser'
+param availabilityZone = -1
 param imageReference = {
   offer: 'WindowsServer'
   publisher: 'MicrosoftWindowsServer'
@@ -4474,7 +4475,6 @@ param osDisk = {
 }
 param osType = 'Windows'
 param vmSize = 'Standard_NV6ads_A10_v5'
-param zone = 0
 // Non-required parameters
 param adminPassword = '<adminPassword>'
 param extensionNvidiaGpuDriverWindows = {
@@ -4502,6 +4502,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'VMAdministrator'
+    availabilityZone: -1
     imageReference: {
       offer: 'WindowsServer'
       publisher: 'MicrosoftWindowsServer'
@@ -4523,24 +4524,19 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     osDisk: {
       diskSizeGB: 128
       managedDisk: {
-        diskEncryptionSet: {
-          id: '<id>'
-        }
+        diskEncryptionSetResourceId: '<diskEncryptionSetResourceId>'
         storageAccountType: 'Premium_LRS'
       }
     }
     osType: 'Windows'
     vmSize: 'Standard_D2s_v3'
-    zone: 0
     // Non-required parameters
     adminPassword: '<adminPassword>'
     dataDisks: [
       {
         diskSizeGB: 128
         managedDisk: {
-          diskEncryptionSet: {
-            id: '<id>'
-          }
+          diskEncryptionSetResourceId: '<diskEncryptionSetResourceId>'
           storageAccountType: 'Premium_LRS'
         }
       }
@@ -4565,6 +4561,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     // Required parameters
     "adminUsername": {
       "value": "VMAdministrator"
+    },
+    "availabilityZone": {
+      "value": -1
     },
     "imageReference": {
       "value": {
@@ -4594,9 +4593,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
       "value": {
         "diskSizeGB": 128,
         "managedDisk": {
-          "diskEncryptionSet": {
-            "id": "<id>"
-          },
+          "diskEncryptionSetResourceId": "<diskEncryptionSetResourceId>",
           "storageAccountType": "Premium_LRS"
         }
       }
@@ -4607,9 +4604,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "vmSize": {
       "value": "Standard_D2s_v3"
     },
-    "zone": {
-      "value": 0
-    },
     // Non-required parameters
     "adminPassword": {
       "value": "<adminPassword>"
@@ -4619,9 +4613,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
         {
           "diskSizeGB": 128,
           "managedDisk": {
-            "diskEncryptionSet": {
-              "id": "<id>"
-            },
+            "diskEncryptionSetResourceId": "<diskEncryptionSetResourceId>",
             "storageAccountType": "Premium_LRS"
           }
         }
@@ -4646,6 +4638,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'VMAdministrator'
+param availabilityZone = -1
 param imageReference = {
   offer: 'WindowsServer'
   publisher: 'MicrosoftWindowsServer'
@@ -4667,24 +4660,19 @@ param nicConfigurations = [
 param osDisk = {
   diskSizeGB: 128
   managedDisk: {
-    diskEncryptionSet: {
-      id: '<id>'
-    }
+    diskEncryptionSetResourceId: '<diskEncryptionSetResourceId>'
     storageAccountType: 'Premium_LRS'
   }
 }
 param osType = 'Windows'
 param vmSize = 'Standard_D2s_v3'
-param zone = 0
 // Non-required parameters
 param adminPassword = '<adminPassword>'
 param dataDisks = [
   {
     diskSizeGB: 128
     managedDisk: {
-      diskEncryptionSet: {
-        id: '<id>'
-      }
+      diskEncryptionSetResourceId: '<diskEncryptionSetResourceId>'
       storageAccountType: 'Premium_LRS'
     }
   }
@@ -4710,6 +4698,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'localAdminUser'
+    availabilityZone: -1
     imageReference: {
       offer: 'WindowsServer'
       publisher: 'MicrosoftWindowsServer'
@@ -4737,7 +4726,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     }
     osType: 'Windows'
     vmSize: 'Standard_D2s_v3'
-    zone: 0
     // Non-required parameters
     adminPassword: '<adminPassword>'
     location: '<location>'
@@ -4761,6 +4749,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     // Required parameters
     "adminUsername": {
       "value": "localAdminUser"
+    },
+    "availabilityZone": {
+      "value": -1
     },
     "imageReference": {
       "value": {
@@ -4801,9 +4792,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "vmSize": {
       "value": "Standard_D2s_v3"
     },
-    "zone": {
-      "value": 0
-    },
     // Non-required parameters
     "adminPassword": {
       "value": "<adminPassword>"
@@ -4830,6 +4818,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'localAdminUser'
+param availabilityZone = -1
 param imageReference = {
   offer: 'WindowsServer'
   publisher: 'MicrosoftWindowsServer'
@@ -4857,7 +4846,6 @@ param osDisk = {
 }
 param osType = 'Windows'
 param vmSize = 'Standard_D2s_v3'
-param zone = 0
 // Non-required parameters
 param adminPassword = '<adminPassword>'
 param location = '<location>'
@@ -4882,6 +4870,7 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
   params: {
     // Required parameters
     adminUsername: 'localAdminUser'
+    availabilityZone: 2
     imageReference: {
       offer: 'WindowsServer'
       publisher: 'MicrosoftWindowsServer'
@@ -4909,7 +4898,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     }
     osType: 'Windows'
     vmSize: 'Standard_D2s_v3'
-    zone: 2
     // Non-required parameters
     adminPassword: '<adminPassword>'
     dataDisks: [
@@ -4941,6 +4929,9 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     // Required parameters
     "adminUsername": {
       "value": "localAdminUser"
+    },
+    "availabilityZone": {
+      "value": 2
     },
     "imageReference": {
       "value": {
@@ -4981,9 +4972,6 @@ module virtualMachine 'br/public:avm/res/compute/virtual-machine:<version>' = {
     "vmSize": {
       "value": "Standard_D2s_v3"
     },
-    "zone": {
-      "value": 2
-    },
     // Non-required parameters
     "adminPassword": {
       "value": "<adminPassword>"
@@ -5018,6 +5006,7 @@ using 'br/public:avm/res/compute/virtual-machine:<version>'
 
 // Required parameters
 param adminUsername = 'localAdminUser'
+param availabilityZone = 2
 param imageReference = {
   offer: 'WindowsServer'
   publisher: 'MicrosoftWindowsServer'
@@ -5045,7 +5034,6 @@ param osDisk = {
 }
 param osType = 'Windows'
 param vmSize = 'Standard_D2s_v3'
-param zone = 2
 // Non-required parameters
 param adminPassword = '<adminPassword>'
 param dataDisks = [
@@ -5070,13 +5058,13 @@ param location = '<location>'
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`adminUsername`](#parameter-adminusername) | securestring | Administrator username. |
+| [`availabilityZone`](#parameter-availabilityzone) | int | If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone numbers here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones). |
 | [`imageReference`](#parameter-imagereference) | object | OS image reference. In case of marketplace images, it's the combination of the publisher, offer, sku, version attributes. In case of custom images it's the resource ID of the custom image. |
 | [`name`](#parameter-name) | string | The name of the virtual machine to be created. You should use a unique prefix to reduce name collisions in Active Directory. |
 | [`nicConfigurations`](#parameter-nicconfigurations) | array | Configures NICs and PIPs. |
 | [`osDisk`](#parameter-osdisk) | object | Specifies the OS disk. For security reasons, it is recommended to specify DiskEncryptionSet into the osDisk object.  Restrictions: DiskEncryptionSet cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VMs. |
 | [`osType`](#parameter-ostype) | string | The chosen OS type. |
 | [`vmSize`](#parameter-vmsize) | string | Specifies the size for the VMs. |
-| [`zone`](#parameter-zone) | int | If set to 1, 2 or 3, the availability zone for all VMs is hardcoded to that value. If zero, then availability zones is not used. Cannot be used in combination with availability set nor scale set. |
 
 **Optional parameters**
 
@@ -5162,6 +5150,22 @@ Administrator username.
 
 - Required: Yes
 - Type: securestring
+
+### Parameter: `availabilityZone`
+
+If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone numbers here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones).
+
+- Required: Yes
+- Type: int
+- Allowed:
+  ```Bicep
+  [
+    -1
+    1
+    2
+    3
+  ]
+  ```
 
 ### Parameter: `imageReference`
 
@@ -6935,22 +6939,6 @@ Specifies the size for the VMs.
 
 - Required: Yes
 - Type: string
-
-### Parameter: `zone`
-
-If set to 1, 2 or 3, the availability zone for all VMs is hardcoded to that value. If zero, then availability zones is not used. Cannot be used in combination with availability set nor scale set.
-
-- Required: Yes
-- Type: int
-- Allowed:
-  ```Bicep
-  [
-    0
-    1
-    2
-    3
-  ]
-  ```
 
 ### Parameter: `additionalUnattendContent`
 

--- a/avm/res/compute/virtual-machine/main.json
+++ b/avm/res/compute/virtual-machine/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "17675001299145418136"
+      "version": "0.36.177.2456",
+      "templateHash": "4089843043248436881"
     },
     "name": "Virtual Machines",
     "description": "This module deploys a Virtual Machine with one or multiple NICs and optionally one or multiple public IPs."
@@ -1935,16 +1935,16 @@
         "description": "Optional. Specifies the gallery applications that should be made available to the VM/VMSS."
       }
     },
-    "zone": {
+    "availabilityZone": {
       "type": "int",
       "allowedValues": [
-        0,
+        -1,
         1,
         2,
         3
       ],
       "metadata": {
-        "description": "Required. If set to 1, 2 or 3, the availability zone for all VMs is hardcoded to that value. If zero, then availability zones is not used. Cannot be used in combination with availability set nor scale set."
+        "description": "Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone numbers here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones)."
       }
     },
     "nicConfigurations": {
@@ -2417,7 +2417,7 @@
         "diskIOPSReadWrite": "[tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex()], 'diskIOPSReadWrite')]",
         "diskMBpsReadWrite": "[tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex()], 'diskMBpsReadWrite')]"
       },
-      "zones": "[if(and(not(equals(parameters('zone'), 0)), not(contains(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex()].managedDisk, 'storageAccountType'), 'ZRS'))), array(string(parameters('zone'))), null())]",
+      "zones": "[if(and(not(equals(parameters('availabilityZone'), -1)), not(contains(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex()].managedDisk, 'storageAccountType'), 'ZRS'))), array(string(parameters('availabilityZone'))), null())]",
       "tags": "[coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
     },
     "vm": {
@@ -2427,7 +2427,7 @@
       "location": "[parameters('location')]",
       "identity": "[variables('identity')]",
       "tags": "[parameters('tags')]",
-      "zones": "[if(not(equals(parameters('zone'), 0)), array(string(parameters('zone'))), null())]",
+      "zones": "[if(not(equals(parameters('availabilityZone'), -1)), array(string(parameters('availabilityZone'))), null())]",
       "plan": "[parameters('plan')]",
       "properties": {
         "hardwareProfile": {
@@ -2446,11 +2446,11 @@
               "input": {
                 "lun": "[coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')], 'lun'), copyIndex('dataDisks'))]",
                 "name": "[if(not(empty(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')].managedDisk, 'id'))), last(split(coalesce(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')].managedDisk.id, ''), '/')), coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')], 'name'), format('{0}-disk-data-{1}', parameters('name'), padLeft(add(copyIndex('dataDisks'), 1), 2, '0'))))]",
-                "createOption": "[if(or(not(equals(resourceId('Microsoft.Compute/disks', coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')], 'name'), format('{0}-disk-data-{1}', parameters('name'), padLeft(add(copyIndex('dataDisks'), 1), 2, '0')))), null())), not(empty(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')].managedDisk, 'id')))), 'Attach', coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')], 'createoption'), 'Empty'))]",
+                "createOption": "[if(or(not(equals(if(empty(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')].managedDisk, 'id')), resourceId('Microsoft.Compute/disks', coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')], 'name'), format('{0}-disk-data-{1}', parameters('name'), padLeft(add(copyIndex('dataDisks'), 1), 2, '0')))), null()), null())), not(empty(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')].managedDisk, 'id')))), 'Attach', coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')], 'createoption'), 'Empty'))]",
                 "deleteOption": "[if(not(empty(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')].managedDisk, 'id'))), 'Detach', coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')], 'deleteOption'), 'Delete'))]",
                 "caching": "[if(not(empty(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')].managedDisk, 'id'))), 'None', coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')], 'caching'), 'ReadOnly'))]",
                 "managedDisk": {
-                  "id": "[coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')].managedDisk, 'id'), resourceId('Microsoft.Compute/disks', coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')], 'name'), format('{0}-disk-data-{1}', parameters('name'), padLeft(add(copyIndex('dataDisks'), 1), 2, '0')))))]",
+                  "id": "[coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')].managedDisk, 'id'), if(empty(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')].managedDisk, 'id')), resourceId('Microsoft.Compute/disks', coalesce(tryGet(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')], 'name'), format('{0}-disk-data-{1}', parameters('name'), padLeft(add(copyIndex('dataDisks'), 1), 2, '0')))), null()))]",
                   "diskEncryptionSet": "[if(contains(coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')].managedDisk, 'diskEncryptionSet'), createObject('id', coalesce(parameters('dataDisks'), createArray())[copyIndex('dataDisks')].managedDisk.diskEncryptionSet.id), null())]"
                 }
               }
@@ -2699,8 +2699,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "8672724576831743385"
+              "version": "0.36.177.2456",
+              "templateHash": "2776867808756314911"
             }
           },
           "definitions": {
@@ -5610,8 +5610,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "11010105954455348"
+              "version": "0.36.177.2456",
+              "templateHash": "3746146591166938391"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension."
@@ -5814,8 +5814,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "11010105954455348"
+              "version": "0.36.177.2456",
+              "templateHash": "3746146591166938391"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension."
@@ -6021,8 +6021,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "11010105954455348"
+              "version": "0.36.177.2456",
+              "templateHash": "3746146591166938391"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension."
@@ -6223,8 +6223,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "11010105954455348"
+              "version": "0.36.177.2456",
+              "templateHash": "3746146591166938391"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension."
@@ -6430,8 +6430,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "11010105954455348"
+              "version": "0.36.177.2456",
+              "templateHash": "3746146591166938391"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension."
@@ -6632,8 +6632,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "11010105954455348"
+              "version": "0.36.177.2456",
+              "templateHash": "3746146591166938391"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension."
@@ -6842,8 +6842,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "11010105954455348"
+              "version": "0.36.177.2456",
+              "templateHash": "3746146591166938391"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension."
@@ -7056,8 +7056,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "11010105954455348"
+              "version": "0.36.177.2456",
+              "templateHash": "3746146591166938391"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension."
@@ -7264,8 +7264,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "11010105954455348"
+              "version": "0.36.177.2456",
+              "templateHash": "3746146591166938391"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension."
@@ -7468,8 +7468,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "11010105954455348"
+              "version": "0.36.177.2456",
+              "templateHash": "3746146591166938391"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension."
@@ -7681,8 +7681,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "11010105954455348"
+              "version": "0.36.177.2456",
+              "templateHash": "3746146591166938391"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension."
@@ -7890,8 +7890,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "11010105954455348"
+              "version": "0.36.177.2456",
+              "templateHash": "3746146591166938391"
             },
             "name": "Virtual Machine Extensions",
             "description": "This module deploys a Virtual Machine Extension."
@@ -8085,8 +8085,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "1854213848782186224"
+              "version": "0.36.177.2456",
+              "templateHash": "4883720476465660475"
             },
             "name": "Recovery Service Vaults Protection Container Protected Item",
             "description": "This module deploys a Recovery Services Vault Protection Container Protected Item."

--- a/avm/res/compute/virtual-machine/tests/e2e/atmg/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/atmg/main.test.bicep
@@ -69,7 +69,7 @@ module testDeployment '../../../main.bicep' = [
         sku: '22_04-lts-gen2'
         version: 'latest'
       }
-      zone: 0
+      availabilityZone: -1
       nicConfigurations: [
         {
           ipConfigurations: [
@@ -106,8 +106,5 @@ module testDeployment '../../../main.bicep' = [
         }
       ]
     }
-    dependsOn: [
-      nestedDependencies // Required to leverage `existing` SSH key reference
-    ]
   }
 ]

--- a/avm/res/compute/virtual-machine/tests/e2e/linux.defaults/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/linux.defaults/main.test.bicep
@@ -68,7 +68,7 @@ module testDeployment '../../../main.bicep' = [
         sku: '22_04-lts-gen2'
         version: 'latest'
       }
-      zone: 0
+      availabilityZone: -1
       nicConfigurations: [
         {
           ipConfigurations: [
@@ -97,8 +97,5 @@ module testDeployment '../../../main.bicep' = [
         }
       ]
     }
-    dependsOn: [
-      nestedDependencies // Required to leverage `existing` SSH key reference
-    ]
   }
 ]

--- a/avm/res/compute/virtual-machine/tests/e2e/linux.max/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/linux.max/main.test.bicep
@@ -206,7 +206,7 @@ module testDeployment '../../../main.bicep' = {
     }
     osType: 'Linux'
     vmSize: 'Standard_D2s_v3'
-    zone: 1
+    availabilityZone: 1
     backupPolicyName: nestedDependencies.outputs.recoveryServicesVaultBackupPolicyName
     backupVaultName: nestedDependencies.outputs.recoveryServicesVaultName
     backupVaultResourceGroup: nestedDependencies.outputs.recoveryServicesVaultResourceGroupName
@@ -369,7 +369,4 @@ module testDeployment '../../../main.bicep' = {
       Role: 'DeploymentValidation'
     }
   }
-  dependsOn: [
-    nestedDependencies // Required to leverage `existing` SSH key reference
-  ]
 }

--- a/avm/res/compute/virtual-machine/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/waf-aligned/main.test.bicep
@@ -179,7 +179,7 @@ module testDeployment '../../../main.bicep' = [
       osType: 'Windows'
       vmSize: 'Standard_D2s_v3'
       adminPassword: password
-      zone: 2
+      availabilityZone: 2
       backupPolicyName: nestedDependencies.outputs.recoveryServicesVaultBackupPolicyName
       backupVaultName: nestedDependencies.outputs.recoveryServicesVaultName
       backupVaultResourceGroup: nestedDependencies.outputs.recoveryServicesVaultResourceGroupName

--- a/avm/res/compute/virtual-machine/tests/e2e/windows.defaults/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/windows.defaults/main.test.bicep
@@ -63,7 +63,7 @@ module testDeployment '../../../main.bicep' = [
         sku: '2022-datacenter-azure-edition'
         version: 'latest'
       }
-      zone: 0
+      availabilityZone: -1
       nicConfigurations: [
         {
           ipConfigurations: [

--- a/avm/res/compute/virtual-machine/tests/e2e/windows.disks/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/windows.disks/main.test.bicep
@@ -64,7 +64,7 @@ module testDeployment '../../../main.bicep' = [
         sku: '2022-datacenter-azure-edition'
         version: 'latest'
       }
-      zone: 1
+      availabilityZone: 1
       nicConfigurations: [
         {
           ipConfigurations: [

--- a/avm/res/compute/virtual-machine/tests/e2e/windows.guestconfiguration/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/windows.guestconfiguration/main.test.bicep
@@ -66,7 +66,7 @@ module testDeployment '../../../main.bicep' = [
         sku: '2022-datacenter-azure-edition'
         version: 'latest'
       }
-      zone: 0
+      availabilityZone: -1
       nicConfigurations: [
         {
           ipConfigurations: [

--- a/avm/res/compute/virtual-machine/tests/e2e/windows.hostpool/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/windows.hostpool/main.test.bicep
@@ -63,7 +63,7 @@ module testDeployment '../../../main.bicep' = [
       managedIdentities: {
         systemAssigned: true
       }
-      zone: 0
+      availabilityZone: -1
       imageReference: {
         publisher: 'MicrosoftWindowsServer'
         offer: 'WindowsServer'

--- a/avm/res/compute/virtual-machine/tests/e2e/windows.max/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/windows.max/main.test.bicep
@@ -210,7 +210,7 @@ module testDeployment '../../../main.bicep' = [
       osType: 'Windows'
       vmSize: 'Standard_D2s_v3'
       adminPassword: password
-      zone: 2
+      availabilityZone: 2
       backupPolicyName: nestedDependencies.outputs.recoveryServicesVaultBackupPolicyName
       backupVaultName: nestedDependencies.outputs.recoveryServicesVaultName
       backupVaultResourceGroup: nestedDependencies.outputs.recoveryServicesVaultResourceGroupName

--- a/avm/res/compute/virtual-machine/tests/e2e/windows.nvidia/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/windows.nvidia/main.test.bicep
@@ -63,7 +63,7 @@ module testDeployment '../../../main.bicep' = [
         sku: '2022-datacenter-azure-edition'
         version: 'latest'
       }
-      zone: 0
+      availabilityZone: -1
       nicConfigurations: [
         {
           ipConfigurations: [

--- a/avm/res/compute/virtual-machine/tests/e2e/windows.ssecmk/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/windows.ssecmk/main.test.bicep
@@ -69,7 +69,7 @@ module testDeployment '../../../main.bicep' = [
         sku: '2019-datacenter'
         version: 'latest'
       }
-      zone: 0
+      availabilityZone: -1
       nicConfigurations: [
         {
           ipConfigurations: [
@@ -85,9 +85,7 @@ module testDeployment '../../../main.bicep' = [
         diskSizeGB: 128
         managedDisk: {
           storageAccountType: 'Premium_LRS'
-          diskEncryptionSet: {
-            id: nestedDependencies.outputs.diskEncryptionSetResourceId
-          }
+          diskEncryptionSetResourceId: nestedDependencies.outputs.diskEncryptionSetResourceId
         }
       }
       osType: 'Windows'
@@ -98,9 +96,7 @@ module testDeployment '../../../main.bicep' = [
           diskSizeGB: 128
           managedDisk: {
             storageAccountType: 'Premium_LRS'
-            diskEncryptionSet: {
-              id: nestedDependencies.outputs.diskEncryptionSetResourceId
-            }
+            diskEncryptionSetResourceId: nestedDependencies.outputs.diskEncryptionSetResourceId
           }
         }
       ]

--- a/avm/res/compute/virtual-machine/tests/e2e/windows.vmss/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/windows.vmss/main.test.bicep
@@ -66,7 +66,7 @@ module testDeployment '../../../main.bicep' = [
         sku: '2022-datacenter-azure-edition'
         version: 'latest'
       }
-      zone: 0
+      availabilityZone: -1
       nicConfigurations: [
         {
           ipConfigurations: [

--- a/avm/res/compute/virtual-machine/tests/e2e/windows.zrsdisks/main.test.bicep
+++ b/avm/res/compute/virtual-machine/tests/e2e/windows.zrsdisks/main.test.bicep
@@ -63,7 +63,7 @@ module testDeployment '../../../main.bicep' = [
         sku: '2022-datacenter-azure-edition'
         version: 'latest'
       }
-      zone: 2
+      availabilityZone: 2
       nicConfigurations: [
         {
           ipConfigurations: [

--- a/avm/res/compute/virtual-machine/tests/unit/avm.core.team.tests.ps1
+++ b/avm/res/compute/virtual-machine/tests/unit/avm.core.team.tests.ps1
@@ -28,7 +28,7 @@ BeforeAll {
 Describe 'AVM Core Team Module Specific Tests' {
     Context 'WAF - Reliability Pillar - Parameter Tests' {
         It 'VM Module Availability Zone Parameter Should Not Have A Default Value Set' {
-            $isRequired = Get-IsParameterRequired -TemplateFileContent $moduleJsonContentHashtable -Parameter $moduleJsonContentHashtable.parameters.zone
+            $isRequired = Get-IsParameterRequired -TemplateFileContent $moduleJsonContentHashtable -Parameter $moduleJsonContentHashtable.parameters.availabilityZone
             $isRequired | Should -Be $true
         }
     }

--- a/avm/res/compute/virtual-machine/version.json
+++ b/avm/res/compute/virtual-machine/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.15"
+  "version": "0.16"
 }


### PR DESCRIPTION
## Description

- Renamed `zone` parameter to `availabilityZone`
- Changed `availabilityZone` allowed set from `[0,1,2,3]` to `[-1,1,2,3]`. `-1` works in the same way as the previous `0` to specify that no zone is to be set

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.compute.virtual-machine](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine.yml/badge.svg?branch=users%2Falsehr%2FvmZones&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine.yml)         |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
