### PR TITLE
doc: Export peeringType and subnetType to enable intellisense formatting

### DIFF
--- a/avm/res/network/virtual-network/main.bicep
+++ b/avm/res/network/virtual-network/main.bicep
@@ -318,6 +318,7 @@ output location string = virtualNetwork.location
 //   Definitions   //
 // =============== //
 
+@export()
 type peeringType = {
   @description('Optional. The Name of VNET Peering resource. If not provided, default value will be peer-localVnetName-remoteVnetName.')
   name: string?
@@ -362,6 +363,7 @@ type peeringType = {
   remotePeeringUseRemoteGateways: bool?
 }
 
+@export()
 type subnetType = {
   @description('Required. The Name of the subnet resource.')
   name: string


### PR DESCRIPTION
We want to use the vnet module from AVM and have subnetType intellisense. However this is not exported, this PR makes sure the type is exported.


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [X ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
