### PR TITLE
feat: AVD Scaling Plan - Updated to latest versions

### DIFF
--- a/avm/res/desktop-virtualization/scaling-plan/CHANGELOG.md
+++ b/avm/res/desktop-virtualization/scaling-plan/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/desktop-virtualization/scaling-plan/CHANGELOG.md).
 
+## 0.4.0
+
+### Changes
+
+- Updated `avm-common-types` version to latest version `0.6.0`, enabling custom notes on locks
+- Added diverse types
+
+### Breaking Changes
+
+- Introduced a type `hostPoolReferenceType` for the parameter `hostPoolReference` that expects a `hostPoolResourceId` instead of the previous `hostPoolArmPath`
+- The property `scalingPlanEnabled` of the new type `hostPoolReferenceType` defaults to `true`
+
 ## 0.3.2
 
 ### Changes

--- a/avm/res/desktop-virtualization/scaling-plan/README.md
+++ b/avm/res/desktop-virtualization/scaling-plan/README.md
@@ -22,7 +22,7 @@ This module deploys an Azure Virtual Desktop Scaling Plan.
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.DesktopVirtualization/scalingPlans` | [2023-09-05](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DesktopVirtualization/2023-09-05/scalingPlans) |
+| `Microsoft.DesktopVirtualization/scalingPlans` | [2025-03-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DesktopVirtualization/2025-03-01-preview/scalingPlans) |
 | `Microsoft.Insights/diagnosticSettings` | [2021-05-01-preview](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings) |
 
 ## Usage examples
@@ -50,10 +50,7 @@ This instance deploys the module with the minimum set of required parameters.
 module scalingPlan 'br/public:avm/res/desktop-virtualization/scaling-plan:<version>' = {
   name: 'scalingPlanDeployment'
   params: {
-    // Required parameters
     name: 'dvspmin002'
-    // Non-required parameters
-    location: '<location>'
   }
 }
 ```
@@ -70,13 +67,8 @@ module scalingPlan 'br/public:avm/res/desktop-virtualization/scaling-plan:<versi
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    // Required parameters
     "name": {
       "value": "dvspmin002"
-    },
-    // Non-required parameters
-    "location": {
-      "value": "<location>"
     }
   }
 }
@@ -92,10 +84,7 @@ module scalingPlan 'br/public:avm/res/desktop-virtualization/scaling-plan:<versi
 ```bicep-params
 using 'br/public:avm/res/desktop-virtualization/scaling-plan:<version>'
 
-// Required parameters
 param name = 'dvspmin002'
-// Non-required parameters
-param location = '<location>'
 ```
 
 </details>
@@ -135,7 +124,7 @@ module scalingPlan 'br/public:avm/res/desktop-virtualization/scaling-plan:<versi
     friendlyName: 'friendlyName'
     hostPoolReferences: [
       {
-        hostPoolArmPath: '<hostPoolArmPath>'
+        hostPoolResourceId: '<hostPoolResourceId>'
         scalingPlanEnabled: true
       }
     ]
@@ -322,7 +311,7 @@ module scalingPlan 'br/public:avm/res/desktop-virtualization/scaling-plan:<versi
     "hostPoolReferences": {
       "value": [
         {
-          "hostPoolArmPath": "<hostPoolArmPath>",
+          "hostPoolResourceId": "<hostPoolResourceId>",
           "scalingPlanEnabled": true
         }
       ]
@@ -509,7 +498,7 @@ param diagnosticSettings = [
 param friendlyName = 'friendlyName'
 param hostPoolReferences = [
   {
-    hostPoolArmPath: '<hostPoolArmPath>'
+    hostPoolResourceId: '<hostPoolResourceId>'
     scalingPlanEnabled: true
   }
 ]
@@ -681,7 +670,6 @@ module scalingPlan 'br/public:avm/res/desktop-virtualization/scaling-plan:<versi
       }
     ]
     friendlyName: 'myFriendlyName'
