### PR TITLE
fix: Correctly pass `parametersMerged` to policy assignment pattern module at all scopes

### DIFF
--- a/avm/ptn/authorization/policy-assignment/CHANGELOG.md
+++ b/avm/ptn/authorization/policy-assignment/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/policy-assignment/CHANGELOG.md).
 
+## 0.5.1
+
+### Changes
+
+- Fixed bug where `parameterOverrides` was not being correctly passed to the policy assignment module for some scopes (subscription & resource group).
+
+### Breaking Changes
+
+- None
+
 ## 0.5.0
 
 ### Changes

--- a/avm/ptn/authorization/policy-assignment/main.bicep
+++ b/avm/ptn/authorization/policy-assignment/main.bicep
@@ -146,7 +146,7 @@ module policyAssignment_sub 'modules/subscription.bicep' = if (!empty(subscripti
     policyDefinitionId: policyDefinitionId
     displayName: !empty(displayName) ? displayName : ''
     description: !empty(description) ? description : ''
-    parameters: !empty(parameters) ? parameters : {}
+    parameters: !empty(parametersMerged) ? parametersMerged : {}
     identity: identity
     userAssignedIdentityId: userAssignedIdentityId
     roleDefinitionIds: !empty(roleDefinitionIds) ? roleDefinitionIds : []
@@ -170,7 +170,7 @@ module policyAssignment_rg 'modules/resource-group.bicep' = if (!empty(resourceG
     policyDefinitionId: policyDefinitionId
     displayName: !empty(displayName) ? displayName : ''
     description: !empty(description) ? description : ''
-    parameters: !empty(parameters) ? parameters : {}
+    parameters: !empty(parametersMerged) ? parametersMerged : {}
     identity: identity
     userAssignedIdentityId: userAssignedIdentityId
     roleDefinitionIds: !empty(roleDefinitionIds) ? roleDefinitionIds : []

--- a/avm/ptn/authorization/policy-assignment/main.json
+++ b/avm/ptn/authorization/policy-assignment/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "1195510837296458963"
+      "templateHash": "3078997291416932467"
     },
     "name": "Policy Assignments (All scopes)",
     "description": "This module deploys a Policy Assignment at a Management Group, Subscription or Resource Group scope."
@@ -987,7 +987,7 @@
           },
           "displayName": "[if(not(empty(parameters('displayName'))), createObject('value', parameters('displayName')), createObject('value', ''))]",
           "description": "[if(not(empty(parameters('description'))), createObject('value', parameters('description')), createObject('value', ''))]",
-          "parameters": "[if(not(empty(parameters('parameters'))), createObject('value', parameters('parameters')), createObject('value', createObject()))]",
+          "parameters": "[if(not(empty(variables('parametersMerged'))), createObject('value', variables('parametersMerged')), createObject('value', createObject()))]",
           "identity": {
             "value": "[parameters('identity')]"
           },
@@ -1253,7 +1253,7 @@
           },
           "displayName": "[if(not(empty(parameters('displayName'))), createObject('value', parameters('displayName')), createObject('value', ''))]",
           "description": "[if(not(empty(parameters('description'))), createObject('value', parameters('description')), createObject('value', ''))]",
-          "parameters": "[if(not(empty(parameters('parameters'))), createObject('value', parameters('parameters')), createObject('value', createObject()))]",
+          "parameters": "[if(not(empty(variables('parametersMerged'))), createObject('value', variables('parametersMerged')), createObject('value', createObject()))]",
           "identity": {
             "value": "[parameters('identity')]"
           },


### PR DESCRIPTION
## Description

fix: Correctly pass `parametersMerged` to policy assignment pattern module at all scopes. Was missing sub and RG scope

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.ptn.authorization.policy-assignment](https://github.com/jtracey93/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-assignment.yml/badge.svg?branch=fix%2Fpol-asi-typo)](https://github.com/jtracey93/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-assignment.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
