### PR TITLE
fix: PublicIP - Renamed parameter `zones` to `availabilityZones`

### DIFF
--- a/avm/res/network/public-ip-address/CHANGELOG.md
+++ b/avm/res/network/public-ip-address/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/public-ip-address/CHANGELOG.md).
 
+## 0.9.0
+
+### Changes
+
+- None
+
+### Breaking Changes
+
+- Renamed parameter `zones` to `availabilityZones`
+
 ## 0.8.0
 
 ### Changes

--- a/avm/res/network/public-ip-address/README.md
+++ b/avm/res/network/public-ip-address/README.md
@@ -112,6 +112,11 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
     // Required parameters
     name: 'npiamax001'
     // Non-required parameters
+    availabilityZones: [
+      1
+      2
+      3
+    ]
     ddosSettings: '<ddosSettings>'
     diagnosticSettings: [
       {
@@ -163,11 +168,6 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
       'hidden-title': 'This is visible in the resource name'
       Role: 'DeploymentValidation'
     }
-    zones: [
-      1
-      2
-      3
-    ]
   }
 }
 ```
@@ -189,6 +189,13 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
       "value": "npiamax001"
     },
     // Non-required parameters
+    "availabilityZones": {
+      "value": [
+        1,
+        2,
+        3
+      ]
+    },
     "ddosSettings": {
       "value": "<ddosSettings>"
     },
@@ -265,13 +272,6 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
         "hidden-title": "This is visible in the resource name",
         "Role": "DeploymentValidation"
       }
-    },
-    "zones": {
-      "value": [
-        1,
-        2,
-        3
-      ]
     }
   }
 }
@@ -290,6 +290,11 @@ using 'br/public:avm/res/network/public-ip-address:<version>'
 // Required parameters
 param name = 'npiamax001'
 // Non-required parameters
+param availabilityZones = [
+  1
+  2
+  3
+]
 param ddosSettings = '<ddosSettings>'
 param diagnosticSettings = [
   {
@@ -341,11 +346,6 @@ param tags = {
   'hidden-title': 'This is visible in the resource name'
   Role: 'DeploymentValidation'
 }
-param zones = [
-  1
-  2
-  3
-]
 ```
 
 </details>
@@ -367,6 +367,11 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
     // Required parameters
     name: 'npiawaf001'
     // Non-required parameters
+    availabilityZones: [
+      1
+      2
+      3
+    ]
     ddosSettings: '<ddosSettings>'
     diagnosticSettings: [
       {
@@ -410,11 +415,6 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
       'hidden-title': 'This is visible in the resource name'
       Role: 'DeploymentValidation'
     }
-    zones: [
-      1
-      2
-      3
-    ]
   }
 }
 ```
@@ -436,6 +436,13 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
       "value": "npiawaf001"
     },
     // Non-required parameters
+    "availabilityZones": {
+      "value": [
+        1,
+        2,
+        3
+      ]
+    },
     "ddosSettings": {
       "value": "<ddosSettings>"
     },
@@ -502,13 +509,6 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
         "hidden-title": "This is visible in the resource name",
         "Role": "DeploymentValidation"
       }
-    },
-    "zones": {
-      "value": [
-        1,
-        2,
-        3
-      ]
     }
   }
 }
@@ -527,6 +527,11 @@ using 'br/public:avm/res/network/public-ip-address:<version>'
 // Required parameters
 param name = 'npiawaf001'
 // Non-required parameters
+param availabilityZones = [
+  1
+  2
+  3
+]
 param ddosSettings = '<ddosSettings>'
 param diagnosticSettings = [
   {
@@ -570,11 +575,6 @@ param tags = {
   'hidden-title': 'This is visible in the resource name'
   Role: 'DeploymentValidation'
 }
-param zones = [
-  1
-  2
-  3
-]
 ```
 
 </details>
