### PR TITLE
fix: Bastion - Renamed `zones` to `availabilityZones` parameter and added default

### DIFF
--- a/avm/res/network/bastion-host/CHANGELOG.md
+++ b/avm/res/network/bastion-host/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/bastion-host/CHANGELOG.md).
 
+## 0.7.0
+
+### Changes
+
+- None
+
+### Breaking Changes
+
+- Renamed `zones` to `availabilityZones` parameter
+- Changed default of `availabilityZones` to `[1,2,3]`
+
 ## 0.6.1
 
 ### Changes

--- a/avm/res/network/bastion-host/README.md
+++ b/avm/res/network/bastion-host/README.md
@@ -381,6 +381,11 @@ module bastionHost 'br/public:avm/res/network/bastion-host:<version>' = {
     name: 'nbhmax001'
     virtualNetworkResourceId: '<virtualNetworkResourceId>'
     // Non-required parameters
+    availabilityZones: [
+      1
+      2
+      3
+    ]
     bastionSubnetPublicIpResourceId: '<bastionSubnetPublicIpResourceId>'
     diagnosticSettings: [
       {
@@ -426,11 +431,6 @@ module bastionHost 'br/public:avm/res/network/bastion-host:<version>' = {
       'hidden-title': 'This is visible in the resource name'
       Role: 'DeploymentValidation'
     }
-    zones: [
-      1
-      2
-      3
-    ]
   }
 }
 ```
@@ -455,6 +455,13 @@ module bastionHost 'br/public:avm/res/network/bastion-host:<version>' = {
       "value": "<virtualNetworkResourceId>"
     },
     // Non-required parameters
+    "availabilityZones": {
+      "value": [
+        1,
+        2,
+        3
+      ]
+    },
     "bastionSubnetPublicIpResourceId": {
       "value": "<bastionSubnetPublicIpResourceId>"
     },
@@ -523,13 +530,6 @@ module bastionHost 'br/public:avm/res/network/bastion-host:<version>' = {
         "hidden-title": "This is visible in the resource name",
         "Role": "DeploymentValidation"
       }
-    },
-    "zones": {
-      "value": [
-        1,
-        2,
-        3
-      ]
     }
   }
 }
@@ -549,6 +549,11 @@ using 'br/public:avm/res/network/bastion-host:<version>'
 param name = 'nbhmax001'
 param virtualNetworkResourceId = '<virtualNetworkResourceId>'
 // Non-required parameters
+param availabilityZones = [
+  1
+  2
+  3
+]
 param bastionSubnetPublicIpResourceId = '<bastionSubnetPublicIpResourceId>'
 param diagnosticSettings = [
   {
@@ -594,11 +599,6 @@ param tags = {
   'hidden-title': 'This is visible in the resource name'
   Role: 'DeploymentValidation'
 }
-param zones = [
-  1
-  2
-  3
-]
 ```
 
 </details>
@@ -851,6 +851,7 @@ param tags = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`availabilityZones`](#parameter-availabilityzones) | array | The list of Availability zones to use for the zone-redundant resources. |
 | [`bastionSubnetPublicIpResourceId`](#parameter-bastionsubnetpublicipresourceid) | string | The Public IP resource ID to associate to the azureBastionSubnet. If empty, then the Public IP that is created as part of this module will be applied to the azureBastionSubnet. This parameter is ignored when enablePrivateOnlyBastion is true. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
 | [`disableCopyPaste`](#parameter-disablecopypaste) | bool | Choose to disable or enable Copy Paste. For Basic and Developer SKU Copy/Paste is always enabled. |
@@ -868,7 +869,6 @@ param tags = {
 | [`scaleUnits`](#parameter-scaleunits) | int | The scale units for the Bastion Host resource. The Basic and Developer SKU only support 2 scale units. |
 | [`skuName`](#parameter-skuname) | string | The SKU of this Bastion Host. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
-| [`zones`](#parameter-zones) | array | A list of availability zones denoting where the Bastion Host resource needs to come from. This is not supported for the Developer SKU. |
 
 ### Parameter: `name`
 
@@ -883,6 +883,29 @@ Shared services Virtual Network resource Id.
 
 - Required: Yes
 - Type: string
+
+### Parameter: `availabilityZones`
+
+The list of Availability zones to use for the zone-redundant resources.
+
+- Required: No
+- Type: array
+- Default:
+  ```Bicep
+  [
+    1
+    2
+    3
+  ]
+  ```
+- Allowed:
+  ```Bicep
+  [
+    1
+    2
+    3
+  ]
+  ```
 
 ### Parameter: `bastionSubnetPublicIpResourceId`
 
@@ -1259,22 +1282,6 @@ Tags of the resource.
 
 - Required: No
 - Type: object
-
-### Parameter: `zones`
-
-A list of availability zones denoting where the Bastion Host resource needs to come from. This is not supported for the Developer SKU.
-
-- Required: No
-- Type: array
-- Default: `[]`
-- Allowed:
-  ```Bicep
-  [
-    1
-    2
-    3
-  ]
-  ```
 
 ## Outputs
 

--- a/avm/res/network/bastion-host/main.bicep
+++ b/avm/res/network/bastion-host/main.bicep
@@ -69,13 +69,13 @@ param tags object?
 @description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
 
-@description('Optional. A list of availability zones denoting where the Bastion Host resource needs to come from. This is not supported for the Developer SKU.')
+@description('Optional. The list of Availability zones to use for the zone-redundant resources.')
 @allowed([
   1
   2
   3
 ])
-param zones int[] = [] // Availability Zones are currently in preview and only available in certain regions, therefore the default is an empty array.
+param availabilityZones int[] = [1, 2, 3]
 
 var enableReferencedModulesTelemetry = false
 
@@ -170,7 +170,7 @@ module publicIPAddress 'br/public:avm/res/network/public-ip-address:0.8.0' = if 
     skuName: publicIPAddressObject.?skuName
     skuTier: publicIPAddressObject.?skuTier
     tags: publicIPAddressObject.?tags ?? tags
-    zones: publicIPAddressObject.?zones ?? (length(zones) > 0 ? zones : null) // if zones of the Public IP is empty, use the zones from the bastion host only if not empty (if empty, the default of the public IP will be used)
+    zones: publicIPAddressObject.?zones ?? (!empty(availabilityZones) ? availabilityZones : null) // if zones of the Public IP is empty, use the zones from the bastion host only if not empty (if empty, the default of the public IP will be used)
   }
 }
 
@@ -215,7 +215,7 @@ resource azureBastion 'Microsoft.Network/bastionHosts@2024-05-01' = {
   sku: {
     name: skuName
   }
-  zones: skuName == 'Developer' ? [] : map(zones, zone => string(zone))
+  zones: skuName == 'Developer' ? [] : map(availabilityZones, zone => '${zone}')
   properties: bastionpropertiesVar
 }
 

--- a/avm/res/network/bastion-host/main.json
+++ b/avm/res/network/bastion-host/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "542037632528730428"
+      "version": "0.36.177.2456",
+      "templateHash": "13177747660527689400"
     },
     "name": "Bastion Hosts",
     "description": "This module deploys a Bastion Host."
@@ -361,19 +361,23 @@
         "description": "Optional. Enable/Disable usage telemetry for module."
       }
     },
-    "zones": {
+    "availabilityZones": {
       "type": "array",
       "items": {
         "type": "int"
       },
-      "defaultValue": [],
+      "defaultValue": [
+        1,
+        2,
+        3
+      ],
       "allowedValues": [
         1,
         2,
         3
       ],
       "metadata": {
-        "description": "Optional. A list of availability zones denoting where the Bastion Host resource needs to come from. This is not supported for the Developer SKU."
+        "description": "Optional. The list of Availability zones to use for the zone-redundant resources."
       }
     }
   },
@@ -424,7 +428,7 @@
       "sku": {
         "name": "[parameters('skuName')]"
       },
-      "zones": "[if(equals(parameters('skuName'), 'Developer'), createArray(), map(parameters('zones'), lambda('zone', string(lambdaVariables('zone')))))]",
+      "zones": "[if(equals(parameters('skuName'), 'Developer'), createArray(), map(parameters('availabilityZones'), lambda('zone', format('{0}', lambdaVariables('zone')))))]",
       "properties": "[union(createObject('scaleUnits', if(or(equals(parameters('skuName'), 'Basic'), equals(parameters('skuName'), 'Developer')), 2, parameters('scaleUnits')), 'ipConfigurations', if(equals(parameters('skuName'), 'Developer'), createArray(), createArray(createObject('name', 'IpConfAzureBastionSubnet', 'properties', union(createObject('subnet', createObject('id', format('{0}/subnets/AzureBastionSubnet', parameters('virtualNetworkResourceId')))), if(not(parameters('enablePrivateOnlyBastion')), createObject('publicIPAddress', createObject('id', if(not(empty(parameters('bastionSubnetPublicIpResourceId'))), parameters('bastionSubnetPublicIpResourceId'), reference('publicIPAddress').outputs.resourceId.value))), createObject())))))), if(equals(parameters('skuName'), 'Developer'), createObject('virtualNetwork', createObject('id', parameters('virtualNetworkResourceId'))), createObject()), if(or(or(equals(parameters('skuName'), 'Basic'), equals(parameters('skuName'), 'Standard')), equals(parameters('skuName'), 'Premium')), createObject('enableKerberos', parameters('enableKerberos')), createObject()), if(or(equals(parameters('skuName'), 'Standard'), equals(parameters('skuName'), 'Premium')), createObject('enableTunneling', if(equals(parameters('skuName'), 'Standard'), true(), if(parameters('enableSessionRecording'), false(), true())), 'disableCopyPaste', parameters('disableCopyPaste'), 'enableFileCopy', parameters('enableFileCopy'), 'enableIpConnect', parameters('enableIpConnect'), 'enableShareableLink', parameters('enableShareableLink')), createObject()), if(equals(parameters('skuName'), 'Premium'), createObject('enableSessionRecording', parameters('enableSessionRecording'), 'enablePrivateOnlyBastion', parameters('enablePrivateOnlyBastion')), createObject()))]",
       "dependsOn": [
         "publicIPAddress"
@@ -546,7 +550,7 @@
             "value": "[coalesce(tryGet(parameters('publicIPAddressObject'), 'tags'), parameters('tags'))]"
           },
           "zones": {
-            "value": "[coalesce(tryGet(parameters('publicIPAddressObject'), 'zones'), if(greater(length(parameters('zones')), 0), parameters('zones'), null()))]"
+            "value": "[coalesce(tryGet(parameters('publicIPAddressObject'), 'zones'), if(not(empty(parameters('availabilityZones'))), parameters('availabilityZones'), null()))]"
           }
         },
         "template": {

--- a/avm/res/network/bastion-host/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/bastion-host/tests/e2e/max/main.test.bicep
@@ -117,7 +117,7 @@ module testDeployment '../../../main.bicep' = [
         Environment: 'Non-Prod'
         Role: 'DeploymentValidation'
       }
-      zones: [
+      availabilityZones: [
         1
         2
         3

--- a/avm/res/network/bastion-host/version.json
+++ b/avm/res/network/bastion-host/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.6"
+  "version": "0.7"
 }


### PR DESCRIPTION
## Description

- Renamed `zones` to `availabilityZones` parameter
- Changed default of `availabilityZones` to `[1,2,3]`

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.res.network.bastion-host](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.bastion-host.yml/badge.svg?branch=users%2Falsehr%2FbastionZone&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.bastion-host.yml)       |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
