### PR TITLE
feat: Added support for default data collection rules to operational-insights/workspace

### DIFF
--- a/avm/res/operational-insights/workspace/CHANGELOG.md
+++ b/avm/res/operational-insights/workspace/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/operational-insights/workspace/CHANGELOG.md).
 
-## 0.13
+## 0.13.0
 
 ### Changes
 

--- a/avm/res/operational-insights/workspace/CHANGELOG.md
+++ b/avm/res/operational-insights/workspace/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/operational-insights/workspace/CHANGELOG.md).
 
+## 0.13
+
+### Changes
+
+- Added support for default data collection rules
+
+### Breaking Changes
+
+- None
+
 ## 0.12.1
 
 ### Changes

--- a/avm/res/operational-insights/workspace/README.md
+++ b/avm/res/operational-insights/workspace/README.md
@@ -231,6 +231,7 @@ module workspace 'br/public:avm/res/operational-insights/workspace:<version>' = 
     }
     publicNetworkAccessForIngestion: 'Disabled'
     publicNetworkAccessForQuery: 'Enabled'
+    defaultDataCollectionRuleResourceId: '<defaultDataCollectionRuleResourceId>'
     savedSearches: [
       {
         category: 'VDC Saved Searches'
@@ -2612,6 +2613,7 @@ param tags = {
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`features`](#parameter-features) | object | The workspace features. |
 | [`forceCmkForQuery`](#parameter-forcecmkforquery) | bool | Indicates whether customer managed storage is mandatory for query management. |
+| [`defaultDataCollectionRuleResourceId`](#parameter-defaultDataCollectionRuleResourceId) | string | The resource ID of the default Data Collection Rule to use for this workspace. |
 | [`gallerySolutions`](#parameter-gallerysolutions) | array | List of gallerySolutions to be created in the log analytics workspace. |
 | [`linkedServices`](#parameter-linkedservices) | array | List of services to be linked. |
 | [`location`](#parameter-location) | string | Location for all resources. |
@@ -3105,6 +3107,13 @@ Flag that describes if we want to remove the data after 30 days.
 
 - Required: No
 - Type: bool
+
+### Parameter: `defaultDataCollectionRuleResourceId`
+
+The resource ID of the default Data Collection Rule to use for this workspace.
+
+- Required: No
+- Type: string
 
 ### Parameter: `forceCmkForQuery`
 

--- a/avm/res/operational-insights/workspace/README.md
+++ b/avm/res/operational-insights/workspace/README.md
@@ -231,7 +231,6 @@ module workspace 'br/public:avm/res/operational-insights/workspace:<version>' = 
     }
     publicNetworkAccessForIngestion: 'Disabled'
     publicNetworkAccessForQuery: 'Enabled'
-    defaultDataCollectionRuleResourceId: '<defaultDataCollectionRuleResourceId>'
     savedSearches: [
       {
         category: 'VDC Saved Searches'
@@ -2609,11 +2608,11 @@ param tags = {
 | [`dataExports`](#parameter-dataexports) | array | LAW data export instances to be deployed. |
 | [`dataRetention`](#parameter-dataretention) | int | Number of days data will be retained for. |
 | [`dataSources`](#parameter-datasources) | array | LAW data sources to configure. |
+| [`defaultDataCollectionRuleResourceId`](#parameter-defaultdatacollectionruleresourceid) | string | The resource ID of the default Data Collection Rule to use for this workspace. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`features`](#parameter-features) | object | The workspace features. |
 | [`forceCmkForQuery`](#parameter-forcecmkforquery) | bool | Indicates whether customer managed storage is mandatory for query management. |
-| [`defaultDataCollectionRuleResourceId`](#parameter-defaultDataCollectionRuleResourceId) | string | The resource ID of the default Data Collection Rule to use for this workspace. |
 | [`gallerySolutions`](#parameter-gallerysolutions) | array | List of gallerySolutions to be created in the log analytics workspace. |
 | [`linkedServices`](#parameter-linkedservices) | array | List of services to be linked. |
 | [`location`](#parameter-location) | string | Location for all resources. |
@@ -2902,6 +2901,13 @@ Tags to configure in the resource.
 - Required: No
 - Type: object
 
+### Parameter: `defaultDataCollectionRuleResourceId`
+
+The resource ID of the default Data Collection Rule to use for this workspace.
+
+- Required: No
+- Type: string
+
 ### Parameter: `diagnosticSettings`
 
 The diagnostic settings of the service.
@@ -3107,13 +3113,6 @@ Flag that describes if we want to remove the data after 30 days.
 
 - Required: No
 - Type: bool
-
-### Parameter: `defaultDataCollectionRuleResourceId`
-
-The resource ID of the default Data Collection Rule to use for this workspace.
-
-- Required: No
-- Type: string
 
 ### Parameter: `forceCmkForQuery`
 

--- a/avm/res/operational-insights/workspace/main.bicep
+++ b/avm/res/operational-insights/workspace/main.bicep
@@ -91,6 +91,9 @@ param diagnosticSettings diagnosticSettingType[]?
 @description('Optional. Indicates whether customer managed storage is mandatory for query management.')
 param forceCmkForQuery bool = true
 
+@description('Optional. The resource ID of the default Data Collection Rule to use for this workspace.')
+param defaultDataCollectionRuleResourceId string?
+
 import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
 @description('Optional. The lock settings of the service.')
 param lock lockType?
@@ -214,6 +217,7 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-02
     publicNetworkAccessForQuery: publicNetworkAccessForQuery
     forceCmkForQuery: forceCmkForQuery
     replication: replication
+    defaultDataCollectionRuleResourceId: defaultDataCollectionRuleResourceId
   }
   identity: identity
 }

--- a/avm/res/operational-insights/workspace/main.json
+++ b/avm/res/operational-insights/workspace/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "13983309349104101401"
+      "templateHash": "1141450595918624353"
     },
     "name": "Log Analytics Workspaces",
     "description": "This module deploys a Log Analytics Workspace."
@@ -1171,6 +1171,13 @@
         "description": "Optional. Indicates whether customer managed storage is mandatory for query management."
       }
     },
+    "defaultDataCollectionRuleResourceId": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The resource ID of the default Data Collection Rule to use for this workspace."
+      }
+    },
     "lock": {
       "$ref": "#/definitions/lockType",
       "nullable": true,
@@ -1277,7 +1284,8 @@
         "publicNetworkAccessForIngestion": "[parameters('publicNetworkAccessForIngestion')]",
         "publicNetworkAccessForQuery": "[parameters('publicNetworkAccessForQuery')]",
         "forceCmkForQuery": "[parameters('forceCmkForQuery')]",
-        "replication": "[parameters('replication')]"
+        "replication": "[parameters('replication')]",
+        "defaultDataCollectionRuleResourceId": "[parameters('defaultDataCollectionRuleResourceId')]"
       },
       "identity": "[variables('identity')]"
     },

--- a/avm/res/operational-insights/workspace/version.json
+++ b/avm/res/operational-insights/workspace/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.12"
+  "version": "0.13"
 }


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #123
-->

- New parameter `defaultDataCollectionRuleResourceId` has been added to the avm/res/operational-insights/workspace module to support adding default data collection rules to workspaces.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
