### PR TITLE
feat: CI - Update issue assignment logic so that manually removed owners are not automatically added again

### DIFF
--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -309,8 +309,10 @@ function Set-AvmGitHubIssueOwnerConfig {
                 ($_.event -eq 'assigned') -and ($_.actor.login -ne 'avm-team-linter[bot]')
             }).assignee.login
         $assigneesToRemove = $existingAssignees | Where-Object {
-            ($ownerTeamMembers -notcontains $_) -and
-            ($usersAssignedManually -notcontains $_)
+            $manuallyAssigned = $usersAssignedManually -contains $_
+            $inOwnerTeam = $ownerTeamMembers -notcontains $_
+            $orphaned = $moduleCsvData.ModuleStatus -eq 'Orphaned'
+            -not $manuallyAssigned -and (-not $inOwnerTeam -or $orphaned)
         }
         foreach ($excessAssignee in $assigneesToRemove) {
             $anyUpdate = $true

--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -309,10 +309,10 @@ function Set-AvmGitHubIssueOwnerConfig {
                 ($_.event -eq 'assigned') -and ($_.actor.login -ne 'avm-team-linter[bot]')
             }).assignee.login
         $assigneesToRemove = $existingAssignees | Where-Object {
-            $manuallyAssigned = $usersAssignedManually -contains $_
-            $inOwnerTeam = $ownerTeamMembers -notcontains $_
-            $orphaned = $moduleCsvData.ModuleStatus -eq 'Orphaned'
-            -not $manuallyAssigned -and (-not $inOwnerTeam -or $orphaned)
+            $wasManuallyAssigned = $usersAssignedManually -contains $_
+            $isInOwnerTeam = $ownerTeamMembers -contains $_
+            $isOrphaned = $moduleCsvData.ModuleStatus -eq 'Orphaned'
+            -not $wasManuallyAssigned -and (-not $isInOwnerTeam -or $isOrphaned)
         }
         foreach ($excessAssignee in $assigneesToRemove) {
             $anyUpdate = $true

--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -272,7 +272,7 @@ function Set-AvmGitHubIssueOwnerConfig {
 
                 if ($timelineEvents | Where-Object { ($_.event -eq 'unassigned') -and ($_.assignee.login -eq $alias) }) {
                     # Skipping this alias as it was previously manually unassigned
-                    Write-Verbose ('    🚫  Issue [{0}] {1}: Skipping assignment of owner team member [{2}]' -f $issue.number, $shortTitle, $alias) -Verbose
+                    Write-Verbose ('    🚫  Issue [{0}] {1}: Skipping re-assignment of owner team member [{2}] as they were manually unassigned' -f $issue.number, $shortTitle, $alias) -Verbose
                     continue
                 }
 

--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -272,7 +272,7 @@ function Set-AvmGitHubIssueOwnerConfig {
 
                 if ($timelineEvents | Where-Object { ($_.event -eq 'unassigned') -and ($_.assignee.login -eq $alias) }) {
                     # Skipping this alias as it was previously manually unassigned
-                    Write-Verbose ('    🚫  Issue [{0}] {1}: Skipping re-assignment of owner team member [{2}] as they were manually unassigned' -f $issue.number, $shortTitle, $alias) -Verbose
+                    Write-Verbose ('    🫷  Issue [{0}] {1}: Skipping re-assignment of owner team member [{2}] as they were manually unassigned' -f $issue.number, $shortTitle, $alias) -Verbose
                     continue
                 }
 

--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -272,7 +272,7 @@ function Set-AvmGitHubIssueOwnerConfig {
 
                 if ($timelineEvents | Where-Object { ($_.event -eq 'unassigned') -and ($_.assignee.login -eq $alias) }) {
                     # Skipping this alias as it was previously manually unassigned
-                    Write-Verbose ('    🚫  Issue [{0}] {1}: Skipping assignment of owner team member [{2}]' -f $issue.number, $shortTitle, $alias)
+                    Write-Verbose ('    🚫  Issue [{0}] {1}: Skipping assignment of owner team member [{2}]' -f $issue.number, $shortTitle, $alias) -Verbose
                     continue
                 }
 

--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -269,6 +269,13 @@ function Set-AvmGitHubIssueOwnerConfig {
             # Assign owner team members
             # -------------------------
             foreach ($alias in ($ownerTeamMembers | Where-Object { $existingAssignees -notcontains $_ })) {
+
+                if ($timelineEvents | Where-Object { ($_.event -eq 'unassigned') -and ($_.assignee.login -eq $alias) }) {
+                    # Skipping this alias as it was previously manually unassigned
+                    Write-Verbose ('    🚫  Issue [{0}] {1}: Skipping assignment of owner team member [{2}]' -f $issue.number, $shortTitle, $alias)
+                    continue
+                }
+
                 $anyUpdate = $true
                 $statistics.'Added assignees'++
                 if ($PSCmdlet.ShouldProcess("Owner team member [$alias] to issue [$($issue.number)]", 'Assign')) {
@@ -311,7 +318,7 @@ function Set-AvmGitHubIssueOwnerConfig {
             if ($PSCmdlet.ShouldProcess("Excess assignee [$excessAssignee] from issue [$($issue.number)]", 'Remove')) {
                 $null = gh issue edit $issue.number --remove-assignee $excessAssignee --repo $fullRepositoryName
             }
-            Write-Verbose ('    🗑️  Issue [{0}] {1}: Removed excess assignee [{2}]' -f $issue.number, $shortTitle, $excessAssignee) -Verbose
+            Write-Verbose ('    ♻️  Issue [{0}] {1}: Removed excess assignee [{2}]' -f $issue.number, $shortTitle, $excessAssignee) -Verbose
         }
 
         if ($anyUpdate) {


### PR DESCRIPTION
## Description

Changes `Set-AvmGitHubIssueOwnerConfig` so that it only re-assigns an owner if the owner was not previously manually removed

Also, members of the module owner team would be removed from an issue if a module was orphaned and they not manually added.

Looks similar too (but was since slightly altered):
<img width="1050" height="383" alt="image" src="https://github.com/user-attachments/assets/d2d6b5ea-c801-44cb-8eae-bc37f9983e79" />


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![.Platform - Set GitHub issue owner config](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.set-avm-github-issue-owner-config.yml/badge.svg?branch=users%2Falsehr%2FskipReassign&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.set-avm-github-issue-owner-config.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
