### PR TITLE
fix: added missing changelog section for peeringType and subnetType

### DIFF
--- a/avm/res/network/virtual-network/CHANGELOG.md
+++ b/avm/res/network/virtual-network/CHANGELOG.md
@@ -4,7 +4,13 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ## 0.7.2
 
+### Changes
+
 - Export peeringType and subnetType to enable intellisense formatting
+
+### Breaking Changes
+
+- None
 
 ## 0.7.1
 


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #123
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [X] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] I have run `Set-AVMModule` locally to generate the supporting module files.
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
