### PR TITLE
fix: VirtualMachineScaleSet - Added allowedSet and type to `availabilityZones` parameter

### DIFF
--- a/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
+++ b/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
@@ -10,7 +10,8 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Breaking Changes
 
-- Added allowed set [1,2,3] to availabilityZones parameter. I.e., zones must be provided as integers, not strings
+- Changed type of `availabilityZones` parameter from `array` to `int[]`, i.e., zones must be provided as integers, not strings
+- Added allowed set [1,2,3] to availabilityZones parameter.
 
 ## 0.8.1
 

--- a/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
+++ b/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md).
 
+## 0.9.0
+
+### Changes
+
+- None
+
+### Breaking Changes
+
+- Added allowed set [1,2,3] to availabilityZones parameter. I.e., zones must be provided as integers, not strings
+
 ## 0.8.1
 
 ### Changes

--- a/avm/res/compute/virtual-machine-scale-set/README.md
+++ b/avm/res/compute/virtual-machine-scale-set/README.md
@@ -523,7 +523,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     skuName: 'Standard_B12ms'
     // Non-required parameters
     availabilityZones: [
-      '2'
+      2
     ]
     bootDiagnosticEnabled: true
     bootDiagnosticStorageAccountName: '<bootDiagnosticStorageAccountName>'
@@ -714,7 +714,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     // Non-required parameters
     "availabilityZones": {
       "value": [
-        "2"
+        2
       ]
     },
     "bootDiagnosticEnabled": {
@@ -931,7 +931,7 @@ param osType = 'Linux'
 param skuName = 'Standard_B12ms'
 // Non-required parameters
 param availabilityZones = [
-  '2'
+  2
 ]
 param bootDiagnosticEnabled = true
 param bootDiagnosticStorageAccountName = '<bootDiagnosticStorageAccountName>'
@@ -2927,6 +2927,14 @@ The virtual machine scale set zones. NOTE: Availability zones can only be set wh
 - Required: No
 - Type: array
 - Default:
+  ```Bicep
+  [
+    1
+    2
+    3
+  ]
+  ```
+- Allowed:
   ```Bicep
   [
     1

--- a/avm/res/compute/virtual-machine-scale-set/main.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/main.bicep
@@ -298,7 +298,12 @@ param skuName string
 param skuCapacity int = 1
 
 @description('Optional. The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set.')
-param availabilityZones array = [1, 2, 3]
+@allowed([
+  1
+  2
+  3
+])
+param availabilityZones int[] = [1, 2, 3]
 
 @description('Optional. Tags of the resource.')
 param tags object?
@@ -510,7 +515,7 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2024-07-01' = {
   location: location
   tags: tags
   identity: identity
-  zones: availabilityZones
+  zones: map(availabilityZones, zone => '${zone}')
   properties: {
     orchestrationMode: orchestrationMode
     proximityPlacementGroup: !empty(proximityPlacementGroupResourceId)

--- a/avm/res/compute/virtual-machine-scale-set/main.json
+++ b/avm/res/compute/virtual-machine-scale-set/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "12100503841715754172"
+      "version": "0.36.177.2456",
+      "templateHash": "13577614175022538372"
     },
     "name": "Virtual Machine Scale Sets",
     "description": "This module deploys a Virtual Machine Scale Set."
@@ -815,7 +815,15 @@
     },
     "availabilityZones": {
       "type": "array",
+      "items": {
+        "type": "int"
+      },
       "defaultValue": [
+        1,
+        2,
+        3
+      ],
+      "allowedValues": [
         1,
         2,
         3
@@ -973,7 +981,7 @@
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
       "identity": "[variables('identity')]",
-      "zones": "[parameters('availabilityZones')]",
+      "zones": "[map(parameters('availabilityZones'), lambda('zone', format('{0}', lambdaVariables('zone'))))]",
       "properties": {
         "orchestrationMode": "[parameters('orchestrationMode')]",
         "proximityPlacementGroup": "[if(not(empty(parameters('proximityPlacementGroupResourceId'))), createObject('id', parameters('proximityPlacementGroupResourceId')), null())]",
@@ -1194,8 +1202,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2691883054312794420"
+              "version": "0.36.177.2456",
+              "templateHash": "11060050324068350818"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -1361,8 +1369,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2691883054312794420"
+              "version": "0.36.177.2456",
+              "templateHash": "11060050324068350818"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -1523,7 +1531,7 @@
           },
           "protectedSettings": {
             "value": {
-              "workspaceKey": "[if(not(empty(parameters('monitoringWorkspaceResourceId'))), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(if(not(empty(parameters('monitoringWorkspaceResourceId'))), parameters('monitoringWorkspaceResourceId'), '//'), '/')[2], split(if(not(empty(parameters('monitoringWorkspaceResourceId'))), parameters('monitoringWorkspaceResourceId'), '////'), '/')[4]), 'Microsoft.OperationalInsights/workspaces', last(split(if(not(empty(parameters('monitoringWorkspaceResourceId'))), parameters('monitoringWorkspaceResourceId'), 'law'), '/'))), '2021-06-01').primarySharedKey, '')]"
+              "workspaceKey": "[if(not(empty(parameters('monitoringWorkspaceResourceId'))), listKeys('vmss_logAnalyticsWorkspace', '2021-06-01').primarySharedKey, '')]"
             }
           }
         },
@@ -1533,8 +1541,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2691883054312794420"
+              "version": "0.36.177.2456",
+              "templateHash": "11060050324068350818"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -1697,8 +1705,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2691883054312794420"
+              "version": "0.36.177.2456",
+              "templateHash": "11060050324068350818"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -1860,8 +1868,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2691883054312794420"
+              "version": "0.36.177.2456",
+              "templateHash": "11060050324068350818"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -2031,8 +2039,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2691883054312794420"
+              "version": "0.36.177.2456",
+              "templateHash": "11060050324068350818"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -2206,8 +2214,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2691883054312794420"
+              "version": "0.36.177.2456",
+              "templateHash": "11060050324068350818"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -2375,8 +2383,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2691883054312794420"
+              "version": "0.36.177.2456",
+              "templateHash": "11060050324068350818"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/main.test.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/main.test.bicep
@@ -95,7 +95,7 @@ module testDeployment '../../../main.bicep' = [
       osType: 'Linux'
       skuName: 'Standard_B12ms'
       availabilityZones: [
-        '2'
+        2
       ]
       bootDiagnosticEnabled: true
       bootDiagnosticStorageAccountName: nestedDependencies.outputs.storageAccountName

--- a/avm/res/compute/virtual-machine-scale-set/version.json
+++ b/avm/res/compute/virtual-machine-scale-set/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.8"
+  "version": "0.9"
 }


### PR DESCRIPTION
## Description

- Changed type of `availabilityZones` parameter from `array` to `int[]`, i.e., zones must be provided as integers, not strings
- Added allowed set [1,2,3] to availabilityZones parameter.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.compute.virtual-machine-scale-set](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine-scale-set.yml/badge.svg?branch=users%2Falsehr%2FvmssZones&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine-scale-set.yml)     |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
