### PR TITLE
fix: AzureFirewall - Renamed `zones` to `availabilityZones` parameter and added allowedSet

### DIFF
--- a/avm/res/network/azure-firewall/CHANGELOG.md
+++ b/avm/res/network/azure-firewall/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/azure-firewall/CHANGELOG.md).
 
+## 0.8.0
+
+### Changes
+
+- None
+
+### Breaking Changes
+
+- Renamed parameter `zones` to `availabilityZones` and added allowed set `[1,2,3]`. As such, users **must** provide zones as integer values
+
 ## 0.7.1
 
 ### Changes

--- a/avm/res/network/azure-firewall/README.md
+++ b/avm/res/network/azure-firewall/README.md
@@ -806,6 +806,11 @@ module azureFirewall 'br/public:avm/res/network/azure-firewall:<version>' = {
         }
       }
     ]
+    availabilityZones: [
+      1
+      2
+      3
+    ]
     diagnosticSettings: [
       {
         eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -896,11 +901,6 @@ module azureFirewall 'br/public:avm/res/network/azure-firewall:<version>' = {
       Role: 'DeploymentValidation'
     }
     virtualNetworkResourceId: '<virtualNetworkResourceId>'
-    zones: [
-      '1'
-      '2'
-      '3'
-    ]
   }
 }
 ```
@@ -974,6 +974,13 @@ module azureFirewall 'br/public:avm/res/network/azure-firewall:<version>' = {
             ]
           }
         }
+      ]
+    },
+    "availabilityZones": {
+      "value": [
+        1,
+        2,
+        3
       ]
     },
     "diagnosticSettings": {
@@ -1081,13 +1088,6 @@ module azureFirewall 'br/public:avm/res/network/azure-firewall:<version>' = {
     },
     "virtualNetworkResourceId": {
       "value": "<virtualNetworkResourceId>"
-    },
-    "zones": {
-      "value": [
-        "1",
-        "2",
-        "3"
-      ]
     }
   }
 }
@@ -1157,6 +1157,11 @@ param applicationRuleCollections = [
       ]
     }
   }
+]
+param availabilityZones = [
+  1
+  2
+  3
 ]
 param diagnosticSettings = [
   {
@@ -1248,11 +1253,6 @@ param tags = {
   Role: 'DeploymentValidation'
 }
 param virtualNetworkResourceId = '<virtualNetworkResourceId>'
-param zones = [
-  '1'
-  '2'
-  '3'
-]
 ```
 
 </details>
@@ -1274,6 +1274,7 @@ module azureFirewall 'br/public:avm/res/network/azure-firewall:<version>' = {
     // Required parameters
     name: 'nafpip001'
     // Non-required parameters
+    availabilityZones: []
     azureSkuTier: 'Basic'
     location: '<location>'
     managementIPAddressObject: {
@@ -1291,7 +1292,6 @@ module azureFirewall 'br/public:avm/res/network/azure-firewall:<version>' = {
       skuTier: 'Regional'
     }
     virtualNetworkResourceId: '<virtualNetworkResourceId>'
-    zones: []
   }
 }
 ```
@@ -1313,6 +1313,9 @@ module azureFirewall 'br/public:avm/res/network/azure-firewall:<version>' = {
       "value": "nafpip001"
     },
     // Non-required parameters
+    "availabilityZones": {
+      "value": []
+    },
     "azureSkuTier": {
       "value": "Basic"
     },
@@ -1339,9 +1342,6 @@ module azureFirewall 'br/public:avm/res/network/azure-firewall:<version>' = {
     },
     "virtualNetworkResourceId": {
       "value": "<virtualNetworkResourceId>"
-    },
-    "zones": {
-      "value": []
     }
   }
 }
@@ -1360,6 +1360,7 @@ using 'br/public:avm/res/network/azure-firewall:<version>'
 // Required parameters
 param name = 'nafpip001'
 // Non-required parameters
+param availabilityZones = []
 param azureSkuTier = 'Basic'
 param location = '<location>'
 param managementIPAddressObject = {
@@ -1377,7 +1378,6 @@ param publicIPAddressObject = {
   skuTier: 'Regional'
 }
 param virtualNetworkResourceId = '<virtualNetworkResourceId>'
-param zones = []
 ```
 
 </details>
