### PR TITLE
fix: `avm/ptn/azd/monitoring` - Update main.json to fix static validation error

### DIFF
--- a/avm/ptn/azd/monitoring/CHANGELOG.md
+++ b/avm/ptn/azd/monitoring/CHANGELOG.md
@@ -6,7 +6,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Changes
 
-- Re-compiled main.json with latest Bicep version
+- Re-compiled `main.json` with latest Bicep version
 
 ### Breaking Changes
 

--- a/avm/ptn/azd/monitoring/CHANGELOG.md
+++ b/avm/ptn/azd/monitoring/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/monitoring/CHANGELOG.md).
 
+## 0.1.2
+
+### Changes
+
+- Re-compiled main.json with latest Bicep version
+
+### Breaking Changes
+
+- None
+
 ## 0.1.1
 
 ### Changes

--- a/avm/ptn/azd/monitoring/main.json
+++ b/avm/ptn/azd/monitoring/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "12625947102641948653"
+      "version": "0.36.177.2456",
+      "templateHash": "10426848890322826437"
     },
     "name": "Azd Azure Monitoring",
     "description": "Creates an Application Insights instance and a Log Analytics workspace.\n\n**Note:** This module is not intended for broad, generic use, as it was designed to cater for the requirements of the AZD CLI product. Feature requests and bug fix requests are welcome if they support the development of the AZD CLI but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case."
@@ -3171,7 +3171,7 @@
         "mode": "Incremental",
         "parameters": {
           "logAnalyticsWorkspaceResourceId": {
-            "value": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'loganalytics'), '2022-09-01').resourceId]"
+            "value": "[reference('logAnalytics').outputs.resourceId.value]"
           },
           "name": {
             "value": "[parameters('applicationInsightsName')]"
@@ -5634,14 +5634,14 @@
       "metadata": {
         "description": "The resource ID of the loganalytics workspace."
       },
-      "value": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'loganalytics'), '2022-09-01').resourceId]"
+      "value": "[reference('logAnalytics').outputs.resourceId.value]"
     },
     "logAnalyticsWorkspaceName": {
       "type": "string",
       "metadata": {
         "description": "The name of the log analytics workspace."
       },
-      "value": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'loganalytics'), '2022-09-01').name]"
+      "value": "[reference('logAnalytics').outputs.name.value]"
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes #5648

```
Expected strings to be the same, because the [azd/monitoring] [main.json] should be based on the latest [main.bicep] file. Please run [ bicep build >bicepFilePath< ] using the latest Bicep CLI version., but they were different.
  Expected length: 163413
  Actual length:   163543
  Strings differ at index 1427.
  Expected: '...\n      "type": "string",\n      "value": "[reference('l...'
  But was:  '...\n      "type": "string",\n      "value": "[listOutputsW...'
  -----------------------------------------------^
  at (ConvertTo-Json $originalJson -Depth 99) | Should -Be (ConvertTo-Json $newJson -Depth 99) -Because "the [$moduleFolderName] [main.json] should be based on the latest [main.bicep] file. Please run [` bicep build >bicepFilePath< `] using the latest Bicep CLI version.", /home/runner/work/bicep-registry-modules/bicep-registry-modules/utilities/pipelines/staticValidation/compliance/module.tests.ps1:550
  at <ScriptBlock>, /home/runner/work/bicep-registry-modules/bicep-registry-modules/utilities/pipelines/staticValidation/compliance/module.tests.ps1:550
```

## Pipeline Reference
`Test-ModuleLocally` passes:
<img width="1201" height="603" alt="image" src="https://github.com/user-attachments/assets/45725d8a-ef4c-47c5-88d6-6e1292a5a7fd" />


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
