### PR TITLE
fix: HubNetworking - Fixed incorrect input types

### DIFF
--- a/avm/ptn/network/hub-networking/CHANGELOG.md
+++ b/avm/ptn/network/hub-networking/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/network/hub-networking/CHANGELOG.md).
 
+## 0.5.0
+
+### Changes
+
+- Changed incorrect type of `hub.azureFirewallSettings.diagnosticSettings` from object to array
+- Removed numerous redundant fallback values (as they're anyways the default in the referenced module)
+- Updated API & referenced module versions
+- Small type changes
+
+### Breaking Changes
+
+- Renamed input parameter `hub.azureFirewallSettings.virtualHub` to `virtualHubResourceId`
+
 ## 0.4.0
 
 ### Changes

--- a/avm/ptn/network/hub-networking/README.md
+++ b/avm/ptn/network/hub-networking/README.md
@@ -109,6 +109,20 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
         addressPrefixes: '<addressPrefixes>'
         azureFirewallSettings: {
           azureSkuTier: 'Standard'
+          diagnosticSettings: [
+            {
+              eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
+              eventHubName: '<eventHubName>'
+              metricCategories: [
+                {
+                  category: 'AllMetrics'
+                }
+              ]
+              name: 'customSetting'
+              storageAccountResourceId: '<storageAccountResourceId>'
+              workspaceResourceId: '<workspaceResourceId>'
+            }
+          ]
           location: '<location>'
           publicIPAddressObject: {
             name: 'hub1-waf-pip'
@@ -297,6 +311,20 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
           "addressPrefixes": "<addressPrefixes>",
           "azureFirewallSettings": {
             "azureSkuTier": "Standard",
+            "diagnosticSettings": [
+              {
+                "eventHubAuthorizationRuleResourceId": "<eventHubAuthorizationRuleResourceId>",
+                "eventHubName": "<eventHubName>",
+                "metricCategories": [
+                  {
+                    "category": "AllMetrics"
+                  }
+                ],
+                "name": "customSetting",
+                "storageAccountResourceId": "<storageAccountResourceId>",
+                "workspaceResourceId": "<workspaceResourceId>"
+              }
+            ],
             "location": "<location>",
             "publicIPAddressObject": {
               "name": "hub1-waf-pip"
@@ -485,6 +513,20 @@ param hubVirtualNetworks = {
     addressPrefixes: '<addressPrefixes>'
     azureFirewallSettings: {
       azureSkuTier: 'Standard'
+      diagnosticSettings: [
+        {
+          eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
+          eventHubName: '<eventHubName>'
+          metricCategories: [
+            {
+              category: 'AllMetrics'
+            }
+          ]
+          name: 'customSetting'
+          storageAccountResourceId: '<storageAccountResourceId>'
+          workspaceResourceId: '<workspaceResourceId>'
+        }
+      ]
       location: '<location>'
       publicIPAddressObject: {
         name: 'hub1-waf-pip'
@@ -888,6 +930,14 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
         addressPrefixes: '<addressPrefixes>'
         azureFirewallSettings: {
           azureSkuTier: 'Standard'
+          diagnosticSettings: [
+            {
+              eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
+              eventHubName: '<eventHubName>'
+              storageAccountResourceId: '<storageAccountResourceId>'
+              workspaceResourceId: '<workspaceResourceId>'
+            }
+          ]
           location: '<location>'
           publicIPAddressObject: {
             name: 'hub1PublicIp'
@@ -985,6 +1035,14 @@ module hubNetworking 'br/public:avm/ptn/network/hub-networking:<version>' = {
           "addressPrefixes": "<addressPrefixes>",
           "azureFirewallSettings": {
             "azureSkuTier": "Standard",
+            "diagnosticSettings": [
+              {
+                "eventHubAuthorizationRuleResourceId": "<eventHubAuthorizationRuleResourceId>",
+                "eventHubName": "<eventHubName>",
+                "storageAccountResourceId": "<storageAccountResourceId>",
+                "workspaceResourceId": "<workspaceResourceId>"
+              }
+            ],
             "location": "<location>",
             "publicIPAddressObject": {
               "name": "hub1PublicIp"
@@ -1082,6 +1140,14 @@ param hubVirtualNetworks = {
     addressPrefixes: '<addressPrefixes>'
     azureFirewallSettings: {
       azureSkuTier: 'Standard'
+      diagnosticSettings: [
+        {
+          eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
+          eventHubName: '<eventHubName>'
+          storageAccountResourceId: '<storageAccountResourceId>'
+          workspaceResourceId: '<workspaceResourceId>'
+        }
+      ]
       location: '<location>'
       publicIPAddressObject: {
         name: 'hub1PublicIp'
@@ -1252,7 +1318,7 @@ The Azure Firewall config.
 | [`applicationRuleCollections`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsapplicationrulecollections) | array | Application rule collections. |
 | [`azureFirewallName`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsazurefirewallname) | string | The name of the Azure Firewall. |
 | [`azureSkuTier`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsazureskutier) | string | Azure Firewall SKU. |
-| [`diagnosticSettings`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsdiagnosticsettings) | object | Diagnostic settings. |
+| [`diagnosticSettings`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsdiagnosticsettings) | array | Diagnostic settings. |
 | [`firewallPolicyId`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsfirewallpolicyid) | string | Firewall policy ID. |
 | [`hubIpAddresses`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingshubipaddresses) | object | Hub IP addresses. |
 | [`location`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingslocation) | string | The location of the virtual network. Defaults to the location of the resource group. |
@@ -1266,7 +1332,7 @@ The Azure Firewall config.
 | [`roleAssignments`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsroleassignments) | array | Role assignments. |
 | [`tags`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingstags) | object | Tags of the resource. |
 | [`threatIntelMode`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsthreatintelmode) | string | Threat Intel mode. |
-| [`virtualHub`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsvirtualhub) | string | Virtual Hub ID. |
+| [`virtualHubResourceId`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingsvirtualhubresourceid) | string | Virtual Hub resource dID. |
 | [`zones`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingszones) | array | Zones. |
 
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.azureFirewallSettings.additionalPublicIpConfigurations`
@@ -1310,7 +1376,7 @@ Azure Firewall SKU.
 Diagnostic settings.
 
 - Required: No
-- Type: object
+- Type: array
 
 **Optional parameters**
 
@@ -1485,6 +1551,7 @@ Lock settings.
 | :-- | :-- | :-- |
 | [`kind`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingslockkind) | string | Specify the type of lock. |
 | [`name`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingslockname) | string | Specify the name of lock. |
+| [`notes`](#parameter-hubvirtualnetworks>any_other_property<azurefirewallsettingslocknotes) | string | Specify the notes of the lock. |
 
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.azureFirewallSettings.lock.kind`
 
@@ -1504,6 +1571,13 @@ Specify the type of lock.
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.azureFirewallSettings.lock.name`
 
 Specify the name of lock.
+
+- Required: No
+- Type: string
+
+### Parameter: `hubVirtualNetworks.>Any_other_property<.azureFirewallSettings.lock.notes`
+
+Specify the notes of the lock.
 
 - Required: No
 - Type: string
@@ -1661,9 +1735,9 @@ Threat Intel mode.
 - Required: No
 - Type: string
 
-### Parameter: `hubVirtualNetworks.>Any_other_property<.azureFirewallSettings.virtualHub`
+### Parameter: `hubVirtualNetworks.>Any_other_property<.azureFirewallSettings.virtualHubResourceId`
 
-Virtual Hub ID.
+Virtual Hub resource dID.
 
 - Required: No
 - Type: string
@@ -1968,6 +2042,7 @@ The lock settings of the virtual network.
 | :-- | :-- | :-- |
 | [`kind`](#parameter-hubvirtualnetworks>any_other_property<lockkind) | string | Specify the type of lock. |
 | [`name`](#parameter-hubvirtualnetworks>any_other_property<lockname) | string | Specify the name of lock. |
+| [`notes`](#parameter-hubvirtualnetworks>any_other_property<locknotes) | string | Specify the notes of the lock. |
 
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.lock.kind`
 
@@ -1987,6 +2062,13 @@ Specify the type of lock.
 ### Parameter: `hubVirtualNetworks.>Any_other_property<.lock.name`
 
 Specify the name of lock.
+
+- Required: No
+- Type: string
+
+### Parameter: `hubVirtualNetworks.>Any_other_property<.lock.notes`
+
+Specify the notes of the lock.
 
 - Required: No
 - Type: string
@@ -2206,11 +2288,12 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/res/network/azure-firewall:0.6.1` | Remote reference |
+| `br/public:avm/res/network/azure-firewall:0.7.1` | Remote reference |
 | `br/public:avm/res/network/bastion-host:0.6.1` | Remote reference |
-| `br/public:avm/res/network/route-table:0.4.0` | Remote reference |
+| `br/public:avm/res/network/route-table:0.4.1` | Remote reference |
 | `br/public:avm/res/network/virtual-network:0.7.0` | Remote reference |
 | `br/public:avm/utl/types/avm-common-types:0.5.1` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.6.0` | Remote reference |
 
 ## Data Collection
 

--- a/avm/ptn/network/hub-networking/main.json
+++ b/avm/ptn/network/hub-networking/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "9686235822977727339"
+      "version": "0.36.177.2456",
+      "templateHash": "16748208297449362021"
     },
     "name": "Hub Networking",
     "description": "This module is designed to simplify the creation of multi-region hub networks in Azure. It will create a number of virtual networks and subnets, and optionally peer them together in a mesh topology with routing."
@@ -149,6 +149,9 @@
           },
           "dnsServers": {
             "type": "array",
+            "items": {
+              "type": "string"
+            },
             "nullable": true,
             "metadata": {
               "description": "Optional. The DNS servers of the virtual network."
@@ -300,11 +303,11 @@
             "description": "Optional. Hub IP addresses."
           }
         },
-        "virtualHub": {
+        "virtualHubResourceId": {
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Virtual Hub ID."
+            "description": "Optional. Virtual Hub resource dID."
           }
         },
         "additionalPublicIpConfigurations": {
@@ -334,7 +337,10 @@
           }
         },
         "diagnosticSettings": {
-          "$ref": "#/definitions/diagnosticSettingFullType",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/diagnosticSettingFullType"
+          },
           "nullable": true,
           "metadata": {
             "description": "Optional. Diagnostic settings."
@@ -560,7 +566,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     },
@@ -585,12 +591,19 @@
           "metadata": {
             "description": "Optional. Specify the type of lock."
           }
+        },
+        "notes": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specify the notes of the lock."
+          }
         }
       },
       "metadata": {
         "description": "An AVM-aligned type for a lock.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     },
@@ -665,7 +678,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     }
@@ -706,7 +719,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2023-07-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.ptn.network-hubnetworking.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -796,40 +809,40 @@
             "value": "[items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value.addressPrefixes]"
           },
           "ddosProtectionPlanResourceId": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'ddosProtectionPlanResourceId'), '')]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'ddosProtectionPlanResourceId')]"
           },
           "diagnosticSettings": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'diagnosticSettings'), createArray())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'diagnosticSettings')]"
           },
           "dnsServers": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'dnsServers'), createArray())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'dnsServers')]"
           },
           "enableTelemetry": {
             "value": "[parameters('enableTelemetry')]"
           },
           "flowTimeoutInMinutes": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'flowTimeoutInMinutes'), 0)]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'flowTimeoutInMinutes')]"
           },
           "location": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'location'), '')]"
