### PR TITLE
feat: CI -  Adjusted wording of one of the changelog tests

### DIFF
--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -1988,7 +1988,7 @@ Describe 'Module tests' -Tag 'Module' {
                 }
             }
 
-            $incorrectVersions | Should -BeNullOrEmpty -Because ('the list of entires in the changelog that don\''t exist as published versions in the list at https://mcr.microsoft.com/v2/bicep/avm/{0}/{1}/tags/list should be empty' -f $ModuleType, $moduleFolderName)
+            $incorrectVersions | Should -BeNullOrEmpty -Because ('the list of changelog entries that are not present as published versions at https://mcr.microsoft.com/v2/bicep/avm/{0}/{1}/tags/list should be empty.' -f $ModuleType, $moduleFolderName)
         }
     }
 

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -1988,7 +1988,7 @@ Describe 'Module tests' -Tag 'Module' {
                 }
             }
 
-            $incorrectVersions | Should -BeNullOrEmpty -Because ('the list of entires in the changelog that don\''t exist as published versions in https://mcr.microsoft.com/v2/bicep/avm/{0}/{1}/tags/list should be empty' -f $ModuleType, $moduleFolderName)
+            $incorrectVersions | Should -BeNullOrEmpty -Because ('the list of entires in the changelog that don\''t exist as published versions in the list at https://mcr.microsoft.com/v2/bicep/avm/{0}/{1}/tags/list should be empty' -f $ModuleType, $moduleFolderName)
         }
     }
 

--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -1988,7 +1988,7 @@ Describe 'Module tests' -Tag 'Module' {
                 }
             }
 
-            $incorrectVersions | Should -BeNullOrEmpty -Because ('all versions should exist as published version in https://mcr.microsoft.com/v2/bicep/avm/{0}/{1}/tags/list' -f $ModuleType, $moduleFolderName)
+            $incorrectVersions | Should -BeNullOrEmpty -Because ('the list of entires in the changelog that don\''t exist as published versions in https://mcr.microsoft.com/v2/bicep/avm/{0}/{1}/tags/list should be empty' -f $ModuleType, $moduleFolderName)
         }
     }
 


### PR DESCRIPTION
## Description

Changed to wording of the 'because' of the `Module tests / Changelog tests / [<>] CHANGELOG.md must contain only versions, that are published` test to be more meaningful.

Current reference
<img width="1905" height="191" alt="image" src="https://github.com/user-attachments/assets/93a42c22-309c-4286-8c67-3fa0ab310043" />
([ref](https://github.com/ckane/bicep-registry-modules/actions/runs/17419397938))

Especially if an older module version does not exist (because its test & publishing pipeline run failed) it may be confusing for later contributors considering the current wording.

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
