### PR TITLE
fix: Add tags to resource groups and new output

### DIFF
--- a/avm/ptn/lz/sub-vending/CHANGELOG.md
+++ b/avm/ptn/lz/sub-vending/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/lz/sub-vending/CHANGELOG.md).
 
+## 0.3.7
+
+### Changes
+
+- Added tag assignments to resource groups
+- Added output for virtual WAN hub connection name
+
+### Breaking Changes
+
+- None
+
 ## 0.3.6
 
 ### Changes

--- a/avm/ptn/lz/sub-vending/README.md
+++ b/avm/ptn/lz/sub-vending/README.md
@@ -5239,6 +5239,7 @@ An array of of objects of virtual hub route table resource IDs to propagate rout
 | `subscriptionAcceptOwnershipUrl` | string | The Subscription Ownership URL. Only used when creating MCA Subscriptions across tenants. |
 | `subscriptionId` | string | The Subscription ID that has been created or provided. |
 | `subscriptionResourceId` | string | The Subscription Resource ID that has been created or provided. |
+| `virtualWanHubConnectionName` | string | The name of the Virtual WAN Hub Connection. |
 
 ## Cross-referenced modules
 

--- a/avm/ptn/lz/sub-vending/main.bicep
+++ b/avm/ptn/lz/sub-vending/main.bicep
@@ -539,3 +539,6 @@ output failedResourceProviders string = !empty(resourceProviders)
 output failedResourceProvidersFeatures string = !empty(resourceProviders)
   ? createSubscriptionResources.?outputs.failedFeatures ?? ''
   : ''
+
+@description('The name of the Virtual WAN Hub Connection.')
+output virtualWanHubConnectionName string = createSubscriptionResources.?outputs.virtualWanHubConnectionName ?? ''

--- a/avm/ptn/lz/sub-vending/main.json
+++ b/avm/ptn/lz/sub-vending/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.177.2456",
-      "templateHash": "8583773534390061326"
+      "version": "0.37.4.10188",
+      "templateHash": "18227739879857491478"
     },
     "name": "Sub-vending",
     "description": "This module deploys a subscription to accelerate deployment of landing zones. For more information on how to use it, please visit this [Wiki](https://github.com/Azure/bicep-lz-vending/wiki).",
@@ -1884,8 +1884,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.177.2456",
-              "templateHash": "12805422112803379676"
+              "version": "0.37.4.10188",
+              "templateHash": "2886800634378115051"
             }
           },
           "parameters": {
@@ -2134,8 +2134,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.177.2456",
-              "templateHash": "14944664980450651122"
+              "version": "0.37.4.10188",
+              "templateHash": "9930983297015493660"
             },
             "name": "`/subResourcesWrapper/deploy.bicep` Parameters",
             "description": "This module is used by the [`bicep-lz-vending`](https://aka.ms/sub-vending/bicep) module to help orchestrate the deployment",
@@ -4044,8 +4044,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.177.2456",
-                      "templateHash": "16831425075990364151"
+                      "version": "0.37.4.10188",
+                      "templateHash": "10119532997954158148"
                     }
                   },
                   "parameters": {
@@ -4106,8 +4106,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.177.2456",
-                      "templateHash": "2895301038955288884"
+                      "version": "0.37.4.10188",
+                      "templateHash": "15753993745852490416"
                     }
                   },
                   "parameters": {
@@ -4166,8 +4166,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.177.2456",
-                              "templateHash": "17589843071604103422"
+                              "version": "0.37.4.10188",
+                              "templateHash": "17777929966904635893"
                             }
                           },
                           "parameters": {
@@ -4222,8 +4222,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.36.177.2456",
-                                      "templateHash": "88148186443948071"
+                                      "version": "0.37.4.10188",
+                                      "templateHash": "17895554561530196302"
                                     }
                                   },
                                   "parameters": {
@@ -4300,8 +4300,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.177.2456",
-                              "templateHash": "11167942621783024948"
+                              "version": "0.37.4.10188",
+                              "templateHash": "2329361910473224649"
                             }
                           },
                           "parameters": {
@@ -4355,8 +4355,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.36.177.2456",
-                                      "templateHash": "8274128509069242714"
+                                      "version": "0.37.4.10188",
+                                      "templateHash": "17671496048922498595"
                                     }
                                   },
                                   "parameters": {
@@ -4462,6 +4462,9 @@
                     "value": "[parameters('virtualNetworkLocation')]"
                   },
                   "lock": "[if(parameters('virtualNetworkResourceGroupLockEnabled'), createObject('value', createObject('kind', 'CanNotDelete', 'name', 'CanNotDelete')), createObject('value', null()))]",
