### PR TITLE
fix: Update misspelled type name at 'avm/res/sql/server'

### DIFF
--- a/avm/res/sql/server/main.bicep
+++ b/avm/res/sql/server/main.bicep
@@ -48,7 +48,7 @@ param firewallRules firewallRuleType[]?
 param virtualNetworkRules virtualNetworkRuleType[]?
 
 @description('Optional. The security alert policies to create in the server.')
-param securityAlertPolicies securityAlerPolicyType[]?
+param securityAlertPolicies securityAlertPolicyType[]?
 
 @description('Optional. The keys to configure.')
 param keys keyType[]?
@@ -982,7 +982,7 @@ type virtualNetworkRuleType = {
 
 @export()
 @description('The type for a security alert policy.')
-type securityAlerPolicyType = {
+type securityAlertPolicyType = {
   @description('Required. The name of the Security Alert Policy.')
   name: string
 

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "14482393169612232058"
+      "templateHash": "9457010424663674252"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -848,7 +848,7 @@
         "description": "The type for a virtual network rule."
       }
     },
-    "securityAlerPolicyType": {
+    "securityAlertPolicyType": {
       "type": "object",
       "properties": {
         "name": {
@@ -2050,7 +2050,7 @@
     "securityAlertPolicies": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/securityAlerPolicyType"
+        "$ref": "#/definitions/securityAlertPolicyType"
       },
       "nullable": true,
       "metadata": {


### PR DESCRIPTION
## Description

Fixing the type name of `securityAlertPolicyType`.

Fixes #5743

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.sql.server](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg?branch=5743)](https://github.com/peterbud/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version