-    location: '<location>'
     tags: {
       Environment: 'Non-Prod'
       'hidden-title': 'This is visible in the resource name'
@@ -724,9 +712,6 @@ module scalingPlan 'br/public:avm/res/desktop-virtualization/scaling-plan:<versi
     "friendlyName": {
       "value": "myFriendlyName"
     },
-    "location": {
-      "value": "<location>"
-    },
     "tags": {
       "value": {
         "Environment": "Non-Prod",
@@ -761,7 +746,6 @@ param diagnosticSettings = [
   }
 ]
 param friendlyName = 'myFriendlyName'
-param location = '<location>'
 param tags = {
   Environment: 'Non-Prod'
   'hidden-title': 'This is visible in the resource name'
@@ -955,6 +939,32 @@ Host pool references of the Scaling Plan.
 - Required: No
 - Type: array
 
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`hostPoolResourceId`](#parameter-hostpoolreferenceshostpoolresourceid) | string | Arm path of referenced hostpool. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`scalingPlanEnabled`](#parameter-hostpoolreferencesscalingplanenabled) | bool | Is the scaling plan enabled for this hostpool. Defaults to `true`. |
+
+### Parameter: `hostPoolReferences.hostPoolResourceId`
+
+Arm path of referenced hostpool.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `hostPoolReferences.scalingPlanEnabled`
+
+Is the scaling plan enabled for this hostpool. Defaults to `true`.
+
+- Required: No
+- Type: bool
+
 ### Parameter: `hostPoolType`
 
 Host pool type of the Scaling Plan.
@@ -991,6 +1001,7 @@ The lock settings of the service.
 | :-- | :-- | :-- |
 | [`kind`](#parameter-lockkind) | string | Specify the type of lock. |
 | [`name`](#parameter-lockname) | string | Specify the name of lock. |
+| [`notes`](#parameter-locknotes) | string | Specify the notes of the lock. |
 
 ### Parameter: `lock.kind`
 
@@ -1010,6 +1021,13 @@ Specify the type of lock.
 ### Parameter: `lock.name`
 
 Specify the name of lock.
+
+- Required: No
+- Type: string
+
+### Parameter: `lock.notes`
+
+Specify the notes of the lock.
 
 - Required: No
 - Type: string
@@ -1168,7 +1186,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.5.1` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.6.0` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/desktop-virtualization/scaling-plan/main.bicep
+++ b/avm/res/desktop-virtualization/scaling-plan/main.bicep
@@ -24,52 +24,100 @@ param hostPoolType string = 'Pooled'
 param exclusionTag string?
 
 @sys.description('Optional. Schedules of the Scaling Plan.')
-param schedules array?
+param schedules resourceInput<'Microsoft.DesktopVirtualization/scalingPlans@2025-03-01-preview'>.properties.schedules?
 
 @sys.description('Optional. Host pool references of the Scaling Plan.')
-param hostPoolReferences array?
+param hostPoolReferences hostPoolReferenceType[]?
 
 @sys.description('Optional. Description of the Scaling Plan.')
 param description string = name
 
 @sys.description('Optional. Tags of the resource.')
-param tags object?
+param tags resourceInput<'Microsoft.DesktopVirtualization/scalingPlans@2025-03-01-preview'>.tags?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
 @sys.description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
 @sys.description('Optional. The lock settings of the service.')
 param lock lockType?
 
 @sys.description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
 
-import { diagnosticSettingLogsOnlyType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { diagnosticSettingLogsOnlyType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
 @sys.description('Optional. The database-level diagnostic settings of the service.')
 param diagnosticSettings diagnosticSettingLogsOnlyType[]?
 
 var builtInRoleNames = {
-  Owner: '/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635'
-  Contributor: '/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
-  Reader: '/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7'
-  'Role Based Access Control Administrator': '/providers/Microsoft.Authorization/roleDefinitions/f58310d9-a9f6-439a-9e8d-f62e7b41a168'
-  'User Access Administrator': '/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
-  'Application Group Contributor': '/providers/Microsoft.Authorization/roleDefinitions/ca6382a4-1721-4bcf-a114-ff0c70227b6b'
-  'Desktop Virtualization Application Group Contributor': '/providers/Microsoft.Authorization/roleDefinitions/86240b0e-9422-4c43-887b-b61143f32ba8'
-  'Desktop Virtualization Application Group Reader': '/providers/Microsoft.Authorization/roleDefinitions/aebf23d0-b568-4e86-b8f9-fe83a2c6ab55'
-  'Desktop Virtualization Contributor': '/providers/Microsoft.Authorization/roleDefinitions/082f0a83-3be5-4ba1-904c-961cca79b387'
-  'Desktop Virtualization Host Pool Contributor': '/providers/Microsoft.Authorization/roleDefinitions/e307426c-f9b6-4e81-87de-d99efb3c32bc'
-  'Desktop Virtualization Host Pool Reader': '/providers/Microsoft.Authorization/roleDefinitions/ceadfde2-b300-400a-ab7b-6143895aa822'
-  'Desktop Virtualization Power On Off Contributor': '/providers/Microsoft.Authorization/roleDefinitions/40c5ff49-9181-41f8-ae61-143b0e78555e'
-  'Desktop Virtualization Reader': '/providers/Microsoft.Authorization/roleDefinitions/49a72310-ab8d-41df-bbb0-79b649203868'
-  'Desktop Virtualization Session Host Operator': '/providers/Microsoft.Authorization/roleDefinitions/2ad6aaab-ead9-4eaa-8ac5-da422f562408'
-  'Desktop Virtualization User': '/providers/Microsoft.Authorization/roleDefinitions/1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63'
-  'Desktop Virtualization User Session Operator': '/providers/Microsoft.Authorization/roleDefinitions/ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6'
-  'Desktop Virtualization Virtual Machine Contributor': '/providers/Microsoft.Authorization/roleDefinitions/a959dbd1-f747-45e3-8ba6-dd80f235f97c'
-  'Desktop Virtualization Workspace Contributor': '/providers/Microsoft.Authorization/roleDefinitions/21efdde3-836f-432b-bf3d-3e8e734d4b2b'
-  'Desktop Virtualization Workspace Reader': '/providers/Microsoft.Authorization/roleDefinitions/0fa44ee9-7a7d-466b-9bb2-2bf446b1204d'
+  Owner: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
+  Contributor: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+  Reader: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+  'Role Based Access Control Administrator': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
+  )
+  'User Access Administrator': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
+  )
+  'Application Group Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'ca6382a4-1721-4bcf-a114-ff0c70227b6b'
+  )
+  'Desktop Virtualization Application Group Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '86240b0e-9422-4c43-887b-b61143f32ba8'
+  )
+  'Desktop Virtualization Application Group Reader': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'aebf23d0-b568-4e86-b8f9-fe83a2c6ab55'
+  )
+  'Desktop Virtualization Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '082f0a83-3be5-4ba1-904c-961cca79b387'
+  )
+  'Desktop Virtualization Host Pool Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'e307426c-f9b6-4e81-87de-d99efb3c32bc'
+  )
+  'Desktop Virtualization Host Pool Reader': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'ceadfde2-b300-400a-ab7b-6143895aa822'
+  )
+  'Desktop Virtualization Power On Off Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '40c5ff49-9181-41f8-ae61-143b0e78555e'
+  )
+  'Desktop Virtualization Reader': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '49a72310-ab8d-41df-bbb0-79b649203868'
+  )
+  'Desktop Virtualization Session Host Operator': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '2ad6aaab-ead9-4eaa-8ac5-da422f562408'
+  )
+  'Desktop Virtualization User': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63'
+  )
+  'Desktop Virtualization User Session Operator': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6'
+  )
+  'Desktop Virtualization Virtual Machine Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'a959dbd1-f747-45e3-8ba6-dd80f235f97c'
+  )
+  'Desktop Virtualization Workspace Contributor': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '21efdde3-836f-432b-bf3d-3e8e734d4b2b'
+  )
+  'Desktop Virtualization Workspace Reader': subscriptionResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    '0fa44ee9-7a7d-466b-9bb2-2bf446b1204d'
+  )
 }
 
 var formattedRoleAssignments = [
@@ -102,7 +150,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource scalingPlan 'Microsoft.DesktopVirtualization/scalingPlans@2023-09-05' = {
+resource scalingPlan 'Microsoft.DesktopVirtualization/scalingPlans@2025-03-01-preview' = {
   name: name
   location: location
   tags: tags
@@ -112,7 +160,10 @@ resource scalingPlan 'Microsoft.DesktopVirtualization/scalingPlans@2023-09-05' =
     hostPoolType: hostPoolType
     exclusionTag: exclusionTag
     schedules: schedules
-    hostPoolReferences: hostPoolReferences
+    hostPoolReferences: map(hostPoolReferences ?? [], reference => {
+      hostPoolArmPath: reference.hostPoolResourceId
+      scalingPlanEnabled: reference.?scalingPlanEnabled ?? true
+    })
     description: description
   }
 }
@@ -177,3 +228,17 @@ output name string = scalingPlan.name
 
 @sys.description('The location of the Scaling Plan.')
 output location string = scalingPlan.location
+
+// ================ //
+// Definitions      //
+// ================ //
+
+@sys.export()
+@sys.description('The type of a host pool reference.')
+type hostPoolReferenceType = {
+  @sys.description('Required. Arm path of referenced hostpool.')
+  hostPoolResourceId: string
+
+  @sys.description('Optional. Is the scaling plan enabled for this hostpool. Defaults to `true`.')
+  scalingPlanEnabled: bool?
+}

--- a/avm/res/desktop-virtualization/scaling-plan/main.json
+++ b/avm/res/desktop-virtualization/scaling-plan/main.json
@@ -5,13 +5,35 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "16349287678283571682"
+      "version": "0.36.177.2456",
+      "templateHash": "14206119473189075951"
     },
     "name": "Azure Virtual Desktop Scaling Plan",
     "description": "This module deploys an Azure Virtual Desktop Scaling Plan."
   },
   "definitions": {
+    "hostPoolReferenceType": {
+      "type": "object",
+      "properties": {
+        "hostPoolResourceId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. Arm path of referenced hostpool."
+          }
+        },
+        "scalingPlanEnabled": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Is the scaling plan enabled for this hostpool. Defaults to `true`."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The type of a host pool reference."
+      }
+    },
     "diagnosticSettingLogsOnlyType": {
       "type": "object",
       "properties": {
@@ -105,7 +127,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a diagnostic setting. To be used if only logs are supported by the resource provider.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     },
@@ -130,12 +152,19 @@
           "metadata": {
             "description": "Optional. Specify the type of lock."
           }
+        },
+        "notes": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specify the notes of the lock."
+          }
         }
       },
       "metadata": {
         "description": "An AVM-aligned type for a lock.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     },
@@ -210,7 +239,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
         }
       }
     }