+                  "tags": {
+                    "value": "[parameters('virtualNetworkResourceGroupTags')]"
+                  },
                   "enableTelemetry": {
                     "value": "[parameters('enableTelemetry')]"
                   }
@@ -4956,6 +4959,9 @@
                     "value": "[parameters('virtualNetworkLocation')]"
                   },
                   "lock": "[if(parameters('userAssignedIdentitiesResourceGroupLockEnabled'), createObject('value', createObject('kind', 'CanNotDelete', 'name', 'CanNotDelete')), createObject('value', null()))]",
+                  "tags": {
+                    "value": "[parameters('subscriptionTags')]"
+                  },
                   "enableTelemetry": {
                     "value": "[parameters('enableTelemetry')]"
                   }
@@ -5462,8 +5468,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.177.2456",
-                      "templateHash": "2895301038955288884"
+                      "version": "0.37.4.10188",
+                      "templateHash": "15753993745852490416"
                     }
                   },
                   "parameters": {
@@ -5522,8 +5528,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.177.2456",
-                              "templateHash": "17589843071604103422"
+                              "version": "0.37.4.10188",
+                              "templateHash": "17777929966904635893"
                             }
                           },
                           "parameters": {
@@ -5578,8 +5584,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.36.177.2456",
-                                      "templateHash": "88148186443948071"
+                                      "version": "0.37.4.10188",
+                                      "templateHash": "17895554561530196302"
                                     }
                                   },
                                   "parameters": {
@@ -5656,8 +5662,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.36.177.2456",
-                              "templateHash": "11167942621783024948"
+                              "version": "0.37.4.10188",
+                              "templateHash": "2329361910473224649"
                             }
                           },
                           "parameters": {
@@ -5711,8 +5717,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.36.177.2456",
-                                      "templateHash": "8274128509069242714"
+                                      "version": "0.37.4.10188",
+                                      "templateHash": "17671496048922498595"
                                     }
                                   },
                                   "parameters": {
@@ -10007,8 +10013,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.177.2456",
-                      "templateHash": "18339309058131370516"
+                      "version": "0.37.4.10188",
+                      "templateHash": "17543656022324673718"
                     }
                   },
                   "parameters": {
@@ -25363,6 +25369,9 @@
                   "location": {
                     "value": "[parameters('deploymentScriptLocation')]"
                   },
+                  "tags": {
+                    "value": "[parameters('subscriptionTags')]"
+                  },
                   "enableTelemetry": {
                     "value": "[parameters('enableTelemetry')]"
                   }
@@ -25855,6 +25864,9 @@
                   },
                   "location": {
                     "value": "[coalesce(parameters('virtualNetworkLocation'), deployment().location)]"
+                  },
+                  "tags": {
+                    "value": "[parameters('virtualNetworkResourceGroupTags')]"
                   },
                   "enableTelemetry": {
                     "value": "[parameters('enableTelemetry')]"
@@ -45251,6 +45263,9 @@
                     "value": "[coalesce(tryGet(parameters('additionalVirtualNetworks')[copyIndex()], 'location'), deployment().location)]"
                   },
                   "lock": "[if(coalesce(tryGet(parameters('additionalVirtualNetworks')[copyIndex()], 'resourceGroupLockEnabled'), true()), createObject('value', createObject('kind', 'CanNotDelete', 'name', 'CanNotDelete')), createObject('value', null()))]",
+                  "tags": {
+                    "value": "[parameters('virtualNetworkResourceGroupTags')]"
+                  },
                   "enableTelemetry": {
                     "value": "[parameters('enableTelemetry')]"
                   }
