### PR TITLE
feat: Add endpoints and immutableId as outputs exposed by this module

### DIFF
--- a/avm/res/insights/data-collection-rule/CHANGELOG.md
+++ b/avm/res/insights/data-collection-rule/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/data-collection-rule/CHANGELOG.md).
 
+## 0.6.3
+
+### Changes
+
+- Add output `immutableId` to allow use of the DCR's `immutableId`, if generated
+- Add output `endpoints` to allow use of the DCR's logging & metrics endpoints, if generated
+
+### Breaking Changes
+
+- None
+
 ## 0.6.2
 
 ### Changes

--- a/avm/res/insights/data-collection-rule/CHANGELOG.md
+++ b/avm/res/insights/data-collection-rule/CHANGELOG.md
@@ -8,15 +8,6 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 - Add output `immutableId` to allow use of the DCR's `immutableId`, if generated
 - Add output `endpoints` to allow use of the DCR's logging & metrics endpoints, if generated
-
-### Breaking Changes
-
-- None
-
-## 0.6.2
-
-### Changes
-
 - Updated LockType to 'avm-common-types version' `0.6.0`, enabling custom notes for locks.
 
 ### Breaking Changes

--- a/avm/res/insights/data-collection-rule/CHANGELOG.md
+++ b/avm/res/insights/data-collection-rule/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/data-collection-rule/CHANGELOG.md).
 
-## 0.6.3
+## 0.7.0
 
 ### Changes
 

--- a/avm/res/insights/data-collection-rule/README.md
+++ b/avm/res/insights/data-collection-rule/README.md
@@ -3635,6 +3635,8 @@ Resource tags.
 
 | Output | Type | Description |
 | :-- | :-- | :-- |
+| `endpoints` | object | The endpoints of the dataCollectionRule, if created |
+| `immutableId` | string | The ImmutableId of the dataCollectionRule |
 | `location` | string | The location the resource was deployed into. |
 | `name` | string | The name of the dataCollectionRule. |
 | `resourceGroupName` | string | The name of the resource group the dataCollectionRule was created in. |

--- a/avm/res/insights/data-collection-rule/README.md
+++ b/avm/res/insights/data-collection-rule/README.md
@@ -3635,8 +3635,8 @@ Resource tags.
 
 | Output | Type | Description |
 | :-- | :-- | :-- |
-| `endpoints` | object | The endpoints of the dataCollectionRule, if created |
-| `immutableId` | string | The ImmutableId of the dataCollectionRule |
+| `endpoints` | object | The endpoints of the dataCollectionRule, if created. |
+| `immutableId` | string | The ImmutableId of the dataCollectionRule. |
 | `location` | string | The location the resource was deployed into. |
 | `name` | string | The name of the dataCollectionRule. |
 | `resourceGroupName` | string | The name of the resource group the dataCollectionRule was created in. |

--- a/avm/res/insights/data-collection-rule/main.bicep
+++ b/avm/res/insights/data-collection-rule/main.bicep
@@ -163,10 +163,10 @@ output systemAssignedMIPrincipalId string? = dataCollectionRuleProperties.kind =
   ? dataCollectionRuleAll.?identity.?principalId
   : dataCollectionRule.?identity.?principalId
 
-@description('The endpoints of the dataCollectionRule, if created')
+@description('The endpoints of the dataCollectionRule, if created.')
 output endpoints object? = !empty(createdDCR.?properties.?endpoints) ? createdDCR.properties.endpoints : null
 
-@description('The ImmutableId of the dataCollectionRule')
+@description('The ImmutableId of the dataCollectionRule.')
 output immutableId string? = !empty(createdDCR.?properties.?immutableId) ? createdDCR.properties.immutableId : null
 // =============== //
 //   Definitions   //

--- a/avm/res/insights/data-collection-rule/main.bicep
+++ b/avm/res/insights/data-collection-rule/main.bicep
@@ -125,6 +125,10 @@ resource dataCollectionRuleAll 'Microsoft.Insights/dataCollectionRules@2023-03-1
   properties: dataCollectionRulePropertiesUnion
 }
 