@@ -263,13 +292,19 @@
     },
     "schedules": {
       "type": "array",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.DesktopVirtualization/scalingPlans@2025-03-01-preview#properties/properties/properties/schedules"
+        },
         "description": "Optional. Schedules of the Scaling Plan."
-      }
+      },
+      "nullable": true
     },
     "hostPoolReferences": {
       "type": "array",
+      "items": {
+        "$ref": "#/definitions/hostPoolReferenceType"
+      },
       "nullable": true,
       "metadata": {
         "description": "Optional. Host pool references of the Scaling Plan."
@@ -284,10 +319,13 @@
     },
     "tags": {
       "type": "object",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.DesktopVirtualization/scalingPlans@2025-03-01-preview#properties/tags"
+        },
         "description": "Optional. Tags of the resource."
-      }
+      },
+      "nullable": true
     },
     "roleAssignments": {
       "type": "array",
@@ -333,25 +371,25 @@
       }
     ],
     "builtInRoleNames": {
-      "Owner": "/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
-      "Contributor": "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
-      "Reader": "/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
-      "Role Based Access Control Administrator": "/providers/Microsoft.Authorization/roleDefinitions/f58310d9-a9f6-439a-9e8d-f62e7b41a168",
-      "User Access Administrator": "/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9",
-      "Application Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ca6382a4-1721-4bcf-a114-ff0c70227b6b",
-      "Desktop Virtualization Application Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/86240b0e-9422-4c43-887b-b61143f32ba8",
-      "Desktop Virtualization Application Group Reader": "/providers/Microsoft.Authorization/roleDefinitions/aebf23d0-b568-4e86-b8f9-fe83a2c6ab55",
-      "Desktop Virtualization Contributor": "/providers/Microsoft.Authorization/roleDefinitions/082f0a83-3be5-4ba1-904c-961cca79b387",
-      "Desktop Virtualization Host Pool Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e307426c-f9b6-4e81-87de-d99efb3c32bc",
-      "Desktop Virtualization Host Pool Reader": "/providers/Microsoft.Authorization/roleDefinitions/ceadfde2-b300-400a-ab7b-6143895aa822",
-      "Desktop Virtualization Power On Off Contributor": "/providers/Microsoft.Authorization/roleDefinitions/40c5ff49-9181-41f8-ae61-143b0e78555e",
-      "Desktop Virtualization Reader": "/providers/Microsoft.Authorization/roleDefinitions/49a72310-ab8d-41df-bbb0-79b649203868",
-      "Desktop Virtualization Session Host Operator": "/providers/Microsoft.Authorization/roleDefinitions/2ad6aaab-ead9-4eaa-8ac5-da422f562408",
-      "Desktop Virtualization User": "/providers/Microsoft.Authorization/roleDefinitions/1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63",
-      "Desktop Virtualization User Session Operator": "/providers/Microsoft.Authorization/roleDefinitions/ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6",
-      "Desktop Virtualization Virtual Machine Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a959dbd1-f747-45e3-8ba6-dd80f235f97c",
-      "Desktop Virtualization Workspace Contributor": "/providers/Microsoft.Authorization/roleDefinitions/21efdde3-836f-432b-bf3d-3e8e734d4b2b",
-      "Desktop Virtualization Workspace Reader": "/providers/Microsoft.Authorization/roleDefinitions/0fa44ee9-7a7d-466b-9bb2-2bf446b1204d"
+      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+      "Application Group Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ca6382a4-1721-4bcf-a114-ff0c70227b6b')]",
+      "Desktop Virtualization Application Group Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '86240b0e-9422-4c43-887b-b61143f32ba8')]",
+      "Desktop Virtualization Application Group Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'aebf23d0-b568-4e86-b8f9-fe83a2c6ab55')]",
+      "Desktop Virtualization Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '082f0a83-3be5-4ba1-904c-961cca79b387')]",
+      "Desktop Virtualization Host Pool Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e307426c-f9b6-4e81-87de-d99efb3c32bc')]",
+      "Desktop Virtualization Host Pool Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ceadfde2-b300-400a-ab7b-6143895aa822')]",
+      "Desktop Virtualization Power On Off Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '40c5ff49-9181-41f8-ae61-143b0e78555e')]",
+      "Desktop Virtualization Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '49a72310-ab8d-41df-bbb0-79b649203868')]",
+      "Desktop Virtualization Session Host Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2ad6aaab-ead9-4eaa-8ac5-da422f562408')]",
+      "Desktop Virtualization User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63')]",
+      "Desktop Virtualization User Session Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6')]",
+      "Desktop Virtualization Virtual Machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a959dbd1-f747-45e3-8ba6-dd80f235f97c')]",
+      "Desktop Virtualization Workspace Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '21efdde3-836f-432b-bf3d-3e8e734d4b2b')]",
+      "Desktop Virtualization Workspace Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0fa44ee9-7a7d-466b-9bb2-2bf446b1204d')]"
     }
   },
   "resources": {
@@ -377,7 +415,7 @@
     },
     "scalingPlan": {
       "type": "Microsoft.DesktopVirtualization/scalingPlans",
-      "apiVersion": "2023-09-05",
+      "apiVersion": "2025-03-01-preview",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -387,7 +425,7 @@
         "hostPoolType": "[parameters('hostPoolType')]",
         "exclusionTag": "[parameters('exclusionTag')]",
         "schedules": "[parameters('schedules')]",
-        "hostPoolReferences": "[parameters('hostPoolReferences')]",
+        "hostPoolReferences": "[map(coalesce(parameters('hostPoolReferences'), createArray()), lambda('reference', createObject('hostPoolArmPath', lambdaVariables('reference').hostPoolResourceId, 'scalingPlanEnabled', coalesce(tryGet(lambdaVariables('reference'), 'scalingPlanEnabled'), true()))))]",
         "description": "[parameters('description')]"
       }
     },