+            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'location'), parameters('location'))]"
           },
           "lock": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock'), createObject())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock')]"
           },
           "roleAssignments": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'roleAssignments'), createArray())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'roleAssignments')]"
           },
           "subnets": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'subnets'), createArray())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'subnets')]"
           },
           "tags": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags'), createObject())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags')]"
           },
           "vnetEncryption": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'vnetEncryption'), false())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'vnetEncryption')]"
           },
           "vnetEncryptionEnforcement": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'vnetEncryptionEnforcement'), '')]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'vnetEncryptionEnforcement')]"
           }
         },
         "template": {
@@ -2476,8 +2489,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "10982468062828755606"
+              "version": "0.36.177.2456",
+              "templateHash": "4461721076505384845"
             },
             "name": "Virtual Networks",
             "description": "This module deploys a Virtual Network."
@@ -2554,16 +2567,16 @@
             "value": "[parameters('enableTelemetry')]"
           },
           "roleAssignments": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'roleAssignments'), createArray())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'roleAssignments')]"
           },
           "routes": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'routes'), createArray())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'routes')]"
           },
           "tags": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags'), createObject())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags')]"
           },
           "lock": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock'), createObject())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock')]"
           }
         },
         "template": {
@@ -2573,14 +2586,63 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "5827817137345359685"
+              "version": "0.34.44.8038",
+              "templateHash": "2458661232490352903"
             },
             "name": "Route Tables",