@@ -47438,8 +47453,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.177.2456",
-                      "templateHash": "18339309058131370516"
+                      "version": "0.37.4.10188",
+                      "templateHash": "17543656022324673718"
                     }
                   },
                   "parameters": {
@@ -47553,8 +47568,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.177.2456",
-                      "templateHash": "109949312866318067"
+                      "version": "0.37.4.10188",
+                      "templateHash": "8720977001389603483"
                     }
                   },
                   "parameters": {
@@ -47623,8 +47638,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.177.2456",
-                      "templateHash": "109949312866318067"
+                      "version": "0.37.4.10188",
+                      "templateHash": "8720977001389603483"
                     }
                   },
                   "parameters": {
@@ -47670,6 +47685,10 @@
             "failedFeatures": {
               "type": "string",
               "value": "[if(not(empty(parameters('resourceProviders'))), tryGet(if(not(empty(parameters('resourceProviders'))), reference('registerResourceProviders'), null()), 'outputs', 'outputs', 'value', 'failedFeaturesRegistrations'), '')]"
+            },
+            "virtualWanHubConnectionName": {
+              "type": "string",
+              "value": "[variables('virtualWanHubConnectionName')]"
             }
           }
         }
@@ -47721,6 +47740,13 @@
         "description": "The resource providers features that failed to register."
       },
       "value": "[if(not(empty(parameters('resourceProviders'))), coalesce(tryGet(if(or(parameters('subscriptionAliasEnabled'), not(empty(parameters('existingSubscriptionId')))), reference('createSubscriptionResources'), null()), 'outputs', 'failedFeatures', 'value'), ''), '')]"
+    },
+    "virtualWanHubConnectionName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Virtual WAN Hub Connection."
+      },
+      "value": "[coalesce(tryGet(if(or(parameters('subscriptionAliasEnabled'), not(empty(parameters('existingSubscriptionId')))), reference('createSubscriptionResources'), null()), 'outputs', 'virtualWanHubConnectionName', 'value'), '')]"
     }
   }
 }

--- a/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
+++ b/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
@@ -572,6 +572,7 @@ module createResourceGroupForLzNetworking 'br/public:avm/res/resources/resource-
           name: 'CanNotDelete'
         }
       : null
+    tags: virtualNetworkResourceGroupTags
     enableTelemetry: enableTelemetry
   }
 }
@@ -588,6 +589,7 @@ module createResourceGroupForIdentities 'br/public:avm/res/resources/resource-gr
           name: 'CanNotDelete'
         }
       : null
+    tags: subscriptionTags
     enableTelemetry: enableTelemetry
   }
 }
@@ -1341,6 +1343,7 @@ module createResourceGroupForDeploymentScript 'br/public:avm/res/resources/resou
   params: {
     name: deploymentScriptResourceGroupName
     location: deploymentScriptLocation
+    tags: subscriptionTags
     enableTelemetry: enableTelemetry
   }
 }
@@ -1351,6 +1354,7 @@ module createResourceGroupForRouteTables 'br/public:avm/res/resources/resource-g
   params: {
     name: routeTablesResourceGroupName
     location: virtualNetworkLocation ?? deployment().location
+    tags: virtualNetworkResourceGroupTags
     enableTelemetry: enableTelemetry
   }
 }
@@ -1672,6 +1676,7 @@ module createResourceGroupForAdditionalLzNetworking 'br/public:avm/res/resources
             name: 'CanNotDelete'
           }
         : null
+      tags: virtualNetworkResourceGroupTags
       enableTelemetry: enableTelemetry
     }
   }
@@ -1809,6 +1814,8 @@ output failedProviders string = !empty(resourceProviders)
 output failedFeatures string = !empty(resourceProviders)
   ? registerResourceProviders.?outputs.outputs.failedFeaturesRegistrations
   : ''
+
+output virtualWanHubConnectionName string = virtualWanHubConnectionName
 
 // ================ //
 // Definitions      //


### PR DESCRIPTION
## Description

- Added output to virtual WAN hub connection name
- Added tags to all created resource groups

fixes #5711 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
|[![avm.ptn.lz.sub-vending](https://github.com/sebassem/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml/badge.svg?branch=avm/lz/vending/patches)](https://github.com/sebassem/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [X] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [X] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