@@ -487,7 +525,7 @@
       "metadata": {
         "description": "The location of the Scaling Plan."
       },
-      "value": "[reference('scalingPlan', '2023-09-05', 'full').location]"
+      "value": "[reference('scalingPlan', '2025-03-01-preview', 'full').location]"
     }
   }
 }

--- a/avm/res/desktop-virtualization/scaling-plan/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/desktop-virtualization/scaling-plan/tests/e2e/defaults/main.test.bicep
@@ -23,7 +23,7 @@ param namePrefix string = '#_namePrefix_#'
 // General resources
 // =================
 
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -39,7 +39,6 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}002'
-      location: resourceLocation
     }
   }
 ]

--- a/avm/res/desktop-virtualization/scaling-plan/tests/e2e/max/dependencies.bicep
+++ b/avm/res/desktop-virtualization/scaling-plan/tests/e2e/max/dependencies.bicep
@@ -1,23 +1,23 @@
 @sys.description('Optional. The location to deploy to.')
 param location string = resourceGroup().location
 
-param tags object = {}
-
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
 @description('Optional. Expiration time of Host Pool registration token. Should be between one hour and 30 days from now and the format is like \'2023-12-24T12:00:00.0000000Z\'. If not provided, the expiration time will be set to two days from now.')
 param expirationTime string = dateTimeAdd(utcNow(), 'P2D')
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+#disable-next-line use-recent-api-versions
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2025-01-31-preview' = {
   name: managedIdentityName
   location: location
 }
 
