### PR TITLE
ci: remove child module allowed list from workflow triggers

### DIFF
--- a/.github/workflows/avm.ptn.aca-lza.hosting-environment.yml
+++ b/.github/workflows/avm.ptn.aca-lza.hosting-environment.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/aca-lza/hosting-environment/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.ai-ml.ai-foundry.yml
+++ b/.github/workflows/avm.ptn.ai-ml.ai-foundry.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/ai-ml/ai-foundry/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.ai-platform.baseline.yml
+++ b/.github/workflows/avm.ptn.ai-platform.baseline.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/ai-platform/baseline/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.alz.empty.yml
+++ b/.github/workflows/avm.ptn.alz.empty.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/alz/empty/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.app-service-lza.hosting-environment.yml
+++ b/.github/workflows/avm.ptn.app-service-lza.hosting-environment.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/app-service-lza/hosting-environment/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.app.container-job-toolkit.yml
+++ b/.github/workflows/avm.ptn.app.container-job-toolkit.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/app/container-job-toolkit/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.app.iaas-vm-cosmosdb-tier4.yml
+++ b/.github/workflows/avm.ptn.app.iaas-vm-cosmosdb-tier4.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/app/iaas-vm-cosmosdb-tier4/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.authorization.pim-role-assignment.yml
+++ b/.github/workflows/avm.ptn.authorization.pim-role-assignment.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/authorization/pim-role-assignment/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.authorization.policy-assignment.yml
+++ b/.github/workflows/avm.ptn.authorization.policy-assignment.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/authorization/policy-assignment/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.authorization.policy-exemption.yml
+++ b/.github/workflows/avm.ptn.authorization.policy-exemption.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/authorization/policy-exemption/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.authorization.resource-role-assignment.yml
+++ b/.github/workflows/avm.ptn.authorization.resource-role-assignment.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/authorization/resource-role-assignment/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.authorization.role-assignment.yml
+++ b/.github/workflows/avm.ptn.authorization.role-assignment.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/authorization/role-assignment/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.authorization.role-definition.yml
+++ b/.github/workflows/avm.ptn.authorization.role-definition.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/authorization/role-definition/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.azd.acr-container-app.yml
+++ b/.github/workflows/avm.ptn.azd.acr-container-app.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/azd/acr-container-app/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.azd.aks-automatic-cluster.yml
+++ b/.github/workflows/avm.ptn.azd.aks-automatic-cluster.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/azd/aks-automatic-cluster/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.azd.aks.yml
+++ b/.github/workflows/avm.ptn.azd.aks.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/azd/aks/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.azd.apim-api.yml
+++ b/.github/workflows/avm.ptn.azd.apim-api.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/azd/apim-api/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.azd.container-app-upsert.yml
+++ b/.github/workflows/avm.ptn.azd.container-app-upsert.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/azd/container-app-upsert/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.azd.container-apps-stack.yml
+++ b/.github/workflows/avm.ptn.azd.container-apps-stack.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/azd/container-apps-stack/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.azd.insights-dashboard.yml
+++ b/.github/workflows/avm.ptn.azd.insights-dashboard.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/azd/insights-dashboard/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.azd.monitoring.yml
+++ b/.github/workflows/avm.ptn.azd.monitoring.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/azd/monitoring/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.data.private-analytical-workspace.yml
+++ b/.github/workflows/avm.ptn.data.private-analytical-workspace.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/data/private-analytical-workspace/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.deployment-script.import-image-to-acr.yml
+++ b/.github/workflows/avm.ptn.deployment-script.import-image-to-acr.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/deployment-script/import-image-to-acr/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.dev-ops.cicd-agents-and-runners.yml
+++ b/.github/workflows/avm.ptn.dev-ops.cicd-agents-and-runners.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/dev-ops/cicd-agents-and-runners/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.finops-toolkit.finops-hub.yml
+++ b/.github/workflows/avm.ptn.finops-toolkit.finops-hub.yml
@@ -28,6 +28,7 @@ on:
       - "avm/ptn/finops-toolkit/finops-hub/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.lz.sub-vending.yml
