### PR TITLE
feat: CI - Added case handling for non-identified issue type to owner config logic

### DIFF
--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -377,7 +377,7 @@ function Set-AvmGitHubIssueOwnerConfig {
     Write-Verbose ($moduleDistributionData | ForEach-Object {
             [PSCustomObject]@{
                 Name = $_.ModuleName
-                Type = ('{0} {1}' -f $_.ModuleType, ($_.ModuleType -eq 'res' ? '📄' : $_.ModuleType -eq 'ptn' ? '📁' :  $_.ModuleType -eq 'utl' ? '🔨' : '👀'))
+                Type = ('{0} {1}' -f $_.ModuleType, ($_.ModuleType -eq 'res' ? '📄' : $_.ModuleType -eq 'ptn' ? '📁' :  $_.ModuleType -eq 'utl' ? '🔨' : '⚠️'))
                 '#'  = $_.References.Count
             }
         } | Sort-Object -Property { $_.'#' } -Descending | Format-Table | Out-String) -Verbose

--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -128,7 +128,11 @@ function Set-AvmGitHubIssueOwnerConfig {
 
         if (-not $issue.title.StartsWith('[AVM Module Issue]')) {
             # Not a module issue. Skipping
-            Write-Verbose ('    ℹ️  Issue [{0}] {1}: Not a module issue but [{2}]. Skipping' -f $issue.number, $shortTitle, $issueCategory) -Verbose
+            if ([String]::IsNullOrEmpty($issueCategory)) {
+                Write-Verbose ('    📎  Issue [{0}] {1}: Not a module issue and unknown category. Is skipped and should be reviewed & updated by maintainers.' -f $issue.number, $shortTitle) -Verbose
+            } else {
+                Write-Verbose ('    ℹ️  Issue [{0}] {1}: Not a module issue but [{2}]. Skipping' -f $issue.number, $shortTitle, $issueCategory) -Verbose
+            }
             $processedCount++
             continue
         }

--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -98,6 +98,7 @@ function Set-AvmGitHubIssueOwnerConfig {
         "`nTotals`n------"                 = $null
         'Total issues'                     = $issues.Count
         'Updated issues'                   = 0
+        'Issues to review by core team'    = 0
 
         "`nCategories`n----------"         = $null
         '📦 Module issues'                 = 0
@@ -130,6 +131,7 @@ function Set-AvmGitHubIssueOwnerConfig {
             # Not a module issue. Skipping
             if ([String]::IsNullOrEmpty($issueCategory)) {
                 Write-Verbose ('    ⚠️  Issue [{0}] {1}: Not a module issue and unknown category. Is skipped and should be reviewed & updated by maintainers.' -f $issue.number, $shortTitle) -Verbose
+                $statistics.'Issues to review by core team'++
             } else {
                 Write-Verbose ('    ℹ️  Issue [{0}] {1}: Not a module issue but [{2}]. Skipping' -f $issue.number, $shortTitle, $issueCategory) -Verbose
             }
@@ -152,6 +154,7 @@ function Set-AvmGitHubIssueOwnerConfig {
 
         if ([string]::IsNullOrEmpty($moduleName)) {
             Write-Warning ('    ⚠️  Issue [{0}] {1}: No valid module name was found in the issue. Skipping' -f $issue.number, $shortTitle)
+            $statistics.'Issues to review by core team'++
             $processedCount++
             continue
         }
@@ -175,6 +178,7 @@ function Set-AvmGitHubIssueOwnerConfig {
         # new/unknown module
         if ($null -eq $moduleCsvData) {
             Write-Warning ('    ⚠️  Issue [{0}] {1}: Module [{2}] not found in CSV. Skipping assignment.' -f $issue.number, $shortTitle, $moduleName)
+            $statistics.'Issues to review by core team'++
             $reply = @"
 **@$($issue.user.login), thanks for submitting this issue for the ``$moduleName`` module!**
 
@@ -217,6 +221,7 @@ function Set-AvmGitHubIssueOwnerConfig {
         if ($moduleCsvData.ModuleStatus -eq 'Orphaned' -and $existingLabels -notcontains 'Status: Module Orphaned :yellow_circle:') {
             # Added as I found several incorrectly labeled issues
             Write-Warning ('    ⚠️  Issue [{0}] {1}: Module [{2}] is orphaned but not assigned the required label. Please check.' -f $issue.number, $shortTitle, $moduleName)
+            $statistics.'Issues to review by core team'++
         }
 
         # ============= #

--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -130,7 +130,7 @@ function Set-AvmGitHubIssueOwnerConfig {
         if (-not $issue.title.StartsWith('[AVM Module Issue]')) {
             # Not a module issue. Skipping
             if ([String]::IsNullOrEmpty($issueCategory)) {
-                Write-Verbose ('    ⚠️  Issue [{0}] {1}: Not a module issue and unknown category. Is skipped and should be reviewed & updated by maintainers.' -f $issue.number, $shortTitle) -Verbose
+                Write-Verbose ('    ⚠️  Issue [{0}] {1}: Not a module issue and unknown category. Is skipped and should be reviewed & updated by the core team.' -f $issue.number, $shortTitle) -Verbose
                 $statistics.'Issues to review by core team'++
             } else {
                 Write-Verbose ('    ℹ️  Issue [{0}] {1}: Not a module issue but [{2}]. Skipping' -f $issue.number, $shortTitle, $issueCategory) -Verbose

--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -129,7 +129,7 @@ function Set-AvmGitHubIssueOwnerConfig {
         if (-not $issue.title.StartsWith('[AVM Module Issue]')) {
             # Not a module issue. Skipping
             if ([String]::IsNullOrEmpty($issueCategory)) {
-                Write-Verbose ('    📎  Issue [{0}] {1}: Not a module issue and unknown category. Is skipped and should be reviewed & updated by maintainers.' -f $issue.number, $shortTitle) -Verbose
+                Write-Verbose ('    ⚠️  Issue [{0}] {1}: Not a module issue and unknown category. Is skipped and should be reviewed & updated by maintainers.' -f $issue.number, $shortTitle) -Verbose
             } else {
                 Write-Verbose ('    ℹ️  Issue [{0}] {1}: Not a module issue but [{2}]. Skipping' -f $issue.number, $shortTitle, $issueCategory) -Verbose
             }

--- a/utilities/pipelines/platform/Sync-AvmModulesList.ps1
+++ b/utilities/pipelines/platform/Sync-AvmModulesList.ps1
@@ -186,7 +186,7 @@ $([Environment]::NewLine)
 
     $issuesFound = $body -ne ''
 
-    $title = '[AVM core] AVM Module Issue template is not in sync with published resource modules and pattern modules list'
+    $title = '[AVM CI Environment Issue] AVM Module Issue template is not in sync with published resource modules and pattern modules list'
     $label = 'Type: AVM :a: :v: :m:,Type: Hygiene :broom:'
     $issues = gh issue list --state open --limit 500 --label $label --json 'title,url' --repo $Repo | ConvertFrom-Json -Depth 100
 


### PR DESCRIPTION
## Description

Added a case that when the issue type cannot be identified it will produce a corresponding log entry for the core team to address

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![.Platform - Set GitHub issue owner config](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.set-avm-github-issue-owner-config.yml/badge.svg?branch=users%2Falsehr%2FconfigNonCategory&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.set-avm-github-issue-owner-config.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
