### PR TITLE
fix: Incorrect database ownership during initial deployment

### DIFF
--- a/avm/res/db-for-postgre-sql/flexible-server/CHANGELOG.md
+++ b/avm/res/db-for-postgre-sql/flexible-server/CHANGELOG.md
@@ -2,22 +2,11 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/db-for-postgre-sql/flexible-server/CHANGELOG.md).
 
-## 0.12.1
+## 0.13.0
 
 ### Changes
 
-- Bugfix: Fixed issue where setting `highAvailability` to `Disabled`, the deployment would throw an error due to an incorrect module-internal logic.
-- Updated diverse API versions
-
-### Breaking Changes
-
-- None
-
-## 0.12.0
-
-### Changes
-
-- Initial version
+- Bugfix: Fixed issue where the incorrect database ownership was set during initial deployment of DB for Postgre SQL Flexible Server.
 
 ### Breaking Changes
 

--- a/avm/res/db-for-postgre-sql/flexible-server/CHANGELOG.md
+++ b/avm/res/db-for-postgre-sql/flexible-server/CHANGELOG.md
@@ -11,3 +11,24 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 ### Breaking Changes
 
 - None
+
+## 0.12.1
+
+### Changes
+
+- Bugfix: Fixed issue where setting `highAvailability` to `Disabled`, the deployment would throw an error due to an incorrect module-internal logic.
+- Updated diverse API versions
+
+### Breaking Changes
+
+- None
+
+## 0.12.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/db-for-postgre-sql/flexible-server/main.bicep
+++ b/avm/res/db-for-postgre-sql/flexible-server/main.bicep
@@ -379,6 +379,9 @@ module flexibleServer_databases 'database/main.bicep' = [
       collation: database.?collation
       charset: database.?charset
     }
+    dependsOn: [
+      flexibleServer_roleAssignments
+    ]
   }
 ]
 

--- a/avm/res/db-for-postgre-sql/flexible-server/main.json
+++ b/avm/res/db-for-postgre-sql/flexible-server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.177.2456",
-      "templateHash": "1737270530686697849"
+      "templateHash": "16300464404055290658"
     },
     "name": "DBforPostgreSQL Flexible Servers",
     "description": "This module deploys a DBforPostgreSQL Flexible Server."
@@ -1299,7 +1299,8 @@
         }
       },
       "dependsOn": [
-        "flexibleServer"
+        "flexibleServer",
+        "flexibleServer_roleAssignments"
       ]
     },
     "flexibleServer_firewallRules": {

--- a/avm/res/db-for-postgre-sql/flexible-server/version.json
+++ b/avm/res/db-for-postgre-sql/flexible-server/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.12"
+  "version": "0.13"
 }


### PR DESCRIPTION
Added depends on to fix Incorrect database ownership during initial deployment of DB for Postgre SQL Flexible Server

## Description

Closes #3596 


## Pipeline Reference

[![avm.res.db-for-postgre-sql.flexible-server](https://github.com/arnoldna/bicep-registry-modules/actions/workflows/avm.res.db-for-postgre-sql.flexible-server.yml/badge.svg?branch=avm%2Fres%2Fdb-for-postgre-sql%2Fflexible-server)](https://github.com/arnoldna/bicep-registry-modules/actions/workflows/avm.res.db-for-postgre-sql.flexible-server.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [X] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
