### PR TITLE
fix: Public-IP-Prefix - Renamed parameter `zones` to `availabilityZones`

### DIFF
--- a/avm/res/network/public-ip-prefix/CHANGELOG.md
+++ b/avm/res/network/public-ip-prefix/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/public-ip-prefix/CHANGELOG.md).
 
+## 0.7.0
+
+### Changes
+
+- None
+
+### Breaking Changes
+
+- Renamed `zones` parameter to `availabilityZones`
+
 ## 0.6.0
 
 ### Changes

--- a/avm/res/network/public-ip-prefix/README.md
+++ b/avm/res/network/public-ip-prefix/README.md
@@ -192,6 +192,10 @@ module publicIpPrefix 'br/public:avm/res/network/public-ip-prefix:<version>' = {
     name: 'npipmax001'
     prefixLength: 28
     // Non-required parameters
+    availabilityZones: [
+      1
+      2
+    ]
     ipTags: [
       {
         ipTagType: 'RoutingPreference'
@@ -227,10 +231,6 @@ module publicIpPrefix 'br/public:avm/res/network/public-ip-prefix:<version>' = {
       'hidden-title': 'This is visible in the resource name'
       Role: 'DeploymentValidation'
     }
-    zones: [
-      1
-      2
-    ]
   }
 }
 ```
@@ -255,6 +255,12 @@ module publicIpPrefix 'br/public:avm/res/network/public-ip-prefix:<version>' = {
       "value": 28
     },
     // Non-required parameters
+    "availabilityZones": {
+      "value": [
+        1,
+        2
+      ]
+    },
     "ipTags": {
       "value": [
         {
@@ -299,12 +305,6 @@ module publicIpPrefix 'br/public:avm/res/network/public-ip-prefix:<version>' = {
         "hidden-title": "This is visible in the resource name",
         "Role": "DeploymentValidation"
       }
-    },
-    "zones": {
-      "value": [
-        1,
-        2
-      ]
     }
   }
 }
@@ -324,6 +324,10 @@ using 'br/public:avm/res/network/public-ip-prefix:<version>'
 param name = 'npipmax001'
 param prefixLength = 28
 // Non-required parameters
+param availabilityZones = [
+  1
+  2
+]
 param ipTags = [
   {
     ipTagType: 'RoutingPreference'
@@ -359,10 +363,6 @@ param tags = {
   'hidden-title': 'This is visible in the resource name'
   Role: 'DeploymentValidation'
 }
-param zones = [
-  1
-  2
-]
 ```
 
 </details>
@@ -467,6 +467,7 @@ param tags = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`availabilityZones`](#parameter-availabilityzones) | array | A list of availability zones denoting the IP allocated for the resource needs to come from. This is only applicable for regional public IP prefixes and must be empty for global public IP prefixes. |
 | [`customIPPrefix`](#parameter-customipprefix) | object | The custom IP address prefix that this prefix is associated with. A custom IP address prefix is a contiguous range of IP addresses owned by an external customer and provisioned into a subscription. When a custom IP prefix is in Provisioned, Commissioning, or Commissioned state, a linked public IP prefix can be created. Either as a subset of the custom IP prefix range or the entire range. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`ipTags`](#parameter-iptags) | array | The list of tags associated with the public IP prefix. |
@@ -476,7 +477,6 @@ param tags = {
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`tier`](#parameter-tier) | string | Tier of a public IP prefix SKU. If set to `Global`, the `zones` property must be empty. |
-| [`zones`](#parameter-zones) | array | A list of availability zones denoting the IP allocated for the resource needs to come from. This is only applicable for regional public IP prefixes and must be empty for global public IP prefixes. |
 
 ### Parameter: `name`
 
@@ -493,6 +493,29 @@ Length of the Public IP Prefix.
 - Type: int
 - MinValue: 21
 - MaxValue: 127
+
+### Parameter: `availabilityZones`
+
+A list of availability zones denoting the IP allocated for the resource needs to come from. This is only applicable for regional public IP prefixes and must be empty for global public IP prefixes.
+
+- Required: No
+- Type: array
+- Default:
+  ```Bicep
+  [
+    1
+    2
+    3
+  ]
+  ```
+- Allowed:
+  ```Bicep
+  [
+    1
+    2
+    3
+  ]
+  ```
 
 ### Parameter: `customIPPrefix`
 
@@ -720,29 +743,6 @@ Tier of a public IP prefix SKU. If set to `Global`, the `zones` property must be
   [
     'Global'
     'Regional'
-  ]
-  ```
-
-### Parameter: `zones`
-
-A list of availability zones denoting the IP allocated for the resource needs to come from. This is only applicable for regional public IP prefixes and must be empty for global public IP prefixes.
-
-- Required: No
-- Type: array
-- Default:
-  ```Bicep
-  [
-    1
-    2
-    3
-  ]
-  ```
-- Allowed:
-  ```Bicep
-  [
-    1
-    2
-    3
   ]
   ```
 

--- a/avm/res/network/public-ip-prefix/main.bicep
+++ b/avm/res/network/public-ip-prefix/main.bicep
@@ -50,7 +50,7 @@ param ipTags ipTagType[]?
   2
   3
 ])
-param zones int[] = [
+param availabilityZones int[] = [
   1
   2
   3
@@ -115,7 +115,7 @@ resource publicIpPrefix 'Microsoft.Network/publicIPPrefixes@2024-01-01' = {
     name: 'Standard'
     tier: tier
   }
-  zones: map(zones, zone => string(zone))
+  zones: map(availabilityZones, zone => string(zone))
   properties: {
     customIPPrefix: !empty(customIPPrefix) ? customIPPrefix : null
     publicIPAddressVersion: publicIPAddressVersion

--- a/avm/res/network/public-ip-prefix/main.json
+++ b/avm/res/network/public-ip-prefix/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "1837206327927302660"
+      "version": "0.36.177.2456",
+      "templateHash": "8755931358914857266"
     },
     "name": "Public IP Prefixes",
     "description": "This module deploys a Public IP Prefix."
@@ -224,7 +224,7 @@
         "description": "Optional. The list of tags associated with the public IP prefix."
       }
     },
-    "zones": {
+    "availabilityZones": {
       "type": "array",
       "items": {
         "type": "int"
@@ -299,7 +299,7 @@
         "name": "Standard",
         "tier": "[parameters('tier')]"
       },
-      "zones": "[map(parameters('zones'), lambda('zone', string(lambdaVariables('zone'))))]",
+      "zones": "[map(parameters('availabilityZones'), lambda('zone', string(lambdaVariables('zone'))))]",
       "properties": {
         "customIPPrefix": "[if(not(empty(parameters('customIPPrefix'))), parameters('customIPPrefix'), null())]",
         "publicIPAddressVersion": "[parameters('publicIPAddressVersion')]",

--- a/avm/res/network/public-ip-prefix/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/public-ip-prefix/tests/e2e/max/main.test.bicep
@@ -84,7 +84,7 @@ module testDeployment '../../../main.bicep' = [
         Environment: 'Non-Prod'
         Role: 'DeploymentValidation'
       }
-      zones: [
+      availabilityZones: [
         1
         2
       ]

--- a/avm/res/network/public-ip-prefix/version.json
+++ b/avm/res/network/public-ip-prefix/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.6"
+  "version": "0.7"
 }


### PR DESCRIPTION
## Description

Renamed parameter `zones` to `availabilityZones`

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|   [![avm.res.network.public-ip-prefix](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-prefix.yml/badge.svg?branch=users%2Falsehr%2FpipPrefixZones)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-prefix.yml)       |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
