### PR TITLE
fix: Expose publicNetworkAccess property to allow enabling/disabling public network access for MongoDB cluster. 

### DIFF
--- a/avm/res/document-db/mongo-cluster/CHANGELOG.md
+++ b/avm/res/document-db/mongo-cluster/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/document-db/mongo-cluster/CHANGELOG.md).
 
+## 0.4.3
+
+### Changes
+
+- Add documentation for the new `publicNetworkAccess` parameter, describing its usage and allowed values in the README.
+
+### Breaking Changes
+
+- None
+
+## 0.4.2
+
+### Changes
+
+- Add `publicNetworkAccess` parameter to enable or disable public network access.
+
+### Breaking Changes
+
+- None
+
 ## 0.4.2
 
 ### Changes

--- a/avm/res/document-db/mongo-cluster/README.md
+++ b/avm/res/document-db/mongo-cluster/README.md
@@ -705,6 +705,7 @@ param tags = {
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`networkAcls`](#parameter-networkacls) | object | IP addresses to allow access to the cluster from. |
 | [`privateEndpoints`](#parameter-privateendpoints) | array | Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. |
+| [`publicNetworkAccess`](#parameter-publicnetworkaccess) | string | Controls public network access to the cluster. Allowed values: "Enabled", "Disabled". |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Tags of the Database Account resource. |
 
@@ -1487,6 +1488,21 @@ Tags to be applied on all resources/Resource Groups in this deployment.
 
 - Required: No
 - Type: object
+
+### Parameter: `publicNetworkAccess`
+
+Controls public network access to the cluster. Allowed values: "Enabled", "Disabled".
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Enabled'
+    'Disabled'
+  ]
+  ```
+- Default: 'Enabled'
 
 ### Parameter: `roleAssignments`
 

--- a/avm/res/document-db/mongo-cluster/main.bicep
+++ b/avm/res/document-db/mongo-cluster/main.bicep
@@ -69,13 +69,6 @@ param enableMicrosoftEntraAuth bool = false
 @description('Optional. The Microsoft Entra ID authentication identity assignments to be created for the cluster.')
 param entraAuthIdentities authIdentityType[]?
 
-@description('Optional. Controls public network access to the cluster. Allowed values: "Enabled", "Disabled".')
-@allowed([
-  'Enabled'
-  'Disabled'
-])
-param publicNetworkAccess string = 'Enabled'
-
 var enableReferencedModulesTelemetry = false
 
 var builtInRoleNames = {
@@ -148,7 +141,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource mongoCluster 'Microsoft.DocumentDB/mongoClusters@2025-07-01-preview' = {
+resource mongoCluster 'Microsoft.DocumentDB/mongoClusters@2025-04-01-preview' = {
   name: name
   tags: tags
   location: location
@@ -182,7 +175,6 @@ resource mongoCluster 'Microsoft.DocumentDB/mongoClusters@2025-07-01-preview' = 
           : []
       )
     }
-    publicNetworkAccess: publicNetworkAccess
   }
 }
 

--- a/avm/res/document-db/mongo-cluster/main.bicep
+++ b/avm/res/document-db/mongo-cluster/main.bicep
@@ -69,6 +69,13 @@ param enableMicrosoftEntraAuth bool = false
 @description('Optional. The Microsoft Entra ID authentication identity assignments to be created for the cluster.')
 param entraAuthIdentities authIdentityType[]?
 
+@description('Optional. Controls public network access to the cluster. Allowed values: "Enabled", "Disabled".')
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+param publicNetworkAccess string = 'Enabled'
+
 var enableReferencedModulesTelemetry = false
 
 var builtInRoleNames = {
@@ -141,7 +148,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource mongoCluster 'Microsoft.DocumentDB/mongoClusters@2025-04-01-preview' = {
+resource mongoCluster 'Microsoft.DocumentDB/mongoClusters@2025-07-01-preview' = {
   name: name
   tags: tags
   location: location
@@ -175,6 +182,7 @@ resource mongoCluster 'Microsoft.DocumentDB/mongoClusters@2025-04-01-preview' = 
           : []
       )
     }
+    publicNetworkAccess: publicNetworkAccess
   }
 }
 


### PR DESCRIPTION
## Description

Expose publicNetworkAccess property to allow disabling public network access for MongoDB cluster. This property is available on mongo cluster API version 'Microsoft.DocumentDB/mongoClusters@2025-07-01-preview' and isnt yet surfaced on AVM module. This will allow the users to enable or disable public network access to mongo cluster. Added relevant documentation to readme.
Fixes #5901 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