-            "description": "This module deploys a User Defined Route Table (UDR).",
-            "owner": "Azure/module-maintainers"
+            "description": "This module deploys a User Defined Route Table (UDR)."
           },
           "definitions": {
+            "routeType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Name of the route."
+                  }
+                },
+                "properties": {
+                  "type": "object",
+                  "properties": {
+                    "nextHopType": {
+                      "type": "string",
+                      "allowedValues": [
+                        "Internet",
+                        "None",
+                        "VirtualAppliance",
+                        "VirtualNetworkGateway",
+                        "VnetLocal"
+                      ],
+                      "metadata": {
+                        "description": "Required. The type of Azure hop the packet should be sent to."
+                      }
+                    },
+                    "addressPrefix": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The destination CIDR to which the route applies."
+                      }
+                    },
+                    "nextHopIpAddress": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. Properties of the route."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true,
+                "description": "The type for a route."
+              }
+            },
             "lockType": {
               "type": "object",
               "properties": {
@@ -2604,137 +2666,87 @@
                   }
                 }
               },
-              "nullable": true
+              "metadata": {
+                "description": "An AVM-aligned type for a lock.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
             },
             "roleAssignmentType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
-                    }
-                  },
-                  "roleDefinitionIdOrName": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-                    }
-                  },
-                  "principalId": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
-                    }
-                  },
-                  "principalType": {
-                    "type": "string",
-                    "allowedValues": [
-                      "Device",
-                      "ForeignGroup",
-                      "Group",
-                      "ServicePrincipal",
-                      "User"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The principal type of the assigned principal ID."
-                    }
-                  },
-                  "description": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The description of the role assignment."
-                    }
-                  },
-                  "condition": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-                    }
-                  },
-                  "conditionVersion": {
-                    "type": "string",
-                    "allowedValues": [
-                      "2.0"
-                    ],
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. Version of the condition."
-                    }
-                  },
-                  "delegatedManagedIdentityResourceId": {
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {
-                      "description": "Optional. The Resource Id of the delegated managed identity resource."
-                    }
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
                   }
                 }
               },
