### PR TITLE
feat: AVD Workspace - Updated to latest versions

### DIFF
--- a/avm/res/desktop-virtualization/workspace/CHANGELOG.md
+++ b/avm/res/desktop-virtualization/workspace/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/desktop-virtualization/workspace/CHANGELOG.md).
 
+## 0.9.0
+
+### Changes
+
+- Updated to latest avm-common-types, enabling custom notes on locks
+- Updated API version of workspace resource to `2025-03-01-preview`
+
+### Breaking Changes
+
+- Changed behavior of `publicNetworkAccess` to automatically set `Disabled` if private endpoints are provided - unless the `publicNetworkAccess` value is set explicitely
+
 ## 0.8.0
 
 ### Changes

--- a/avm/res/desktop-virtualization/workspace/CHANGELOG.md
+++ b/avm/res/desktop-virtualization/workspace/CHANGELOG.md
@@ -11,7 +11,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Breaking Changes
 
-- Changed behavior of `publicNetworkAccess` to automatically set `Disabled` if private endpoints are provided - unless the `publicNetworkAccess` value is set explicitely
+- Changed behavior of `publicNetworkAccess` to automatically set `Disabled` if private endpoints are provided - unless the `publicNetworkAccess` value is set explicitly
 
 ## 0.8.0
 

--- a/avm/res/desktop-virtualization/workspace/README.md
+++ b/avm/res/desktop-virtualization/workspace/README.md
@@ -108,7 +108,9 @@ module workspace 'br/public:avm/res/desktop-virtualization/workspace:<version>' 
     // Required parameters
     name: 'dvwsmax001'
     // Non-required parameters