+// Resolve which of the Data Collection Rule entities were actually constructed, so we know which one to
+// reference for outputs later on.
+var createdDCR = dataCollectionRuleProperties.kind == 'All' ? dataCollectionRuleAll : dataCollectionRule
+
 // Using a module as a workaround for issues with conditional scope: https://github.com/Azure/bicep/issues/7367
 module dataCollectionRule_conditionalScopeResources 'modules/nested_conditionalScope.bicep' = if ((!empty(lock ?? {}) && lock.?kind != 'None') || (!empty(roleAssignments ?? []))) {
   name: '${uniqueString(deployment().name, location)}-DCR-ConditionalScope'
@@ -161,6 +165,11 @@ output systemAssignedMIPrincipalId string? = dataCollectionRuleProperties.kind =
   ? dataCollectionRuleAll.?identity.?principalId
   : dataCollectionRule.?identity.?principalId
 
+@description('The endpoints of the dataCollectionRule, if created')
+output endpoints object? = !empty(createdDCR.?properties.?endpoints) ? createdDCR.properties.endpoints : null
+
+@description('The ImmutableId of the dataCollectionRule')
+output immutableId string? = !empty(createdDCR.?properties.?immutableId) ? createdDCR.properties.immutableId : null
 // =============== //
 //   Definitions   //
 // =============== //

--- a/avm/res/insights/data-collection-rule/main.bicep
+++ b/avm/res/insights/data-collection-rule/main.bicep
@@ -152,7 +152,7 @@ output resourceId string = dataCollectionRuleProperties.kind == 'All' ? dataColl
 output resourceGroupName string = resourceGroup().name
 
 @description('The location the resource was deployed into.')
-output location string = dataCollectionRuleProperties.kind == 'All' ? dataCollectionRuleAll.location : dataCollectionRule.location
+output location string = dataCollectionRuleProperties.kind == 'All' ? dataCollectionRuleAll!.location : dataCollectionRule!.location
 
 @description('The principal ID of the system assigned identity.')
 output systemAssignedMIPrincipalId string? = dataCollectionRuleProperties.kind == 'All'
@@ -160,10 +160,10 @@ output systemAssignedMIPrincipalId string? = dataCollectionRuleProperties.kind =
   : dataCollectionRule.?identity.?principalId
 
 @description('The endpoints of the dataCollectionRule, if created.')
-output endpoints object? = dataCollectionRuleProperties.kind == 'All' ? dataCollectionRuleAll.properties.?endpoints : dataCollectionRule.properties.?endpoints
+output endpoints resourceOutput<'Microsoft.Insights/dataCollectionRules@2023-03-11'>.properties.endpoints? = dataCollectionRuleProperties.kind == 'All' ? dataCollectionRuleAll!.properties.?endpoints : dataCollectionRule!.properties.?endpoints
 
 @description('The ImmutableId of the dataCollectionRule.')
-output immutableId string? = dataCollectionRuleProperties.kind == 'All' ? dataCollectionRuleAll.properties.?immutableId : dataCollectionRule.properties.?immutableId
+output immutableId string? = dataCollectionRuleProperties.kind == 'All' ? dataCollectionRuleAll!.properties.?immutableId : dataCollectionRule!.properties.?immutableId
 
 // =============== //
 //   Definitions   //

--- a/avm/res/insights/data-collection-rule/main.bicep
+++ b/avm/res/insights/data-collection-rule/main.bicep
@@ -147,18 +147,16 @@ module dataCollectionRule_conditionalScopeResources 'modules/nested_conditionalS
 // =========== //
 
 @description('The name of the dataCollectionRule.')
-output name string = dataCollectionRuleProperties.kind == 'All' ? dataCollectionRuleAll.name : dataCollectionRule.name
+output name string = createdDCR.name
 
 @description('The resource ID of the dataCollectionRule.')
-output resourceId string = dataCollectionRuleProperties.kind == 'All' ? dataCollectionRuleAll.id : dataCollectionRule.id
+output resourceId string = createdDCR.id
 
 @description('The name of the resource group the dataCollectionRule was created in.')
 output resourceGroupName string = resourceGroup().name
 
 @description('The location the resource was deployed into.')
-output location string = dataCollectionRuleProperties.kind == 'All'
-  ? dataCollectionRuleAll.location
-  : dataCollectionRule.location
+output location string = createdDCR.location
 
 @description('The principal ID of the system assigned identity.')
 output systemAssignedMIPrincipalId string? = dataCollectionRuleProperties.kind == 'All'

--- a/avm/res/insights/data-collection-rule/main.json
+++ b/avm/res/insights/data-collection-rule/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "6373748746647451100"
+      "templateHash": "8608727180008596705"
     },
     "name": "Data Collection Rules",
     "description": "This module deploys a Data Collection Rule."
@@ -854,10 +854,14 @@
     },
     "endpoints": {
       "type": "object",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Insights/dataCollectionRules@2023-03-11#properties/properties/properties/endpoints",
+          "output": true
+        },
         "description": "The endpoints of the dataCollectionRule, if created."
       },
+      "nullable": true,
       "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), tryGet(reference('dataCollectionRuleAll'), 'endpoints'), tryGet(reference('dataCollectionRule'), 'endpoints'))]"
     },
     "immutableId": {

--- a/avm/res/insights/data-collection-rule/main.json
+++ b/avm/res/insights/data-collection-rule/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "7234814696449651914"
+      "templateHash": "6373748746647451100"
     },
     "name": "Data Collection Rules",
     "description": "This module deploys a Data Collection Rule."
@@ -821,14 +821,14 @@
       "metadata": {
         "description": "The name of the dataCollectionRule."
       },