@@ -592,6 +592,7 @@ param zones = [
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`availabilityZones`](#parameter-availabilityzones) | array | A list of availability zones denoting the IP allocated for the resource needs to come from. |
 | [`ddosSettings`](#parameter-ddossettings) | object | The DDoS protection plan configuration associated with the public IP address. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
 | [`dnsSettings`](#parameter-dnssettings) | object | The DNS settings of the public IP address. |
@@ -607,7 +608,6 @@ param zones = [
 | [`skuName`](#parameter-skuname) | string | Name of a public IP address SKU. |
 | [`skuTier`](#parameter-skutier) | string | Tier of a public IP address SKU. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
-| [`zones`](#parameter-zones) | array | A list of availability zones denoting the IP allocated for the resource needs to come from. |
 
 ### Parameter: `name`
 
@@ -615,6 +615,29 @@ The name of the Public IP Address.
 
 - Required: Yes
 - Type: string
+
+### Parameter: `availabilityZones`
+
+A list of availability zones denoting the IP allocated for the resource needs to come from.
+
+- Required: No
+- Type: array
+- Default:
+  ```Bicep
+  [
+    1
+    2
+    3
+  ]
+  ```
+- Allowed:
+  ```Bicep
+  [
+    1
+    2
+    3
+  ]
+  ```
 
 ### Parameter: `ddosSettings`
 
@@ -1141,29 +1164,6 @@ Tags of the resource.
 
 - Required: No
 - Type: object
-
-### Parameter: `zones`
-
-A list of availability zones denoting the IP allocated for the resource needs to come from.
-
-- Required: No
-- Type: array
-- Default:
-  ```Bicep
-  [
-    1
-    2
-    3
-  ]
-  ```
-- Allowed:
-  ```Bicep
-  [
-    1
-    2
-    3
-  ]
-  ```
 
 ## Outputs
 

--- a/avm/res/network/public-ip-address/main.bicep
+++ b/avm/res/network/public-ip-address/main.bicep
@@ -20,7 +20,7 @@ param publicIPAllocationMethod string = 'Static'
   2
   3
 ])
-param zones int[] = [
+param availabilityZones int[] = [
   1
   2
   3
@@ -152,7 +152,7 @@ resource publicIpAddress 'Microsoft.Network/publicIPAddresses@2024-05-01' = {
     name: skuName
     tier: skuTier
   }
-  zones: map(zones, zone => string(zone))
+  zones: map(availabilityZones, zone => string(zone))
   properties: {
     ddosSettings: ddosSettings
     dnsSettings: dnsSettings

--- a/avm/res/network/public-ip-address/main.json
+++ b/avm/res/network/public-ip-address/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "11118459859179868367"
+      "version": "0.36.177.2456",
+      "templateHash": "16328824611121617710"
     },
     "name": "Public IP Addresses",
     "description": "This module deploys a Public IP Address."
@@ -358,7 +358,7 @@
         "description": "Optional. The public IP address allocation method."
       }
     },
-    "zones": {
+    "availabilityZones": {
       "type": "array",
       "items": {
         "type": "int"
@@ -542,7 +542,7 @@
         "name": "[parameters('skuName')]",
         "tier": "[parameters('skuTier')]"
       },
-      "zones": "[map(parameters('zones'), lambda('zone', string(lambdaVariables('zone'))))]",
+      "zones": "[map(parameters('availabilityZones'), lambda('zone', string(lambdaVariables('zone'))))]",
       "properties": {
         "ddosSettings": "[parameters('ddosSettings')]",
         "dnsSettings": "[parameters('dnsSettings')]",

--- a/avm/res/network/public-ip-address/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/public-ip-address/tests/e2e/max/main.test.bicep
@@ -104,7 +104,7 @@ module testDeployment '../../../main.bicep' = [
       skuName: 'Standard'
       skuTier: 'Regional'
       publicIPAddressVersion: 'IPv4'
-      zones: [
+      availabilityZones: [
         1
         2
         3

--- a/avm/res/network/public-ip-address/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/public-ip-address/tests/e2e/waf-aligned/main.test.bicep
@@ -96,7 +96,7 @@ module testDeployment '../../../main.bicep' = [
       skuName: 'Standard'
       skuTier: 'Regional'
       publicIPAddressVersion: 'IPv4'
-      zones: [
+      availabilityZones: [
         1
         2
         3

--- a/avm/res/network/public-ip-address/version.json
+++ b/avm/res/network/public-ip-address/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.8"
+  "version": "0.9"
 }


### PR DESCRIPTION
## Description

Renamed parameter `zones` to `availabilityZones`

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|     [![avm.res.network.public-ip-address](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml/badge.svg?branch=users%2Falsehr%2FpipZone&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml)     |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