-    applicationGroupReferences: []
+    applicationGroupReferences: [
+      '<applicationGroupResourceId>'
+    ]
     diagnosticSettings: [
       {
         eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -254,7 +256,9 @@ module workspace 'br/public:avm/res/desktop-virtualization/workspace:<version>' 
     },
     // Non-required parameters
     "applicationGroupReferences": {
-      "value": []
+      "value": [
+        "<applicationGroupResourceId>"
+      ]
     },
     "diagnosticSettings": {
       "value": [
@@ -412,7 +416,9 @@ using 'br/public:avm/res/desktop-virtualization/workspace:<version>'
 // Required parameters
 param name = 'dvwsmax001'
 // Non-required parameters
-param applicationGroupReferences = []
+param applicationGroupReferences = [
+  '<applicationGroupResourceId>'
+]
 param diagnosticSettings = [
   {
     eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'

--- a/avm/res/desktop-virtualization/workspace/README.md
+++ b/avm/res/desktop-virtualization/workspace/README.md
@@ -22,10 +22,10 @@ This module deploys an Azure Virtual Desktop Workspace.
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.DesktopVirtualization/workspaces` | [2022-10-14-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DesktopVirtualization/2022-10-14-preview/workspaces) |
+| `Microsoft.DesktopVirtualization/workspaces` | [2025-03-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DesktopVirtualization/2025-03-01-preview/workspaces) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
-| `Microsoft.Network/privateEndpoints` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-11-01/privateEndpoints) |
-| `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-11-01/privateEndpoints/privateDnsZoneGroups) |
+| `Microsoft.Network/privateEndpoints` | [2024-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/privateEndpoints) |
+| `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | [2024-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/privateEndpoints/privateDnsZoneGroups) |
 
 ## Usage examples
 
@@ -565,6 +565,70 @@ module workspace 'br/public:avm/res/desktop-virtualization/workspace:<version>' 
         workspaceResourceId: '<workspaceResourceId>'
       }
     ]
+    privateEndpoints: [
+      {
+        customDnsConfigs: []
+        ipConfigurations: [
+          {
+            name: 'myIPconfig-feed1'
+            properties: {
+              groupId: 'feed'
+              memberName: 'web-r0'
+              privateIPAddress: '10.0.0.10'
+            }
+          }
+          {
+            name: 'myIPconfig-feed2'
+            properties: {
+              groupId: 'feed'
+              memberName: 'web-r1'
+              privateIPAddress: '10.0.0.13'
+            }
+          }
+        ]
+        privateDnsZoneGroup: {
+          privateDnsZoneGroupConfigs: [
+            {
+              privateDnsZoneResourceId: '<privateDnsZoneResourceId>'
+            }
+          ]
+        }
+        service: 'feed'
+        subnetResourceId: '<subnetResourceId>'
+        tags: {
+          Environment: 'Non-Prod'
+          'hidden-title': 'This is visible in the resource name'
+          Role: 'DeploymentValidation'
+        }
+      }
+      {
+        customDnsConfigs: []
+        ipConfigurations: [
+          {
+            name: 'myIPconfig-global'
+            properties: {
+              groupId: 'global'
+              memberName: 'web'
+              privateIPAddress: '10.0.0.11'
+            }
+          }
+        ]
+        privateDnsZoneGroup: {
+          privateDnsZoneGroupConfigs: [
+            {
+              privateDnsZoneResourceId: '<privateDnsZoneResourceId>'
+            }
+          ]
+        }
+        service: 'global'
+        subnetResourceId: '<subnetResourceId>'
+        tags: {
+          Environment: 'Non-Prod'
+          'hidden-title': 'This is visible in the resource name'
+          Role: 'DeploymentValidation'
+        }
+      }
+    ]
     tags: {
       Environment: 'Non-Prod'
       'hidden-title': 'This is visible in the resource name'
@@ -601,6 +665,72 @@ module workspace 'br/public:avm/res/desktop-virtualization/workspace:<version>' 
         }
       ]
     },
+    "privateEndpoints": {
+      "value": [
+        {
+          "customDnsConfigs": [],
+          "ipConfigurations": [
+            {
+              "name": "myIPconfig-feed1",
+              "properties": {
+                "groupId": "feed",
+                "memberName": "web-r0",
+                "privateIPAddress": "10.0.0.10"
+              }
+            },
+            {
+              "name": "myIPconfig-feed2",
+              "properties": {
+                "groupId": "feed",
+                "memberName": "web-r1",
+                "privateIPAddress": "10.0.0.13"
+              }
+            }
+          ],
+          "privateDnsZoneGroup": {
+            "privateDnsZoneGroupConfigs": [
+              {
+                "privateDnsZoneResourceId": "<privateDnsZoneResourceId>"
+              }
+            ]
+          },
+          "service": "feed",
+          "subnetResourceId": "<subnetResourceId>",
+          "tags": {
+            "Environment": "Non-Prod",
+            "hidden-title": "This is visible in the resource name",
+            "Role": "DeploymentValidation"
+          }
+        },
+        {
+          "customDnsConfigs": [],
+          "ipConfigurations": [
+            {
+              "name": "myIPconfig-global",
+              "properties": {
+                "groupId": "global",
+                "memberName": "web",
+                "privateIPAddress": "10.0.0.11"
+              }
+            }
+          ],
+          "privateDnsZoneGroup": {
+            "privateDnsZoneGroupConfigs": [
+              {
+                "privateDnsZoneResourceId": "<privateDnsZoneResourceId>"
+              }
+            ]
+          },
+          "service": "global",
+          "subnetResourceId": "<subnetResourceId>",
+          "tags": {
+            "Environment": "Non-Prod",
+            "hidden-title": "This is visible in the resource name",
+            "Role": "DeploymentValidation"
+          }
+        }
+      ]
+    },
     "tags": {
       "value": {
         "Environment": "Non-Prod",
@@ -633,6 +763,70 @@ param diagnosticSettings = [
     workspaceResourceId: '<workspaceResourceId>'
   }
 ]
+param privateEndpoints = [
+  {
+    customDnsConfigs: []
+    ipConfigurations: [
+      {
+        name: 'myIPconfig-feed1'
+        properties: {
+          groupId: 'feed'
+          memberName: 'web-r0'
+          privateIPAddress: '10.0.0.10'
+        }
+      }
+      {
+        name: 'myIPconfig-feed2'
+        properties: {
+          groupId: 'feed'
+          memberName: 'web-r1'
+          privateIPAddress: '10.0.0.13'
+        }
+      }
+    ]
+    privateDnsZoneGroup: {
+      privateDnsZoneGroupConfigs: [
+        {
+          privateDnsZoneResourceId: '<privateDnsZoneResourceId>'
+        }
+      ]
+    }
+    service: 'feed'
+    subnetResourceId: '<subnetResourceId>'
+    tags: {
+      Environment: 'Non-Prod'
+      'hidden-title': 'This is visible in the resource name'
+      Role: 'DeploymentValidation'
+    }
+  }
+  {
+    customDnsConfigs: []
+    ipConfigurations: [
+      {
+        name: 'myIPconfig-global'
+        properties: {
+          groupId: 'global'
+          memberName: 'web'
+          privateIPAddress: '10.0.0.11'
+        }
+      }
+    ]
+    privateDnsZoneGroup: {
+      privateDnsZoneGroupConfigs: [
+        {
+          privateDnsZoneResourceId: '<privateDnsZoneResourceId>'
+        }
+      ]
+    }
+    service: 'global'
+    subnetResourceId: '<subnetResourceId>'
+    tags: {
+      Environment: 'Non-Prod'
+      'hidden-title': 'This is visible in the resource name'
+      Role: 'DeploymentValidation'
+    }
+  }
+]
 param tags = {
   Environment: 'Non-Prod'
   'hidden-title': 'This is visible in the resource name'
@@ -663,7 +857,7 @@ param tags = {
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`privateEndpoints`](#parameter-privateendpoints) | array | Configuration details for private endpoints. |
-| [`publicNetworkAccess`](#parameter-publicnetworkaccess) | string | Public network access for the workspace. Enabled by default. |
+| [`publicNetworkAccess`](#parameter-publicnetworkaccess) | string | Public network access for the workspace. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 
@@ -680,7 +874,6 @@ Array of application group references.
 
 - Required: No
 - Type: array
-- Default: `[]`
 
 ### Parameter: `description`
 
@@ -839,6 +1032,7 @@ The lock settings of the service.
 | :-- | :-- | :-- |
 | [`kind`](#parameter-lockkind) | string | Specify the type of lock. |
 | [`name`](#parameter-lockname) | string | Specify the name of lock. |
+| [`notes`](#parameter-locknotes) | string | Specify the notes of the lock. |
 
 ### Parameter: `lock.kind`
 
@@ -858,6 +1052,13 @@ Specify the type of lock.
 ### Parameter: `lock.name`
 
 Specify the name of lock.
+
+- Required: No
+- Type: string
+
+### Parameter: `lock.notes`
+
+Specify the notes of the lock.
 
 - Required: No
 - Type: string
@@ -1041,6 +1242,7 @@ Specify the type of lock.
 | :-- | :-- | :-- |
 | [`kind`](#parameter-privateendpointslockkind) | string | Specify the type of lock. |
 | [`name`](#parameter-privateendpointslockname) | string | Specify the name of lock. |
+| [`notes`](#parameter-privateendpointslocknotes) | string | Specify the notes of the lock. |
 
 ### Parameter: `privateEndpoints.lock.kind`
 
@@ -1060,6 +1262,13 @@ Specify the type of lock.
 ### Parameter: `privateEndpoints.lock.name`
 
 Specify the name of lock.
+
+- Required: No
+- Type: string
+
+### Parameter: `privateEndpoints.lock.notes`
+
+Specify the notes of the lock.
 
 - Required: No
 - Type: string
@@ -1275,11 +1484,10 @@ Tags to be applied on all resources/Resource Groups in this deployment.
 
 ### Parameter: `publicNetworkAccess`
 
-Public network access for the workspace. Enabled by default.
+Public network access for the workspace.
 
 - Required: No
 - Type: string
-- Default: `'Enabled'`
 
 ### Parameter: `roleAssignments`
 
@@ -1421,8 +1629,8 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/res/network/private-endpoint:0.10.1` | Remote reference |
-| `br/public:avm/utl/types/avm-common-types:0.5.1` | Remote reference |
+| `br/public:avm/res/network/private-endpoint:0.11.0` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.6.0` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/desktop-virtualization/workspace/main.bicep
+++ b/avm/res/desktop-virtualization/workspace/main.bicep
@@ -8,10 +8,10 @@ param name string
 param location string = resourceGroup().location
 
 @sys.description('Optional. Tags of the resource.')
-param tags object?
+param tags resourceInput<'Microsoft.DesktopVirtualization/workspaces@2025-03-01-preview'>.tags?
 
 @sys.description('Optional. Array of application group references.')
-param applicationGroupReferences array = []
+param applicationGroupReferences string[]?
 
 @sys.description('Optional. Description of the workspace.')
 param description string = ''
@@ -19,50 +19,98 @@ param description string = ''
 @sys.description('Optional. Friendly name of the workspace.')
 param friendlyName string = name
 
-@sys.description('Optional. Public network access for the workspace. Enabled by default.')
-param publicNetworkAccess string = 'Enabled'
+@sys.description('Optional. Public network access for the workspace.')
+param publicNetworkAccess string?
 
-import { privateEndpointSingleServiceType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { privateEndpointSingleServiceType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
 @sys.description('Optional. Configuration details for private endpoints.')
 param privateEndpoints privateEndpointSingleServiceType[]?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
 @sys.description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
 @sys.description('Optional. The lock settings of the service.')
 param lock lockType?
 
 @sys.description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
 
-import { diagnosticSettingLogsOnlyType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { diagnosticSettingLogsOnlyType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
 @sys.description('Optional. The diagnostic settings of the service.')
 param diagnosticSettings diagnosticSettingLogsOnlyType[]?
 
 var enableReferencedModulesTelemetry = false
 
 var builtInRoleNames = {
-  Owner: '/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635'
-  Contributor: '/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
-  Reader: '/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7'
-  'Role Based Access Control Administrator': '/providers/Microsoft.Authorization/roleDefinitions/f58310d9-a9f6-439a-9e8d-f62e7b41a168'
-  'User Access Administrator': '/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
-  'Application Group Contributor': '/providers/Microsoft.Authorization/roleDefinitions/ca6382a4-1721-4bcf-a114-ff0c70227b6b'
-  'Desktop Virtualization Application Group Contributor': '/providers/Microsoft.Authorization/roleDefinitions/86240b0e-9422-4c43-887b-b61143f32ba8'
-  'Desktop Virtualization Application Group Reader': '/providers/Microsoft.Authorization/roleDefinitions/aebf23d0-b568-4e86-b8f9-fe83a2c6ab55'
-  'Desktop Virtualization Contributor': '/providers/Microsoft.Authorization/roleDefinitions/082f0a83-3be5-4ba1-904c-961cca79b387'
-  'Desktop Virtualization Host Pool Contributor': '/providers/Microsoft.Authorization/roleDefinitions/e307426c-f9b6-4e81-87de-d99efb3c32bc'
-  'Desktop Virtualization Host Pool Reader': '/providers/Microsoft.Authorization/roleDefinitions/ceadfde2-b300-400a-ab7b-6143895aa822'
-  'Desktop Virtualization Power On Off Contributor': '/providers/Microsoft.Authorization/roleDefinitions/40c5ff49-9181-41f8-ae61-143b0e78555e'
-  'Desktop Virtualization Reader': '/providers/Microsoft.Authorization/roleDefinitions/49a72310-ab8d-41df-bbb0-79b649203868'
-  'Desktop Virtualization Session Host Operator': '/providers/Microsoft.Authorization/roleDefinitions/2ad6aaab-ead9-4eaa-8ac5-da422f562408'
-  'Desktop Virtualization User': '/providers/Microsoft.Authorization/roleDefinitions/1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63'
-  'Desktop Virtualization User Session Operator': '/providers/Microsoft.Authorization/roleDefinitions/ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6'
-  'Desktop Virtualization Virtual Machine Contributor': '/providers/Microsoft.Authorization/roleDefinitions/a959dbd1-f747-45e3-8ba6-dd80f235f97c'
-  'Desktop Virtualization Workspace Contributor': '/providers/Microsoft.Authorization/roleDefinitions/21efdde3-836f-432b-bf3d-3e8e734d4b2b'
-  'Desktop Virtualization Workspace Reader': '/providers/Microsoft.Authorization/roleDefinitions/0fa44ee9-7a7d-466b-9bb2-2bf446b1204d'
+  Owner: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
+  Contributor: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+  Reader: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+  'Role Based Access Control Administrator': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
+  )
+  'User Access Administrator': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
+  )
+  'Application Group Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'ca6382a4-1721-4bcf-a114-ff0c70227b6b'
+  )
+  'Desktop Virtualization Application Group Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '86240b0e-9422-4c43-887b-b61143f32ba8'
+  )
+  'Desktop Virtualization Application Group Reader': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'aebf23d0-b568-4e86-b8f9-fe83a2c6ab55'
+  )
+  'Desktop Virtualization Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '082f0a83-3be5-4ba1-904c-961cca79b387'
+  )
+  'Desktop Virtualization Host Pool Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'e307426c-f9b6-4e81-87de-d99efb3c32bc'
+  )
+  'Desktop Virtualization Host Pool Reader': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'ceadfde2-b300-400a-ab7b-6143895aa822'
+  )
+  'Desktop Virtualization Power On Off Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '40c5ff49-9181-41f8-ae61-143b0e78555e'
+  )
+  'Desktop Virtualization Reader': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '49a72310-ab8d-41df-bbb0-79b649203868'
+  )
+  'Desktop Virtualization Session Host Operator': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '2ad6aaab-ead9-4eaa-8ac5-da422f562408'
+  )
+  'Desktop Virtualization User': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63'
+  )
+  'Desktop Virtualization User Session Operator': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6'
+  )
+  'Desktop Virtualization Virtual Machine Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'a959dbd1-f747-45e3-8ba6-dd80f235f97c'
+  )
+  'Desktop Virtualization Workspace Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '21efdde3-836f-432b-bf3d-3e8e734d4b2b'
+  )
+  'Desktop Virtualization Workspace Reader': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '0fa44ee9-7a7d-466b-9bb2-2bf446b1204d'
+  )
 }
 
 var formattedRoleAssignments = [
@@ -98,7 +146,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource workspace 'Microsoft.DesktopVirtualization/workspaces@2022-10-14-preview' = {
+resource workspace 'Microsoft.DesktopVirtualization/workspaces@2025-03-01-preview' = {
   name: name
   location: location
   tags: tags
@@ -106,11 +154,13 @@ resource workspace 'Microsoft.DesktopVirtualization/workspaces@2022-10-14-previe
     applicationGroupReferences: applicationGroupReferences
     description: description
     friendlyName: friendlyName
-    publicNetworkAccess: publicNetworkAccess
+    publicNetworkAccess: !empty(publicNetworkAccess)
+      ? publicNetworkAccess
+      : (!empty(privateEndpoints ?? []) ? 'Disabled' : 'Enabled')
   }
 }
 
-module workspace_privateEndpoints 'br/public:avm/res/network/private-endpoint:0.10.1' = [
+module workspace_privateEndpoints 'br/public:avm/res/network/private-endpoint:0.11.0' = [
   for (privateEndpoint, index) in (privateEndpoints ?? []): {
     name: '${uniqueString(deployment().name, location)}-keyVault-PrivateEndpoint-${index}'
     scope: resourceGroup(
@@ -169,9 +219,9 @@ resource workspace_lock 'Microsoft.Authorization/locks@2020-05-01' = if (!empty(
   name: lock.?name ?? 'lock-${name}'
   properties: {
     level: lock.?kind ?? ''
-    notes: lock.?kind == 'CanNotDelete'
+    notes: lock.?notes ?? (lock.?kind == 'CanNotDelete'
       ? 'Cannot delete resource or child resources.'
-      : 'Cannot delete or modify the resource or child resources.'
+      : 'Cannot delete or modify the resource or child resources.')
   }
   scope: workspace
 }

--- a/avm/res/desktop-virtualization/workspace/main.json
+++ b/avm/res/desktop-virtualization/workspace/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "5960826739257881645"
+      "version": "0.36.177.2456",
+      "templateHash": "12589699034212879170"
     },
     "name": "Workspace",
     "description": "This module deploys an Azure Virtual Desktop Workspace."
@@ -97,7 +97,7 @@
       },
       "metadata": {
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     },
@@ -139,7 +139,7 @@
       },
       "metadata": {
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     },
@@ -180,7 +180,7 @@
       },
       "metadata": {
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     },
@@ -277,7 +277,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a diagnostic setting. To be used if only logs are supported by the resource provider.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     },
@@ -302,12 +302,19 @@
           "metadata": {
             "description": "Optional. Specify the type of lock."
           }
+        },
+        "notes": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specify the notes of the lock."
+          }
         }
       },
       "metadata": {
         "description": "An AVM-aligned type for a lock.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     },
@@ -449,7 +456,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a private endpoint. To be used if the private endpoint's default service / groupId can be assumed (i.e., for services that only have one Private Endpoint type like 'vault' for key vault).",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     },
@@ -524,7 +531,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     }
@@ -545,14 +552,20 @@
     },
     "tags": {
       "type": "object",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.DesktopVirtualization/workspaces@2025-03-01-preview#properties/tags"
+        },
         "description": "Optional. Tags of the resource."
-      }
+      },
+      "nullable": true
     },
     "applicationGroupReferences": {
       "type": "array",
-      "defaultValue": [],
+      "items": {
+        "type": "string"
+      },
+      "nullable": true,
       "metadata": {
         "description": "Optional. Array of application group references."
       }
@@ -573,9 +586,9 @@
     },
     "publicNetworkAccess": {
       "type": "string",
-      "defaultValue": "Enabled",
+      "nullable": true,
       "metadata": {
-        "description": "Optional. Public network access for the workspace. Enabled by default."
+        "description": "Optional. Public network access for the workspace."
       }
     },
     "privateEndpoints": {
@@ -633,25 +646,25 @@
     ],
     "enableReferencedModulesTelemetry": false,
     "builtInRoleNames": {
-      "Owner": "/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
-      "Contributor": "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
-      "Reader": "/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
-      "Role Based Access Control Administrator": "/providers/Microsoft.Authorization/roleDefinitions/f58310d9-a9f6-439a-9e8d-f62e7b41a168",
-      "User Access Administrator": "/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9",
-      "Application Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ca6382a4-1721-4bcf-a114-ff0c70227b6b",
-      "Desktop Virtualization Application Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/86240b0e-9422-4c43-887b-b61143f32ba8",
-      "Desktop Virtualization Application Group Reader": "/providers/Microsoft.Authorization/roleDefinitions/aebf23d0-b568-4e86-b8f9-fe83a2c6ab55",
-      "Desktop Virtualization Contributor": "/providers/Microsoft.Authorization/roleDefinitions/082f0a83-3be5-4ba1-904c-961cca79b387",
-      "Desktop Virtualization Host Pool Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e307426c-f9b6-4e81-87de-d99efb3c32bc",
-      "Desktop Virtualization Host Pool Reader": "/providers/Microsoft.Authorization/roleDefinitions/ceadfde2-b300-400a-ab7b-6143895aa822",
-      "Desktop Virtualization Power On Off Contributor": "/providers/Microsoft.Authorization/roleDefinitions/40c5ff49-9181-41f8-ae61-143b0e78555e",
-      "Desktop Virtualization Reader": "/providers/Microsoft.Authorization/roleDefinitions/49a72310-ab8d-41df-bbb0-79b649203868",
-      "Desktop Virtualization Session Host Operator": "/providers/Microsoft.Authorization/roleDefinitions/2ad6aaab-ead9-4eaa-8ac5-da422f562408",
-      "Desktop Virtualization User": "/providers/Microsoft.Authorization/roleDefinitions/1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63",
-      "Desktop Virtualization User Session Operator": "/providers/Microsoft.Authorization/roleDefinitions/ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6",
-      "Desktop Virtualization Virtual Machine Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a959dbd1-f747-45e3-8ba6-dd80f235f97c",
-      "Desktop Virtualization Workspace Contributor": "/providers/Microsoft.Authorization/roleDefinitions/21efdde3-836f-432b-bf3d-3e8e734d4b2b",
-      "Desktop Virtualization Workspace Reader": "/providers/Microsoft.Authorization/roleDefinitions/0fa44ee9-7a7d-466b-9bb2-2bf446b1204d"
+      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+      "Application Group Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ca6382a4-1721-4bcf-a114-ff0c70227b6b')]",
+      "Desktop Virtualization Application Group Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '86240b0e-9422-4c43-887b-b61143f32ba8')]",
+      "Desktop Virtualization Application Group Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'aebf23d0-b568-4e86-b8f9-fe83a2c6ab55')]",
+      "Desktop Virtualization Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '082f0a83-3be5-4ba1-904c-961cca79b387')]",
+      "Desktop Virtualization Host Pool Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e307426c-f9b6-4e81-87de-d99efb3c32bc')]",
+      "Desktop Virtualization Host Pool Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ceadfde2-b300-400a-ab7b-6143895aa822')]",
+      "Desktop Virtualization Power On Off Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '40c5ff49-9181-41f8-ae61-143b0e78555e')]",
+      "Desktop Virtualization Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '49a72310-ab8d-41df-bbb0-79b649203868')]",
+      "Desktop Virtualization Session Host Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2ad6aaab-ead9-4eaa-8ac5-da422f562408')]",
+      "Desktop Virtualization User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63')]",
+      "Desktop Virtualization User Session Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6')]",
+      "Desktop Virtualization Virtual Machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a959dbd1-f747-45e3-8ba6-dd80f235f97c')]",
+      "Desktop Virtualization Workspace Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '21efdde3-836f-432b-bf3d-3e8e734d4b2b')]",
+      "Desktop Virtualization Workspace Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0fa44ee9-7a7d-466b-9bb2-2bf446b1204d')]"
     }
   },
   "resources": {
@@ -677,7 +690,7 @@
     },
     "workspace": {
       "type": "Microsoft.DesktopVirtualization/workspaces",
-      "apiVersion": "2022-10-14-preview",
+      "apiVersion": "2025-03-01-preview",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -685,7 +698,7 @@
         "applicationGroupReferences": "[parameters('applicationGroupReferences')]",
         "description": "[parameters('description')]",
         "friendlyName": "[parameters('friendlyName')]",
-        "publicNetworkAccess": "[parameters('publicNetworkAccess')]"
+        "publicNetworkAccess": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(not(empty(coalesce(parameters('privateEndpoints'), createArray()))), 'Disabled', 'Enabled'))]"
       }
     },
     "workspace_lock": {
@@ -696,7 +709,7 @@
       "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
       "properties": {
         "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
-        "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+        "notes": "[coalesce(tryGet(parameters('lock'), 'notes'), if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.'))]"
       },
       "dependsOn": [
         "workspace"
@@ -818,8 +831,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.13.18514",
-              "templateHash": "15954548978129725136"
+              "version": "0.34.44.8038",
+              "templateHash": "12389807800450456797"
             },
             "name": "Private Endpoints",
             "description": "This module deploys a Private Endpoint."
@@ -1228,7 +1241,7 @@
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2024-03-01",
-              "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.10.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.11.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -1246,7 +1259,7 @@
             },
             "privateEndpoint": {
               "type": "Microsoft.Network/privateEndpoints",
-              "apiVersion": "2023-11-01",
+              "apiVersion": "2024-05-01",
               "name": "[parameters('name')]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
@@ -1334,8 +1347,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.33.13.18514",
-                      "templateHash": "5440815542537978381"
+                      "version": "0.34.44.8038",
+                      "templateHash": "13997305779829540948"
                     },
                     "name": "Private Endpoint Private DNS Zone Groups",
                     "description": "This module deploys a Private Endpoint Private DNS Zone Group."
@@ -1407,12 +1420,12 @@
                     "privateEndpoint": {
                       "existing": true,
                       "type": "Microsoft.Network/privateEndpoints",
-                      "apiVersion": "2023-11-01",
+                      "apiVersion": "2024-05-01",
                       "name": "[parameters('privateEndpointName')]"
                     },
                     "privateDnsZoneGroup": {
                       "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
-                      "apiVersion": "2023-11-01",
+                      "apiVersion": "2024-05-01",
                       "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
                       "properties": {
                         "privateDnsZoneConfigs": "[variables('privateDnsZoneConfigsVar')]"
@@ -1476,7 +1489,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('privateEndpoint', '2023-11-01', 'full').location]"
+              "value": "[reference('privateEndpoint', '2024-05-01', 'full').location]"
             },
             "customDnsConfigs": {
               "type": "array",
@@ -1541,7 +1554,7 @@
       "metadata": {
         "description": "The location of the workspace."
       },
-      "value": "[reference('workspace', '2022-10-14-preview', 'full').location]"
+      "value": "[reference('workspace', '2025-03-01-preview', 'full').location]"
     },
     "privateEndpoints": {
       "type": "array",

--- a/avm/res/desktop-virtualization/workspace/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/desktop-virtualization/workspace/tests/e2e/defaults/main.test.bicep
@@ -23,7 +23,7 @@ param namePrefix string = '#_namePrefix_#'
 // General resources
 // =================
 
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/desktop-virtualization/workspace/tests/e2e/max/main.test.bicep
+++ b/avm/res/desktop-virtualization/workspace/tests/e2e/max/main.test.bicep
@@ -65,7 +65,9 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: resourceLocation
-      applicationGroupReferences: []
+      applicationGroupReferences: [
+        nestedDependencies.outputs.applicationGroupResourceId
+      ]
       friendlyName: 'AVD Workspace'
       publicNetworkAccess: 'Disabled'
       diagnosticSettings: [

--- a/avm/res/desktop-virtualization/workspace/tests/e2e/max/main.test.bicep
+++ b/avm/res/desktop-virtualization/workspace/tests/e2e/max/main.test.bicep
@@ -33,8 +33,9 @@ module nestedDependencies 'dependencies.bicep' = {
   name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
   params: {
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
-    location: resourceLocation
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
+    applicationGroupName: 'dep-${namePrefix}-appg-${serviceShort}'
+    hostPoolName: 'dep-${namePrefix}-hp-${serviceShort}'
   }
 }
 
@@ -49,7 +50,6 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
     logAnalyticsWorkspaceName: 'dep-${namePrefix}-law-${serviceShort}'
     eventHubNamespaceEventHubName: 'dep-${namePrefix}-evh-${serviceShort}01'
     eventHubNamespaceName: 'dep-${namePrefix}-evhns-${serviceShort}01'
-    location: resourceLocation
   }
 }
 

--- a/avm/res/desktop-virtualization/workspace/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/desktop-virtualization/workspace/tests/e2e/waf-aligned/dependencies.bicep
@@ -4,15 +4,6 @@ param location string = resourceGroup().location
 @description('Required. The name of the Virtual Network to create.')
 param virtualNetworkName string
 
-@description('Required. The name of the Managed Identity to create.')
-param managedIdentityName string
-
-@description('Required. The name of the Host Pool to create.')
-param hostPoolName string
-
-@description('Required. The name of the Application Group to create.')
-param applicationGroupName string
-
 var addressPrefix = '10.0.0.0/16'
 
 #disable-next-line use-recent-api-versions
@@ -54,41 +45,8 @@ resource privateDNSZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
   }
 }
 
-#disable-next-line use-recent-api-versions
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2025-01-31-preview' = {
-  name: managedIdentityName
-  location: location
-}
-
-#disable-next-line use-recent-api-versions
-resource hostPool 'Microsoft.DesktopVirtualization/hostPools@2025-03-01-preview' = {
-  name: hostPoolName
-  location: location
-  properties: {
-    hostPoolType: 'Pooled'
-    loadBalancerType: 'BreadthFirst'
-    preferredAppGroupType: 'Desktop'
-  }
-}
-
-#disable-next-line use-recent-api-versions
-resource applicationGroup 'Microsoft.DesktopVirtualization/applicationGroups@2025-03-01-preview' = {
-  name: applicationGroupName
-  location: location
-  properties: {
-    applicationGroupType: 'Desktop'
-    hostPoolArmPath: hostPool.id
-  }
-}
-
 @description('The resource ID of the created Virtual Network Subnet.')
 output subnetResourceId string = virtualNetwork.properties.subnets[0].id
 
 @description('The resource ID of the created Private DNS Zone.')
 output privateDNSZoneResourceId string = privateDNSZone.id
-
-@description('The principal ID of the created Managed Identity.')
-output managedIdentityPrincipalId string = managedIdentity.properties.principalId
-
-@description('The resource ID of the created Application Group.')
-output applicationGroupResourceId string = applicationGroup.id

--- a/avm/res/desktop-virtualization/workspace/version.json
+++ b/avm/res/desktop-virtualization/workspace/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.8"
+  "version": "0.9"
 }


### PR DESCRIPTION
## Description

Closes #5724

### Changes

- Updated to latest avm-common-types, enabling custom notes on locks
- Updated API version of workspace resource to `2025-03-01-preview`
- Added ApplicationGroup reference to max test
- Added PE to waf test

### Breaking Changes

- Changed behavior of `publicNetworkAccess` to automatically set `Disabled` if private endpoints are provided - unless the `publicNetworkAccess` value is set explicitly



## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.desktop-virtualization.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.workspace.yml/badge.svg?branch=users%2Falsehr%2F5724_api&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.workspace.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