-              "nullable": true
-            },
-            "routeType": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "metadata": {
-                      "description": "Required. Name of the route."
-                    }
-                  },
-                  "properties": {
-                    "type": "object",
-                    "properties": {
-                      "nextHopType": {
-                        "type": "string",
-                        "allowedValues": [
-                          "Internet",
-                          "None",
-                          "VirtualAppliance",
-                          "VirtualNetworkGateway",
-                          "VnetLocal"
-                        ],
-                        "metadata": {
-                          "description": "Required. The type of Azure hop the packet should be sent to."
-                        }
-                      },
-                      "addressPrefix": {
-                        "type": "string",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. The destination CIDR to which the route applies."
-                        }
-                      },
-                      "hasBgpOverride": {
-                        "type": "bool",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. A value indicating whether this route overrides overlapping BGP routes regardless of LPM."
-                        }
-                      },
-                      "nextHopIpAddress": {
-                        "type": "string",
-                        "nullable": true,
-                        "metadata": {
-                          "description": "Optional. The IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance."
-                        }
-                      }
-                    },
-                    "metadata": {
-                      "description": "Required. Properties of the route."
-                    }
-                  }
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
                 }
-              },
-              "nullable": true
+              }
             }
           },
           "parameters": {
@@ -2752,7 +2764,11 @@
               }
             },
             "routes": {
-              "$ref": "#/definitions/routeType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/routeType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. An array of routes to be established within the hub route table."
               }
