### PR TITLE
fix: Some Bicep issues when trying to deploy ContainerApps

### DIFF
--- a/avm/res/web/site/CHANGELOG.md
+++ b/avm/res/web/site/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/web/site/CHANGELOG.md).
 
+## 0.19.3
+
+### Changes
+
+- Fix `clientAffinityEnabled`, `clientCertMode`, `publicNetworkAccess` for `serverFarmResourceId == ''` case so they aren't given incompatible values when making container functionapp
+- Pass through `managedEnvironmentId` value to assignment as it can be `null`, so no `empty` test needed
+- Change output type of `customDomainVerificationId` to be nullable because the value in `slotType` can be `null`
+
+### Breaking Changes
+
+- None
+
 ## 0.19.2
 
 ### Changes

--- a/avm/res/web/site/main.bicep
+++ b/avm/res/web/site/main.bicep
@@ -265,7 +265,7 @@ resource app 'Microsoft.Web/sites@2024-11-01' = {
   tags: tags
   identity: identity
   properties: {
-    managedEnvironmentId: !empty(managedEnvironmentResourceId) ? managedEnvironmentResourceId : null
+    managedEnvironmentId: managedEnvironmentResourceId
     serverFarmId: contains(managedEnvironmentSupportedKinds, kind) && !empty(managedEnvironmentResourceId)
       ? null
       : serverFarmResourceId

--- a/avm/res/web/site/main.bicep
+++ b/avm/res/web/site/main.bicep
@@ -538,7 +538,7 @@ output location string = app.location
 output defaultHostname string = app.properties.defaultHostName
 
 @description('Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification.')
-output customDomainVerificationId string = app.properties.customDomainVerificationId
+output customDomainVerificationId string? = app.properties.customDomainVerificationId
 
 @description('The outbound IP addresses of the app.')
 output outboundIpAddresses string = app.properties.outboundIpAddresses

--- a/avm/res/web/site/main.bicep
+++ b/avm/res/web/site/main.bicep
@@ -269,7 +269,7 @@ resource app 'Microsoft.Web/sites@2024-11-01' = {
     serverFarmId: contains(managedEnvironmentSupportedKinds, kind) && !empty(managedEnvironmentResourceId)
       ? null
       : serverFarmResourceId
-    clientAffinityEnabled: clientAffinityEnabled
+    clientAffinityEnabled: !empty(serverFarmResourceId) ? clientAffinityEnabled : null
     clientAffinityProxyEnabled: clientAffinityProxyEnabled
     clientAffinityPartitioningEnabled: clientAffinityPartitioningEnabled
     httpsOnly: httpsOnly
@@ -285,7 +285,7 @@ resource app 'Microsoft.Web/sites@2024-11-01' = {
     functionAppConfig: functionAppConfig
     clientCertEnabled: clientCertEnabled
     clientCertExclusionPaths: clientCertExclusionPaths
-    clientCertMode: clientCertMode
+    clientCertMode: !empty(serverFarmResourceId) ? clientCertMode : null
     cloningInfo: cloningInfo
     containerSize: containerSize
     dailyMemoryTimeQuota: dailyMemoryTimeQuota
@@ -293,9 +293,9 @@ resource app 'Microsoft.Web/sites@2024-11-01' = {
     hostNameSslStates: hostNameSslStates
     hyperV: hyperV
     redundancyMode: redundancyMode
-    publicNetworkAccess: !empty(publicNetworkAccess)
-      ? any(publicNetworkAccess)
-      : (!empty(privateEndpoints) ? 'Disabled' : 'Enabled')
+    publicNetworkAccess: !empty(serverFarmResourceId)
+      ? (!empty(publicNetworkAccess) ? any(publicNetworkAccess) : (!empty(privateEndpoints) ? 'Disabled' : 'Enabled'))
+      : null
     scmSiteAlsoStopped: scmSiteAlsoStopped
     endToEndEncryptionEnabled: e2eEncryptionEnabled
     dnsConfiguration: dnsConfiguration

--- a/avm/res/web/site/main.json
+++ b/avm/res/web/site/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "8557212666369750117"
+      "templateHash": "7049129840128232061"
     },
     "name": "Web/Function Apps",
     "description": "This module deploys a Web or Function App."
@@ -5041,9 +5041,9 @@
       "tags": "[parameters('tags')]",
       "identity": "[variables('identity')]",
       "properties": {
-        "managedEnvironmentId": "[if(not(empty(parameters('managedEnvironmentResourceId'))), parameters('managedEnvironmentResourceId'), null())]",
+        "managedEnvironmentId": "[parameters('managedEnvironmentResourceId')]",
         "serverFarmId": "[if(and(contains(variables('managedEnvironmentSupportedKinds'), parameters('kind')), not(empty(parameters('managedEnvironmentResourceId')))), null(), parameters('serverFarmResourceId'))]",
-        "clientAffinityEnabled": "[parameters('clientAffinityEnabled')]",
+        "clientAffinityEnabled": "[if(not(empty(parameters('serverFarmResourceId'))), parameters('clientAffinityEnabled'), null())]",
         "clientAffinityProxyEnabled": "[parameters('clientAffinityProxyEnabled')]",
         "clientAffinityPartitioningEnabled": "[parameters('clientAffinityPartitioningEnabled')]",
         "httpsOnly": "[parameters('httpsOnly')]",
@@ -5055,7 +5055,7 @@
         "functionAppConfig": "[parameters('functionAppConfig')]",
         "clientCertEnabled": "[parameters('clientCertEnabled')]",
         "clientCertExclusionPaths": "[parameters('clientCertExclusionPaths')]",
-        "clientCertMode": "[parameters('clientCertMode')]",
+        "clientCertMode": "[if(not(empty(parameters('serverFarmResourceId'))), parameters('clientCertMode'), null())]",
         "cloningInfo": "[parameters('cloningInfo')]",
         "containerSize": "[parameters('containerSize')]",
         "dailyMemoryTimeQuota": "[parameters('dailyMemoryTimeQuota')]",
@@ -5063,7 +5063,7 @@
         "hostNameSslStates": "[parameters('hostNameSslStates')]",
         "hyperV": "[parameters('hyperV')]",
         "redundancyMode": "[parameters('redundancyMode')]",
-        "publicNetworkAccess": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(not(empty(parameters('privateEndpoints'))), 'Disabled', 'Enabled'))]",
+        "publicNetworkAccess": "[if(not(empty(parameters('serverFarmResourceId'))), if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(not(empty(parameters('privateEndpoints'))), 'Disabled', 'Enabled')), null())]",
         "scmSiteAlsoStopped": "[parameters('scmSiteAlsoStopped')]",
         "endToEndEncryptionEnabled": "[parameters('e2eEncryptionEnabled')]",
         "dnsConfiguration": "[parameters('dnsConfiguration')]",
@@ -12735,6 +12735,7 @@
     },
     "customDomainVerificationId": {
       "type": "string",
+      "nullable": true,
       "metadata": {
         "description": "Unique identifier that verifies the custom domains assigned to the app. Customer will add this ID to a txt record for verification."
       },


### PR DESCRIPTION
## Description

Fixes a couple of incompatibilities when attempting to use the `web/sites` module for deploying a function app in a containerapp environment. The current implementation allows `serverFarmResourceId` to be `''` in order to support ContainerApp rather than App Service Plan deployment. However, this means `clientAffinityEnabled`, `clientCertMode`, and `publicNetworkAccess` should all be `null` as these appear to be handled by the Container App deployment. This module currently attempts to set these to a defined value, which is incompatible and results in a failed deployment.

Similarly, while `customDomainVerificationId` is defined as optional (can be `null`) on input, the output type requires it to be a `string`. These changes also fix this by making the output allowed to be `null` as well.

## Pipeline Status

[![avm.res.web.site](https://github.com/ckane/bicep-registry-modules/actions/workflows/avm.res.web.site.yml/badge.svg?branch=containerapp-issues-ckane)](https://github.com/ckane/bicep-registry-modules/actions/workflows/avm.res.web.site.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
