### PR TITLE
fix: CI - Small updates to statistic generated via the `Set-AvmGitHubIssueOwnerConfig` function

### DIFF
--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -334,6 +334,8 @@ function Set-AvmGitHubIssueOwnerConfig {
     Write-Verbose '' -Verbose
     Write-Verbose '# Assignee distribution' -Verbose
     Write-Verbose '# ---------------------' -Verbose
+    # Expand issues by assignees
+    # E.g., if one issue has two assignees, the list will contain two copies of that issue, one per assignee
     $expandedList = [System.Collections.ArrayList]@()
     foreach ($issue in $issues) {
         $assignees = $issue.assignees

--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -110,7 +110,6 @@ function Set-AvmGitHubIssueOwnerConfig {
     $processedCount = 1
     $totalCount = $issues.Count
     foreach ($issue in $issues) {
-        continue
         $anyUpdate = $false
         $plainTitle = $issue.title -replace '^.+?]:? '
         $issueCategory = ($issue.title -replace [regex]::Escape($plainTitle)).Trim().TrimStart('[').TrimEnd(':').TrimEnd(']')

--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -110,6 +110,7 @@ function Set-AvmGitHubIssueOwnerConfig {
     $processedCount = 1
     $totalCount = $issues.Count
     foreach ($issue in $issues) {
+
         $anyUpdate = $false
         $plainTitle = $issue.title -replace '^.+?]:? '
         $issueCategory = ($issue.title -replace [regex]::Escape($plainTitle)).Trim().TrimStart('[').TrimEnd(':').TrimEnd(']')

--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -337,18 +337,15 @@ function Set-AvmGitHubIssueOwnerConfig {
     $expandedList = [System.Collections.ArrayList]@()
     foreach ($issue in $issues) {
         $assignees = $issue.assignees
-
         if (-not $assignees) {
             $assignees = @(@{ login = 'Unassigned' })
         }
-
         foreach ($assignee in $assignees) {
             $copy = $issue.PsObject.Copy()
             $copy.assignee = $assignee
             $expandedList += $copy
         }
     }
-
     Write-Verbose ($expandedList | Group-Object -Property { $_.assignee.login } | ForEach-Object {
             [PSCustomObject]@{
                 Assignee = ($_.name ? $_.name : 'Unassigned')


### PR DESCRIPTION
## Description

Turns out the `assignee` field only contains a single value even if multiple assignees are created. Hence changed the logic to make use of the `assignees` field.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![.Platform - Set GitHub issue owner config](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.set-avm-github-issue-owner-config.yml/badge.svg?branch=users%2Falsehr%2FstatisticsUpdate&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.set-avm-github-issue-owner-config.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