@@ -2766,12 +2782,17 @@
             },
             "lock": {
               "$ref": "#/definitions/lockType",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. The lock settings of the service."
               }
             },
             "roleAssignments": {
-              "$ref": "#/definitions/roleAssignmentType",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Array of role assignments to create."
               }
@@ -2813,7 +2834,7 @@
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2024-03-01",
-              "name": "[take(format('46d3xbcp.res.network-routetable.{0}.{1}', replace('0.4.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4)), 64)]",
+              "name": "[take(format('46d3xbcp.res.network-routetable.{0}.{1}', replace('0.4.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4)), 64)]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -2935,7 +2956,7 @@
             "value": "[reference(format('hubVirtualNetwork[{0}]', copyIndex())).outputs.resourceId.value]"
           },
           "diagnosticSettings": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'diagnosticSettings'), createArray())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'diagnosticSettings')]"
           },
           "disableCopyPaste": {
             "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'disableCopyPaste'), true())]"
@@ -2944,10 +2965,10 @@
             "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'enableFileCopy'), false())]"
           },
           "enableIpConnect": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'enableIpConnect'), false())]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'enableIpConnect')]"
           },
           "enableShareableLink": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'enableShareableLink'), false())]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'enableShareableLink')]"
           },
           "location": {
             "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'location'), parameters('location'))]"
@@ -2956,7 +2977,7 @@
             "value": "[parameters('enableTelemetry')]"
           },
           "roleAssignments": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'roleAssignments'), createArray())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'roleAssignments')]"
           },
           "scaleUnits": {
             "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'scaleUnits'), 4)]"
@@ -2965,13 +2986,13 @@
             "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'skuName'), 'Standard')]"
           },
           "tags": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags'), createObject())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags')]"
           },
           "lock": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock'), createObject())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock')]"
           },
           "enableKerberos": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'enableKerberos'), false())]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'bastionHost'), 'enableKerberos')]"
           }
         },
         "template": {
@@ -4261,67 +4282,67 @@
             "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'azureFirewallName'), items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].key)]"
           },
           "hubIPAddresses": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'hubIpAddresses'), createObject())]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'hubIpAddresses')]"
           },
-          "virtualHubId": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'virtualHub'), '')]"
+          "virtualHubResourceId": {
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'virtualHubResourceId')]"
           },
           "virtualNetworkResourceId": {
-            "value": "[coalesce(reference(format('hubVirtualNetwork[{0}]', copyIndex())).outputs.resourceId.value, '')]"
+            "value": "[reference(format('hubVirtualNetwork[{0}]', copyIndex())).outputs.resourceId.value]"
           },
           "additionalPublicIpConfigurations": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'additionalPublicIpConfigurations'), createArray())]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'additionalPublicIpConfigurations')]"
           },
           "applicationRuleCollections": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'applicationRuleCollections'), createArray())]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'applicationRuleCollections')]"
           },
           "azureSkuTier": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'azureSkuTier'), createObject())]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'azureSkuTier')]"
           },
           "diagnosticSettings": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'diagnosticSettings'), createArray())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'diagnosticSettings')]"
           },
           "enableTelemetry": {
             "value": "[parameters('enableTelemetry')]"
           },
           "firewallPolicyId": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'firewallPolicyId'), '')]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'firewallPolicyId')]"
           },
           "location": {
             "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'location'), parameters('location'))]"
           },
           "lock": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock'), createObject())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'lock')]"
           },
           "managementIPAddressObject": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'managementIPAddressObject'), createObject())]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'managementIPAddressObject')]"
           },
           "managementIPResourceID": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'managementIPResourceID'), '')]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'managementIPResourceID')]"
           },
           "natRuleCollections": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'natRuleCollections'), createArray())]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'natRuleCollections')]"
           },
           "networkRuleCollections": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'networkRuleCollections'), createArray())]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'networkRuleCollections')]"
           },
           "publicIPAddressObject": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'publicIPAddressObject'), createObject())]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'publicIPAddressObject')]"
           },
           "publicIPResourceID": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'publicIPResourceID'), '')]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'publicIPResourceID')]"
           },
           "roleAssignments": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'roleAssignments'), createArray())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'roleAssignments')]"
           },
           "tags": {
-            "value": "[coalesce(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags'), createObject())]"
+            "value": "[tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'tags')]"
           },
           "threatIntelMode": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'threatIntelMode'), '')]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'threatIntelMode')]"
           },
           "zones": {
-            "value": "[coalesce(tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'zones'), createArray())]"
+            "value": "[tryGet(tryGet(items(coalesce(parameters('hubVirtualNetworks'), createObject()))[copyIndex()].value, 'azureFirewallSettings'), 'zones')]"
           }
         },
         "template": {
@@ -4331,8 +4352,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "5582840972782005047"
+              "version": "0.36.1.42791",
+              "templateHash": "3706058764629825741"
             },
             "name": "Azure Firewalls",
             "description": "This module deploys an Azure Firewall."