-      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')).name]"
+      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), parameters('name'), parameters('name'))]"
     },
     "resourceId": {
       "type": "string",
       "metadata": {
         "description": "The resource ID of the dataCollectionRule."
       },
-      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')).id]"
+      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), resourceId('Microsoft.Insights/dataCollectionRules', parameters('name')), resourceId('Microsoft.Insights/dataCollectionRules', parameters('name')))]"
     },
     "resourceGroupName": {
       "type": "string",
@@ -842,7 +842,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')).location]"
+      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full').location, reference('dataCollectionRule', '2023-03-11', 'full').location)]"
     },
     "systemAssignedMIPrincipalId": {
       "type": "string",
@@ -858,7 +858,7 @@
       "metadata": {
         "description": "The endpoints of the dataCollectionRule, if created."
       },
-      "value": "[if(not(empty(tryGet(tryGet(if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')), 'properties'), 'endpoints'))), if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')).properties.endpoints, null())]"
+      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), tryGet(reference('dataCollectionRuleAll'), 'endpoints'), tryGet(reference('dataCollectionRule'), 'endpoints'))]"
     },
     "immutableId": {
       "type": "string",
@@ -866,7 +866,7 @@
       "metadata": {
         "description": "The ImmutableId of the dataCollectionRule."
       },
-      "value": "[if(not(empty(tryGet(tryGet(if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')), 'properties'), 'immutableId'))), if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')).properties.immutableId, null())]"
+      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), tryGet(reference('dataCollectionRuleAll'), 'immutableId'), tryGet(reference('dataCollectionRule'), 'immutableId'))]"
     }
   }
 }

--- a/avm/res/insights/data-collection-rule/main.json
+++ b/avm/res/insights/data-collection-rule/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "10340605731952055244"
+      "templateHash": "10527336981370900309"
     },
     "name": "Data Collection Rules",
     "description": "This module deploys a Data Collection Rule."
@@ -821,14 +821,14 @@
       "metadata": {
         "description": "The name of the dataCollectionRule."
       },
-      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), parameters('name'), parameters('name'))]"
+      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')).name]"
     },
     "resourceId": {
       "type": "string",
       "metadata": {
         "description": "The resource ID of the dataCollectionRule."
       },
-      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), resourceId('Microsoft.Insights/dataCollectionRules', parameters('name')), resourceId('Microsoft.Insights/dataCollectionRules', parameters('name')))]"
+      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')).id]"
     },
     "resourceGroupName": {
       "type": "string",
@@ -842,7 +842,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full').location, reference('dataCollectionRule', '2023-03-11', 'full').location)]"
+      "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')).location]"
     },
     "systemAssignedMIPrincipalId": {
       "type": "string",
@@ -851,6 +851,22 @@
         "description": "The principal ID of the system assigned identity."
       },
       "value": "[if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), tryGet(tryGet(if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), null()), 'identity'), 'principalId'), tryGet(tryGet(if(not(equals(parameters('dataCollectionRuleProperties').kind, 'All')), reference('dataCollectionRule', '2023-03-11', 'full'), null()), 'identity'), 'principalId'))]"
+    },
+    "endpoints": {
+      "type": "object",
+      "nullable": true,
+      "metadata": {
+        "description": "The endpoints of the dataCollectionRule, if created"
+      },
+      "value": "[if(not(empty(tryGet(tryGet(if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')), 'properties'), 'endpoints'))), if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')).properties.endpoints, null())]"
+    },
+    "immutableId": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "The ImmutableId of the dataCollectionRule"
+      },
+      "value": "[if(not(empty(tryGet(tryGet(if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')), 'properties'), 'immutableId'))), if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')).properties.immutableId, null())]"
     }
   }
 }

--- a/avm/res/insights/data-collection-rule/main.json
+++ b/avm/res/insights/data-collection-rule/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "10527336981370900309"
+      "templateHash": "7234814696449651914"
     },
     "name": "Data Collection Rules",
     "description": "This module deploys a Data Collection Rule."
@@ -856,7 +856,7 @@
       "type": "object",
       "nullable": true,
       "metadata": {
-        "description": "The endpoints of the dataCollectionRule, if created"
+        "description": "The endpoints of the dataCollectionRule, if created."
       },
       "value": "[if(not(empty(tryGet(tryGet(if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')), 'properties'), 'endpoints'))), if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')).properties.endpoints, null())]"
     },
@@ -864,7 +864,7 @@
       "type": "string",
       "nullable": true,
       "metadata": {
-        "description": "The ImmutableId of the dataCollectionRule"
+        "description": "The ImmutableId of the dataCollectionRule."
       },
       "value": "[if(not(empty(tryGet(tryGet(if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')), 'properties'), 'immutableId'))), if(equals(parameters('dataCollectionRuleProperties').kind, 'All'), reference('dataCollectionRuleAll', '2023-03-11', 'full'), reference('dataCollectionRule', '2023-03-11', 'full')).properties.immutableId, null())]"
     }

--- a/avm/res/insights/data-collection-rule/version.json
+++ b/avm/res/insights/data-collection-rule/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.6"
+  "version": "0.7"
 }


### PR DESCRIPTION
## Description

Exposes the following properties as outputs:
- `immutableId`
- `endpoints`: these are the two URL endpoints for metrics and logs pushes

## Pipeline Reference

[![avm.res.insights.data-collection-rule](https://github.com/ckane/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-rule.yml/badge.svg?branch=endpoint-outputs-for-dcr)](https://github.com/ckane/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-rule.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version