### PR TITLE
fix: CI - Switch to explicit hashes during `diff` comparison

### DIFF
--- a/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
+++ b/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
@@ -35,7 +35,7 @@ function Get-ModifiedFileList {
     }
 
     if ($diff.Count -gt 0) {
-        Write-Verbose ("[{0}] Plain diff files found `git diff`:`n[{1}]" -f $diff.Count, ($diff.FullName | ConvertTo-Json | Out-String)) -Verbose
+        Write-Verbose ("[{0}] Plain diff files found `git diff`:`n[{1}]" -f $diff.Count, ($diff | ConvertTo-Json | Out-String)) -Verbose
     } else {
         Write-Verbose 'Plain diff files found via `git diff`.' -Verbose
     }

--- a/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
+++ b/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
@@ -19,6 +19,7 @@ function Get-ModifiedFileList {
 
     git remote add 'upstream' 'https://github.com/Azure/bicep-registry-modules.git' 2>$null # Add remote source if not already added
     git fetch 'upstream' 'main' -q # Fetch the latest changes from upstream main
+    Start-Sleep 5 # Wait for git to finish fetching
     $currentBranch = Get-GitBranchName
     $inUpstream = (git remote get-url origin) -match '\/Azure\/' # If in upstream the value would be [https://github.com/Azure/bicep-registry-modules.git]
 


### PR DESCRIPTION
## Description

Switch to explicit hashes during `diff` comparison

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