+++ b/.github/workflows/avm.ptn.lz.sub-vending.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/lz/sub-vending/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.mgmt-groups.subscription-placement.yml
+++ b/.github/workflows/avm.ptn.mgmt-groups.subscription-placement.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/mgmt-groups/subscription-placement/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.network.hub-networking.yml
+++ b/.github/workflows/avm.ptn.network.hub-networking.yml
@@ -31,6 +31,7 @@ on:
       - "avm/ptn/network/hub-networking/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 env:
   modulePath: "avm/ptn/network/hub-networking"

--- a/.github/workflows/avm.ptn.network.private-link-private-dns-zones.yml
+++ b/.github/workflows/avm.ptn.network.private-link-private-dns-zones.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/network/private-link-private-dns-zones/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.policy-insights.remediation.yml
+++ b/.github/workflows/avm.ptn.policy-insights.remediation.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/policy-insights/remediation/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.sa.content-processing.yml
+++ b/.github/workflows/avm.ptn.sa.content-processing.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/sa/content-processing/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.sa.conversation-knowledge-mining.yml
+++ b/.github/workflows/avm.ptn.sa.conversation-knowledge-mining.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/sa/conversation-knowledge-mining/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.sa.modernize-your-code.yml
+++ b/.github/workflows/avm.ptn.sa.modernize-your-code.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/azd/ml-hub-dependencies/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.sa.multi-agent-custom-automation-engine.yml
+++ b/.github/workflows/avm.ptn.sa.multi-agent-custom-automation-engine.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/sa/multi-agent-custom-automation-engine/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.security.security-center.yml
+++ b/.github/workflows/avm.ptn.security.security-center.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/security/security-center/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.subscription.service-health-alerts.yml
+++ b/.github/workflows/avm.ptn.subscription.service-health-alerts.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/subscription/service-health-alerts/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml
+++ b/.github/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/virtual-machine-images/azure-image-builder/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.aad.domain-service.yml
+++ b/.github/workflows/avm.res.aad.domain-service.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/aad/domain-service/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.alerts-management.action-rule.yml
+++ b/.github/workflows/avm.res.alerts-management.action-rule.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/alerts-management/action-rule/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/analysis-services/server/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.api-management.service.yml
+++ b/.github/workflows/avm.res.api-management.service.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/api-management/service/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.app-configuration.configuration-store.yml
+++ b/.github/workflows/avm.res.app-configuration.configuration-store.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/app-configuration/configuration-store/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.app.container-app.yml
+++ b/.github/workflows/avm.res.app.container-app.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/app/container-app/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.app.job.yml
+++ b/.github/workflows/avm.res.app.job.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/app/job/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.app.managed-environment.yml
+++ b/.github/workflows/avm.res.app.managed-environment.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/app/managed-environment/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.app.session-pool.yml
+++ b/.github/workflows/avm.res.app.session-pool.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/app/session-pool/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.authorization.role-assignment.yml
+++ b/.github/workflows/avm.res.authorization.role-assignment.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/authorization/role-assignment/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.automation.automation-account.yml
+++ b/.github/workflows/avm.res.automation.automation-account.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/automation/automation-account/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.azure-stack-hci.cluster.yml
+++ b/.github/workflows/avm.res.azure-stack-hci.cluster.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/azure-stack-hci/cluster/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.azure-stack-hci.logical-network.yml
+++ b/.github/workflows/avm.res.azure-stack-hci.logical-network.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/azure-stack-hci/logical-network/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.azure-stack-hci.network-interface.yml
+++ b/.github/workflows/avm.res.azure-stack-hci.network-interface.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/azure-stack-hci/network-interface/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.azure-stack-hci.virtual-hard-disk.yml
+++ b/.github/workflows/avm.res.azure-stack-hci.virtual-hard-disk.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/azure-stack-hci/virtual-hard-disk/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.batch.batch-account.yml
+++ b/.github/workflows/avm.res.batch.batch-account.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/batch/batch-account/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.cache.redis-enterprise.yml
+++ b/.github/workflows/avm.res.cache.redis-enterprise.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/cache/redis-enterprise/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.cache.redis.yml
+++ b/.github/workflows/avm.res.cache.redis.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/cache/redis/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.cdn.profile.yml
+++ b/.github/workflows/avm.res.cdn.profile.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/cdn/profile/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.cognitive-services.account.yml
+++ b/.github/workflows/avm.res.cognitive-services.account.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/cognitive-services/account/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.communication.communication-service.yml
+++ b/.github/workflows/avm.res.communication.communication-service.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/communication/communication-service/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.communication.email-service.yml
+++ b/.github/workflows/avm.res.communication.email-service.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/communication/email-service/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.compute.availability-set.yml
+++ b/.github/workflows/avm.res.compute.availability-set.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/compute/availability-set/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.compute.disk-encryption-set.yml
+++ b/.github/workflows/avm.res.compute.disk-encryption-set.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/compute/disk-encryption-set/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.compute.disk.yml
+++ b/.github/workflows/avm.res.compute.disk.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/compute/disk/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.compute.gallery.yml
+++ b/.github/workflows/avm.res.compute.gallery.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/compute/gallery/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.compute.image.yml
+++ b/.github/workflows/avm.res.compute.image.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/compute/image/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.compute.proximity-placement-group.yml
+++ b/.github/workflows/avm.res.compute.proximity-placement-group.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/compute/proximity-placement-group/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.compute.ssh-public-key.yml
+++ b/.github/workflows/avm.res.compute.ssh-public-key.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/compute/ssh-public-key/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.compute.virtual-machine-scale-set.yml
+++ b/.github/workflows/avm.res.compute.virtual-machine-scale-set.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/compute/virtual-machine-scale-set/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.compute.virtual-machine.yml
+++ b/.github/workflows/avm.res.compute.virtual-machine.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/compute/virtual-machine/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.consumption.budget.yml
+++ b/.github/workflows/avm.res.consumption.budget.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/consumption/budget/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.container-instance.container-group.yml
+++ b/.github/workflows/avm.res.container-instance.container-group.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/container-instance/container-group/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.container-registry.registry.yml
+++ b/.github/workflows/avm.res.container-registry.registry.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/container-registry/registry/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.container-service.managed-cluster.yml
+++ b/.github/workflows/avm.res.container-service.managed-cluster.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/container-service/managed-cluster/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.data-factory.factory.yml
+++ b/.github/workflows/avm.res.data-factory.factory.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/data-factory/factory/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.data-protection.backup-vault.yml
+++ b/.github/workflows/avm.res.data-protection.backup-vault.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/data-protection/backup-vault/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.databricks.access-connector.yml
+++ b/.github/workflows/avm.res.databricks.access-connector.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/databricks/access-connector/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.databricks.workspace.yml
+++ b/.github/workflows/avm.res.databricks.workspace.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/databricks/workspace/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.db-for-my-sql.flexible-server.yml
+++ b/.github/workflows/avm.res.db-for-my-sql.flexible-server.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/db-for-my-sql/flexible-server/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.db-for-postgre-sql.flexible-server.yml
+++ b/.github/workflows/avm.res.db-for-postgre-sql.flexible-server.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/db-for-postgre-sql/flexible-server/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.desktop-virtualization.application-group.yml
+++ b/.github/workflows/avm.res.desktop-virtualization.application-group.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/desktop-virtualization/application-group/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.desktop-virtualization.host-pool.yml
+++ b/.github/workflows/avm.res.desktop-virtualization.host-pool.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/desktop-virtualization/host-pool/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.desktop-virtualization.scaling-plan.yml
+++ b/.github/workflows/avm.res.desktop-virtualization.scaling-plan.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/desktop-virtualization/scaling-plan/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.desktop-virtualization.workspace.yml
+++ b/.github/workflows/avm.res.desktop-virtualization.workspace.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/desktop-virtualization/workspace/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.dev-center.devcenter.yml
+++ b/.github/workflows/avm.res.dev-center.devcenter.yml
@@ -32,6 +32,7 @@ on:
       - "avm/ptn/azd/ml-ai-environment/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.dev-center.network-connection.yml
