### PR TITLE
fix: CI - Added retry to git fetch

### DIFF
--- a/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
+++ b/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
@@ -26,11 +26,17 @@ function Get-ModifiedFileList {
         $currentCommit = git rev-parse 'main' # Get the current main's commit
         $previousCommit = git rev-parse 'upstream/main^' # Get the previous main's commit in upstream
 
+        $retryCount = 0
         while ($currentCommit -eq $previousCommit) {
             Write-Warning 'Current and previous commits are the same. Trying again'
             git fetch 'upstream' 'main' -q # Fetch the latest changes from upstream main
             Start-Sleep 5 # Wait for git to finish fetching
             $previousCommit = git rev-parse 'upstream/main^' # Get the previous main's commit in upstream
+
+            if ($retryCount -ge 5) {
+                throw 'Failed to get a different previous commit after 5 retries. Exiting.'
+            }
+            $retryCount++
         }
 
         Write-Verbose ('Currently in upstream [main]. Fetching changes of current commit [{0}] against [main^-1] [{1}].' -f $currentCommit.Substring(0, 7), $previousCommit.Substring(0, 7)) -Verbose
@@ -39,11 +45,17 @@ function Get-ModifiedFileList {
         $currentCommit = git rev-parse --short=8 'HEAD' # Get the current commit
         $currentUpstreamCommit = git rev-parse 'upstream/main' # Get the previous main's commit in upstream
 
+        $retryCount = 0
         while ($currentCommit -eq $currentUpstreamCommit) {
             Write-Warning 'Current and commit and upstream main are the same. Trying again'
             git fetch 'upstream' 'main' -q # Fetch the latest changes from upstream main
             Start-Sleep 5 # Wait for git to finish fetching
             $currentUpstreamCommit = git rev-parse 'upstream/main' # Get the previous main's commit in upstream
+
+            if ($retryCount -ge 5) {
+                throw 'Failed to get a different previous commit after 5 retries. Exiting.'
+            }
+            $retryCount++
         }
         Write-Verbose ('{0} Fetching changes of current commit [{1}] against upstream [main] [{2}]' -f ($inUpstream ? "Currently in upstream [$currentBranch]." : 'Currently in a fork.'), $currentCommit.Substring(0, 7), $currentUpstreamCommit.Substring(0, 7)) -Verbose
         $diff = git diff --name-only --diff-filter=AM $currentUpstreamCommit

--- a/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
+++ b/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
@@ -23,7 +23,6 @@ function Get-ModifiedFileList {
 
     # Note: Fetches only the name of the modified files
     if ($inUpstream -and $currentBranch -eq 'main') {
-
         $currentCommit = git rev-parse 'main' # Get the current main's commit
         $previousCommit = git rev-parse 'upstream/main^' # Get the previous main's commit in upstream
 

--- a/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
+++ b/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
@@ -35,9 +35,9 @@ function Get-ModifiedFileList {
         }
 
         Write-Verbose ('Currently in upstream [main]. Fetching changes of current commit [{0}] against [main^-1] [{1}].' -f $currentCommit.Substring(0, 7), $previousCommit.Substring(0, 7)) -Verbose
-        $diff = git diff --name-only --diff-filter=AM $currentCommit $previousCommit
+        $diff = git diff --name-only --diff-filter=AM $previousCommit
     } else {
-        $currentCommit = git rev-parse 'main' # Get the current main's commit
+        $currentCommit = git rev-parse --short=8 'HEAD' # Get the current main's commit
         $currentUpstreamCommit = git rev-parse 'upstream/main' # Get the previous main's commit in upstream
 
         while ($currentCommit -eq $currentUpstreamCommit) {
@@ -47,7 +47,7 @@ function Get-ModifiedFileList {
             $currentUpstreamCommit = git rev-parse 'upstream/main' # Get the previous main's commit in upstream
         }
         Write-Verbose ('{0} Fetching changes of current commit [{1}] against upstream [main] [{2}]' -f ($inUpstream ? "Currently in upstream [$currentBranch]." : 'Currently in a fork.'), $currentCommit.Substring(0, 7), $currentUpstreamCommit.Substring(0, 7)) -Verbose
-        $diff = git diff --name-only --diff-filter=AM $currentCommit $currentUpstreamCommit
+        $diff = git diff --name-only --diff-filter=AM $currentUpstreamCommit
     }
 
     if ($diff.Count -gt 0) {

--- a/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
+++ b/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
@@ -18,20 +18,36 @@ Get modified files between previous and current commit depending on if you are r
 function Get-ModifiedFileList {
 
     git remote add 'upstream' 'https://github.com/Azure/bicep-registry-modules.git' 2>$null # Add remote source if not already added
-    git fetch 'upstream' 'main' -q # Fetch the latest changes from upstream main
-    Start-Sleep 5 # Wait for git to finish fetching
     $currentBranch = Get-GitBranchName
     $inUpstream = (git remote get-url origin) -match '\/Azure\/' # If in upstream the value would be [https://github.com/Azure/bicep-registry-modules.git]
 
     # Note: Fetches only the name of the modified files
     if ($inUpstream -and $currentBranch -eq 'main') {
+
         $currentCommit = git rev-parse 'main' # Get the current main's commit
         $previousCommit = git rev-parse 'upstream/main^' # Get the previous main's commit in upstream
+
+        while ($currentCommit -eq $previousCommit) {
+            Write-Warning 'Current and previous commits are the same. Trying again'
+            git fetch 'upstream' 'main' -q # Fetch the latest changes from upstream main
+            Start-Sleep 5 # Wait for git to finish fetching
+            $previousCommit = git rev-parse 'upstream/main^' # Get the previous main's commit in upstream
+        }
+
         Write-Verbose ('Currently in upstream [main]. Fetching changes of current commit [{0}] against [main^-1] [{1}].' -f $currentCommit.Substring(0, 7), $previousCommit.Substring(0, 7)) -Verbose
         $diff = git diff --name-only --diff-filter=AM $currentCommit $previousCommit
     } else {
-        Write-Verbose ('{0} Fetching changes against upstream [main]' -f ($inUpstream ? "Currently in upstream [$currentBranch]." : 'Currently in a fork.')) -Verbose
-        $diff = git diff --name-only --diff-filter=AM 'upstream/main'
+        $currentCommit = git rev-parse 'main' # Get the current main's commit
+        $currentUpstreamCommit = git rev-parse 'upstream/main' # Get the previous main's commit in upstream
+
+        while ($currentCommit -eq $currentUpstreamCommit) {
+            Write-Warning 'Current and commit and upstream main are the same. Trying again'
+            git fetch 'upstream' 'main' -q # Fetch the latest changes from upstream main
+            Start-Sleep 5 # Wait for git to finish fetching
+            $currentUpstreamCommit = git rev-parse 'upstream/main' # Get the previous main's commit in upstream
+        }
+        Write-Verbose ('{0} Fetching changes of current commit [{1}] against upstream [main] [{2}]' -f ($inUpstream ? "Currently in upstream [$currentBranch]." : 'Currently in a fork.'), $currentCommit.Substring(0, 7), $currentUpstreamCommit.Substring(0, 7)) -Verbose
+        $diff = git diff --name-only --diff-filter=AM $currentCommit $currentUpstreamCommit
     }
 
     if ($diff.Count -gt 0) {

--- a/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
+++ b/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
@@ -37,7 +37,7 @@ function Get-ModifiedFileList {
         Write-Verbose ('Currently in upstream [main]. Fetching changes of current commit [{0}] against [main^-1] [{1}].' -f $currentCommit.Substring(0, 7), $previousCommit.Substring(0, 7)) -Verbose
         $diff = git diff --name-only --diff-filter=AM $previousCommit
     } else {
-        $currentCommit = git rev-parse --short=8 'HEAD' # Get the current main's commit
+        $currentCommit = git rev-parse --short=8 'HEAD' # Get the current commit
         $currentUpstreamCommit = git rev-parse 'upstream/main' # Get the previous main's commit in upstream
 
         while ($currentCommit -eq $currentUpstreamCommit) {


### PR DESCRIPTION
## Description

Adding a retry to git fetch as it may not always propagate in the expected time frame.

Example:
Failed case: [ref](https://github.com/Azure/bicep-registry-modules/actions/runs/17022323966/job/48257648824#step:4:157)
<img width="800" height="240" alt="image" src="https://github.com/user-attachments/assets/a39ec3ef-1fd7-40ac-bac8-f6f8e4a9dde3" />

Should have been:
<img width="800" height="286" alt="image" src="https://github.com/user-attachments/assets/2ac41d45-2da6-422f-8e08-94d9084307d0" />
of the same PR for a differnt module: [ref](https://github.com/Azure/bicep-registry-modules/actions/runs/17022323977/job/48253445536#step:4:157)

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.analysis-services.server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml/badge.svg?branch=users%2Falsehr%2FfailIfCommitsAreIdentical&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)