### PR TITLE
fix: CI - Suppressed 'Get-Item' for removed files when resolving a `git diff`

### DIFF
--- a/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
+++ b/utilities/pipelines/publish/helper/Get-ModulesToPublish.ps1
@@ -51,7 +51,7 @@ function Get-ModifiedFileList {
         Write-Verbose 'Plain diff files found via `git diff`.' -Verbose
     }
 
-    $modifiedFiles = $diff | Get-Item -Force
+    $modifiedFiles = $diff | Get-Item -Force -ErrorAction 'SilentlyContinue' # Silently continue to ignore files that were removed
 
     if ($modifiedFiles.Count -gt 0) {
         Write-Verbose ("[{0}] Modified files found `git diff`:`n[{1}]" -f $modifiedFiles.Count, ($modifiedFiles.FullName | ConvertTo-Json | Out-String)) -Verbose


### PR DESCRIPTION
## Description

Suppressed 'Get-Item' for removed files when resolving a `git diff`
As can be seen here: https://github.com/Azure/bicep-registry-modules/actions/runs/17100576210/job/48495769509#step:4:272 without the suppression the workflow may throw some errors.

Successful test **after** the change is introduced: https://github.com/Azure/bicep-registry-modules/actions/runs/17101001188

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