+++ b/.github/workflows/avm.res.dev-center.network-connection.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/dev-center/network-connection/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.dev-center.project.yml
+++ b/.github/workflows/avm.res.dev-center.project.yml
@@ -32,6 +32,7 @@ on:
       - avm/res/dev-center/project/**
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.dev-ops-infrastructure.pool.yml
+++ b/.github/workflows/avm.res.dev-ops-infrastructure.pool.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/dev-ops-infrastructure/pool/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.dev-test-lab.lab.yml
+++ b/.github/workflows/avm.res.dev-test-lab.lab.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/dev-test-lab/lab/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.digital-twins.digital-twins-instance.yml
+++ b/.github/workflows/avm.res.digital-twins.digital-twins-instance.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/digital-twins/digital-twins-instance/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.document-db.database-account.yml
+++ b/.github/workflows/avm.res.document-db.database-account.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/document-db/database-account/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.document-db.mongo-cluster.yml
+++ b/.github/workflows/avm.res.document-db.mongo-cluster.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/document-db/mongo-cluster/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.elastic-san.elastic-san.yml
+++ b/.github/workflows/avm.res.elastic-san.elastic-san.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/elastic-san/elastic-san/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.event-grid.domain.yml
+++ b/.github/workflows/avm.res.event-grid.domain.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/event-grid/domain/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.event-grid.namespace.yml
+++ b/.github/workflows/avm.res.event-grid.namespace.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/event-grid/namespace/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.event-grid.system-topic.yml
+++ b/.github/workflows/avm.res.event-grid.system-topic.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/event-grid/system-topic/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.event-grid.topic.yml
+++ b/.github/workflows/avm.res.event-grid.topic.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/event-grid/topic/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.event-hub.namespace.yml
+++ b/.github/workflows/avm.res.event-hub.namespace.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/event-hub/namespace/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.fabric.capacity.yml
+++ b/.github/workflows/avm.res.fabric.capacity.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/fabric/capacity/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.health-bot.health-bot.yml
+++ b/.github/workflows/avm.res.health-bot.health-bot.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/health-bot/health-bot/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.healthcare-apis.workspace.yml
+++ b/.github/workflows/avm.res.healthcare-apis.workspace.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/healthcare-apis/workspace/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.hybrid-compute.gateway.yml
+++ b/.github/workflows/avm.res.hybrid-compute.gateway.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/hybrid-compute/gateway/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.hybrid-compute.license.yml
+++ b/.github/workflows/avm.res.hybrid-compute.license.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/hybrid-compute/license/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.hybrid-compute.machine.yml
+++ b/.github/workflows/avm.res.hybrid-compute.machine.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/hybrid-compute/machine/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.hybrid-container-service.provisioned-cluster-instance.yml
+++ b/.github/workflows/avm.res.hybrid-container-service.provisioned-cluster-instance.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/hybrid-container-service/provisioned-cluster-instance/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.insights.action-group.yml
+++ b/.github/workflows/avm.res.insights.action-group.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/insights/action-group/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.insights.activity-log-alert.yml
+++ b/.github/workflows/avm.res.insights.activity-log-alert.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/insights/activity-log-alert/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.insights.component.yml
+++ b/.github/workflows/avm.res.insights.component.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/insights/component/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.insights.data-collection-endpoint.yml
+++ b/.github/workflows/avm.res.insights.data-collection-endpoint.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/insights/data-collection-endpoint/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.insights.data-collection-rule.yml
+++ b/.github/workflows/avm.res.insights.data-collection-rule.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/insights/data-collection-rule/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.insights.diagnostic-setting.yml
+++ b/.github/workflows/avm.res.insights.diagnostic-setting.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/insights/diagnostic-setting/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.insights.metric-alert.yml
+++ b/.github/workflows/avm.res.insights.metric-alert.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/insights/metric-alert/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.insights.private-link-scope.yml
+++ b/.github/workflows/avm.res.insights.private-link-scope.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/insights/private-link-scope/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.insights.scheduled-query-rule.yml
+++ b/.github/workflows/avm.res.insights.scheduled-query-rule.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/insights/scheduled-query-rule/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.insights.webtest.yml
+++ b/.github/workflows/avm.res.insights.webtest.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/insights/webtest/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.key-vault.vault.yml
+++ b/.github/workflows/avm.res.key-vault.vault.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/key-vault/vault/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.kubernetes-configuration.extension.yml
+++ b/.github/workflows/avm.res.kubernetes-configuration.extension.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/kubernetes-configuration/extension/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.kubernetes-configuration.flux-configuration.yml
+++ b/.github/workflows/avm.res.kubernetes-configuration.flux-configuration.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/kubernetes-configuration/flux-configuration/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.kubernetes.connected-cluster.yml
+++ b/.github/workflows/avm.res.kubernetes.connected-cluster.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/kubernetes/connected-cluster/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.kusto.cluster.yml
+++ b/.github/workflows/avm.res.kusto.cluster.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/kusto/cluster/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.load-test-service.load-test.yml
+++ b/.github/workflows/avm.res.load-test-service.load-test.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/load-test-service/load-test/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.logic.workflow.yml
+++ b/.github/workflows/avm.res.logic.workflow.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/logic/workflow/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.machine-learning-services.registry.yml
+++ b/.github/workflows/avm.res.machine-learning-services.registry.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/machine-learning-services/registry/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.machine-learning-services.workspace.yml
+++ b/.github/workflows/avm.res.machine-learning-services.workspace.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/machine-learning-services/workspace/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.maintenance.configuration-assignment.yml
+++ b/.github/workflows/avm.res.maintenance.configuration-assignment.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/maintenance/configuration-assignment/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.maintenance.maintenance-configuration.yml
+++ b/.github/workflows/avm.res.maintenance.maintenance-configuration.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/maintenance/maintenance-configuration/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.managed-identity.user-assigned-identity.yml
+++ b/.github/workflows/avm.res.managed-identity.user-assigned-identity.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/managed-identity/user-assigned-identity/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.managed-services.registration-definition.yml
+++ b/.github/workflows/avm.res.managed-services.registration-definition.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/managed-services/registration-definition/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.management.management-group.yml
+++ b/.github/workflows/avm.res.management.management-group.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/management/management-group/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.maps.account.yml
+++ b/.github/workflows/avm.res.maps.account.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/maps/account/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.net-app.net-app-account.yml
+++ b/.github/workflows/avm.res.net-app.net-app-account.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/net-app/net-app-account/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.application-gateway-web-application-firewall-policy.yml
+++ b/.github/workflows/avm.res.network.application-gateway-web-application-firewall-policy.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/application-gateway-web-application-firewall-policy/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.application-gateway.yml
+++ b/.github/workflows/avm.res.network.application-gateway.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/application-gateway/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.application-security-group.yml
+++ b/.github/workflows/avm.res.network.application-security-group.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/application-security-group/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.azure-firewall.yml
+++ b/.github/workflows/avm.res.network.azure-firewall.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/azure-firewall/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.bastion-host.yml
+++ b/.github/workflows/avm.res.network.bastion-host.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/bastion-host/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.connection.yml
+++ b/.github/workflows/avm.res.network.connection.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/connection/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.ddos-protection-plan.yml
+++ b/.github/workflows/avm.res.network.ddos-protection-plan.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/ddos-protection-plan/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.dns-forwarding-ruleset.yml
+++ b/.github/workflows/avm.res.network.dns-forwarding-ruleset.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/dns-forwarding-ruleset/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.dns-resolver.yml
+++ b/.github/workflows/avm.res.network.dns-resolver.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/dns-resolver/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.dns-zone.yml
+++ b/.github/workflows/avm.res.network.dns-zone.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/dns-zone/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.express-route-circuit.yml
+++ b/.github/workflows/avm.res.network.express-route-circuit.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/express-route-circuit/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.express-route-gateway.yml
+++ b/.github/workflows/avm.res.network.express-route-gateway.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/express-route-gateway/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.express-route-port.yml
+++ b/.github/workflows/avm.res.network.express-route-port.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/express-route-port/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.firewall-policy.yml
+++ b/.github/workflows/avm.res.network.firewall-policy.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/firewall-policy/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.front-door-web-application-firewall-policy.yml
+++ b/.github/workflows/avm.res.network.front-door-web-application-firewall-policy.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/front-door-web-application-firewall-policy/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.ip-group.yml
+++ b/.github/workflows/avm.res.network.ip-group.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/ip-group/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.load-balancer.yml
+++ b/.github/workflows/avm.res.network.load-balancer.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/load-balancer/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.local-network-gateway.yml
+++ b/.github/workflows/avm.res.network.local-network-gateway.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/local-network-gateway/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.nat-gateway.yml
+++ b/.github/workflows/avm.res.network.nat-gateway.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/nat-gateway/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.network-interface.yml
+++ b/.github/workflows/avm.res.network.network-interface.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/network-interface/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.network-manager.yml
+++ b/.github/workflows/avm.res.network.network-manager.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/network-manager/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.network-security-group.yml
+++ b/.github/workflows/avm.res.network.network-security-group.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/network-security-group/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.network-security-perimeter.yml
+++ b/.github/workflows/avm.res.network.network-security-perimeter.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/network-security-perimeter/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.network-watcher.yml
+++ b/.github/workflows/avm.res.network.network-watcher.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/network-watcher/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.p2s-vpn-gateway.yml
+++ b/.github/workflows/avm.res.network.p2s-vpn-gateway.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/p2s-vpn-gateway/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.private-dns-zone.yml
+++ b/.github/workflows/avm.res.network.private-dns-zone.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/private-dns-zone/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.private-endpoint.yml
+++ b/.github/workflows/avm.res.network.private-endpoint.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/private-endpoint/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.private-link-service.yml
+++ b/.github/workflows/avm.res.network.private-link-service.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/private-link-service/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.public-ip-address.yml
+++ b/.github/workflows/avm.res.network.public-ip-address.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/public-ip-address/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.public-ip-prefix.yml
+++ b/.github/workflows/avm.res.network.public-ip-prefix.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/public-ip-prefix/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.route-table.yml
+++ b/.github/workflows/avm.res.network.route-table.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/route-table/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.service-endpoint-policy.yml
+++ b/.github/workflows/avm.res.network.service-endpoint-policy.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/service-endpoint-policy/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.trafficmanagerprofile.yml
+++ b/.github/workflows/avm.res.network.trafficmanagerprofile.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/trafficmanagerprofile/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.virtual-hub.yml
+++ b/.github/workflows/avm.res.network.virtual-hub.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/virtual-hub/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.virtual-network-gateway.yml
+++ b/.github/workflows/avm.res.network.virtual-network-gateway.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/virtual-network-gateway/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.virtual-network.yml
+++ b/.github/workflows/avm.res.network.virtual-network.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/virtual-network/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.virtual-wan.yml
+++ b/.github/workflows/avm.res.network.virtual-wan.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/virtual-wan/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.vpn-gateway.yml
+++ b/.github/workflows/avm.res.network.vpn-gateway.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/vpn-gateway/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.vpn-server-configuration.yml
+++ b/.github/workflows/avm.res.network.vpn-server-configuration.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/vpn-server-configuration/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.network.vpn-site.yml
+++ b/.github/workflows/avm.res.network.vpn-site.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/network/vpn-site/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.operational-insights.workspace.yml
+++ b/.github/workflows/avm.res.operational-insights.workspace.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/operational-insights/workspace/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.operations-management.solution.yml
+++ b/.github/workflows/avm.res.operations-management.solution.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/operations-management/solution/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.portal.dashboard.yml
+++ b/.github/workflows/avm.res.portal.dashboard.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/portal/dashboard/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.power-bi-dedicated.capacity.yml
+++ b/.github/workflows/avm.res.power-bi-dedicated.capacity.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/power-bi-dedicated/capacity/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.purview.account.yml
+++ b/.github/workflows/avm.res.purview.account.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/purview/account/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.recovery-services.vault.yml
+++ b/.github/workflows/avm.res.recovery-services.vault.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/recovery-services/vault/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.relay.namespace.yml
+++ b/.github/workflows/avm.res.relay.namespace.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/relay/namespace/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.resource-graph.query.yml
+++ b/.github/workflows/avm.res.resource-graph.query.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/resource-graph/query/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.resources.deployment-script.yml
+++ b/.github/workflows/avm.res.resources.deployment-script.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/resources/deployment-script/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.resources.resource-group.yml
+++ b/.github/workflows/avm.res.resources.resource-group.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/resources/resource-group/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.search.search-service.yml
+++ b/.github/workflows/avm.res.search.search-service.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/search/search-service/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.security-insights.data-connector.yml
+++ b/.github/workflows/avm.res.security-insights.data-connector.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/security-insights/data-connector/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.security-insights.setting.yml
+++ b/.github/workflows/avm.res.security-insights.setting.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/security-insights/setting/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.service-bus.namespace.yml
+++ b/.github/workflows/avm.res.service-bus.namespace.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/service-bus/namespace/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.service-fabric.cluster.yml
+++ b/.github/workflows/avm.res.service-fabric.cluster.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/service-fabric/cluster/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.service-networking.traffic-controller.yml
+++ b/.github/workflows/avm.res.service-networking.traffic-controller.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/service-networking/traffic-controller/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.signal-r-service.signal-r.yml
+++ b/.github/workflows/avm.res.signal-r-service.signal-r.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/signal-r-service/signal-r/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.signal-r-service.web-pub-sub.yml
+++ b/.github/workflows/avm.res.signal-r-service.web-pub-sub.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/signal-r-service/web-pub-sub/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.sql.instance-pool.yml
+++ b/.github/workflows/avm.res.sql.instance-pool.yml
@@ -33,6 +33,7 @@ on:
       - "avm/res/sql/instance-pool/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.sql.managed-instance.yml
+++ b/.github/workflows/avm.res.sql.managed-instance.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/sql/managed-instance/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.sql.server.yml
+++ b/.github/workflows/avm.res.sql.server.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/sql/server/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.storage.storage-account.yml
+++ b/.github/workflows/avm.res.storage.storage-account.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/storage/storage-account/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.synapse.private-link-hub.yml
+++ b/.github/workflows/avm.res.synapse.private-link-hub.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/synapse/private-link-hub/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.synapse.workspace.yml
+++ b/.github/workflows/avm.res.synapse.workspace.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/synapse/workspace/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.virtual-machine-images.image-template.yml
+++ b/.github/workflows/avm.res.virtual-machine-images.image-template.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/virtual-machine-images/image-template/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.web.connection.yml
+++ b/.github/workflows/avm.res.web.connection.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/web/connection/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.web.hosting-environment.yml
+++ b/.github/workflows/avm.res.web.hosting-environment.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/web/hosting-environment/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.web.serverfarm.yml
+++ b/.github/workflows/avm.res.web.serverfarm.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/web/serverfarm/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.web.site.yml
+++ b/.github/workflows/avm.res.web.site.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/web/site/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.res.web.static-site.yml
+++ b/.github/workflows/avm.res.web.static-site.yml
@@ -32,6 +32,7 @@ on:
       - "avm/res/web/static-site/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/.github/workflows/avm.utl.types.avm-common-types.yml
+++ b/.github/workflows/avm.utl.types.avm-common-types.yml
@@ -32,6 +32,7 @@ on:
       - "avm/utl/types/avm-common-types/**"
       - "utilities/pipelines/**"
       - "!utilities/pipelines/platform/**"
+      - "!*/**/child-module-publish-allowed-list.json"
       - "!*/**/README.md"
 
 env:

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -583,6 +583,7 @@ Describe 'Pipeline tests' -Tag 'Pipeline' {
             "$RelativeModulePath/**",
             'utilities/pipelines/**',
             '!utilities/pipelines/platform/**',
+            '!*/**/child-module-publish-allowed-list.json',
             '!*/**/README.md'
         )
 
@@ -606,6 +607,7 @@ Describe 'Pipeline tests' -Tag 'Pipeline' {
             "$RelativeModulePath/**",
             'utilities/pipelines/**',
             '!utilities/pipelines/platform/**',
+            '!*/**/child-module-publish-allowed-list.json',
             '!*/**/README.md'
         )
 


### PR DESCRIPTION
## Description

Exempt child module allowed list from module workflow path filters. This is to avoid triggering all workflows anytime a new child module is allowed for publishing.
Update pipeline Pester tests accordingly.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.analysis-services.server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml/badge.svg?event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