@@ -1561,6 +1561,11 @@ module azureFirewall 'br/public:avm/res/network/azure-firewall:<version>' = {
         }
       }
     ]
+    availabilityZones: [
+      1
+      2
+      3
+    ]
     diagnosticSettings: [
       {
         eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -1612,11 +1617,6 @@ module azureFirewall 'br/public:avm/res/network/azure-firewall:<version>' = {
       Role: 'DeploymentValidation'
     }
     virtualNetworkResourceId: '<virtualNetworkResourceId>'
-    zones: [
-      '1'
-      '2'
-      '3'
-    ]
   }
 }
 ```
@@ -1692,6 +1692,13 @@ module azureFirewall 'br/public:avm/res/network/azure-firewall:<version>' = {
         }
       ]
     },
+    "availabilityZones": {
+      "value": [
+        1,
+        2,
+        3
+      ]
+    },
     "diagnosticSettings": {
       "value": [
         {
@@ -1754,13 +1761,6 @@ module azureFirewall 'br/public:avm/res/network/azure-firewall:<version>' = {
     },
     "virtualNetworkResourceId": {
       "value": "<virtualNetworkResourceId>"
-    },
-    "zones": {
-      "value": [
-        "1",
-        "2",
-        "3"
-      ]
     }
   }
 }
@@ -1831,6 +1831,11 @@ param applicationRuleCollections = [
     }
   }
 ]
+param availabilityZones = [
+  1
+  2
+  3
+]
 param diagnosticSettings = [
   {
     eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -1882,11 +1887,6 @@ param tags = {
   Role: 'DeploymentValidation'
 }
 param virtualNetworkResourceId = '<virtualNetworkResourceId>'
-param zones = [
-  '1'
-  '2'
-  '3'
-]
 ```
 
 </details>