-resource hostPool 'Microsoft.DesktopVirtualization/hostPools@2022-09-09' = {
+#disable-next-line use-recent-api-versions
+resource hostPool 'Microsoft.DesktopVirtualization/hostPools@2025-03-01-preview' = {
   name: 'myHostPool'
   location: location
-  tags: tags
+  tags: {}
   properties: {
     friendlyName: 'hostPoolFriendlyName'
     description: 'myDescription'
@@ -46,7 +46,7 @@ resource hostPool 'Microsoft.DesktopVirtualization/hostPools@2022-09-09' = {
 }
 
 @description('The resource ID of the created host pool.')
-output hostPoolId string = hostPool.id
+output hostPoolResourceId string = hostPool.id
 
 @description('The principal ID of the created Managed Identity.')
 output managedIdentityPrincipalId string = managedIdentity.properties.principalId

--- a/avm/res/desktop-virtualization/scaling-plan/tests/e2e/max/main.test.bicep
+++ b/avm/res/desktop-virtualization/scaling-plan/tests/e2e/max/main.test.bicep
@@ -23,7 +23,7 @@ param namePrefix string = '#_namePrefix_#'
 // General resources
 // =================
 
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -32,7 +32,6 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
   params: {
-    location: resourceLocation
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
   }
 }
@@ -48,7 +47,6 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
     logAnalyticsWorkspaceName: 'dep-${namePrefix}-law-${serviceShort}'
     eventHubNamespaceEventHubName: 'dep-${namePrefix}-evh-${serviceShort}01'
     eventHubNamespaceName: 'dep-${namePrefix}-evhns-${serviceShort}01'
-    location: resourceLocation
   }
 }
 