@@ -5161,7 +5182,7 @@
                 "description": "Conditional. IP addresses associated with AzureFirewall. Required if `virtualHubId` is supplied."
               }
             },
-            "virtualHubId": {
+            "virtualHubResourceId": {
               "type": "string",
               "defaultValue": "",
               "metadata": {
@@ -5178,6 +5199,20 @@
               ],
               "metadata": {
                 "description": "Optional. The operation mode for Threat Intel."
+              }
+            },
+            "autoscaleMaxCapacity": {
+              "type": "int",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The maximum number of capacity units for this azure firewall. Use null to reset the value to the service default."
+              }
+            },
+            "autoscaleMinCapacity": {
+              "type": "int",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The minimum number of capacity units for this azure firewall. Use null to reset the value to the service default."
               }
             },
             "zones": {
@@ -5234,10 +5269,13 @@
             },
             "tags": {
               "type": "object",
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/azureFirewalls@2024-05-01#properties/tags"
+                },
                 "description": "Optional. Tags of the Azure Firewall resource."
-              }
+              },
+              "nullable": true
             },
             "enableTelemetry": {
               "type": "bool",
@@ -5282,7 +5320,7 @@
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2024-03-01",
-              "name": "[format('46d3xbcp.res.network-azurefirewall.{0}.{1}', replace('0.6.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "name": "[format('46d3xbcp.res.network-azurefirewall.{0}.{1}', replace('0.7.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -5305,7 +5343,7 @@
               "location": "[parameters('location')]",
               "zones": "[if(equals(length(parameters('zones')), 0), null(), parameters('zones'))]",
               "tags": "[parameters('tags')]",
-              "properties": "[if(equals(variables('azureSkuName'), 'AZFW_VNet'), createObject('threatIntelMode', parameters('threatIntelMode'), 'firewallPolicy', if(not(empty(parameters('firewallPolicyId'))), createObject('id', parameters('firewallPolicyId')), null()), 'ipConfigurations', concat(createArray(createObject('name', if(not(empty(parameters('publicIPResourceID'))), last(split(parameters('publicIPResourceID'), '/')), reference('publicIPAddress').outputs.name.value), 'properties', union(createObject('subnet', createObject('id', format('{0}/subnets/AzureFirewallSubnet', parameters('virtualNetworkResourceId')))), if(or(not(empty(parameters('publicIPResourceID'))), not(empty(parameters('publicIPAddressObject')))), createObject('publicIPAddress', createObject('id', if(not(empty(parameters('publicIPResourceID'))), parameters('publicIPResourceID'), reference('publicIPAddress').outputs.resourceId.value))), createObject())))), variables('additionalPublicIpConfigurationsVar')), 'managementIpConfiguration', if(variables('requiresManagementIp'), createObject('name', if(not(empty(parameters('managementIPResourceID'))), last(split(parameters('managementIPResourceID'), '/')), reference('managementIPAddress').outputs.name.value), 'properties', createObject('subnet', createObject('id', format('{0}/subnets/AzureFirewallManagementSubnet', parameters('virtualNetworkResourceId'))), 'publicIPAddress', createObject('id', if(not(empty(parameters('managementIPResourceID'))), parameters('managementIPResourceID'), reference('managementIPAddress').outputs.resourceId.value)))), null()), 'sku', createObject('name', variables('azureSkuName'), 'tier', parameters('azureSkuTier')), 'applicationRuleCollections', coalesce(parameters('applicationRuleCollections'), createArray()), 'natRuleCollections', coalesce(parameters('natRuleCollections'), createArray()), 'networkRuleCollections', coalesce(parameters('networkRuleCollections'), createArray())), createObject('firewallPolicy', if(not(empty(parameters('firewallPolicyId'))), createObject('id', parameters('firewallPolicyId')), null()), 'sku', createObject('name', variables('azureSkuName'), 'tier', parameters('azureSkuTier')), 'hubIPAddresses', if(not(empty(parameters('hubIPAddresses'))), parameters('hubIPAddresses'), null()), 'virtualHub', if(not(empty(parameters('virtualHubId'))), createObject('id', parameters('virtualHubId')), null())))]",
+              "properties": "[if(equals(variables('azureSkuName'), 'AZFW_VNet'), createObject('threatIntelMode', parameters('threatIntelMode'), 'firewallPolicy', if(not(empty(parameters('firewallPolicyId'))), createObject('id', parameters('firewallPolicyId')), null()), 'ipConfigurations', concat(createArray(createObject('name', if(not(empty(parameters('publicIPResourceID'))), last(split(parameters('publicIPResourceID'), '/')), reference('publicIPAddress').outputs.name.value), 'properties', union(if(equals(variables('azureSkuName'), 'AZFW_VNet'), createObject('subnet', createObject('id', format('{0}/subnets/AzureFirewallSubnet', parameters('virtualNetworkResourceId')))), createObject()), if(or(not(empty(parameters('publicIPResourceID'))), not(empty(parameters('publicIPAddressObject')))), createObject('publicIPAddress', createObject('id', if(not(empty(parameters('publicIPResourceID'))), parameters('publicIPResourceID'), reference('publicIPAddress').outputs.resourceId.value))), createObject())))), variables('additionalPublicIpConfigurationsVar')), 'managementIpConfiguration', if(variables('requiresManagementIp'), createObject('name', if(not(empty(parameters('managementIPResourceID'))), last(split(parameters('managementIPResourceID'), '/')), reference('managementIPAddress').outputs.name.value), 'properties', createObject('subnet', createObject('id', format('{0}/subnets/AzureFirewallManagementSubnet', parameters('virtualNetworkResourceId'))), 'publicIPAddress', createObject('id', if(not(empty(parameters('managementIPResourceID'))), parameters('managementIPResourceID'), reference('managementIPAddress').outputs.resourceId.value)))), null()), 'sku', createObject('name', variables('azureSkuName'), 'tier', parameters('azureSkuTier')), 'applicationRuleCollections', coalesce(parameters('applicationRuleCollections'), createArray()), 'natRuleCollections', coalesce(parameters('natRuleCollections'), createArray()), 'networkRuleCollections', coalesce(parameters('networkRuleCollections'), createArray())), createObject('autoscaleConfiguration', createObject('maxCapacity', parameters('autoscaleMaxCapacity'), 'minCapacity', parameters('autoscaleMinCapacity')), 'firewallPolicy', if(not(empty(parameters('firewallPolicyId'))), createObject('id', parameters('firewallPolicyId')), null()), 'sku', createObject('name', variables('azureSkuName'), 'tier', parameters('azureSkuTier')), 'hubIPAddresses', if(not(empty(parameters('hubIPAddresses'))), parameters('hubIPAddresses'), null()), 'virtualHub', if(not(empty(parameters('virtualHubResourceId'))), createObject('id', parameters('virtualHubResourceId')), null())))]",
               "dependsOn": [
                 "managementIPAddress",
                 "publicIPAddress"
@@ -6905,8 +6943,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "2411952300275373712"
+              "version": "0.36.177.2456",
+              "templateHash": "11012657474272986842"
             },
             "name": "Existing Virtual Network Subnets",
             "description": "This module retrieves an existing Virtual Network Subnet."
@@ -6914,16 +6952,14 @@
           "parameters": {
             "subnetName": {
               "type": "string",
-              "defaultValue": "",
               "metadata": {
-                "description": "Optional. The name of the subnet."
+                "description": "Required. The name of the subnet."
               }
             },
             "virtualNetworkName": {
               "type": "string",
-              "defaultValue": "",
               "metadata": {
-                "description": "Optional. The name of the virtual network."
+                "description": "Required. The name of the virtual network."
               }
             }
           },
@@ -6987,8 +7023,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "12435502464958912992"
+              "version": "0.36.177.2456",
+              "templateHash": "10553951738547470795"
             },
             "name": "Virtual Network Subnets",
             "description": "This module deploys a Virtual Network Subnet."

--- a/avm/ptn/network/hub-networking/modules/getSubnet.bicep
+++ b/avm/ptn/network/hub-networking/modules/getSubnet.bicep
@@ -1,11 +1,11 @@
 metadata name = 'Existing Virtual Network Subnets'
 metadata description = 'This module retrieves an existing Virtual Network Subnet.'
 
-@description('Optional. The name of the subnet.')
-param subnetName string = ''
+@description('Required. The name of the subnet.')
+param subnetName string
 
-@description('Optional. The name of the virtual network.')
-param virtualNetworkName string = ''
+@description('Required. The name of the virtual network.')
+param virtualNetworkName string
 
 resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' existing = {
   name: virtualNetworkName

--- a/avm/ptn/network/hub-networking/tests/e2e/defaults/main.test.bicep
+++ b/avm/ptn/network/hub-networking/tests/e2e/defaults/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/ptn/network/hub-networking/tests/e2e/max/main.test.bicep
+++ b/avm/ptn/network/hub-networking/tests/e2e/max/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -74,6 +74,20 @@ module testDeployment '../../../main.bicep' = [
               1
               2
               3
+            ]
+            diagnosticSettings: [
+              {
+                eventHubAuthorizationRuleResourceId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
+                eventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
+                metricCategories: [
+                  {
+                    category: 'AllMetrics'
+                  }
+                ]
+                name: 'customSetting'
+                storageAccountResourceId: diagnosticDependencies.outputs.storageAccountResourceId
+                workspaceResourceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
+              }
             ]
           }
           bastionHost: {

--- a/avm/ptn/network/hub-networking/tests/e2e/no-addons/main.test.bicep
+++ b/avm/ptn/network/hub-networking/tests/e2e/no-addons/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/ptn/network/hub-networking/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/ptn/network/hub-networking/tests/e2e/waf-aligned/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -72,6 +72,14 @@ module testDeployment '../../../main.bicep' = [
               1
               2
               3
+            ]
+            diagnosticSettings: [
+              {
+                eventHubAuthorizationRuleResourceId: diagnosticDependencies.outputs.eventHubAuthorizationRuleId
+                eventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName
+                storageAccountResourceId: diagnosticDependencies.outputs.storageAccountResourceId
+                workspaceResourceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
+              }
             ]
           }
           bastionHost: {

--- a/avm/ptn/network/hub-networking/version.json
+++ b/avm/ptn/network/hub-networking/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.4"
+  "version": "0.5"
 }


### PR DESCRIPTION
## Description

### Changes

- Changed incorrect type of `hub.azureFirewallSettings.diagnosticSettings` from object to array
- Removed numerous redundant fallback values (as they're anyways the default in the referenced module)
- Updated API & referenced module versions
- Small type changes

### Breaking Changes

- Renamed input parameter `hub.azureFirewallSettings.virtualHub` to `virtualHubResourceId`

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|    [![avm.ptn.network.hub-networking](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml/badge.svg?branch=users%2Falsehr%2FhubnwDiagFix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml)      |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