@@ -1916,6 +1916,7 @@ param zones = [
 | [`applicationRuleCollections`](#parameter-applicationrulecollections) | array | Collection of application rule collections used by Azure Firewall. |
 | [`autoscaleMaxCapacity`](#parameter-autoscalemaxcapacity) | int | The maximum number of capacity units for this azure firewall. Use null to reset the value to the service default. |
 | [`autoscaleMinCapacity`](#parameter-autoscalemincapacity) | int | The minimum number of capacity units for this azure firewall. Use null to reset the value to the service default. |
+| [`availabilityZones`](#parameter-availabilityzones) | array | The list of Availability zones to use for the zone-redundant resources. |
 | [`azureSkuTier`](#parameter-azureskutier) | string | Tier of an Azure Firewall. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
 | [`enableForcedTunneling`](#parameter-enableforcedtunneling) | bool | Enable/Disable forced tunneling. |
@@ -1932,7 +1933,6 @@ param zones = [
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Tags of the Azure Firewall resource. |
 | [`threatIntelMode`](#parameter-threatintelmode) | string | The operation mode for Threat Intel. |
-| [`zones`](#parameter-zones) | array | Zone numbers e.g. 1,2,3. |
 
 ### Parameter: `name`
 
@@ -2207,6 +2207,29 @@ The minimum number of capacity units for this azure firewall. Use null to reset 
 
 - Required: No
 - Type: int
+
+### Parameter: `availabilityZones`
+
+The list of Availability zones to use for the zone-redundant resources.
+
+- Required: No
+- Type: array
+- Default:
+  ```Bicep
+  [
+    1
+    2
+    3
+  ]
+  ```
+- Allowed:
+  ```Bicep
+  [
+    1
+    2
+    3
+  ]
+  ```
 
 ### Parameter: `azureSkuTier`
 
@@ -2946,21 +2969,6 @@ The operation mode for Threat Intel.
     'Alert'
     'Deny'
     'Off'
-  ]
-  ```
-
-### Parameter: `zones`
-
-Zone numbers e.g. 1,2,3.
-
-- Required: No
-- Type: array
-- Default:
-  ```Bicep
-  [
-    1
-    2
-    3
   ]
   ```
 

--- a/avm/res/network/azure-firewall/main.bicep
+++ b/avm/res/network/azure-firewall/main.bicep
@@ -64,12 +64,13 @@ param autoscaleMaxCapacity int?
 @description('Optional. The minimum number of capacity units for this azure firewall. Use null to reset the value to the service default.')
 param autoscaleMinCapacity int?
 
-@description('Optional. Zone numbers e.g. 1,2,3.')
-param zones array = [
+@description('Optional. The list of Availability zones to use for the zone-redundant resources.')
+@allowed([
   1
   2
   3
-]
+])
+param availabilityZones int[] = [1, 2, 3]
 
 @description('Optional. Enable/Disable forced tunneling.')
 param enableForcedTunneling bool = false
@@ -232,7 +233,7 @@ module publicIPAddress 'br/public:avm/res/network/public-ip-address:0.8.0' = if 
     location: location
     lock: lock
     tags: publicIPAddressObject.?tags ?? tags
-    zones: zones
+    zones: availabilityZones
     enableTelemetry: enableReferencedModulesTelemetry
   }
 }
@@ -266,7 +267,7 @@ module managementIPAddress 'br/public:avm/res/network/public-ip-address:0.8.0' =
     diagnosticSettings: managementIPAddressObject.?diagnosticSettings
     location: location
     tags: managementIPAddressObject.?tags ?? tags
-    zones: zones
+    zones: availabilityZones
     enableTelemetry: enableReferencedModulesTelemetry
   }
 }
@@ -274,7 +275,7 @@ module managementIPAddress 'br/public:avm/res/network/public-ip-address:0.8.0' =
 resource azureFirewall 'Microsoft.Network/azureFirewalls@2024-05-01' = {
   name: name
   location: location
-  zones: length(zones) == 0 ? null : zones
+  zones: map(availabilityZones, zone => '${zone}')
   tags: tags
   properties: azureSkuName == 'AZFW_VNet'
     ? {

--- a/avm/res/network/azure-firewall/main.json
+++ b/avm/res/network/azure-firewall/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "6221915549963366860"
+      "version": "0.36.177.2456",
+      "templateHash": "301107264744990959"
     },
     "name": "Azure Firewalls",
     "description": "This module deploys an Azure Firewall."
@@ -868,15 +868,23 @@
         "description": "Optional. The minimum number of capacity units for this azure firewall. Use null to reset the value to the service default."
       }
     },
-    "zones": {
+    "availabilityZones": {
       "type": "array",
+      "items": {
+        "type": "int"
+      },
       "defaultValue": [
         1,
         2,
         3
       ],
+      "allowedValues": [
+        1,
+        2,
+        3
+      ],
       "metadata": {
-        "description": "Optional. Zone numbers e.g. 1,2,3."
+        "description": "Optional. The list of Availability zones to use for the zone-redundant resources."
       }
     },
     "enableForcedTunneling": {
@@ -994,7 +1002,7 @@
       "apiVersion": "2024-05-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
-      "zones": "[if(equals(length(parameters('zones')), 0), null(), parameters('zones'))]",
+      "zones": "[map(parameters('availabilityZones'), lambda('zone', format('{0}', lambdaVariables('zone'))))]",
       "tags": "[parameters('tags')]",
       "properties": "[if(equals(variables('azureSkuName'), 'AZFW_VNet'), createObject('threatIntelMode', parameters('threatIntelMode'), 'firewallPolicy', if(not(empty(parameters('firewallPolicyId'))), createObject('id', parameters('firewallPolicyId')), null()), 'ipConfigurations', concat(createArray(createObject('name', if(not(empty(parameters('publicIPResourceID'))), last(split(parameters('publicIPResourceID'), '/')), reference('publicIPAddress').outputs.name.value), 'properties', union(if(equals(variables('azureSkuName'), 'AZFW_VNet'), createObject('subnet', createObject('id', format('{0}/subnets/AzureFirewallSubnet', parameters('virtualNetworkResourceId')))), createObject()), if(or(not(empty(parameters('publicIPResourceID'))), not(empty(parameters('publicIPAddressObject')))), createObject('publicIPAddress', createObject('id', if(not(empty(parameters('publicIPResourceID'))), parameters('publicIPResourceID'), reference('publicIPAddress').outputs.resourceId.value))), createObject())))), variables('additionalPublicIpConfigurationsVar')), 'managementIpConfiguration', if(variables('requiresManagementIp'), createObject('name', if(not(empty(parameters('managementIPResourceID'))), last(split(parameters('managementIPResourceID'), '/')), reference('managementIPAddress').outputs.name.value), 'properties', createObject('subnet', createObject('id', format('{0}/subnets/AzureFirewallManagementSubnet', parameters('virtualNetworkResourceId'))), 'publicIPAddress', createObject('id', if(not(empty(parameters('managementIPResourceID'))), parameters('managementIPResourceID'), reference('managementIPAddress').outputs.resourceId.value)))), null()), 'sku', createObject('name', variables('azureSkuName'), 'tier', parameters('azureSkuTier')), 'applicationRuleCollections', coalesce(parameters('applicationRuleCollections'), createArray()), 'natRuleCollections', coalesce(parameters('natRuleCollections'), createArray()), 'networkRuleCollections', coalesce(parameters('networkRuleCollections'), createArray())), createObject('autoscaleConfiguration', createObject('maxCapacity', parameters('autoscaleMaxCapacity'), 'minCapacity', parameters('autoscaleMinCapacity')), 'firewallPolicy', if(not(empty(parameters('firewallPolicyId'))), createObject('id', parameters('firewallPolicyId')), null()), 'sku', createObject('name', variables('azureSkuName'), 'tier', parameters('azureSkuTier')), 'hubIPAddresses', if(not(empty(parameters('hubIPAddresses'))), parameters('hubIPAddresses'), null()), 'virtualHub', if(not(empty(parameters('virtualHubResourceId'))), createObject('id', parameters('virtualHubResourceId')), null())))]",
       "dependsOn": [
@@ -1111,7 +1119,7 @@
             "value": "[coalesce(tryGet(parameters('publicIPAddressObject'), 'tags'), parameters('tags'))]"
           },
           "zones": {
-            "value": "[parameters('zones')]"
+            "value": "[parameters('availabilityZones')]"
           },
           "enableTelemetry": {
             "value": "[variables('enableReferencedModulesTelemetry')]"
@@ -1817,7 +1825,7 @@
             "value": "[coalesce(tryGet(parameters('managementIPAddressObject'), 'tags'), parameters('tags'))]"
           },
           "zones": {
-            "value": "[parameters('zones')]"
+            "value": "[parameters('availabilityZones')]"
           },
           "enableTelemetry": {
             "value": "[variables('enableReferencedModulesTelemetry')]"

--- a/avm/res/network/azure-firewall/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/azure-firewall/tests/e2e/max/main.test.bicep
@@ -207,10 +207,10 @@ module testDeployment '../../../main.bicep' = [
           principalType: 'ServicePrincipal'
         }
       ]
-      zones: [
-        '1'
-        '2'
-        '3'
+      availabilityZones: [
+        1
+        2
+        3
       ]
       tags: {
         'hidden-title': 'This is visible in the resource name'

--- a/avm/res/network/azure-firewall/tests/e2e/publicipprefix/main.test.bicep
+++ b/avm/res/network/azure-firewall/tests/e2e/publicipprefix/main.test.bicep
@@ -69,7 +69,7 @@ module testDeployment '../../../main.bicep' = [
         skuName: 'Standard'
         skuTier: 'Regional'
       }
-      zones: []
+      availabilityZones: []
     }
   }
 ]

--- a/avm/res/network/azure-firewall/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/azure-firewall/tests/e2e/waf-aligned/main.test.bicep
@@ -165,10 +165,10 @@ module testDeployment '../../../main.bicep' = [
           }
         }
       ]
-      zones: [
-        '1'
-        '2'
-        '3'
+      availabilityZones: [
+        1
+        2
+        3
       ]
       tags: {
         'hidden-title': 'This is visible in the resource name'

--- a/avm/res/network/azure-firewall/version.json
+++ b/avm/res/network/azure-firewall/version.json
@@ -1,4 +1,4 @@
 {
-    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.7"
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.8"
 }


### PR DESCRIPTION
## Description

- Renamed parameter `zones` to `availabilityZones` and added allowed set `[1,2,3]`. As such, users **must** provide zones as integer values

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.res.network.azure-firewall](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.azure-firewall.yml/badge.svg?branch=users%2Falsehr%2FfirewallZone&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.azure-firewall.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
