### PR TITLE
fix: Removed retired `pathFilter` property of diverse `version.json` files 

### DIFF
--- a/avm/res/api-management/service/version.json
+++ b/avm/res/api-management/service/version.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.10",
-  "pathFilters": [
-    "./main.json"
-  ]
+  "version": "0.10"
 }

--- a/avm/res/authorization/role-assignment/mg-scope/version.json
+++ b/avm/res/authorization/role-assignment/mg-scope/version.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1",
-  "pathFilters": [
-    "./main.json"
-  ]
+  "version": "0.1"
 }

--- a/avm/res/authorization/role-assignment/rg-scope/version.json
+++ b/avm/res/authorization/role-assignment/rg-scope/version.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1",
-  "pathFilters": [
-    "./main.json"
-  ]
+  "version": "0.1"
 }

--- a/avm/res/authorization/role-assignment/sub-scope/version.json
+++ b/avm/res/authorization/role-assignment/sub-scope/version.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1",
-  "pathFilters": [
-    "./main.json"
-  ]
+  "version": "0.1"
 }


### PR DESCRIPTION
## Description

Removed retired `pathFilter` property of diverse `version.json` files


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
