### PR TITLE
feat: Common-Types - Added type to `tags` properties

### DIFF
--- a/avm/utl/types/avm-common-types/CHANGELOG.md
+++ b/avm/utl/types/avm-common-types/CHANGELOG.md
@@ -6,7 +6,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Changes
 
-- Added user-defined type to tags
+- Added user-defined type to `tags`
 
 ### Breaking Changes
 

--- a/avm/utl/types/avm-common-types/CHANGELOG.md
+++ b/avm/utl/types/avm-common-types/CHANGELOG.md
@@ -6,7 +6,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Changes
 
-- Added type to tags
+- Added user-defined type to tags
 
 ### Breaking Changes
 

--- a/avm/utl/types/avm-common-types/CHANGELOG.md
+++ b/avm/utl/types/avm-common-types/CHANGELOG.md
@@ -6,7 +6,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Changes
 
-- Added user-defined type to `tags`
+- Added user-defined type to the `tags` property of each private endpoint interface
 
 ### Breaking Changes
 

--- a/avm/utl/types/avm-common-types/CHANGELOG.md
+++ b/avm/utl/types/avm-common-types/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utl/types/avm-common-types/CHANGELOG.md).
 
+## 0.6.1
+
+### Changes
+
+- Added type to tags
+
+### Breaking Changes
+
+- None
+
 ## 0.6.0
 
 ### Changes

--- a/avm/utl/types/avm-common-types/main.bicep
+++ b/avm/utl/types/avm-common-types/main.bicep
@@ -298,6 +298,7 @@ type privateEndpointSingleServiceType = {
 
   @description('Optional. Tags to be applied on all resources/Resource Groups in this deployment.')
   tags: {
+    @description('Optional. A tag key-value pair.')
     *: string
   }?
 
@@ -356,6 +357,7 @@ type privateEndpointMultiServiceType = {
 
   @description('Optional. Tags to be applied on all resources/resource groups in this deployment.')
   tags: {
+    @description('Optional. A tag key-value pair.')
     *: string
   }?
 

--- a/avm/utl/types/avm-common-types/main.bicep
+++ b/avm/utl/types/avm-common-types/main.bicep
@@ -297,7 +297,9 @@ type privateEndpointSingleServiceType = {
   roleAssignments: roleAssignmentType[]?
 
   @description('Optional. Tags to be applied on all resources/Resource Groups in this deployment.')
-  tags: object?
+  tags: {
+    *: string
+  }?
 
   @description('Optional. Enable/Disable usage telemetry for module.')
   enableTelemetry: bool?
@@ -353,7 +355,9 @@ type privateEndpointMultiServiceType = {
   roleAssignments: roleAssignmentType[]?
 
   @description('Optional. Tags to be applied on all resources/resource groups in this deployment.')
-  tags: object?
+  tags: {
+    *: string
+  }?
 
   @description('Optional. Enable/Disable usage telemetry for module.')
   enableTelemetry: bool?

--- a/avm/utl/types/avm-common-types/main.bicep
+++ b/avm/utl/types/avm-common-types/main.bicep
@@ -297,10 +297,7 @@ type privateEndpointSingleServiceType = {
   roleAssignments: roleAssignmentType[]?
 
   @description('Optional. Tags to be applied on all resources/Resource Groups in this deployment.')
-  tags: {
-    @description('Optional. A tag key-value pair.')
-    *: string
-  }?
+  tags: resourceInput<'Microsoft.Network/privateEndpoints@2024-07-01'>.tags?
 
   @description('Optional. Enable/Disable usage telemetry for module.')
   enableTelemetry: bool?
@@ -356,10 +353,7 @@ type privateEndpointMultiServiceType = {
   roleAssignments: roleAssignmentType[]?
 
   @description('Optional. Tags to be applied on all resources/resource groups in this deployment.')
-  tags: {
-    @description('Optional. A tag key-value pair.')
-    *: string
-  }?
+  tags: resourceInput<'Microsoft.Network/privateEndpoints@2024-07-01'>.tags?
 
   @description('Optional. Enable/Disable usage telemetry for module.')
   enableTelemetry: bool?

--- a/avm/utl/types/avm-common-types/main.json
+++ b/avm/utl/types/avm-common-types/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "16941456620664617208"
+      "version": "0.37.4.10188",
+      "templateHash": "366061785232544119"
     },
     "name": "Default interface types for AVM modules",
     "description": "This module provides you with all common variants for AVM interfaces to be used in AVM modules.\n\nDetails for how to implement these interfaces can be found in the AVM documentation [here](https://azure.github.io/Azure-Verified-Modules/specs/bcp/res/interfaces/).\n"
@@ -699,6 +699,10 @@
         },
         "tags": {
           "type": "object",
+          "properties": {},
+          "additionalProperties": {
+            "type": "string"
+          },
           "nullable": true,
           "metadata": {
             "description": "Optional. Tags to be applied on all resources/Resource Groups in this deployment."
@@ -838,6 +842,10 @@
         },
         "tags": {
           "type": "object",
+          "properties": {},
+          "additionalProperties": {
+            "type": "string"
+          },
           "nullable": true,
           "metadata": {
             "description": "Optional. Tags to be applied on all resources/resource groups in this deployment."

--- a/avm/utl/types/avm-common-types/main.json
+++ b/avm/utl/types/avm-common-types/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "366061785232544119"
+      "templateHash": "4786376631151649274"
     },
     "name": "Default interface types for AVM modules",
     "description": "This module provides you with all common variants for AVM interfaces to be used in AVM modules.\n\nDetails for how to implement these interfaces can be found in the AVM documentation [here](https://azure.github.io/Azure-Verified-Modules/specs/bcp/res/interfaces/).\n"
@@ -699,14 +699,13 @@
         },
         "tags": {
           "type": "object",
-          "properties": {},
-          "additionalProperties": {
-            "type": "string"
-          },
-          "nullable": true,
           "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/privateEndpoints@2024-07-01#properties/tags"
+            },
             "description": "Optional. Tags to be applied on all resources/Resource Groups in this deployment."
-          }
+          },
+          "nullable": true
         },
         "enableTelemetry": {
           "type": "bool",
@@ -842,14 +841,13 @@
         },
         "tags": {
           "type": "object",
-          "properties": {},
-          "additionalProperties": {
-            "type": "string"
-          },
-          "nullable": true,
           "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/privateEndpoints@2024-07-01#properties/tags"
+            },
             "description": "Optional. Tags to be applied on all resources/resource groups in this deployment."
-          }
+          },
+          "nullable": true
         },
         "enableTelemetry": {
           "type": "bool",


### PR DESCRIPTION
## Description

Changed the `object` type of each private endpoint interface's `tags` property to use a user-defined type

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.utl.types.avm-common-types](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml/badge.svg?branch=users%2Falsehr%2FtypesObjects&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