@@ -176,7 +174,7 @@ module testDeployment '../../../main.bicep' = [
       ]
       hostPoolReferences: [
         {
-          hostPoolArmPath: nestedDependencies.outputs.hostPoolId
+          hostPoolResourceId: nestedDependencies.outputs.hostPoolResourceId
           scalingPlanEnabled: true
         }
       ]

--- a/avm/res/desktop-virtualization/scaling-plan/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/desktop-virtualization/scaling-plan/tests/e2e/waf-aligned/main.test.bicep
@@ -23,7 +23,7 @@ param namePrefix string = '#_namePrefix_#'
 // General resources
 // =================
 
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -39,7 +39,6 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
     logAnalyticsWorkspaceName: 'dep-${namePrefix}-law-${serviceShort}'
     eventHubNamespaceEventHubName: 'dep-${namePrefix}-evh-${serviceShort}01'
     eventHubNamespaceName: 'dep-${namePrefix}-evhns-${serviceShort}01'
-    location: resourceLocation
   }
 }
 
@@ -55,7 +54,6 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}002'
       friendlyName: 'myFriendlyName'
-      location: resourceLocation
       description: 'myDescription'
       diagnosticSettings: [
         {

--- a/avm/res/desktop-virtualization/scaling-plan/version.json
+++ b/avm/res/desktop-virtualization/scaling-plan/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.3"
+  "version": "0.4"
 }


### PR DESCRIPTION
## Description

### Changes

- Updated `avm-common-types` version to latest version `0.6.0`, enabling custom notes on locks
- Added diverse types
- Updated tests

### Breaking Changes

- Introduced a type `hostPoolReferenceType` for the parameter `hostPoolReference` that expects a `hostPoolResourceId` instead of the previous `hostPoolArmPath`
- The property `scalingPlanEnabled` of the new type `hostPoolReferenceType` defaults to `true`

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.desktop-virtualization.scaling-plan](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.scaling-plan.yml/badge.svg?branch=users%2Falsehr%2FavdDcalingPlanAPI&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.scaling-plan.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
