### PR TITLE
feat: VMSS - Updated types

### DIFF
--- a/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
+++ b/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
@@ -11,6 +11,8 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 - Added types for parameters `osDisk`, `dataDisks`, `nicConfigurations`, `extensionHealthConfig`, `winRM` & `publicKeys`
 - Fixed incorrect default value of `extensionHealthConfig` parameter
 - Added optional `name` property to `nicConfigurations` parameter
+- Moved Health-Extension to its own deployment block
+- Added `provisionAfterExtensions` property support to all extensions
 
 ### Breaking Changes
 

--- a/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
+++ b/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
@@ -11,7 +11,6 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 - Added types for parameters `osDisk`, `dataDisks`, `nicConfigurations`, `extensionHealthConfig`, `winRM` & `publicKeys`
 - Fixed incorrect default value of `extensionHealthConfig` parameter
 - Added optional `name` property to `nicConfigurations` parameter
-- Moved Health-Extension to its own deployment block
 - Added `provisionAfterExtensions` property support to all extensions
 
 ### Breaking Changes

--- a/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
+++ b/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
@@ -6,12 +6,18 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Changes
 
-- Initial version
+- Introduced user-defined type for `extensionCustomScriptConfig` parameter that is aligned with its [official documentation](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-windows).
+- Added parameters `provisionAfterExtensions` & `provisionAfterExtensions`  to 'extension' child module.
+- Added types for parameters `osDisk`, `dataDisks`, `nicConfigurations`, `extensionHealthConfig`, `winRM` & `publicKeys`
+- Fixed incorrect default value of `extensionHealthConfig` parameter
+- Added optional `name` property to `nicConfigurations` parameter
 
 ### Breaking Changes
 
 - Merged `extensionCustomScriptProtectedSetting` parameter into `extensionCustomScriptConfig`
 - Removed support for the CustomScriptExtension extension to automatically append SAS-Keys to file specified via the `extensionCustomScriptConfig.fileData` property. Instead, the SAS token must either be pre-provided with the URL, or either the settings `extensionCustomScriptConfig.protectedSettings.storageAccountKey` & `extensionCustomScriptConfig.protectedSettings.storageAccountName` or (recommended) `extensionCustomScriptConfig.protectedSettings.managedIdentityResourceId`. For the latter, you can provide either the full resource ID - or set it to `''` if you want it to use the VM's system-assigned identity (if enabled) instead. Note, in either case, the Identity must be granted access to correct Storage Account scope.
+- The updated `osDisk` parameter requires an integer for its `diskSizeGB` property
+- The updated `dataDisks` parameter requires an integer for its `diskSizeGB` property & the `lun` property (which specifies the logical unit number of the data disk. Can be an incremental number)
 
 ## 0.10.0
 

--- a/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
+++ b/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/virtual-machine-scale-set/CHANGELOG.md).
 
+## 0.11.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- Merged `extensionCustomScriptProtectedSetting` parameter into `extensionCustomScriptConfig`
+- Removed support for the CustomScriptExtension extension to automatically append SAS-Keys to file specified via the `extensionCustomScriptConfig.fileData` property. Instead, the SAS token must either be pre-provided with the URL, or either the settings `extensionCustomScriptConfig.protectedSettings.storageAccountKey` & `extensionCustomScriptConfig.protectedSettings.storageAccountName` or (recommended) `extensionCustomScriptConfig.protectedSettings.managedIdentityResourceId`. For the latter, you can provide either the full resource ID - or set it to `''` if you want it to use the VM's system-assigned identity (if enabled) instead. Note, in either case, the Identity must be granted access to correct Storage Account scope.
+
 ## 0.10.0
 
 ### Changes

--- a/avm/res/compute/virtual-machine-scale-set/README.md
+++ b/avm/res/compute/virtual-machine-scale-set/README.md
@@ -571,7 +571,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
         managedIdentityResourceId: '<managedIdentityResourceId>'
       }
       settings: {
-        commandToExecute: 'sudo apt-get update'
+        commandToExecute: '<commandToExecute>'
         fileUris: [
           '<storageAccountCSEFileUrl>'
         ]
@@ -779,7 +779,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
           "managedIdentityResourceId": "<managedIdentityResourceId>"
         },
         "settings": {
-          "commandToExecute": "sudo apt-get update",
+          "commandToExecute": "<commandToExecute>",
           "fileUris": [
             "<storageAccountCSEFileUrl>"
           ]
@@ -981,7 +981,7 @@ param extensionCustomScriptConfig = {
     managedIdentityResourceId: '<managedIdentityResourceId>'
   }
   settings: {
-    commandToExecute: 'sudo apt-get update'
+    commandToExecute: '<commandToExecute>'
     fileUris: [
       '<storageAccountCSEFileUrl>'
     ]

--- a/avm/res/compute/virtual-machine-scale-set/README.md
+++ b/avm/res/compute/virtual-machine-scale-set/README.md
@@ -17,8 +17,8 @@ This module deploys a Virtual Machine Scale Set.
 | :-- | :-- | :-- |
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
-| `Microsoft.Compute/virtualMachineScaleSets` | 2024-07-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.compute_virtualmachinescalesets.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2024-07-01/virtualMachineScaleSets)</li></ul> |
-| `Microsoft.Compute/virtualMachineScaleSets/extensions` | 2023-09-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.compute_virtualmachinescalesets_extensions.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2023-09-01/virtualMachineScaleSets/extensions)</li></ul> |
+| `Microsoft.Compute/virtualMachineScaleSets` | 2024-11-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.compute_virtualmachinescalesets.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2024-11-01/virtualMachineScaleSets)</li></ul> |
+| `Microsoft.Compute/virtualMachineScaleSets/extensions` | 2024-11-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.compute_virtualmachinescalesets_extensions.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2024-11-01/virtualMachineScaleSets/extensions)</li></ul> |
 | `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.insights_diagnosticsettings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)</li></ul> |
 
 ## Usage examples
@@ -90,7 +90,6 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     skuName: 'Standard_B12ms'
     // Non-required parameters
     disablePasswordAuthentication: true
-    location: '<location>'
     publicKeys: [
       {
         keyData: '<keyData>'
@@ -170,9 +169,6 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     "disablePasswordAuthentication": {
       "value": true
     },
-    "location": {
-      "value": "<location>"
-    },
     "publicKeys": {
       "value": [
         {
@@ -234,7 +230,6 @@ param osType = 'Linux'
 param skuName = 'Standard_B12ms'
 // Non-required parameters
 param disablePasswordAuthentication = true
-param location = '<location>'
 param publicKeys = [
   {
     keyData: '<keyData>'
@@ -289,7 +284,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     ]
     osDisk: {
       createOption: 'fromImage'
-      diskSizeGB: '128'
+      diskSizeGB: 128
       managedDisk: {
         storageAccountType: 'Premium_LRS'
       }
@@ -303,7 +298,6 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
       port: 22
       protocol: 'tcp'
     }
-    location: '<location>'
     publicKeys: [
       {
         keyData: '<keyData>'
@@ -367,7 +361,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     "osDisk": {
       "value": {
         "createOption": "fromImage",
-        "diskSizeGB": "128",
+        "diskSizeGB": 128,
         "managedDisk": {
           "storageAccountType": "Premium_LRS"
         }
@@ -389,9 +383,6 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
         "port": 22,
         "protocol": "tcp"
       }
-    },
-    "location": {
-      "value": "<location>"
     },
     "publicKeys": {
       "value": [
@@ -445,7 +436,7 @@ param nicConfigurations = [
 ]
 param osDisk = {
   createOption: 'fromImage'
-  diskSizeGB: '128'
+  diskSizeGB: 128
   managedDisk: {
     storageAccountType: 'Premium_LRS'
   }
@@ -459,7 +450,6 @@ param extensionHealthConfig = {
   port: 22
   protocol: 'tcp'
 }
-param location = '<location>'
 param publicKeys = [
   {
     keyData: '<keyData>'
@@ -514,7 +504,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     ]
     osDisk: {
       createOption: 'fromImage'
-      diskSizeGB: '128'
+      diskSizeGB: 128
       managedDisk: {
         storageAccountType: 'Premium_LRS'
       }
@@ -531,7 +521,8 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
       {
         caching: 'ReadOnly'
         createOption: 'Empty'
-        diskSizeGB: '256'
+        diskSizeGB: 256
+        lun: 1
         managedDisk: {
           storageAccountType: 'Premium_LRS'
         }
@@ -539,7 +530,8 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
       {
         caching: 'ReadOnly'
         createOption: 'Empty'
-        diskSizeGB: '128'
+        diskSizeGB: 128
+        lun: 2
         managedDisk: {
           storageAccountType: 'Premium_LRS'
         }
@@ -575,15 +567,14 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
       }
     }
     extensionCustomScriptConfig: {
-      enabled: true
-      fileData: [
-        {
-          storageAccountId: '<storageAccountId>'
-          uri: '<uri>'
-        }
-      ]
       protectedSettings: {
+        managedIdentityResourceId: '<managedIdentityResourceId>'
+      }
+      settings: {
         commandToExecute: 'sudo apt-get update'
+        fileUris: [
+          '<storageAccountCSEFileUrl>'
+        ]
       }
     }
     extensionDependencyAgentConfig: {
@@ -699,7 +690,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     "osDisk": {
       "value": {
         "createOption": "fromImage",
-        "diskSizeGB": "128",
+        "diskSizeGB": 128,
         "managedDisk": {
           "storageAccountType": "Premium_LRS"
         }
@@ -728,7 +719,8 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
         {
           "caching": "ReadOnly",
           "createOption": "Empty",
-          "diskSizeGB": "256",
+          "diskSizeGB": 256,
+          "lun": 1,
           "managedDisk": {
             "storageAccountType": "Premium_LRS"
           }
@@ -736,7 +728,8 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
         {
           "caching": "ReadOnly",
           "createOption": "Empty",
-          "diskSizeGB": "128",
+          "diskSizeGB": 128,
+          "lun": 2,
           "managedDisk": {
             "storageAccountType": "Premium_LRS"
           }
@@ -782,15 +775,14 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     },
     "extensionCustomScriptConfig": {
       "value": {
-        "enabled": true,
-        "fileData": [
-          {
-            "storageAccountId": "<storageAccountId>",
-            "uri": "<uri>"
-          }
-        ],
         "protectedSettings": {
-          "commandToExecute": "sudo apt-get update"
+          "managedIdentityResourceId": "<managedIdentityResourceId>"
+        },
+        "settings": {
+          "commandToExecute": "sudo apt-get update",
+          "fileUris": [
+            "<storageAccountCSEFileUrl>"
+          ]
         }
       }
     },
@@ -922,7 +914,7 @@ param nicConfigurations = [
 ]
 param osDisk = {
   createOption: 'fromImage'
-  diskSizeGB: '128'
+  diskSizeGB: 128
   managedDisk: {
     storageAccountType: 'Premium_LRS'
   }
@@ -939,7 +931,8 @@ param dataDisks = [
   {
     caching: 'ReadOnly'
     createOption: 'Empty'
-    diskSizeGB: '256'
+    diskSizeGB: 256
+    lun: 1
     managedDisk: {
       storageAccountType: 'Premium_LRS'
     }
@@ -947,7 +940,8 @@ param dataDisks = [
   {
     caching: 'ReadOnly'
     createOption: 'Empty'
-    diskSizeGB: '128'
+    diskSizeGB: 128
+    lun: 2
     managedDisk: {
       storageAccountType: 'Premium_LRS'
     }
@@ -983,15 +977,14 @@ param extensionAzureDiskEncryptionConfig = {
   }
 }
 param extensionCustomScriptConfig = {
-  enabled: true
-  fileData: [
-    {
-      storageAccountId: '<storageAccountId>'
-      uri: '<uri>'
-    }
-  ]
   protectedSettings: {
+    managedIdentityResourceId: '<managedIdentityResourceId>'
+  }
+  settings: {
     commandToExecute: 'sudo apt-get update'
+    fileUris: [
+      '<storageAccountCSEFileUrl>'
+    ]
   }
 }
 param extensionDependencyAgentConfig = {
@@ -1098,7 +1091,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     ]
     osDisk: {
       createOption: 'fromImage'
-      diskSizeGB: '128'
+      diskSizeGB: 128
       managedDisk: {
         diskEncryptionSet: {
           id: '<id>'
@@ -1113,7 +1106,8 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
       {
         caching: 'ReadOnly'
         createOption: 'Empty'
-        diskSizeGB: '128'
+        diskSizeGB: 128
+        lun: 1
         managedDisk: {
           diskEncryptionSet: {
             id: '<id>'
@@ -1127,7 +1121,6 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
       autoUpgradeMinorVersion: true
       enabled: true
     }
-    location: '<location>'
     publicKeys: [
       {
         keyData: '<keyData>'
@@ -1191,7 +1184,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     "osDisk": {
       "value": {
         "createOption": "fromImage",
-        "diskSizeGB": "128",
+        "diskSizeGB": 128,
         "managedDisk": {
           "diskEncryptionSet": {
             "id": "<id>"
@@ -1212,7 +1205,8 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
         {
           "caching": "ReadOnly",
           "createOption": "Empty",
-          "diskSizeGB": "128",
+          "diskSizeGB": 128,
+          "lun": 1,
           "managedDisk": {
             "diskEncryptionSet": {
               "id": "<id>"
@@ -1230,9 +1224,6 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
         "autoUpgradeMinorVersion": true,
         "enabled": true
       }
-    },
-    "location": {
-      "value": "<location>"
     },
     "publicKeys": {
       "value": [
@@ -1286,7 +1277,7 @@ param nicConfigurations = [
 ]
 param osDisk = {
   createOption: 'fromImage'
-  diskSizeGB: '128'
+  diskSizeGB: 128
   managedDisk: {
     diskEncryptionSet: {
       id: '<id>'
@@ -1301,7 +1292,8 @@ param dataDisks = [
   {
     caching: 'ReadOnly'
     createOption: 'Empty'
-    diskSizeGB: '128'
+    diskSizeGB: 128
+    lun: 1
     managedDisk: {
       diskEncryptionSet: {
         id: '<id>'
@@ -1315,7 +1307,6 @@ param extensionMonitoringAgentConfig = {
   autoUpgradeMinorVersion: true
   enabled: true
 }
-param location = '<location>'
 param publicKeys = [
   {
     keyData: '<keyData>'
@@ -1370,7 +1361,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     ]
     osDisk: {
       createOption: 'fromImage'
-      diskSizeGB: '128'
+      diskSizeGB: 128
       managedDisk: {
         storageAccountType: 'Premium_LRS'
       }
@@ -1436,7 +1427,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     "osDisk": {
       "value": {
         "createOption": "fromImage",
-        "diskSizeGB": "128",
+        "diskSizeGB": 128,
         "managedDisk": {
           "storageAccountType": "Premium_LRS"
         }
@@ -1496,7 +1487,7 @@ param nicConfigurations = [
 ]
 param osDisk = {
   createOption: 'fromImage'
-  diskSizeGB: '128'
+  diskSizeGB: 128
   managedDisk: {
     storageAccountType: 'Premium_LRS'
   }
@@ -1553,7 +1544,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     ]
     osDisk: {
       createOption: 'fromImage'
-      diskSizeGB: '128'
+      diskSizeGB: 128
       managedDisk: {
         storageAccountType: 'Premium_LRS'
       }
@@ -1608,15 +1599,14 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
       }
     }
     extensionCustomScriptConfig: {
-      enabled: true
-      fileData: [
-        {
-          storageAccountId: '<storageAccountId>'
-          uri: '<uri>'
-        }
-      ]
       protectedSettings: {
+        managedIdentityResourceId: '<managedIdentityResourceId>'
+      }
+      settings: {
         commandToExecute: '<commandToExecute>'
+        fileUris: [
+          '<storageAccountCSEFileUrl>'
+        ]
       }
     }
     extensionDependencyAgentConfig: {
@@ -1627,11 +1617,9 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     }
     extensionHealthConfig: {
       enabled: true
-      settings: {
-        port: 80
-        protocol: 'http'
-        requestPath: '/'
-      }
+      port: 80
+      protocol: 'http'
+      requestPath: '/'
     }
     extensionMonitoringAgentConfig: {
       autoUpgradeMinorVersion: true
@@ -1736,7 +1724,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     "osDisk": {
       "value": {
         "createOption": "fromImage",
-        "diskSizeGB": "128",
+        "diskSizeGB": 128,
         "managedDisk": {
           "storageAccountType": "Premium_LRS"
         }
@@ -1805,15 +1793,14 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     },
     "extensionCustomScriptConfig": {
       "value": {
-        "enabled": true,
-        "fileData": [
-          {
-            "storageAccountId": "<storageAccountId>",
-            "uri": "<uri>"
-          }
-        ],
         "protectedSettings": {
-          "commandToExecute": "<commandToExecute>"
+          "managedIdentityResourceId": "<managedIdentityResourceId>"
+        },
+        "settings": {
+          "commandToExecute": "<commandToExecute>",
+          "fileUris": [
+            "<storageAccountCSEFileUrl>"
+          ]
         }
       }
     },
@@ -1830,11 +1817,9 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     "extensionHealthConfig": {
       "value": {
         "enabled": true,
-        "settings": {
-          "port": 80,
-          "protocol": "http",
-          "requestPath": "/"
-        }
+        "port": 80,
+        "protocol": "http",
+        "requestPath": "/"
       }
     },
     "extensionMonitoringAgentConfig": {
@@ -1949,7 +1934,7 @@ param nicConfigurations = [
 ]
 param osDisk = {
   createOption: 'fromImage'
-  diskSizeGB: '128'
+  diskSizeGB: 128
   managedDisk: {
     storageAccountType: 'Premium_LRS'
   }
@@ -2004,15 +1989,14 @@ param extensionAzureDiskEncryptionConfig = {
   }
 }
 param extensionCustomScriptConfig = {
-  enabled: true
-  fileData: [
-    {
-      storageAccountId: '<storageAccountId>'
-      uri: '<uri>'
-    }
-  ]
   protectedSettings: {
+    managedIdentityResourceId: '<managedIdentityResourceId>'
+  }
+  settings: {
     commandToExecute: '<commandToExecute>'
+    fileUris: [
+      '<storageAccountCSEFileUrl>'
+    ]
   }
 }
 param extensionDependencyAgentConfig = {
@@ -2023,11 +2007,9 @@ param extensionDSCConfig = {
 }
 param extensionHealthConfig = {
   enabled: true
-  settings: {
-    port: 80
-    protocol: 'http'
-    requestPath: '/'
-  }
+  port: 80
+  protocol: 'http'
+  requestPath: '/'
 }
 param extensionMonitoringAgentConfig = {
   autoUpgradeMinorVersion: true
@@ -2123,7 +2105,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     ]
     osDisk: {
       createOption: 'fromImage'
-      diskSizeGB: '128'
+      diskSizeGB: 128
       managedDisk: {
         storageAccountType: 'Premium_LRS'
       }
@@ -2131,7 +2113,6 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     osType: 'Windows'
     skuName: 'Standard_B12ms'
     // Non-required parameters
-    location: '<location>'
     orchestrationMode: 'Uniform'
     patchMode: 'AutomaticByOS'
   }
@@ -2191,7 +2172,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     "osDisk": {
       "value": {
         "createOption": "fromImage",
-        "diskSizeGB": "128",
+        "diskSizeGB": 128,
         "managedDisk": {
           "storageAccountType": "Premium_LRS"
         }
@@ -2204,9 +2185,6 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
       "value": "Standard_B12ms"
     },
     // Non-required parameters
-    "location": {
-      "value": "<location>"
-    },
     "orchestrationMode": {
       "value": "Uniform"
     },
@@ -2257,7 +2235,7 @@ param nicConfigurations = [
 ]
 param osDisk = {
   createOption: 'fromImage'
-  diskSizeGB: '128'
+  diskSizeGB: 128
   managedDisk: {
     storageAccountType: 'Premium_LRS'
   }
@@ -2265,7 +2243,6 @@ param osDisk = {
 param osType = 'Windows'
 param skuName = 'Standard_B12ms'
 // Non-required parameters
-param location = '<location>'
 param orchestrationMode = 'Uniform'
 param patchMode = 'AutomaticByOS'
 ```
@@ -2371,15 +2348,14 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
       }
     }
     extensionCustomScriptConfig: {
-      enabled: true
-      fileData: [
-        {
-          storageAccountId: '<storageAccountId>'
-          uri: '<uri>'
-        }
-      ]
       protectedSettings: {
+        managedIdentityResourceId: '<managedIdentityResourceId>'
+      }
+      settings: {
         commandToExecute: '<commandToExecute>'
+        fileUris: [
+          '<storageAccountCSEFileUrl>'
+        ]
       }
     }
     extensionDependencyAgentConfig: {
@@ -2537,15 +2513,14 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     },
     "extensionCustomScriptConfig": {
       "value": {
-        "enabled": true,
-        "fileData": [
-          {
-            "storageAccountId": "<storageAccountId>",
-            "uri": "<uri>"
-          }
-        ],
         "protectedSettings": {
-          "commandToExecute": "<commandToExecute>"
+          "managedIdentityResourceId": "<managedIdentityResourceId>"
+        },
+        "settings": {
+          "commandToExecute": "<commandToExecute>",
+          "fileUris": [
+            "<storageAccountCSEFileUrl>"
+          ]
         }
       }
     },
@@ -2699,15 +2674,14 @@ param extensionAzureDiskEncryptionConfig = {
   }
 }
 param extensionCustomScriptConfig = {
-  enabled: true
-  fileData: [
-    {
-      storageAccountId: '<storageAccountId>'
-      uri: '<uri>'
-    }
-  ]
   protectedSettings: {
+    managedIdentityResourceId: '<managedIdentityResourceId>'
+  }
+  settings: {
     commandToExecute: '<commandToExecute>'
+    fileUris: [
+      '<storageAccountCSEFileUrl>'
+    ]
   }
 }
 param extensionDependencyAgentConfig = {
@@ -2754,7 +2728,7 @@ param vmPriority = 'Regular'
 | [`adminUsername`](#parameter-adminusername) | securestring | Administrator username. |
 | [`imageReference`](#parameter-imagereference) | object | OS image reference. In case of marketplace images, it's the combination of the publisher, offer, sku, version attributes. In case of custom images it's the resource ID of the custom image. |
 | [`name`](#parameter-name) | string | Name of the VMSS. |
-| [`nicConfigurations`](#parameter-nicconfigurations) | array | Configures NICs and PIPs. |
+| [`nicConfigurations`](#parameter-nicconfigurations) | array | Configures NICs and PIPs. The first item in the list is considered the `primary` configuration. |
 | [`osDisk`](#parameter-osdisk) | object | Specifies the OS disk. For security reasons, it is recommended to specify DiskEncryptionSet into the osDisk object. Restrictions: DiskEncryptionSet cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VM Scale sets. |
 | [`osType`](#parameter-ostype) | string | The chosen OS type. |
 | [`skuName`](#parameter-skuname) | string | The SKU size of the VMs. |
@@ -2784,7 +2758,7 @@ param vmPriority = 'Regular'
 | [`encryptionAtHost`](#parameter-encryptionathost) | bool | This property can be used by user in the request to enable or disable the Host Encryption for the virtual machine. This will enable the encryption for all the disks including Resource/Temp disk at host itself. For security reasons, it is recommended to set encryptionAtHost to True. Restrictions: Cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your virtual machine scale sets. |
 | [`extensionAntiMalwareConfig`](#parameter-extensionantimalwareconfig) | object | The configuration for the [Anti Malware] extension. Must at least contain the ["enabled": true] property to be executed. |
 | [`extensionAzureDiskEncryptionConfig`](#parameter-extensionazurediskencryptionconfig) | object | The configuration for the [Azure Disk Encryption] extension. Must at least contain the ["enabled": true] property to be executed. Restrictions: Cannot be enabled on disks that have encryption at host enabled. Managed disks encrypted using Azure Disk Encryption cannot be encrypted using customer-managed keys. |
-| [`extensionCustomScriptConfig`](#parameter-extensioncustomscriptconfig) | object | The configuration for the [Custom Script] extension. Must at least contain the ["enabled": true] property to be executed. |
+| [`extensionCustomScriptConfig`](#parameter-extensioncustomscriptconfig) | object | The configuration for the [Custom Script] extension. |
 | [`extensionDependencyAgentConfig`](#parameter-extensiondependencyagentconfig) | object | The configuration for the [Dependency Agent] extension. Must at least contain the ["enabled": true] property to be executed. |
 | [`extensionDomainJoinConfig`](#parameter-extensiondomainjoinconfig) | secureObject | The configuration for the [Domain Join] extension. Must at least contain the ["enabled": true] property to be executed. |
 | [`extensionDomainJoinPassword`](#parameter-extensiondomainjoinpassword) | securestring | Required if name is specified. Password of the user specified in user parameter. |
@@ -2816,7 +2790,6 @@ param vmPriority = 'Regular'
 | [`rebootSetting`](#parameter-rebootsetting) | string | Specifies the reboot setting for all AutomaticByPlatform patch installation operations. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`rollbackFailedInstancesOnPolicyBreach`](#parameter-rollbackfailedinstancesonpolicybreach) | bool | Rollback failed instances to previous model if the Rolling Upgrade policy is violated. |
-| [`sasTokenValidityLength`](#parameter-sastokenvaliditylength) | string | SAS token validity length to use to download files from storage accounts. Usage: 'PT8H' - valid for 8 hours; 'P5D' - valid for 5 days; 'P1Y' - valid for 1 year. When not provided, the SAS token will be valid for 8 hours. |
 | [`scaleInPolicy`](#parameter-scaleinpolicy) | object | Specifies the scale-in policy that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set is scaled-in. |
 | [`scaleSetFaultDomain`](#parameter-scalesetfaultdomain) | int | Fault Domain count for each placement group. |
 | [`scheduledEventsProfile`](#parameter-scheduledeventsprofile) | object | Specifies Scheduled Event related configurations. |
@@ -2834,12 +2807,6 @@ param vmPriority = 'Regular'
 | [`vTpmEnabled`](#parameter-vtpmenabled) | bool | Specifies whether vTPM should be enabled on the virtual machine scale set. This parameter is part of the UefiSettings.  SecurityType should be set to TrustedLaunch to enable UefiSettings. |
 | [`winRM`](#parameter-winrm) | object | Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object. |
 | [`zoneBalance`](#parameter-zonebalance) | bool | Whether to force strictly even Virtual Machine distribution cross x-zones in case there is zone outage. |
-
-**Generated parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`baseTime`](#parameter-basetime) | string | Do not provide a value! This date value is used to generate a registration token. |
 
 ### Parameter: `adminPassword`
 
@@ -2871,10 +2838,60 @@ Name of the VMSS.
 
 ### Parameter: `nicConfigurations`
 
-Configures NICs and PIPs.
+Configures NICs and PIPs. The first item in the list is considered the `primary` configuration.
 
 - Required: Yes
 - Type: array
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`ipConfigurations`](#parameter-nicconfigurationsipconfigurations) | array | Specifies the IP configurations of the network interface. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`enableAcceleratedNetworking`](#parameter-nicconfigurationsenableacceleratednetworking) | bool | Specifies whether the network interface is accelerated networking-enabled. Defaults to `true`. |
+| [`name`](#parameter-nicconfigurationsname) | string | The name of the NIC configuration. If not provided, a name is generated using the `nicSuffic` and an incremental counter. |
+| [`networkSecurityGroupResourceId`](#parameter-nicconfigurationsnetworksecuritygroupresourceid) | string | The resource ID of a network security group to associate with the NIC. |
+| [`nicSuffix`](#parameter-nicconfigurationsnicsuffix) | string | The suffix to add to each NIC configuration name if no `name` was provided. |
+
+### Parameter: `nicConfigurations.ipConfigurations`
+
+Specifies the IP configurations of the network interface.
+
+- Required: Yes
+- Type: array
+
+### Parameter: `nicConfigurations.enableAcceleratedNetworking`
+
+Specifies whether the network interface is accelerated networking-enabled. Defaults to `true`.
+
+- Required: No
+- Type: bool
+
+### Parameter: `nicConfigurations.name`
+
+The name of the NIC configuration. If not provided, a name is generated using the `nicSuffic` and an incremental counter.
+
+- Required: No
+- Type: string
+
+### Parameter: `nicConfigurations.networkSecurityGroupResourceId`
+
+The resource ID of a network security group to associate with the NIC.
+
+- Required: No
+- Type: string
+
+### Parameter: `nicConfigurations.nicSuffix`
+
+The suffix to add to each NIC configuration name if no `name` was provided.
+
+- Required: No
+- Type: string
 
 ### Parameter: `osDisk`
 
@@ -3198,17 +3215,129 @@ The configuration for the [Azure Disk Encryption] extension. Must at least conta
 
 ### Parameter: `extensionCustomScriptConfig`
 
-The configuration for the [Custom Script] extension. Must at least contain the ["enabled": true] property to be executed.
+The configuration for the [Custom Script] extension.
 
 - Required: No
 - Type: object
-- Default:
-  ```Bicep
-  {
-      enabled: false
-      fileData: []
-  }
-  ```
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`autoUpgradeMinorVersion`](#parameter-extensioncustomscriptconfigautoupgrademinorversion) | bool | Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true. Defaults to `true`. |
+| [`enableAutomaticUpgrade`](#parameter-extensioncustomscriptconfigenableautomaticupgrade) | bool | Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available. Defaults to `false`. |
+| [`forceUpdateTag`](#parameter-extensioncustomscriptconfigforceupdatetag) | string | How the extension handler should be forced to update even if the extension configuration has not changed. |
+| [`name`](#parameter-extensioncustomscriptconfigname) | string | The name of the virtual machine extension. Defaults to `CustomScriptExtension`. |
+| [`protectedSettings`](#parameter-extensioncustomscriptconfigprotectedsettings) | secureObject | The configuration of the custom script extension. Note: You can provide any property either in the `settings` or `protectedSettings` but not both. If your property contains secrets, use `protectedSettings`. |
+| [`protectedSettingsFromKeyVault`](#parameter-extensioncustomscriptconfigprotectedsettingsfromkeyvault) | object | The extensions protected settings that are passed by reference, and consumed from key vault. |
+| [`provisionAfterExtensions`](#parameter-extensioncustomscriptconfigprovisionafterextensions) | array | Collection of extension names after which this extension needs to be provisioned. |
+| [`settings`](#parameter-extensioncustomscriptconfigsettings) | object | The configuration of the custom script extension. Note: You can provide any property either in the `settings` or `protectedSettings` but not both. If your property contains secrets, use `protectedSettings`. |
+| [`supressFailures`](#parameter-extensioncustomscriptconfigsupressfailures) | bool | Indicates whether failures stemming from the extension will be suppressed (Operational failures such as not connecting to the VM will not be suppressed regardless of this value). Defaults to `false`. |
+| [`tags`](#parameter-extensioncustomscriptconfigtags) | object | Tags of the resource. |
+| [`typeHandlerVersion`](#parameter-extensioncustomscriptconfigtypehandlerversion) | string | Specifies the version of the script handler. Defaults to `1.10` for Windows and `2.1` for Linux. |
+
+### Parameter: `extensionCustomScriptConfig.autoUpgradeMinorVersion`
+
+Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true. Defaults to `true`.
+
+- Required: No
+- Type: bool
+
+### Parameter: `extensionCustomScriptConfig.enableAutomaticUpgrade`
+
+Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available. Defaults to `false`.
+
+- Required: No
+- Type: bool
+
+### Parameter: `extensionCustomScriptConfig.forceUpdateTag`
+
+How the extension handler should be forced to update even if the extension configuration has not changed.
+
+- Required: No
+- Type: string
+
+### Parameter: `extensionCustomScriptConfig.name`
+
+The name of the virtual machine extension. Defaults to `CustomScriptExtension`.
+
+- Required: No
+- Type: string
+
+### Parameter: `extensionCustomScriptConfig.protectedSettings`
+
+The configuration of the custom script extension. Note: You can provide any property either in the `settings` or `protectedSettings` but not both. If your property contains secrets, use `protectedSettings`.
+
+- Required: No
+- Type: secureObject
+
+### Parameter: `extensionCustomScriptConfig.protectedSettingsFromKeyVault`
+
+The extensions protected settings that are passed by reference, and consumed from key vault.
+
+- Required: No
+- Type: object
+
+### Parameter: `extensionCustomScriptConfig.provisionAfterExtensions`
+
+Collection of extension names after which this extension needs to be provisioned.
+
+- Required: No
+- Type: array
+
+### Parameter: `extensionCustomScriptConfig.settings`
+
+The configuration of the custom script extension. Note: You can provide any property either in the `settings` or `protectedSettings` but not both. If your property contains secrets, use `protectedSettings`.
+
+- Required: No
+- Type: object
+
+**Conditional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`commandToExecute`](#parameter-extensioncustomscriptconfigsettingscommandtoexecute) | string | The entry point script to run. If the command contains any credentials, use the same property of the `protectedSettings` instead. Required if `protectedSettings.commandToExecute` is not provided. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`fileUris`](#parameter-extensioncustomscriptconfigsettingsfileuris) | array | URLs for files to be downloaded. If URLs are sensitive, for example, if they contain keys, this field should be specified in `protectedSettings`. |
+
+### Parameter: `extensionCustomScriptConfig.settings.commandToExecute`
+
+The entry point script to run. If the command contains any credentials, use the same property of the `protectedSettings` instead. Required if `protectedSettings.commandToExecute` is not provided.
+
+- Required: No
+- Type: string
+
+### Parameter: `extensionCustomScriptConfig.settings.fileUris`
+
+URLs for files to be downloaded. If URLs are sensitive, for example, if they contain keys, this field should be specified in `protectedSettings`.
+
+- Required: No
+- Type: array
+
+### Parameter: `extensionCustomScriptConfig.supressFailures`
+
+Indicates whether failures stemming from the extension will be suppressed (Operational failures such as not connecting to the VM will not be suppressed regardless of this value). Defaults to `false`.
+
+- Required: No
+- Type: bool
+
+### Parameter: `extensionCustomScriptConfig.tags`
+
+Tags of the resource.
+
+- Required: No
+- Type: object
+
+### Parameter: `extensionCustomScriptConfig.typeHandlerVersion`
+
+Specifies the version of the script handler. Defaults to `1.10` for Windows and `2.1` for Linux.
+
+- Required: No
+- Type: string
 
 ### Parameter: `extensionDependencyAgentConfig`
 
@@ -3267,13 +3396,106 @@ Turned on by default. The configuration for the [Application Health Monitoring] 
   ```Bicep
   {
       enabled: true
-      settings: {
-        port: 80
-        protocol: 'http'
-        requestPath: '/'
-      }
+      port: 80
+      protocol: 'http'
+      requestPath: '/'
   }
   ```
+
+**Conditional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`port`](#parameter-extensionhealthconfigport) | int | The port to connect to. Defaults to `80`. Required if `protocol` is `tcp`. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`autoUpgradeMinorVersion`](#parameter-extensionhealthconfigautoupgrademinorversion) | bool | Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true. Defaults to `false`. |
+| [`enabled`](#parameter-extensionhealthconfigenabled) | bool | Enable or disable the Health Config extension. Defaults to `false`. |
+| [`gracePeriod`](#parameter-extensionhealthconfiggraceperiod) | int | The grace period for newly created instances. Defaults to `intervalInSeconds` x `numberOfProbes`. |
+| [`intervalInSeconds`](#parameter-extensionhealthconfigintervalinseconds) | int | This is the interval between each health probe. For example, if intervalInSeconds == 5, a probe will be sent to the local application endpoint once every 5 seconds. Defaults to `5`. |
+| [`numberOfProbes`](#parameter-extensionhealthconfignumberofprobes) | int | This is the number of consecutive probes required for the health status to change. For example, if numberOfProbles == 3, you will need 3 consecutive "Healthy" signals to change the health status from "Unhealthy" into "Healthy" state. The same requirement applies to change health status into "Unhealthy" state. Defaults to `1`. |
+| [`protocol`](#parameter-extensionhealthconfigprotocol) | string | The protocol to connect with. Defaults to `http`. |
+| [`requestPath`](#parameter-extensionhealthconfigrequestpath) | string | The path of the request. Not allowed if `protocol` is `tcp`, |
+| [`typeHandlerVersion`](#parameter-extensionhealthconfigtypehandlerversion) | string | Specifies the version of the script handler. Defaults to `2.0`. |
+
+### Parameter: `extensionHealthConfig.port`
+
+The port to connect to. Defaults to `80`. Required if `protocol` is `tcp`.
+
+- Required: No
+- Type: int
+
+### Parameter: `extensionHealthConfig.autoUpgradeMinorVersion`
+
+Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true. Defaults to `false`.
+
+- Required: No
+- Type: bool
+
+### Parameter: `extensionHealthConfig.enabled`
+
+Enable or disable the Health Config extension. Defaults to `false`.
+
+- Required: Yes
+- Type: bool
+
+### Parameter: `extensionHealthConfig.gracePeriod`
+
+The grace period for newly created instances. Defaults to `intervalInSeconds` x `numberOfProbes`.
+
+- Required: No
+- Type: int
+- MaxValue: 14400
+
+### Parameter: `extensionHealthConfig.intervalInSeconds`
+
+This is the interval between each health probe. For example, if intervalInSeconds == 5, a probe will be sent to the local application endpoint once every 5 seconds. Defaults to `5`.
+
+- Required: No
+- Type: int
+- MinValue: 5
+- MaxValue: 60
+
+### Parameter: `extensionHealthConfig.numberOfProbes`
+
+This is the number of consecutive probes required for the health status to change. For example, if numberOfProbles == 3, you will need 3 consecutive "Healthy" signals to change the health status from "Unhealthy" into "Healthy" state. The same requirement applies to change health status into "Unhealthy" state. Defaults to `1`.
+
+- Required: No
+- Type: int
+- MinValue: 1
+- MaxValue: 24
+
+### Parameter: `extensionHealthConfig.protocol`
+
+The protocol to connect with. Defaults to `http`.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'http'
+    'https'
+    'tcp'
+  ]
+  ```
+
+### Parameter: `extensionHealthConfig.requestPath`
+
+The path of the request. Not allowed if `protocol` is `tcp`,
+
+- Required: No
+- Type: string
+
+### Parameter: `extensionHealthConfig.typeHandlerVersion`
+
+Specifies the version of the script handler. Defaults to `2.0`.
+
+- Required: No
+- Type: string
 
 ### Parameter: `extensionMonitoringAgentConfig`
 
@@ -3551,7 +3773,6 @@ The list of SSH public keys used to authenticate with linux based VMs.
 
 - Required: No
 - Type: array
-- Default: `[]`
 
 ### Parameter: `rebootSetting`
 
@@ -3693,14 +3914,6 @@ Rollback failed instances to previous model if the Rolling Upgrade policy is vio
 - Required: No
 - Type: bool
 - Default: `False`
-
-### Parameter: `sasTokenValidityLength`
-
-SAS token validity length to use to download files from storage accounts. Usage: 'PT8H' - valid for 8 hours; 'P5D' - valid for 5 days; 'P1Y' - valid for 1 year. When not provided, the SAS token will be valid for 8 hours.
-
-- Required: No
-- Type: string
-- Default: `'PT8H'`
 
 ### Parameter: `scaleInPolicy`
 
@@ -3849,7 +4062,6 @@ Specifies the Windows Remote Management listeners. This enables remote Windows P
 
 - Required: No
 - Type: object
-- Default: `{}`
 
 ### Parameter: `zoneBalance`
 
@@ -3858,14 +4070,6 @@ Whether to force strictly even Virtual Machine distribution cross x-zones in cas
 - Required: No
 - Type: bool
 - Default: `False`
-
-### Parameter: `baseTime`
-
-Do not provide a value! This date value is used to generate a registration token.
-
-- Required: No
-- Type: string
-- Default: `[utcNow('u')]`
 
 ## Outputs
 
@@ -3883,9 +4087,8 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.4.1` | Remote reference |
-| `br/public:avm/utl/types/avm-common-types:0.5.1` | Remote reference |
 | `br/public:avm/utl/types/avm-common-types:0.6.0` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/compute/virtual-machine-scale-set/README.md
+++ b/avm/res/compute/virtual-machine-scale-set/README.md
@@ -2293,7 +2293,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     ]
     osDisk: {
       createOption: 'fromImage'
-      diskSizeGB: '128'
+      diskSizeGB: 128
       managedDisk: {
         storageAccountType: 'Premium_LRS'
       }
@@ -2444,7 +2444,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     "osDisk": {
       "value": {
         "createOption": "fromImage",
-        "diskSizeGB": "128",
+        "diskSizeGB": 128,
         "managedDisk": {
           "storageAccountType": "Premium_LRS"
         }
@@ -2619,7 +2619,7 @@ param nicConfigurations = [
 ]
 param osDisk = {
   createOption: 'fromImage'
-  diskSizeGB: '128'
+  diskSizeGB: 128
   managedDisk: {
     storageAccountType: 'Premium_LRS'
   }
@@ -3418,7 +3418,7 @@ Turned on by default. The configuration for the [Application Health Monitoring] 
 | [`intervalInSeconds`](#parameter-extensionhealthconfigintervalinseconds) | int | This is the interval between each health probe. For example, if intervalInSeconds == 5, a probe will be sent to the local application endpoint once every 5 seconds. Defaults to `5`. |
 | [`numberOfProbes`](#parameter-extensionhealthconfignumberofprobes) | int | This is the number of consecutive probes required for the health status to change. For example, if numberOfProbles == 3, you will need 3 consecutive "Healthy" signals to change the health status from "Unhealthy" into "Healthy" state. The same requirement applies to change health status into "Unhealthy" state. Defaults to `1`. |
 | [`protocol`](#parameter-extensionhealthconfigprotocol) | string | The protocol to connect with. Defaults to `http`. |
-| [`requestPath`](#parameter-extensionhealthconfigrequestpath) | string | The path of the request. Not allowed if `protocol` is `tcp`, |
+| [`requestPath`](#parameter-extensionhealthconfigrequestpath) | string | The path of the request. Not allowed if `protocol` is `tcp`. |
 | [`typeHandlerVersion`](#parameter-extensionhealthconfigtypehandlerversion) | string | Specifies the version of the script handler. Defaults to `2.0`. |
 
 ### Parameter: `extensionHealthConfig.port`
@@ -3439,7 +3439,7 @@ Indicates whether the extension should use a newer minor version if one is avail
 
 Enable or disable the Health Config extension. Defaults to `false`.
 
-- Required: Yes
+- Required: No
 - Type: bool
 
 ### Parameter: `extensionHealthConfig.gracePeriod`
@@ -3485,7 +3485,7 @@ The protocol to connect with. Defaults to `http`.
 
 ### Parameter: `extensionHealthConfig.requestPath`
 
-The path of the request. Not allowed if `protocol` is `tcp`,
+The path of the request. Not allowed if `protocol` is `tcp`.
 
 - Required: No
 - Type: string

--- a/avm/res/compute/virtual-machine-scale-set/README.md
+++ b/avm/res/compute/virtual-machine-scale-set/README.md
@@ -3402,6 +3402,12 @@ Turned on by default. The configuration for the [Application Health Monitoring] 
   }
   ```
 
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`enabled`](#parameter-extensionhealthconfigenabled) | bool | Enable or disable the Health Config extension. |
+
 **Conditional parameters**
 
 | Parameter | Type | Description |
@@ -3413,13 +3419,21 @@ Turned on by default. The configuration for the [Application Health Monitoring] 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`autoUpgradeMinorVersion`](#parameter-extensionhealthconfigautoupgrademinorversion) | bool | Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true. Defaults to `false`. |
-| [`enabled`](#parameter-extensionhealthconfigenabled) | bool | Enable or disable the Health Config extension. Defaults to `false`. |
+| [`enableAutomaticUpgrade`](#parameter-extensionhealthconfigenableautomaticupgrade) | bool | Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available. Defaults to `true`. |
 | [`gracePeriod`](#parameter-extensionhealthconfiggraceperiod) | int | The grace period for newly created instances. Defaults to `intervalInSeconds` x `numberOfProbes`. |
 | [`intervalInSeconds`](#parameter-extensionhealthconfigintervalinseconds) | int | This is the interval between each health probe. For example, if intervalInSeconds == 5, a probe will be sent to the local application endpoint once every 5 seconds. Defaults to `5`. |
 | [`numberOfProbes`](#parameter-extensionhealthconfignumberofprobes) | int | This is the number of consecutive probes required for the health status to change. For example, if numberOfProbles == 3, you will need 3 consecutive "Healthy" signals to change the health status from "Unhealthy" into "Healthy" state. The same requirement applies to change health status into "Unhealthy" state. Defaults to `1`. |
 | [`protocol`](#parameter-extensionhealthconfigprotocol) | string | The protocol to connect with. Defaults to `http`. |
+| [`provisionAfterExtensions`](#parameter-extensionhealthconfigprovisionafterextensions) | array | Collection of extension names after which this extension needs to be provisioned. |
 | [`requestPath`](#parameter-extensionhealthconfigrequestpath) | string | The path of the request. Not allowed if `protocol` is `tcp`. |
 | [`typeHandlerVersion`](#parameter-extensionhealthconfigtypehandlerversion) | string | Specifies the version of the script handler. Defaults to `2.0`. |
+
+### Parameter: `extensionHealthConfig.enabled`
+
+Enable or disable the Health Config extension.
+
+- Required: Yes
+- Type: bool
 
 ### Parameter: `extensionHealthConfig.port`
 
@@ -3435,9 +3449,9 @@ Indicates whether the extension should use a newer minor version if one is avail
 - Required: No
 - Type: bool
 
-### Parameter: `extensionHealthConfig.enabled`
+### Parameter: `extensionHealthConfig.enableAutomaticUpgrade`
 
-Enable or disable the Health Config extension. Defaults to `false`.
+Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available. Defaults to `true`.
 
 - Required: No
 - Type: bool
@@ -3482,6 +3496,13 @@ The protocol to connect with. Defaults to `http`.
     'tcp'
   ]
   ```
+
+### Parameter: `extensionHealthConfig.provisionAfterExtensions`
+
+Collection of extension names after which this extension needs to be provisioned.
+
+- Required: No
+- Type: array
 
 ### Parameter: `extensionHealthConfig.requestPath`
 

--- a/avm/res/compute/virtual-machine-scale-set/README.md
+++ b/avm/res/compute/virtual-machine-scale-set/README.md
@@ -81,7 +81,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     ]
     osDisk: {
       createOption: 'fromImage'
-      diskSizeGB: '128'
+      diskSizeGB: 128
       managedDisk: {
         storageAccountType: 'Premium_LRS'
       }
@@ -153,7 +153,7 @@ module virtualMachineScaleSet 'br/public:avm/res/compute/virtual-machine-scale-s
     "osDisk": {
       "value": {
         "createOption": "fromImage",
-        "diskSizeGB": "128",
+        "diskSizeGB": 128,
         "managedDisk": {
           "storageAccountType": "Premium_LRS"
         }
@@ -221,7 +221,7 @@ param nicConfigurations = [
 ]
 param osDisk = {
   createOption: 'fromImage'
-  diskSizeGB: '128'
+  diskSizeGB: 128
   managedDisk: {
     storageAccountType: 'Premium_LRS'
   }

--- a/avm/res/compute/virtual-machine-scale-set/extension/README.md
+++ b/avm/res/compute/virtual-machine-scale-set/extension/README.md
@@ -12,7 +12,7 @@ This module deploys a Virtual Machine Scale Set Extension.
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.Compute/virtualMachineScaleSets/extensions` | 2023-09-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.compute_virtualmachinescalesets_extensions.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2023-09-01/virtualMachineScaleSets/extensions)</li></ul> |
+| `Microsoft.Compute/virtualMachineScaleSets/extensions` | 2024-11-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.compute_virtualmachinescalesets_extensions.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2024-11-01/virtualMachineScaleSets/extensions)</li></ul> |
 
 ## Parameters
 
@@ -39,6 +39,8 @@ This module deploys a Virtual Machine Scale Set Extension.
 | :-- | :-- | :-- |
 | [`forceUpdateTag`](#parameter-forceupdatetag) | string | How the extension handler should be forced to update even if the extension configuration has not changed. |
 | [`protectedSettings`](#parameter-protectedsettings) | secureObject | Any object that contains the extension specific protected settings. |
+| [`protectedSettingsFromKeyVault`](#parameter-protectedsettingsfromkeyvault) | object | The extensions protected settings that are passed by reference, and consumed from key vault. |
+| [`provisionAfterExtensions`](#parameter-provisionafterextensions) | array | Collection of extension names after which this extension needs to be provisioned. |
 | [`settings`](#parameter-settings) | object | Any object that contains the extension specific settings. |
 | [`supressFailures`](#parameter-supressfailures) | bool | Indicates whether failures stemming from the extension will be suppressed (Operational failures such as not connecting to the VM will not be suppressed regardless of this value). The default is false. |
 
@@ -97,7 +99,6 @@ How the extension handler should be forced to update even if the extension confi
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ### Parameter: `protectedSettings`
 
@@ -105,7 +106,20 @@ Any object that contains the extension specific protected settings.
 
 - Required: No
 - Type: secureObject
-- Default: `{}`
+
+### Parameter: `protectedSettingsFromKeyVault`
+
+The extensions protected settings that are passed by reference, and consumed from key vault.
+
+- Required: No
+- Type: object
+
+### Parameter: `provisionAfterExtensions`
+
+Collection of extension names after which this extension needs to be provisioned.
+
+- Required: No
+- Type: array
 
 ### Parameter: `settings`
 
@@ -113,7 +127,6 @@ Any object that contains the extension specific settings.
 
 - Required: No
 - Type: object
-- Default: `{}`
 
 ### Parameter: `supressFailures`
 

--- a/avm/res/compute/virtual-machine-scale-set/extension/main.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/extension/main.bicep
@@ -39,7 +39,7 @@ param enableAutomaticUpgrade bool
 param protectedSettingsFromKeyVault resourceInput<'Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01'>.properties.protectedSettingsFromKeyVault?
 
 @description('Optional. Collection of extension names after which this extension needs to be provisioned.')
-param provisionAfterExtensions resourceInput<'Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01'>.properties.provisionAfterExtensions?
+param provisionAfterExtensions string[]?
 
 resource virtualMachineScaleSet 'Microsoft.Compute/virtualMachineScaleSets@2024-11-01' existing = {
   name: virtualMachineScaleSetName

--- a/avm/res/compute/virtual-machine-scale-set/extension/main.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/extension/main.bicep
@@ -20,14 +20,14 @@ param typeHandlerVersion string
 param autoUpgradeMinorVersion bool
 
 @description('Optional. How the extension handler should be forced to update even if the extension configuration has not changed.')
-param forceUpdateTag string = ''
+param forceUpdateTag string?
 
 @description('Optional. Any object that contains the extension specific settings.')
-param settings object = {}
+param settings object? // Type any(...). Cannot use RDTs
 
 @description('Optional. Any object that contains the extension specific protected settings.')
 @secure()
-param protectedSettings object = {}
+param protectedSettings object? // Type any(...). Cannot use RDTs
 
 @description('Optional. Indicates whether failures stemming from the extension will be suppressed (Operational failures such as not connecting to the VM will not be suppressed regardless of this value). The default is false.')
 param supressFailures bool = false
@@ -35,11 +35,17 @@ param supressFailures bool = false
 @description('Required. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available.')
 param enableAutomaticUpgrade bool
 
-resource virtualMachineScaleSet 'Microsoft.Compute/virtualMachineScaleSets@2023-09-01' existing = {
+@description('Optional. The extensions protected settings that are passed by reference, and consumed from key vault.')
+param protectedSettingsFromKeyVault resourceInput<'Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01'>.properties.protectedSettingsFromKeyVault?
+
+@description('Optional. Collection of extension names after which this extension needs to be provisioned.')
+param provisionAfterExtensions resourceInput<'Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01'>.properties.provisionAfterExtensions?
+
+resource virtualMachineScaleSet 'Microsoft.Compute/virtualMachineScaleSets@2024-11-01' existing = {
   name: virtualMachineScaleSetName
 }
 
-resource extension 'Microsoft.Compute/virtualMachineScaleSets/extensions@2023-09-01' = {
+resource extension 'Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01' = {
   name: name
   parent: virtualMachineScaleSet
   properties: {
@@ -48,10 +54,12 @@ resource extension 'Microsoft.Compute/virtualMachineScaleSets/extensions@2023-09
     typeHandlerVersion: typeHandlerVersion
     autoUpgradeMinorVersion: autoUpgradeMinorVersion
     enableAutomaticUpgrade: enableAutomaticUpgrade
-    forceUpdateTag: !empty(forceUpdateTag) ? forceUpdateTag : null
-    settings: !empty(settings) ? settings : null
-    protectedSettings: !empty(protectedSettings) ? protectedSettings : null
+    forceUpdateTag: forceUpdateTag
+    settings: settings
+    protectedSettings: protectedSettings
     suppressFailures: supressFailures
+    protectedSettingsFromKeyVault: protectedSettingsFromKeyVault
+    provisionAfterExtensions: provisionAfterExtensions
   }
 }
 

--- a/avm/res/compute/virtual-machine-scale-set/extension/main.json
+++ b/avm/res/compute/virtual-machine-scale-set/extension/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "5972745166705801067"
+      "templateHash": "1457477458264476892"
     },
     "name": "Virtual Machine Scale Set Extensions",
     "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -94,13 +94,13 @@
     },
     "provisionAfterExtensions": {
       "type": "array",
-      "metadata": {
-        "__bicep_resource_derived_type!": {
-          "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
-        },
-        "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+      "items": {
+        "type": "string"
       },
-      "nullable": true
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+      }
     }
   },
   "resources": {

--- a/avm/res/compute/virtual-machine-scale-set/extension/main.json
+++ b/avm/res/compute/virtual-machine-scale-set/extension/main.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
   "contentVersion": "1.0.0.0",
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "2691883054312794420"
+      "version": "0.37.4.10188",
+      "templateHash": "5972745166705801067"
     },
     "name": "Virtual Machine Scale Set Extensions",
     "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -49,21 +50,21 @@
     },
     "forceUpdateTag": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
       "metadata": {
         "description": "Optional. How the extension handler should be forced to update even if the extension configuration has not changed."
       }
     },
     "settings": {
       "type": "object",
-      "defaultValue": {},
+      "nullable": true,
       "metadata": {
         "description": "Optional. Any object that contains the extension specific settings."
       }
     },
     "protectedSettings": {
       "type": "secureObject",
-      "defaultValue": {},
+      "nullable": true,
       "metadata": {
         "description": "Optional. Any object that contains the extension specific protected settings."
       }
@@ -80,12 +81,38 @@
       "metadata": {
         "description": "Required. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
       }
+    },
+    "protectedSettingsFromKeyVault": {
+      "type": "object",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/protectedSettingsFromKeyVault"
+        },
+        "description": "Optional. The extensions protected settings that are passed by reference, and consumed from key vault."
+      },
+      "nullable": true
+    },
+    "provisionAfterExtensions": {
+      "type": "array",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
+        },
+        "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+      },
+      "nullable": true
     }
   },
-  "resources": [
-    {
+  "resources": {
+    "virtualMachineScaleSet": {
+      "existing": true,
+      "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "apiVersion": "2024-11-01",
+      "name": "[parameters('virtualMachineScaleSetName')]"
+    },
+    "extension": {
       "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-      "apiVersion": "2023-09-01",
+      "apiVersion": "2024-11-01",
       "name": "[format('{0}/{1}', parameters('virtualMachineScaleSetName'), parameters('name'))]",
       "properties": {
         "publisher": "[parameters('publisher')]",
@@ -93,13 +120,15 @@
         "typeHandlerVersion": "[parameters('typeHandlerVersion')]",
         "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
         "enableAutomaticUpgrade": "[parameters('enableAutomaticUpgrade')]",
-        "forceUpdateTag": "[if(not(empty(parameters('forceUpdateTag'))), parameters('forceUpdateTag'), null())]",
-        "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
-        "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
-        "suppressFailures": "[parameters('supressFailures')]"
+        "forceUpdateTag": "[parameters('forceUpdateTag')]",
+        "settings": "[parameters('settings')]",
+        "protectedSettings": "[parameters('protectedSettings')]",
+        "suppressFailures": "[parameters('supressFailures')]",
+        "protectedSettingsFromKeyVault": "[parameters('protectedSettingsFromKeyVault')]",
+        "provisionAfterExtensions": "[parameters('provisionAfterExtensions')]"
       }
     }
-  ],
+  },
   "outputs": {
     "name": {
       "type": "string",

--- a/avm/res/compute/virtual-machine-scale-set/main.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/main.bicep
@@ -556,7 +556,7 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2024-11-01' = {
             : null
         }
       }
-      extensionProfile: extensionHealthConfig.enabled
+      extensionProfile: extensionHealthConfig.?enabled ?? false
         ? {
             extensions: [
               {
@@ -876,7 +876,7 @@ output location string = vmss.location
 @description('The type of the health config extension.')
 type extensionHealthConfigType = {
   @description('Optional. Enable or disable the Health Config extension. Defaults to `false`.')
-  enabled: bool
+  enabled: bool?
 
   @description('Optional. Specifies the version of the script handler. Defaults to `2.0`.')
   typeHandlerVersion: string?
@@ -890,7 +890,7 @@ type extensionHealthConfigType = {
   @description('Conditional. The port to connect to. Defaults to `80`. Required if `protocol` is `tcp`.')
   port: int?
 
-  @description('Optional. The path of the request. Not allowed if `protocol` is `tcp`,')
+  @description('Optional. The path of the request. Not allowed if `protocol` is `tcp`.')
   requestPath: string?
 
   @description('Optional. This is the interval between each health probe. For example, if intervalInSeconds == 5, a probe will be sent to the local application endpoint once every 5 seconds. Defaults to `5`.')

--- a/avm/res/compute/virtual-machine-scale-set/main.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/main.bicep
@@ -23,13 +23,13 @@ param vTpmEnabled bool = false
 param imageReference object
 
 @description('Optional. Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.')
-param plan resourceInput<'Microsoft.Compute/virtualMachineScaleSets@2024-07-01'>.plan?
+param plan resourceInput<'Microsoft.Compute/virtualMachineScaleSets@2024-11-01'>.plan?
 
 @description('Required. Specifies the OS disk. For security reasons, it is recommended to specify DiskEncryptionSet into the osDisk object. Restrictions: DiskEncryptionSet cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VM Scale sets.')
-param osDisk object
+param osDisk resourceInput<'Microsoft.Compute/virtualMachineScaleSets@2024-11-01'>.properties.virtualMachineProfile.storageProfile.osDisk
 
 @description('Optional. Specifies the data disks. For security reasons, it is recommended to specify DiskEncryptionSet into the dataDisk object. Restrictions: DiskEncryptionSet cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VM Scale sets.')
-param dataDisks array = []
+param dataDisks resourceInput<'Microsoft.Compute/virtualMachineScaleSets@2024-11-01'>.properties.virtualMachineProfile.storageProfile.dataDisks = []
 
 @description('Optional. The flag that enables or disables a capability to have one or more managed data disks with UltraSSD_LRS storage account type on the VM or VMSS. Managed disks with storage account type UltraSSD_LRS can be added to a virtual machine or virtual machine scale set only if this property is enabled.')
 param ultraSSDEnabled bool = false
@@ -45,7 +45,7 @@ param adminPassword string
 @description('Optional. Custom data associated to the VM, this value will be automatically converted into base64 to account for the expected VM format.')
 param customData string = ''
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
@@ -55,8 +55,8 @@ param scaleSetFaultDomain int = 1
 @description('Optional. Resource ID of a proximity placement group.')
 param proximityPlacementGroupResourceId string?
 
-@description('Required. Configures NICs and PIPs.')
-param nicConfigurations array
+@description('Required. Configures NICs and PIPs. The first item in the list is considered the `primary` configuration.')
+param nicConfigurations nicConfigurationType[]
 
 @description('Optional. Specifies the priority for the virtual machine.')
 @allowed([
@@ -120,13 +120,11 @@ param extensionAzureDiskEncryptionConfig object = {
 }
 
 @description('Optional. Turned on by default. The configuration for the [Application Health Monitoring] extension. Must at least contain the ["enabled": true] property to be executed.')
-param extensionHealthConfig object = {
+param extensionHealthConfig extensionHealthConfigType = {
   enabled: true
-  settings: {
-    protocol: 'http'
-    port: 80
-    requestPath: '/'
-  }
+  protocol: 'http'
+  port: 80
+  requestPath: '/'
 }
 
 @description('Optional. The configuration for the [Desired State Configuration] extension. Must at least contain the ["enabled": true] property to be executed.')
@@ -134,11 +132,8 @@ param extensionDSCConfig object = {
   enabled: false
 }
 
-@description('Optional. The configuration for the [Custom Script] extension. Must at least contain the ["enabled": true] property to be executed.')
-param extensionCustomScriptConfig object = {
-  enabled: false
-  fileData: []
-}
+@description('Optional. The configuration for the [Custom Script] extension.')
+param extensionCustomScriptConfig extensionCustomScriptConfigType?
 
 @description('Optional. Storage account boot diagnostic base URI.')
 param bootDiagnosticStorageAccountUri string = '.blob.${environment().suffixes.storage}/'
@@ -149,7 +144,7 @@ param bootDiagnosticStorageAccountName string?
 @description('Optional. Enable boot diagnostics to use default managed or secure storage. Defaults set to false.')
 param bootDiagnosticEnabled bool = false
 
-import { diagnosticSettingMetricsOnlyType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { diagnosticSettingMetricsOnlyType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The diagnostic settings of the service.')
 param diagnosticSettings diagnosticSettingMetricsOnlyType[]?
 
@@ -255,14 +250,14 @@ param timeZone string?
 param additionalUnattendContent resourceInput<'Microsoft.Compute/virtualMachineScaleSets@2024-07-01'>.properties.virtualMachineProfile.osProfile.windowsConfiguration.additionalUnattendContent?
 
 @description('Optional. Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object.')
-param winRM object = {}
+param winRM resourceInput<'Microsoft.Compute/virtualMachineScaleSets@2024-07-01'>.properties.virtualMachineProfile.osProfile.windowsConfiguration.winRM?
 
 @description('Optional. Specifies whether password authentication should be disabled.')
 #disable-next-line secure-secrets-in-params // Not a secret
 param disablePasswordAuthentication bool = false
 
 @description('Optional. The list of SSH public keys used to authenticate with linux based VMs.')
-param publicKeys array = []
+param publicKeys resourceInput<'Microsoft.Compute/virtualMachineScaleSets@2024-07-01'>.properties.virtualMachineProfile.osProfile.linuxConfiguration.ssh.publicKeys?
 
 @description('Optional. Specifies set of certificates that should be installed onto the virtual machines in the scale set.')
 #disable-next-line secure-secrets-in-params // Not a secret
@@ -317,32 +312,19 @@ param enableTelemetry bool = true
 ])
 param osType string
 
-@description('Generated. Do not provide a value! This date value is used to generate a registration token.')
-param baseTime string = utcNow('u')
-
-@description('Optional. SAS token validity length to use to download files from storage accounts. Usage: \'PT8H\' - valid for 8 hours; \'P5D\' - valid for 5 days; \'P1Y\' - valid for 1 year. When not provided, the SAS token will be valid for 8 hours.')
-param sasTokenValidityLength string = 'PT8H'
-
-import { managedIdentityAllType } from 'br/public:avm/utl/types/avm-common-types:0.4.1'
+import { managedIdentityAllType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The managed identity definition for this resource.')
 param managedIdentities managedIdentityAllType?
 
-var publicKeysFormatted = [
-  for publicKey in publicKeys: {
-    path: publicKey.path
-    keyData: publicKey.keyData
-  }
-]
-
 var networkInterfaceConfigurations = [
   for (nicConfiguration, index) in nicConfigurations: {
-    name: '${name}${nicConfiguration.nicSuffix}configuration-${index}'
+    name: nicConfiguration.?name ?? '${name}${nicConfiguration.?nicSuffix}configuration-${index}'
     properties: {
       primary: (index == 0) ? true : any(null)
       enableAcceleratedNetworking: nicConfiguration.?enableAcceleratedNetworking ?? true
-      networkSecurityGroup: contains(nicConfiguration, 'nsgId')
+      networkSecurityGroup: contains(nicConfiguration, 'networkSecurityGroupResourceId')
         ? {
-            id: nicConfiguration.nsgId
+            id: nicConfiguration.networkSecurityGroupResourceId!
           }
         : null
       ipConfigurations: nicConfiguration.ipConfigurations
@@ -353,7 +335,7 @@ var networkInterfaceConfigurations = [
 var linuxConfiguration = {
   disablePasswordAuthentication: disablePasswordAuthentication
   ssh: {
-    publicKeys: publicKeysFormatted
+    publicKeys: publicKeys
   }
   provisionVMAgent: provisionVMAgent
   patchSettings: (provisionVMAgent && (patchMode =~ 'AutomaticByPlatform' || patchMode =~ 'ImageDefault'))
@@ -387,15 +369,7 @@ var windowsConfiguration = {
     : null
   timeZone: timeZone
   additionalUnattendContent: additionalUnattendContent
-  winRM: !empty(winRM) ? { listeners: winRM.listeners } : null
-}
-
-var accountSasProperties = {
-  signedServices: 'b'
-  signedPermission: 'r'
-  signedExpiry: dateTimeAdd(baseTime, sasTokenValidityLength)
-  signedResourceTypes: 'o'
-  signedProtocol: 'https'
+  winRM: winRM
 }
 
 var formattedUserAssignedIdentities = reduce(
@@ -509,7 +483,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2024-07-01' = {
+resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2024-11-01' = {
   name: name
   location: location
   tags: tags
@@ -567,43 +541,8 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2024-07-01' = {
       }
       storageProfile: {
         imageReference: imageReference
-        osDisk: {
-          createOption: osDisk.createOption
-          diskSizeGB: osDisk.diskSizeGB
-          caching: osDisk.?caching
-          writeAcceleratorEnabled: osDisk.?writeAcceleratorEnabled
-          diffDiskSettings: osDisk.?diffDiskSettings
-          osType: osDisk.?osType
-          image: osDisk.?image
-          vhdContainers: osDisk.?vhdContainers
-          managedDisk: {
-            storageAccountType: osDisk.managedDisk.storageAccountType
-            diskEncryptionSet: contains(osDisk.managedDisk, 'diskEncryptionSet')
-              ? {
-                  id: osDisk.managedDisk.diskEncryptionSet.id
-                }
-              : null
-          }
-        }
-        dataDisks: [
-          for (dataDisk, index) in dataDisks: {
-            lun: index
-            diskSizeGB: dataDisk.diskSizeGB
-            createOption: dataDisk.createOption
-            caching: dataDisk.caching
-            writeAcceleratorEnabled: osDisk.?writeAcceleratorEnabled
-            managedDisk: {
-              storageAccountType: dataDisk.managedDisk.storageAccountType
-              diskEncryptionSet: contains(dataDisk.managedDisk, 'diskEncryptionSet')
-                ? {
-                    id: dataDisk.managedDisk.diskEncryptionSet.id
-                  }
-                : null
-            }
-            diskIOPSReadWrite: contains(osDisk, 'diskIOPSReadWrite') ? dataDisk.diskIOPSReadWrite : null
-            diskMBpsReadWrite: contains(osDisk, 'diskMBpsReadWrite') ? dataDisk.diskMBpsReadWrite : null
-          }
-        ]
+        osDisk: osDisk
+        dataDisks: dataDisks
       }
       networkProfile: union(
         orchestrationMode == 'Flexible' ? { networkApiVersion: '2020-11-01' } : {},
@@ -630,12 +569,12 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2024-07-01' = {
                   settings: {
                     protocol: extensionHealthConfig.?protocol ?? 'http'
                     port: extensionHealthConfig.?port ?? 80
-                    requestPath: extensionHealthConfig.?requestPath ?? ((contains(extensionHealthConfig, 'protocol') && extensionHealthConfig.protocol != 'tcp')
+                    requestPath: extensionHealthConfig.?requestPath ?? ((contains(extensionHealthConfig, 'protocol') && extensionHealthConfig.?protocol != 'tcp')
                       ? '/'
                       : '')
                     intervalInSeconds: extensionHealthConfig.?intervalInSeconds ?? 5
                     numberOfProbes: extensionHealthConfig.?numberOfProbes ?? 1
-                    gracePeriod: extensionHealthConfig.?gracePeriod ?? 5
+                    gracePeriod: extensionHealthConfig.?gracePeriod ?? ((extensionHealthConfig.?intervalInSeconds ?? 5) * (extensionHealthConfig.?numberOfProbes ?? 1))
                   }
                 }
               }
@@ -788,24 +727,59 @@ module vmss_desiredStateConfigurationExtension 'extension/main.bicep' = if (exte
   ]
 }
 
-module vmss_customScriptExtension 'extension/main.bicep' = if (extensionCustomScriptConfig.enabled) {
+resource cseIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' existing = if (!empty(extensionCustomScriptConfig.?protectedSettings.?managedIdentityResourceId)) {
+  name: last(split(extensionCustomScriptConfig!.protectedSettings!.managedIdentityResourceId!, '/'))
+  scope: resourceGroup(
+    split(extensionCustomScriptConfig!.protectedSettings!.managedIdentityResourceId!, '/')[2],
+    split(extensionCustomScriptConfig!.protectedSettings!.managedIdentityResourceId!, '/')[4]
+  )
+}
+
+module vmss_customScriptExtension 'extension/main.bicep' = if (!empty(extensionCustomScriptConfig)) {
   name: '${uniqueString(deployment().name, location)}-VMSS-CustomScriptExtension'
   params: {
     virtualMachineScaleSetName: vmss.name
-    name: 'CustomScriptExtension'
+    name: extensionCustomScriptConfig.?name ?? 'CustomScriptExtension'
     publisher: osType == 'Windows' ? 'Microsoft.Compute' : 'Microsoft.Azure.Extensions'
     type: osType == 'Windows' ? 'CustomScriptExtension' : 'CustomScript'
     typeHandlerVersion: extensionCustomScriptConfig.?typeHandlerVersion ?? (osType == 'Windows' ? '1.10' : '2.1')
     autoUpgradeMinorVersion: extensionCustomScriptConfig.?autoUpgradeMinorVersion ?? true
     enableAutomaticUpgrade: extensionCustomScriptConfig.?enableAutomaticUpgrade ?? false
+    forceUpdateTag: extensionCustomScriptConfig.?forceUpdateTag
+    provisionAfterExtensions: extensionCustomScriptConfig.?provisionAfterExtensions
+    supressFailures: extensionCustomScriptConfig.?supressFailures ?? false
+    protectedSettingsFromKeyVault: extensionCustomScriptConfig.?protectedSettingsFromKeyVault
     settings: {
-      fileUris: [
-        for fileData in extensionCustomScriptConfig.fileData: contains(fileData, 'storageAccountId')
-          ? '${fileData.uri}?${listAccountSas(fileData.storageAccountId, '2019-04-01', accountSasProperties).accountSasToken}'
-          : fileData.uri
-      ]
+      ...(!empty(extensionCustomScriptConfig!.?settings.?commandToExecute)
+        ? { commandToExecute: extensionCustomScriptConfig!.?settings.?commandToExecute }
+        : {})
+      ...(!empty(extensionCustomScriptConfig!.?settings.?fileUris)
+        ? { fileUris: extensionCustomScriptConfig!.?settings.fileUris }
+        : {})
     }
-    protectedSettings: extensionCustomScriptConfig.?protectedSettings ?? {}
+    protectedSettings: {
+      ...(!empty(extensionCustomScriptConfig!.?protectedSettings.?commandToExecute)
+        ? { commandToExecute: extensionCustomScriptConfig!.protectedSettings!.?commandToExecute }
+        : {})
+      ...(!empty(extensionCustomScriptConfig!.?protectedSettings.?storageAccountName)
+        ? { storageAccountName: extensionCustomScriptConfig!.protectedSettings!.storageAccountName! }
+        : {})
+      ...(!empty(extensionCustomScriptConfig!.?protectedSettings.?storageAccountKey)
+        ? { storageAccountKey: extensionCustomScriptConfig!.protectedSettings!.storageAccountKey! }
+        : {})
+      ...(!empty(extensionCustomScriptConfig!.?protectedSettings.?fileUris)
+        ? { fileUris: extensionCustomScriptConfig!.protectedSettings!.fileUris! }
+        : {})
+      ...(extensionCustomScriptConfig!.?protectedSettings.?managedIdentityResourceId != null
+        ? {
+            managedIdentity: !empty(extensionCustomScriptConfig!.protectedSettings!.?managedIdentityResourceId)
+              ? {
+                  clientId: cseIdentity!.properties.clientId // Uses user-assigned
+                }
+              : {} // Uses system-assigned
+          }
+        : {})
+    }
   }
   dependsOn: [
     vmss_desiredStateConfigurationExtension
@@ -893,3 +867,121 @@ output systemAssignedMIPrincipalId string? = vmss.?identity.?principalId
 
 @description('The location the resource was deployed into.')
 output location string = vmss.location
+
+// =============== //
+//   Definitions   //
+// =============== //
+
+@export()
+@description('The type of the health config extension.')
+type extensionHealthConfigType = {
+  @description('Optional. Enable or disable the Health Config extension. Defaults to `false`.')
+  enabled: bool
+
+  @description('Optional. Specifies the version of the script handler. Defaults to `2.0`.')
+  typeHandlerVersion: string?
+
+  @description('Optional. Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true. Defaults to `false`.')
+  autoUpgradeMinorVersion: bool?
+
+  @description('Optional. The protocol to connect with. Defaults to `http`.')
+  protocol: ('http' | 'https' | 'tcp')?
+
+  @description('Conditional. The port to connect to. Defaults to `80`. Required if `protocol` is `tcp`.')
+  port: int?
+
+  @description('Optional. The path of the request. Not allowed if `protocol` is `tcp`,')
+  requestPath: string?
+
+  @description('Optional. This is the interval between each health probe. For example, if intervalInSeconds == 5, a probe will be sent to the local application endpoint once every 5 seconds. Defaults to `5`.')
+  @minValue(5)
+  @maxValue(60)
+  intervalInSeconds: int?
+
+  @description('Optional. This is the number of consecutive probes required for the health status to change. For example, if numberOfProbles == 3, you will need 3 consecutive "Healthy" signals to change the health status from "Unhealthy" into "Healthy" state. The same requirement applies to change health status into "Unhealthy" state. Defaults to `1`.')
+  @minValue(1)
+  @maxValue(24)
+  numberOfProbes: int?
+
+  @description('Optional. The grace period for newly created instances. Defaults to `intervalInSeconds` x `numberOfProbes`.')
+  @maxValue(14400)
+  gracePeriod: int?
+}
+
+@export()
+@description('The type of a NIC configuration.')
+type nicConfigurationType = {
+  @description('Optional. The name of the NIC configuration. If not provided, a name is generated using the `nicSuffic` and an incremental counter.')
+  name: string?
+
+  @description('Optional. The suffix to add to each NIC configuration name if no `name` was provided.')
+  nicSuffix: string?
+
+  @description('Optional. Specifies whether the network interface is accelerated networking-enabled. Defaults to `true`.')
+  enableAcceleratedNetworking: bool?
+
+  @description('Required. Specifies the IP configurations of the network interface.')
+  ipConfigurations: array
+
+  @description('Optional. The resource ID of a network security group to associate with the NIC.')
+  networkSecurityGroupResourceId: string?
+}
+
+@export()
+@description('The type of a \'CustomScriptExtension\' extension.')
+type extensionCustomScriptConfigType = {
+  @description('Optional. The name of the virtual machine extension. Defaults to `CustomScriptExtension`.')
+  name: string?
+
+  @description('Optional. Specifies the version of the script handler. Defaults to `1.10` for Windows and `2.1` for Linux.')
+  typeHandlerVersion: string?
+
+  @description('Optional. Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true. Defaults to `true`.')
+  autoUpgradeMinorVersion: bool?
+
+  @description('Optional. How the extension handler should be forced to update even if the extension configuration has not changed.')
+  forceUpdateTag: string?
+
+  @description('Optional. The configuration of the custom script extension. Note: You can provide any property either in the `settings` or `protectedSettings` but not both. If your property contains secrets, use `protectedSettings`.')
+  settings: {
+    @description('Conditional. The entry point script to run. If the command contains any credentials, use the same property of the `protectedSettings` instead. Required if `protectedSettings.commandToExecute` is not provided.')
+    commandToExecute: string?
+
+    @description('Optional. URLs for files to be downloaded. If URLs are sensitive, for example, if they contain keys, this field should be specified in `protectedSettings`.')
+    fileUris: string[]?
+  }?
+
+  @description('Optional. The configuration of the custom script extension. Note: You can provide any property either in the `settings` or `protectedSettings` but not both. If your property contains secrets, use `protectedSettings`.')
+  @secure()
+  protectedSettings: {
+    @description('Conditional. The entry point script to run. Use this property if your command contains secrets such as passwords or if your file URIs are sensitive. Required if `settings.commandToExecute` is not provided.')
+    commandToExecute: string?
+
+    @description('Optional. The name of storage account. If you specify storage credentials, all fileUris values must be URLs for Azure blobs..')
+    storageAccountName: string?
+
+    @description('Optional. The access key of the storage account.')
+    storageAccountKey: string?
+
+    @description('Optional. The managed identity for downloading files. Must not be used in conjunction with the `storageAccountName` or `storageAccountKey` property. If you want to use the VM\'s system assigned identity, set the `value` to an empty string.')
+    managedIdentityResourceId: string?
+
+    @description('Optional. URLs for files to be downloaded.')
+    fileUris: string[]?
+  }?
+
+  @description('Optional. Indicates whether failures stemming from the extension will be suppressed (Operational failures such as not connecting to the VM will not be suppressed regardless of this value). Defaults to `false`.')
+  supressFailures: bool?
+
+  @description('Optional. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available. Defaults to `false`.')
+  enableAutomaticUpgrade: bool?
+
+  @description('Optional. Tags of the resource.')
+  tags: resourceInput<'Microsoft.Compute/virtualMachines/extensions@2024-11-01'>.tags?
+
+  @description('Optional. The extensions protected settings that are passed by reference, and consumed from key vault.')
+  protectedSettingsFromKeyVault: resourceInput<'Microsoft.Compute/virtualMachines/extensions@2024-11-01'>.properties.protectedSettingsFromKeyVault?
+
+  @description('Optional. Collection of extension names after which this extension needs to be provisioned.')
+  provisionAfterExtensions: resourceInput<'Microsoft.Compute/virtualMachines/extensions@2024-11-01'>.properties.provisionAfterExtensions?
+}

--- a/avm/res/compute/virtual-machine-scale-set/main.json
+++ b/avm/res/compute/virtual-machine-scale-set/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "3424448177863566091"
+      "templateHash": "11157832261456876697"
     },
     "name": "Virtual Machine Scale Sets",
     "description": "This module deploys a Virtual Machine Scale Set."
@@ -17,6 +17,7 @@
       "properties": {
         "enabled": {
           "type": "bool",
+          "nullable": true,
           "metadata": {
             "description": "Optional. Enable or disable the Health Config extension. Defaults to `false`."
           }
@@ -58,7 +59,7 @@
           "type": "string",
           "nullable": true,
           "metadata": {
-            "description": "Optional. The path of the request. Not allowed if `protocol` is `tcp`,"
+            "description": "Optional. The path of the request. Not allowed if `protocol` is `tcp`."
           }
         },
         "intervalInSeconds": {
@@ -1307,7 +1308,7 @@
               "storageUri": "[if(not(empty(parameters('bootDiagnosticStorageAccountName'))), format('https://{0}{1}', parameters('bootDiagnosticStorageAccountName'), parameters('bootDiagnosticStorageAccountUri')), null())]"
             }
           },
-          "extensionProfile": "[if(parameters('extensionHealthConfig').enabled, createObject('extensions', createArray(createObject('name', 'HealthExtension', 'properties', createObject('publisher', 'Microsoft.ManagedServices', 'type', if(equals(parameters('osType'), 'Windows'), 'ApplicationHealthWindows', 'ApplicationHealthLinux'), 'typeHandlerVersion', coalesce(tryGet(parameters('extensionHealthConfig'), 'typeHandlerVersion'), '2.0'), 'autoUpgradeMinorVersion', coalesce(tryGet(parameters('extensionHealthConfig'), 'autoUpgradeMinorVersion'), false()), 'settings', createObject('protocol', coalesce(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'http'), 'port', coalesce(tryGet(parameters('extensionHealthConfig'), 'port'), 80), 'requestPath', coalesce(tryGet(parameters('extensionHealthConfig'), 'requestPath'), if(and(contains(parameters('extensionHealthConfig'), 'protocol'), not(equals(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'tcp'))), '/', '')), 'intervalInSeconds', coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), 'numberOfProbes', coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1), 'gracePeriod', coalesce(tryGet(parameters('extensionHealthConfig'), 'gracePeriod'), mul(coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1)))))))), null())]",
+          "extensionProfile": "[if(coalesce(tryGet(parameters('extensionHealthConfig'), 'enabled'), false()), createObject('extensions', createArray(createObject('name', 'HealthExtension', 'properties', createObject('publisher', 'Microsoft.ManagedServices', 'type', if(equals(parameters('osType'), 'Windows'), 'ApplicationHealthWindows', 'ApplicationHealthLinux'), 'typeHandlerVersion', coalesce(tryGet(parameters('extensionHealthConfig'), 'typeHandlerVersion'), '2.0'), 'autoUpgradeMinorVersion', coalesce(tryGet(parameters('extensionHealthConfig'), 'autoUpgradeMinorVersion'), false()), 'settings', createObject('protocol', coalesce(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'http'), 'port', coalesce(tryGet(parameters('extensionHealthConfig'), 'port'), 80), 'requestPath', coalesce(tryGet(parameters('extensionHealthConfig'), 'requestPath'), if(and(contains(parameters('extensionHealthConfig'), 'protocol'), not(equals(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'tcp'))), '/', '')), 'intervalInSeconds', coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), 'numberOfProbes', coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1), 'gracePeriod', coalesce(tryGet(parameters('extensionHealthConfig'), 'gracePeriod'), mul(coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1)))))))), null())]",
           "licenseType": "[parameters('licenseType')]",
           "priority": "[parameters('vmPriority')]",
           "evictionPolicy": "[if(parameters('enableEvictionPolicy'), 'Deallocate', null())]",

--- a/avm/res/compute/virtual-machine-scale-set/main.json
+++ b/avm/res/compute/virtual-machine-scale-set/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "6736421211333355117"
+      "templateHash": "4328225862716010669"
     },
     "name": "Virtual Machine Scale Sets",
     "description": "This module deploys a Virtual Machine Scale Set."
@@ -1324,6 +1324,7 @@
               "storageUri": "[if(not(empty(parameters('bootDiagnosticStorageAccountName'))), format('https://{0}{1}', parameters('bootDiagnosticStorageAccountName'), parameters('bootDiagnosticStorageAccountUri')), null())]"
             }
           },
+          "extensionProfile": "[if(coalesce(tryGet(parameters('extensionHealthConfig'), 'enabled'), false()), createObject('extensions', createArray(createObject('name', 'HealthExtension', 'properties', createObject('publisher', 'Microsoft.ManagedServices', 'type', if(equals(parameters('osType'), 'Windows'), 'ApplicationHealthWindows', 'ApplicationHealthLinux'), 'typeHandlerVersion', coalesce(tryGet(parameters('extensionHealthConfig'), 'typeHandlerVersion'), '2.0'), 'autoUpgradeMinorVersion', coalesce(tryGet(parameters('extensionHealthConfig'), 'autoUpgradeMinorVersion'), false()), 'settings', createObject('protocol', coalesce(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'http'), 'port', coalesce(tryGet(parameters('extensionHealthConfig'), 'port'), 80), 'requestPath', coalesce(tryGet(parameters('extensionHealthConfig'), 'requestPath'), if(and(contains(parameters('extensionHealthConfig'), 'protocol'), not(equals(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'tcp'))), '/', '')), 'intervalInSeconds', coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), 'numberOfProbes', coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1), 'gracePeriod', coalesce(tryGet(parameters('extensionHealthConfig'), 'gracePeriod'), mul(coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1)))), 'provisionAfterExtensions', tryGet(parameters('extensionHealthConfig'), 'provisionAfterExtensions'))))), null())]",
           "licenseType": "[parameters('licenseType')]",
           "priority": "[parameters('vmPriority')]",
           "evictionPolicy": "[if(parameters('enableEvictionPolicy'), 'Deallocate', null())]",
@@ -1427,210 +1428,6 @@
         "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
         "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
         "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
-      },
-      "dependsOn": [
-        "vmss"
-      ]
-    },
-    "vmss_healthExtension": {
-      "condition": "[parameters('extensionHealthConfig').enabled]",
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
-      "name": "[format('{0}-VMSS-Health', uniqueString(deployment().name, parameters('location')))]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "virtualMachineScaleSetName": {
-            "value": "[parameters('name')]"
-          },
-          "name": {
-            "value": "HealthExtension"
-          },
-          "publisher": {
-            "value": "Microsoft.ManagedServices"
-          },
-          "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'ApplicationHealthWindows'), createObject('value', 'ApplicationHealthLinux'))]",
-          "typeHandlerVersion": {
-            "value": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'typeHandlerVersion'), '2.0')]"
-          },
-          "autoUpgradeMinorVersion": {
-            "value": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'autoUpgradeMinorVersion'), false())]"
-          },
-          "enableAutomaticUpgrade": {
-            "value": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'enableAutomaticUpgrade'), true())]"
-          },
-          "settings": {
-            "value": {
-              "protocol": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'http')]",
-              "port": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'port'), 80)]",
-              "requestPath": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'requestPath'), if(and(contains(parameters('extensionHealthConfig'), 'protocol'), not(equals(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'tcp'))), '/', ''))]",
-              "intervalInSeconds": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5)]",
-              "numberOfProbes": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1)]",
-              "gracePeriod": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'gracePeriod'), mul(coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1)))]"
-            }
-          },
-          "provisionAfterExtensions": {
-            "value": "[tryGet(parameters('extensionHealthConfig'), 'provisionAfterExtensions')]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "languageVersion": "2.0",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "1457477458264476892"
-            },
-            "name": "Virtual Machine Scale Set Extensions",
-            "description": "This module deploys a Virtual Machine Scale Set Extension."
-          },
-          "parameters": {
-            "virtualMachineScaleSetName": {
-              "type": "string",
-              "metadata": {
-                "description": "Conditional. The name of the parent virtual machine scale set that extension is provisioned for. Required if the template is used in a standalone deployment."
-              }
-            },
-            "name": {
-              "type": "string",
-              "metadata": {
-                "description": "Required. The name of the virtual machine scale set extension."
-              }
-            },
-            "publisher": {
-              "type": "string",
-              "metadata": {
-                "description": "Required. The name of the extension handler publisher."
-              }
-            },
-            "type": {
-              "type": "string",
-              "metadata": {
-                "description": "Required. Specifies the type of the extension; an example is \"CustomScriptExtension\"."
-              }
-            },
-            "typeHandlerVersion": {
-              "type": "string",
-              "metadata": {
-                "description": "Required. Specifies the version of the script handler."
-              }
-            },
-            "autoUpgradeMinorVersion": {
-              "type": "bool",
-              "metadata": {
-                "description": "Required. Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true."
-              }
-            },
-            "forceUpdateTag": {
-              "type": "string",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. How the extension handler should be forced to update even if the extension configuration has not changed."
-              }
-            },
-            "settings": {
-              "type": "object",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Any object that contains the extension specific settings."
-              }
-            },
-            "protectedSettings": {
-              "type": "secureObject",
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Any object that contains the extension specific protected settings."
-              }
-            },
-            "supressFailures": {
-              "type": "bool",
-              "defaultValue": false,
-              "metadata": {
-                "description": "Optional. Indicates whether failures stemming from the extension will be suppressed (Operational failures such as not connecting to the VM will not be suppressed regardless of this value). The default is false."
-              }
-            },
-            "enableAutomaticUpgrade": {
-              "type": "bool",
-              "metadata": {
-                "description": "Required. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
-              }
-            },
-            "protectedSettingsFromKeyVault": {
-              "type": "object",
-              "metadata": {
-                "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/protectedSettingsFromKeyVault"
-                },
-                "description": "Optional. The extensions protected settings that are passed by reference, and consumed from key vault."
-              },
-              "nullable": true
-            },
-            "provisionAfterExtensions": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true,
-              "metadata": {
-                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
-              }
-            }
-          },
-          "resources": {
-            "virtualMachineScaleSet": {
-              "existing": true,
-              "type": "Microsoft.Compute/virtualMachineScaleSets",
-              "apiVersion": "2024-11-01",
-              "name": "[parameters('virtualMachineScaleSetName')]"
-            },
-            "extension": {
-              "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-              "apiVersion": "2024-11-01",
-              "name": "[format('{0}/{1}', parameters('virtualMachineScaleSetName'), parameters('name'))]",
-              "properties": {
-                "publisher": "[parameters('publisher')]",
-                "type": "[parameters('type')]",
-                "typeHandlerVersion": "[parameters('typeHandlerVersion')]",
-                "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
-                "enableAutomaticUpgrade": "[parameters('enableAutomaticUpgrade')]",
-                "forceUpdateTag": "[parameters('forceUpdateTag')]",
-                "settings": "[parameters('settings')]",
-                "protectedSettings": "[parameters('protectedSettings')]",
-                "suppressFailures": "[parameters('supressFailures')]",
-                "protectedSettingsFromKeyVault": "[parameters('protectedSettingsFromKeyVault')]",
-                "provisionAfterExtensions": "[parameters('provisionAfterExtensions')]"
-              }
-            }
-          },
-          "outputs": {
-            "name": {
-              "type": "string",
-              "metadata": {
-                "description": "The name of the extension."
-              },
-              "value": "[parameters('name')]"
-            },
-            "resourceId": {
-              "type": "string",
-              "metadata": {
-                "description": "The ResourceId of the extension."
-              },
-              "value": "[resourceId('Microsoft.Compute/virtualMachineScaleSets/extensions', parameters('virtualMachineScaleSetName'), parameters('name'))]"
-            },
-            "resourceGroupName": {
-              "type": "string",
-              "metadata": {
-                "description": "The name of the Resource Group the extension was created in."
-              },
-              "value": "[resourceGroup().name]"
-            }
-          }
-        }
       },
       "dependsOn": [
         "vmss"

--- a/avm/res/compute/virtual-machine-scale-set/main.json
+++ b/avm/res/compute/virtual-machine-scale-set/main.json
@@ -6,12 +6,290 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "17565260692645137311"
+      "templateHash": "3424448177863566091"
     },
     "name": "Virtual Machine Scale Sets",
     "description": "This module deploys a Virtual Machine Scale Set."
   },
   "definitions": {
+    "extensionHealthConfigType": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "bool",
+          "metadata": {
+            "description": "Optional. Enable or disable the Health Config extension. Defaults to `false`."
+          }
+        },
+        "typeHandlerVersion": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the version of the script handler. Defaults to `2.0`."
+          }
+        },
+        "autoUpgradeMinorVersion": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true. Defaults to `false`."
+          }
+        },
+        "protocol": {
+          "type": "string",
+          "allowedValues": [
+            "http",
+            "https",
+            "tcp"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The protocol to connect with. Defaults to `http`."
+          }
+        },
+        "port": {
+          "type": "int",
+          "nullable": true,
+          "metadata": {
+            "description": "Conditional. The port to connect to. Defaults to `80`. Required if `protocol` is `tcp`."
+          }
+        },
+        "requestPath": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The path of the request. Not allowed if `protocol` is `tcp`,"
+          }
+        },
+        "intervalInSeconds": {
+          "type": "int",
+          "nullable": true,
+          "minValue": 5,
+          "maxValue": 60,
+          "metadata": {
+            "description": "Optional. This is the interval between each health probe. For example, if intervalInSeconds == 5, a probe will be sent to the local application endpoint once every 5 seconds. Defaults to `5`."
+          }
+        },
+        "numberOfProbes": {
+          "type": "int",
+          "nullable": true,
+          "minValue": 1,
+          "maxValue": 24,
+          "metadata": {
+            "description": "Optional. This is the number of consecutive probes required for the health status to change. For example, if numberOfProbles == 3, you will need 3 consecutive \"Healthy\" signals to change the health status from \"Unhealthy\" into \"Healthy\" state. The same requirement applies to change health status into \"Unhealthy\" state. Defaults to `1`."
+          }
+        },
+        "gracePeriod": {
+          "type": "int",
+          "nullable": true,
+          "maxValue": 14400,
+          "metadata": {
+            "description": "Optional. The grace period for newly created instances. Defaults to `intervalInSeconds` x `numberOfProbes`."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The type of the health config extension."
+      }
+    },
+    "nicConfigurationType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The name of the NIC configuration. If not provided, a name is generated using the `nicSuffic` and an incremental counter."
+          }
+        },
+        "nicSuffix": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The suffix to add to each NIC configuration name if no `name` was provided."
+          }
+        },
+        "enableAcceleratedNetworking": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies whether the network interface is accelerated networking-enabled. Defaults to `true`."
+          }
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "metadata": {
+            "description": "Required. Specifies the IP configurations of the network interface."
+          }
+        },
+        "networkSecurityGroupResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The resource ID of a network security group to associate with the NIC."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The type of a NIC configuration."
+      }
+    },
+    "extensionCustomScriptConfigType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The name of the virtual machine extension. Defaults to `CustomScriptExtension`."
+          }
+        },
+        "typeHandlerVersion": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specifies the version of the script handler. Defaults to `1.10` for Windows and `2.1` for Linux."
+          }
+        },
+        "autoUpgradeMinorVersion": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true. Defaults to `true`."
+          }
+        },
+        "forceUpdateTag": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. How the extension handler should be forced to update even if the extension configuration has not changed."
+          }
+        },
+        "settings": {
+          "type": "object",
+          "properties": {
+            "commandToExecute": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The entry point script to run. If the command contains any credentials, use the same property of the `protectedSettings` instead. Required if `protectedSettings.commandToExecute` is not provided."
+              }
+            },
+            "fileUris": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. URLs for files to be downloaded. If URLs are sensitive, for example, if they contain keys, this field should be specified in `protectedSettings`."
+              }
+            }
+          },
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The configuration of the custom script extension. Note: You can provide any property either in the `settings` or `protectedSettings` but not both. If your property contains secrets, use `protectedSettings`."
+          }
+        },
+        "protectedSettings": {
+          "type": "secureObject",
+          "properties": {
+            "commandToExecute": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The entry point script to run. Use this property if your command contains secrets such as passwords or if your file URIs are sensitive. Required if `settings.commandToExecute` is not provided."
+              }
+            },
+            "storageAccountName": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The name of storage account. If you specify storage credentials, all fileUris values must be URLs for Azure blobs.."
+              }
+            },
+            "storageAccountKey": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The access key of the storage account."
+              }
+            },
+            "managedIdentityResourceId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The managed identity for downloading files. Must not be used in conjunction with the `storageAccountName` or `storageAccountKey` property. If you want to use the VM's system assigned identity, set the `value` to an empty string."
+              }
+            },
+            "fileUris": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. URLs for files to be downloaded."
+              }
+            }
+          },
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The configuration of the custom script extension. Note: You can provide any property either in the `settings` or `protectedSettings` but not both. If your property contains secrets, use `protectedSettings`."
+          }
+        },
+        "supressFailures": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Indicates whether failures stemming from the extension will be suppressed (Operational failures such as not connecting to the VM will not be suppressed regardless of this value). Defaults to `false`."
+          }
+        },
+        "enableAutomaticUpgrade": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available. Defaults to `false`."
+          }
+        },
+        "tags": {
+          "type": "object",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Compute/virtualMachines/extensions@2024-11-01#properties/tags"
+            },
+            "description": "Optional. Tags of the resource."
+          },
+          "nullable": true
+        },
+        "protectedSettingsFromKeyVault": {
+          "type": "object",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Compute/virtualMachines/extensions@2024-11-01#properties/properties/properties/protectedSettingsFromKeyVault"
+            },
+            "description": "Optional. The extensions protected settings that are passed by reference, and consumed from key vault."
+          },
+          "nullable": true
+        },
+        "provisionAfterExtensions": {
+          "type": "array",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Compute/virtualMachines/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
+            },
+            "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+          },
+          "nullable": true
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The type of a 'CustomScriptExtension' extension."
+      }
+    },
     "diagnosticSettingMetricsOnlyType": {
       "type": "object",
       "properties": {
@@ -97,7 +375,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a diagnostic setting. To be used if only metrics are supported by the resource provider.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
         }
       }
     },
@@ -162,7 +440,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.4.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
         }
       }
     },
@@ -237,7 +515,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
         }
       }
     }
@@ -294,7 +572,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.Compute/virtualMachineScaleSets@2024-07-01#properties/plan"
+          "source": "Microsoft.Compute/virtualMachineScaleSets@2024-11-01#properties/plan"
         },
         "description": "Optional. Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use."
       },
@@ -303,15 +581,21 @@
     "osDisk": {
       "type": "object",
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Compute/virtualMachineScaleSets@2024-11-01#properties/properties/properties/virtualMachineProfile/properties/storageProfile/properties/osDisk"
+        },
         "description": "Required. Specifies the OS disk. For security reasons, it is recommended to specify DiskEncryptionSet into the osDisk object. Restrictions: DiskEncryptionSet cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VM Scale sets."
       }
     },
     "dataDisks": {
       "type": "array",
-      "defaultValue": [],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Compute/virtualMachineScaleSets@2024-11-01#properties/properties/properties/virtualMachineProfile/properties/storageProfile/properties/dataDisks"
+        },
         "description": "Optional. Specifies the data disks. For security reasons, it is recommended to specify DiskEncryptionSet into the dataDisk object. Restrictions: DiskEncryptionSet cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VM Scale sets."
-      }
+      },
+      "defaultValue": []
     },
     "ultraSSDEnabled": {
       "type": "bool",
@@ -365,8 +649,11 @@
     },
     "nicConfigurations": {
       "type": "array",
+      "items": {
+        "$ref": "#/definitions/nicConfigurationType"
+      },
       "metadata": {
-        "description": "Required. Configures NICs and PIPs."
+        "description": "Required. Configures NICs and PIPs. The first item in the list is considered the `primary` configuration."
       }
     },
     "vmPriority": {
@@ -476,14 +763,12 @@
       }
     },
     "extensionHealthConfig": {
-      "type": "object",
+      "$ref": "#/definitions/extensionHealthConfigType",
       "defaultValue": {
         "enabled": true,
-        "settings": {
-          "protocol": "http",
-          "port": 80,
-          "requestPath": "/"
-        }
+        "protocol": "http",
+        "port": 80,
+        "requestPath": "/"
       },
       "metadata": {
         "description": "Optional. Turned on by default. The configuration for the [Application Health Monitoring] extension. Must at least contain the [\"enabled\": true] property to be executed."
@@ -499,13 +784,10 @@
       }
     },
     "extensionCustomScriptConfig": {
-      "type": "object",
-      "defaultValue": {
-        "enabled": false,
-        "fileData": []
-      },
+      "$ref": "#/definitions/extensionCustomScriptConfigType",
+      "nullable": true,
       "metadata": {
-        "description": "Optional. The configuration for the [Custom Script] extension. Must at least contain the [\"enabled\": true] property to be executed."
+        "description": "Optional. The configuration for the [Custom Script] extension."
       }
     },
     "bootDiagnosticStorageAccountUri": {
@@ -740,10 +1022,13 @@
     },
     "winRM": {
       "type": "object",
-      "defaultValue": {},
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Compute/virtualMachineScaleSets@2024-07-01#properties/properties/properties/virtualMachineProfile/properties/osProfile/properties/windowsConfiguration/properties/winRM"
+        },
         "description": "Optional. Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell. - WinRMConfiguration object."
-      }
+      },
+      "nullable": true
     },
     "disablePasswordAuthentication": {
       "type": "bool",
@@ -754,10 +1039,13 @@
     },
     "publicKeys": {
       "type": "array",
-      "defaultValue": [],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Compute/virtualMachineScaleSets@2024-07-01#properties/properties/properties/virtualMachineProfile/properties/osProfile/properties/linuxConfiguration/properties/ssh/properties/publicKeys"
+        },
         "description": "Optional. The list of SSH public keys used to authenticate with linux based VMs."
-      }
+      },
+      "nullable": true
     },
     "secrets": {
       "type": "array",
@@ -880,20 +1168,6 @@
         "description": "Required. The chosen OS type."
       }
     },
-    "baseTime": {
-      "type": "string",
-      "defaultValue": "[utcNow('u')]",
-      "metadata": {
-        "description": "Generated. Do not provide a value! This date value is used to generate a registration token."
-      }
-    },
-    "sasTokenValidityLength": {
-      "type": "string",
-      "defaultValue": "PT8H",
-      "metadata": {
-        "description": "Optional. SAS token validity length to use to download files from storage accounts. Usage: 'PT8H' - valid for 8 hours; 'P5D' - valid for 5 days; 'P1Y' - valid for 1 year. When not provided, the SAS token will be valid for 8 hours."
-      }
-    },
     "managedIdentities": {
       "$ref": "#/definitions/managedIdentityAllType",
       "nullable": true,
@@ -905,22 +1179,14 @@
   "variables": {
     "copy": [
       {
-        "name": "publicKeysFormatted",
-        "count": "[length(parameters('publicKeys'))]",
-        "input": {
-          "path": "[parameters('publicKeys')[copyIndex('publicKeysFormatted')].path]",
-          "keyData": "[parameters('publicKeys')[copyIndex('publicKeysFormatted')].keyData]"
-        }
-      },
-      {
         "name": "networkInterfaceConfigurations",
         "count": "[length(parameters('nicConfigurations'))]",
         "input": {
-          "name": "[format('{0}{1}configuration-{2}', parameters('name'), parameters('nicConfigurations')[copyIndex('networkInterfaceConfigurations')].nicSuffix, copyIndex('networkInterfaceConfigurations'))]",
+          "name": "[coalesce(tryGet(parameters('nicConfigurations')[copyIndex('networkInterfaceConfigurations')], 'name'), format('{0}{1}configuration-{2}', parameters('name'), tryGet(parameters('nicConfigurations')[copyIndex('networkInterfaceConfigurations')], 'nicSuffix'), copyIndex('networkInterfaceConfigurations')))]",
           "properties": {
             "primary": "[if(equals(copyIndex('networkInterfaceConfigurations'), 0), true(), null())]",
             "enableAcceleratedNetworking": "[coalesce(tryGet(parameters('nicConfigurations')[copyIndex('networkInterfaceConfigurations')], 'enableAcceleratedNetworking'), true())]",
-            "networkSecurityGroup": "[if(contains(parameters('nicConfigurations')[copyIndex('networkInterfaceConfigurations')], 'nsgId'), createObject('id', parameters('nicConfigurations')[copyIndex('networkInterfaceConfigurations')].nsgId), null())]",
+            "networkSecurityGroup": "[if(contains(parameters('nicConfigurations')[copyIndex('networkInterfaceConfigurations')], 'networkSecurityGroupResourceId'), createObject('id', parameters('nicConfigurations')[copyIndex('networkInterfaceConfigurations')].networkSecurityGroupResourceId), null())]",
             "ipConfigurations": "[parameters('nicConfigurations')[copyIndex('networkInterfaceConfigurations')].ipConfigurations]"
           }
         }
@@ -934,7 +1200,7 @@
     "linuxConfiguration": {
       "disablePasswordAuthentication": "[parameters('disablePasswordAuthentication')]",
       "ssh": {
-        "publicKeys": "[variables('publicKeysFormatted')]"
+        "publicKeys": "[parameters('publicKeys')]"
       },
       "provisionVMAgent": "[parameters('provisionVMAgent')]",
       "patchSettings": "[if(and(parameters('provisionVMAgent'), or(equals(toLower(parameters('patchMode')), toLower('AutomaticByPlatform')), equals(toLower(parameters('patchMode')), toLower('ImageDefault')))), createObject('patchMode', parameters('patchMode'), 'assessmentMode', parameters('patchAssessmentMode'), 'automaticByPlatformSettings', if(equals(toLower(parameters('patchMode')), toLower('AutomaticByPlatform')), createObject('bypassPlatformSafetyChecksOnUserSchedule', parameters('bypassPlatformSafetyChecksOnUserSchedule'), 'rebootSetting', parameters('rebootSetting')), null())), null())]"
@@ -945,14 +1211,7 @@
       "patchSettings": "[if(and(parameters('provisionVMAgent'), or(or(equals(toLower(parameters('patchMode')), toLower('AutomaticByPlatform')), equals(toLower(parameters('patchMode')), toLower('AutomaticByOS'))), equals(toLower(parameters('patchMode')), toLower('Manual')))), createObject('patchMode', parameters('patchMode'), 'assessmentMode', parameters('patchAssessmentMode'), 'automaticByPlatformSettings', if(equals(toLower(parameters('patchMode')), toLower('AutomaticByPlatform')), createObject('bypassPlatformSafetyChecksOnUserSchedule', parameters('bypassPlatformSafetyChecksOnUserSchedule'), 'rebootSetting', parameters('rebootSetting')), null())), null())]",
       "timeZone": "[parameters('timeZone')]",
       "additionalUnattendContent": "[parameters('additionalUnattendContent')]",
-      "winRM": "[if(not(empty(parameters('winRM'))), createObject('listeners', parameters('winRM').listeners), null())]"
-    },
-    "accountSasProperties": {
-      "signedServices": "b",
-      "signedPermission": "r",
-      "signedExpiry": "[dateTimeAdd(parameters('baseTime'), parameters('sasTokenValidityLength'))]",
-      "signedResourceTypes": "o",
-      "signedProtocol": "https"
+      "winRM": "[parameters('winRM')]"
     },
     "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
     "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned, UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', null())), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
@@ -1000,7 +1259,7 @@
     },
     "vmss": {
       "type": "Microsoft.Compute/virtualMachineScaleSets",
-      "apiVersion": "2024-07-01",
+      "apiVersion": "2024-11-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -1037,40 +1296,9 @@
             "uefiSettings": "[if(equals(parameters('securityType'), 'TrustedLaunch'), createObject('secureBootEnabled', parameters('secureBootEnabled'), 'vTpmEnabled', parameters('vTpmEnabled')), null())]"
           },
           "storageProfile": {
-            "copy": [
-              {
-                "name": "dataDisks",
-                "count": "[length(parameters('dataDisks'))]",
-                "input": {
-                  "lun": "[copyIndex('dataDisks')]",
-                  "diskSizeGB": "[parameters('dataDisks')[copyIndex('dataDisks')].diskSizeGB]",
-                  "createOption": "[parameters('dataDisks')[copyIndex('dataDisks')].createOption]",
-                  "caching": "[parameters('dataDisks')[copyIndex('dataDisks')].caching]",
-                  "writeAcceleratorEnabled": "[tryGet(parameters('osDisk'), 'writeAcceleratorEnabled')]",
-                  "managedDisk": {
-                    "storageAccountType": "[parameters('dataDisks')[copyIndex('dataDisks')].managedDisk.storageAccountType]",
-                    "diskEncryptionSet": "[if(contains(parameters('dataDisks')[copyIndex('dataDisks')].managedDisk, 'diskEncryptionSet'), createObject('id', parameters('dataDisks')[copyIndex('dataDisks')].managedDisk.diskEncryptionSet.id), null())]"
-                  },
-                  "diskIOPSReadWrite": "[if(contains(parameters('osDisk'), 'diskIOPSReadWrite'), parameters('dataDisks')[copyIndex('dataDisks')].diskIOPSReadWrite, null())]",
-                  "diskMBpsReadWrite": "[if(contains(parameters('osDisk'), 'diskMBpsReadWrite'), parameters('dataDisks')[copyIndex('dataDisks')].diskMBpsReadWrite, null())]"
-                }
-              }
-            ],
             "imageReference": "[parameters('imageReference')]",
-            "osDisk": {
-              "createOption": "[parameters('osDisk').createOption]",
-              "diskSizeGB": "[parameters('osDisk').diskSizeGB]",
-              "caching": "[tryGet(parameters('osDisk'), 'caching')]",
-              "writeAcceleratorEnabled": "[tryGet(parameters('osDisk'), 'writeAcceleratorEnabled')]",
-              "diffDiskSettings": "[tryGet(parameters('osDisk'), 'diffDiskSettings')]",
-              "osType": "[tryGet(parameters('osDisk'), 'osType')]",
-              "image": "[tryGet(parameters('osDisk'), 'image')]",
-              "vhdContainers": "[tryGet(parameters('osDisk'), 'vhdContainers')]",
-              "managedDisk": {
-                "storageAccountType": "[parameters('osDisk').managedDisk.storageAccountType]",
-                "diskEncryptionSet": "[if(contains(parameters('osDisk').managedDisk, 'diskEncryptionSet'), createObject('id', parameters('osDisk').managedDisk.diskEncryptionSet.id), null())]"
-              }
-            }
+            "osDisk": "[parameters('osDisk')]",
+            "dataDisks": "[parameters('dataDisks')]"
           },
           "networkProfile": "[union(if(equals(parameters('orchestrationMode'), 'Flexible'), createObject('networkApiVersion', '2020-11-01'), createObject()), createObject('networkInterfaceConfigurations', variables('networkInterfaceConfigurations')))]",
           "diagnosticsProfile": {
@@ -1079,7 +1307,7 @@
               "storageUri": "[if(not(empty(parameters('bootDiagnosticStorageAccountName'))), format('https://{0}{1}', parameters('bootDiagnosticStorageAccountName'), parameters('bootDiagnosticStorageAccountUri')), null())]"
             }
           },
-          "extensionProfile": "[if(parameters('extensionHealthConfig').enabled, createObject('extensions', createArray(createObject('name', 'HealthExtension', 'properties', createObject('publisher', 'Microsoft.ManagedServices', 'type', if(equals(parameters('osType'), 'Windows'), 'ApplicationHealthWindows', 'ApplicationHealthLinux'), 'typeHandlerVersion', coalesce(tryGet(parameters('extensionHealthConfig'), 'typeHandlerVersion'), '2.0'), 'autoUpgradeMinorVersion', coalesce(tryGet(parameters('extensionHealthConfig'), 'autoUpgradeMinorVersion'), false()), 'settings', createObject('protocol', coalesce(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'http'), 'port', coalesce(tryGet(parameters('extensionHealthConfig'), 'port'), 80), 'requestPath', coalesce(tryGet(parameters('extensionHealthConfig'), 'requestPath'), if(and(contains(parameters('extensionHealthConfig'), 'protocol'), not(equals(parameters('extensionHealthConfig').protocol, 'tcp'))), '/', '')), 'intervalInSeconds', coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), 'numberOfProbes', coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1), 'gracePeriod', coalesce(tryGet(parameters('extensionHealthConfig'), 'gracePeriod'), 5)))))), null())]",
+          "extensionProfile": "[if(parameters('extensionHealthConfig').enabled, createObject('extensions', createArray(createObject('name', 'HealthExtension', 'properties', createObject('publisher', 'Microsoft.ManagedServices', 'type', if(equals(parameters('osType'), 'Windows'), 'ApplicationHealthWindows', 'ApplicationHealthLinux'), 'typeHandlerVersion', coalesce(tryGet(parameters('extensionHealthConfig'), 'typeHandlerVersion'), '2.0'), 'autoUpgradeMinorVersion', coalesce(tryGet(parameters('extensionHealthConfig'), 'autoUpgradeMinorVersion'), false()), 'settings', createObject('protocol', coalesce(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'http'), 'port', coalesce(tryGet(parameters('extensionHealthConfig'), 'port'), 80), 'requestPath', coalesce(tryGet(parameters('extensionHealthConfig'), 'requestPath'), if(and(contains(parameters('extensionHealthConfig'), 'protocol'), not(equals(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'tcp'))), '/', '')), 'intervalInSeconds', coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), 'numberOfProbes', coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1), 'gracePeriod', coalesce(tryGet(parameters('extensionHealthConfig'), 'gracePeriod'), mul(coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1)))))))), null())]",
           "licenseType": "[parameters('licenseType')]",
           "priority": "[parameters('vmPriority')]",
           "evictionPolicy": "[if(parameters('enableEvictionPolicy'), 'Deallocate', null())]",
@@ -1110,6 +1338,15 @@
       "subscriptionId": "[split(if(not(empty(parameters('monitoringWorkspaceResourceId'))), parameters('monitoringWorkspaceResourceId'), '//'), '/')[2]]",
       "resourceGroup": "[split(if(not(empty(parameters('monitoringWorkspaceResourceId'))), parameters('monitoringWorkspaceResourceId'), '////'), '/')[4]]",
       "name": "[last(split(if(not(empty(parameters('monitoringWorkspaceResourceId'))), parameters('monitoringWorkspaceResourceId'), 'law'), '/'))]"
+    },
+    "cseIdentity": {
+      "condition": "[not(empty(tryGet(tryGet(parameters('extensionCustomScriptConfig'), 'protectedSettings'), 'managedIdentityResourceId')))]",
+      "existing": true,
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2024-11-30",
+      "subscriptionId": "[split(parameters('extensionCustomScriptConfig').protectedSettings.managedIdentityResourceId, '/')[2]]",
+      "resourceGroup": "[split(parameters('extensionCustomScriptConfig').protectedSettings.managedIdentityResourceId, '/')[4]]",
+      "name": "[last(split(parameters('extensionCustomScriptConfig').protectedSettings.managedIdentityResourceId, '/'))]"
     },
     "vmss_lock": {
       "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
@@ -1222,12 +1459,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "9930934584678265723"
+              "templateHash": "5972745166705801067"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -1271,21 +1509,21 @@
             },
             "forceUpdateTag": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. How the extension handler should be forced to update even if the extension configuration has not changed."
               }
             },
             "settings": {
               "type": "object",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific settings."
               }
             },
             "protectedSettings": {
               "type": "secureObject",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific protected settings."
               }
@@ -1302,12 +1540,38 @@
               "metadata": {
                 "description": "Required. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
               }
+            },
+            "protectedSettingsFromKeyVault": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/protectedSettingsFromKeyVault"
+                },
+                "description": "Optional. The extensions protected settings that are passed by reference, and consumed from key vault."
+              },
+              "nullable": true
+            },
+            "provisionAfterExtensions": {
+              "type": "array",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
+                },
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              },
+              "nullable": true
             }
           },
-          "resources": [
-            {
+          "resources": {
+            "virtualMachineScaleSet": {
+              "existing": true,
+              "type": "Microsoft.Compute/virtualMachineScaleSets",
+              "apiVersion": "2024-11-01",
+              "name": "[parameters('virtualMachineScaleSetName')]"
+            },
+            "extension": {
               "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-              "apiVersion": "2023-09-01",
+              "apiVersion": "2024-11-01",
               "name": "[format('{0}/{1}', parameters('virtualMachineScaleSetName'), parameters('name'))]",
               "properties": {
                 "publisher": "[parameters('publisher')]",
@@ -1315,13 +1579,15 @@
                 "typeHandlerVersion": "[parameters('typeHandlerVersion')]",
                 "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
                 "enableAutomaticUpgrade": "[parameters('enableAutomaticUpgrade')]",
-                "forceUpdateTag": "[if(not(empty(parameters('forceUpdateTag'))), parameters('forceUpdateTag'), null())]",
-                "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
-                "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
-                "suppressFailures": "[parameters('supressFailures')]"
+                "forceUpdateTag": "[parameters('forceUpdateTag')]",
+                "settings": "[parameters('settings')]",
+                "protectedSettings": "[parameters('protectedSettings')]",
+                "suppressFailures": "[parameters('supressFailures')]",
+                "protectedSettingsFromKeyVault": "[parameters('protectedSettingsFromKeyVault')]",
+                "provisionAfterExtensions": "[parameters('provisionAfterExtensions')]"
               }
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",
@@ -1389,12 +1655,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "9930934584678265723"
+              "templateHash": "5972745166705801067"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -1438,21 +1705,21 @@
             },
             "forceUpdateTag": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. How the extension handler should be forced to update even if the extension configuration has not changed."
               }
             },
             "settings": {
               "type": "object",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific settings."
               }
             },
             "protectedSettings": {
               "type": "secureObject",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific protected settings."
               }
@@ -1469,12 +1736,38 @@
               "metadata": {
                 "description": "Required. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
               }
+            },
+            "protectedSettingsFromKeyVault": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/protectedSettingsFromKeyVault"
+                },
+                "description": "Optional. The extensions protected settings that are passed by reference, and consumed from key vault."
+              },
+              "nullable": true
+            },
+            "provisionAfterExtensions": {
+              "type": "array",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
+                },
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              },
+              "nullable": true
             }
           },
-          "resources": [
-            {
+          "resources": {
+            "virtualMachineScaleSet": {
+              "existing": true,
+              "type": "Microsoft.Compute/virtualMachineScaleSets",
+              "apiVersion": "2024-11-01",
+              "name": "[parameters('virtualMachineScaleSetName')]"
+            },
+            "extension": {
               "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-              "apiVersion": "2023-09-01",
+              "apiVersion": "2024-11-01",
               "name": "[format('{0}/{1}', parameters('virtualMachineScaleSetName'), parameters('name'))]",
               "properties": {
                 "publisher": "[parameters('publisher')]",
@@ -1482,13 +1775,15 @@
                 "typeHandlerVersion": "[parameters('typeHandlerVersion')]",
                 "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
                 "enableAutomaticUpgrade": "[parameters('enableAutomaticUpgrade')]",
-                "forceUpdateTag": "[if(not(empty(parameters('forceUpdateTag'))), parameters('forceUpdateTag'), null())]",
-                "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
-                "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
-                "suppressFailures": "[parameters('supressFailures')]"
+                "forceUpdateTag": "[parameters('forceUpdateTag')]",
+                "settings": "[parameters('settings')]",
+                "protectedSettings": "[parameters('protectedSettings')]",
+                "suppressFailures": "[parameters('supressFailures')]",
+                "protectedSettingsFromKeyVault": "[parameters('protectedSettingsFromKeyVault')]",
+                "provisionAfterExtensions": "[parameters('provisionAfterExtensions')]"
               }
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",
@@ -1561,12 +1856,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "9930934584678265723"
+              "templateHash": "5972745166705801067"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -1610,21 +1906,21 @@
             },
             "forceUpdateTag": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. How the extension handler should be forced to update even if the extension configuration has not changed."
               }
             },
             "settings": {
               "type": "object",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific settings."
               }
             },
             "protectedSettings": {
               "type": "secureObject",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific protected settings."
               }
@@ -1641,12 +1937,38 @@
               "metadata": {
                 "description": "Required. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
               }
+            },
+            "protectedSettingsFromKeyVault": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/protectedSettingsFromKeyVault"
+                },
+                "description": "Optional. The extensions protected settings that are passed by reference, and consumed from key vault."
+              },
+              "nullable": true
+            },
+            "provisionAfterExtensions": {
+              "type": "array",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
+                },
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              },
+              "nullable": true
             }
           },
-          "resources": [
-            {
+          "resources": {
+            "virtualMachineScaleSet": {
+              "existing": true,
+              "type": "Microsoft.Compute/virtualMachineScaleSets",
+              "apiVersion": "2024-11-01",
+              "name": "[parameters('virtualMachineScaleSetName')]"
+            },
+            "extension": {
               "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-              "apiVersion": "2023-09-01",
+              "apiVersion": "2024-11-01",
               "name": "[format('{0}/{1}', parameters('virtualMachineScaleSetName'), parameters('name'))]",
               "properties": {
                 "publisher": "[parameters('publisher')]",
@@ -1654,13 +1976,15 @@
                 "typeHandlerVersion": "[parameters('typeHandlerVersion')]",
                 "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
                 "enableAutomaticUpgrade": "[parameters('enableAutomaticUpgrade')]",
-                "forceUpdateTag": "[if(not(empty(parameters('forceUpdateTag'))), parameters('forceUpdateTag'), null())]",
-                "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
-                "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
-                "suppressFailures": "[parameters('supressFailures')]"
+                "forceUpdateTag": "[parameters('forceUpdateTag')]",
+                "settings": "[parameters('settings')]",
+                "protectedSettings": "[parameters('protectedSettings')]",
+                "suppressFailures": "[parameters('supressFailures')]",
+                "protectedSettingsFromKeyVault": "[parameters('protectedSettingsFromKeyVault')]",
+                "provisionAfterExtensions": "[parameters('provisionAfterExtensions')]"
               }
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",
@@ -1725,12 +2049,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "9930934584678265723"
+              "templateHash": "5972745166705801067"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -1774,21 +2099,21 @@
             },
             "forceUpdateTag": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. How the extension handler should be forced to update even if the extension configuration has not changed."
               }
             },
             "settings": {
               "type": "object",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific settings."
               }
             },
             "protectedSettings": {
               "type": "secureObject",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific protected settings."
               }
@@ -1805,12 +2130,38 @@
               "metadata": {
                 "description": "Required. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
               }
+            },
+            "protectedSettingsFromKeyVault": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/protectedSettingsFromKeyVault"
+                },
+                "description": "Optional. The extensions protected settings that are passed by reference, and consumed from key vault."
+              },
+              "nullable": true
+            },
+            "provisionAfterExtensions": {
+              "type": "array",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
+                },
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              },
+              "nullable": true
             }
           },
-          "resources": [
-            {
+          "resources": {
+            "virtualMachineScaleSet": {
+              "existing": true,
+              "type": "Microsoft.Compute/virtualMachineScaleSets",
+              "apiVersion": "2024-11-01",
+              "name": "[parameters('virtualMachineScaleSetName')]"
+            },
+            "extension": {
               "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-              "apiVersion": "2023-09-01",
+              "apiVersion": "2024-11-01",
               "name": "[format('{0}/{1}', parameters('virtualMachineScaleSetName'), parameters('name'))]",
               "properties": {
                 "publisher": "[parameters('publisher')]",
@@ -1818,13 +2169,15 @@
                 "typeHandlerVersion": "[parameters('typeHandlerVersion')]",
                 "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
                 "enableAutomaticUpgrade": "[parameters('enableAutomaticUpgrade')]",
-                "forceUpdateTag": "[if(not(empty(parameters('forceUpdateTag'))), parameters('forceUpdateTag'), null())]",
-                "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
-                "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
-                "suppressFailures": "[parameters('supressFailures')]"
+                "forceUpdateTag": "[parameters('forceUpdateTag')]",
+                "settings": "[parameters('settings')]",
+                "protectedSettings": "[parameters('protectedSettings')]",
+                "suppressFailures": "[parameters('supressFailures')]",
+                "protectedSettingsFromKeyVault": "[parameters('protectedSettingsFromKeyVault')]",
+                "provisionAfterExtensions": "[parameters('provisionAfterExtensions')]"
               }
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",
@@ -1888,12 +2241,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "9930934584678265723"
+              "templateHash": "5972745166705801067"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -1937,21 +2291,21 @@
             },
             "forceUpdateTag": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. How the extension handler should be forced to update even if the extension configuration has not changed."
               }
             },
             "settings": {
               "type": "object",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific settings."
               }
             },
             "protectedSettings": {
               "type": "secureObject",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific protected settings."
               }
@@ -1968,12 +2322,38 @@
               "metadata": {
                 "description": "Required. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
               }
+            },
+            "protectedSettingsFromKeyVault": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/protectedSettingsFromKeyVault"
+                },
+                "description": "Optional. The extensions protected settings that are passed by reference, and consumed from key vault."
+              },
+              "nullable": true
+            },
+            "provisionAfterExtensions": {
+              "type": "array",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
+                },
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              },
+              "nullable": true
             }
           },
-          "resources": [
-            {
+          "resources": {
+            "virtualMachineScaleSet": {
+              "existing": true,
+              "type": "Microsoft.Compute/virtualMachineScaleSets",
+              "apiVersion": "2024-11-01",
+              "name": "[parameters('virtualMachineScaleSetName')]"
+            },
+            "extension": {
               "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-              "apiVersion": "2023-09-01",
+              "apiVersion": "2024-11-01",
               "name": "[format('{0}/{1}', parameters('virtualMachineScaleSetName'), parameters('name'))]",
               "properties": {
                 "publisher": "[parameters('publisher')]",
@@ -1981,13 +2361,15 @@
                 "typeHandlerVersion": "[parameters('typeHandlerVersion')]",
                 "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
                 "enableAutomaticUpgrade": "[parameters('enableAutomaticUpgrade')]",
-                "forceUpdateTag": "[if(not(empty(parameters('forceUpdateTag'))), parameters('forceUpdateTag'), null())]",
-                "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
-                "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
-                "suppressFailures": "[parameters('supressFailures')]"
+                "forceUpdateTag": "[parameters('forceUpdateTag')]",
+                "settings": "[parameters('settings')]",
+                "protectedSettings": "[parameters('protectedSettings')]",
+                "suppressFailures": "[parameters('supressFailures')]",
+                "protectedSettingsFromKeyVault": "[parameters('protectedSettingsFromKeyVault')]",
+                "provisionAfterExtensions": "[parameters('provisionAfterExtensions')]"
               }
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",
@@ -2059,12 +2441,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "9930934584678265723"
+              "templateHash": "5972745166705801067"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -2108,21 +2491,21 @@
             },
             "forceUpdateTag": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. How the extension handler should be forced to update even if the extension configuration has not changed."
               }
             },
             "settings": {
               "type": "object",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific settings."
               }
             },
             "protectedSettings": {
               "type": "secureObject",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific protected settings."
               }
@@ -2139,12 +2522,38 @@
               "metadata": {
                 "description": "Required. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
               }
+            },
+            "protectedSettingsFromKeyVault": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/protectedSettingsFromKeyVault"
+                },
+                "description": "Optional. The extensions protected settings that are passed by reference, and consumed from key vault."
+              },
+              "nullable": true
+            },
+            "provisionAfterExtensions": {
+              "type": "array",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
+                },
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              },
+              "nullable": true
             }
           },
-          "resources": [
-            {
+          "resources": {
+            "virtualMachineScaleSet": {
+              "existing": true,
+              "type": "Microsoft.Compute/virtualMachineScaleSets",
+              "apiVersion": "2024-11-01",
+              "name": "[parameters('virtualMachineScaleSetName')]"
+            },
+            "extension": {
               "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-              "apiVersion": "2023-09-01",
+              "apiVersion": "2024-11-01",
               "name": "[format('{0}/{1}', parameters('virtualMachineScaleSetName'), parameters('name'))]",
               "properties": {
                 "publisher": "[parameters('publisher')]",
@@ -2152,13 +2561,15 @@
                 "typeHandlerVersion": "[parameters('typeHandlerVersion')]",
                 "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
                 "enableAutomaticUpgrade": "[parameters('enableAutomaticUpgrade')]",
-                "forceUpdateTag": "[if(not(empty(parameters('forceUpdateTag'))), parameters('forceUpdateTag'), null())]",
-                "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
-                "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
-                "suppressFailures": "[parameters('supressFailures')]"
+                "forceUpdateTag": "[parameters('forceUpdateTag')]",
+                "settings": "[parameters('settings')]",
+                "protectedSettings": "[parameters('protectedSettings')]",
+                "suppressFailures": "[parameters('supressFailures')]",
+                "protectedSettingsFromKeyVault": "[parameters('protectedSettingsFromKeyVault')]",
+                "provisionAfterExtensions": "[parameters('provisionAfterExtensions')]"
               }
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",
@@ -2190,7 +2601,7 @@
       ]
     },
     "vmss_customScriptExtension": {
-      "condition": "[parameters('extensionCustomScriptConfig').enabled]",
+      "condition": "[not(empty(parameters('extensionCustomScriptConfig')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
       "name": "[format('{0}-VMSS-CustomScriptExtension', uniqueString(deployment().name, parameters('location')))]",
@@ -2204,7 +2615,7 @@
             "value": "[parameters('name')]"
           },
           "name": {
-            "value": "CustomScriptExtension"
+            "value": "[coalesce(tryGet(parameters('extensionCustomScriptConfig'), 'name'), 'CustomScriptExtension')]"
           },
           "publisher": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'Microsoft.Compute'), createObject('value', 'Microsoft.Azure.Extensions'))]",
           "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'CustomScriptExtension'), createObject('value', 'CustomScript'))]",
@@ -2217,29 +2628,34 @@
           "enableAutomaticUpgrade": {
             "value": "[coalesce(tryGet(parameters('extensionCustomScriptConfig'), 'enableAutomaticUpgrade'), false())]"
           },
+          "forceUpdateTag": {
+            "value": "[tryGet(parameters('extensionCustomScriptConfig'), 'forceUpdateTag')]"
+          },
+          "provisionAfterExtensions": {
+            "value": "[tryGet(parameters('extensionCustomScriptConfig'), 'provisionAfterExtensions')]"
+          },
+          "supressFailures": {
+            "value": "[coalesce(tryGet(parameters('extensionCustomScriptConfig'), 'supressFailures'), false())]"
+          },
+          "protectedSettingsFromKeyVault": {
+            "value": "[tryGet(parameters('extensionCustomScriptConfig'), 'protectedSettingsFromKeyVault')]"
+          },
           "settings": {
-            "value": {
-              "copy": [
-                {
-                  "name": "fileUris",
-                  "count": "[length(parameters('extensionCustomScriptConfig').fileData)]",
-                  "input": "[if(contains(parameters('extensionCustomScriptConfig').fileData[copyIndex('fileUris')], 'storageAccountId'), format('{0}?{1}', parameters('extensionCustomScriptConfig').fileData[copyIndex('fileUris')].uri, listAccountSas(parameters('extensionCustomScriptConfig').fileData[copyIndex('fileUris')].storageAccountId, '2019-04-01', variables('accountSasProperties')).accountSasToken), parameters('extensionCustomScriptConfig').fileData[copyIndex('fileUris')].uri)]"
-                }
-              ]
-            }
+            "value": "[shallowMerge(createArray(if(not(empty(tryGet(tryGet(parameters('extensionCustomScriptConfig'), 'settings'), 'commandToExecute'))), createObject('commandToExecute', tryGet(tryGet(parameters('extensionCustomScriptConfig'), 'settings'), 'commandToExecute')), createObject()), if(not(empty(tryGet(tryGet(parameters('extensionCustomScriptConfig'), 'settings'), 'fileUris'))), createObject('fileUris', tryGet(parameters('extensionCustomScriptConfig'), 'settings', 'fileUris')), createObject())))]"
           },
           "protectedSettings": {
-            "value": "[coalesce(tryGet(parameters('extensionCustomScriptConfig'), 'protectedSettings'), createObject())]"
+            "value": "[shallowMerge(createArray(if(not(empty(tryGet(tryGet(parameters('extensionCustomScriptConfig'), 'protectedSettings'), 'commandToExecute'))), createObject('commandToExecute', tryGet(parameters('extensionCustomScriptConfig').protectedSettings, 'commandToExecute')), createObject()), if(not(empty(tryGet(tryGet(parameters('extensionCustomScriptConfig'), 'protectedSettings'), 'storageAccountName'))), createObject('storageAccountName', parameters('extensionCustomScriptConfig').protectedSettings.storageAccountName), createObject()), if(not(empty(tryGet(tryGet(parameters('extensionCustomScriptConfig'), 'protectedSettings'), 'storageAccountKey'))), createObject('storageAccountKey', parameters('extensionCustomScriptConfig').protectedSettings.storageAccountKey), createObject()), if(not(empty(tryGet(tryGet(parameters('extensionCustomScriptConfig'), 'protectedSettings'), 'fileUris'))), createObject('fileUris', parameters('extensionCustomScriptConfig').protectedSettings.fileUris), createObject()), if(not(equals(tryGet(tryGet(parameters('extensionCustomScriptConfig'), 'protectedSettings'), 'managedIdentityResourceId'), null())), createObject('managedIdentity', if(not(empty(tryGet(parameters('extensionCustomScriptConfig').protectedSettings, 'managedIdentityResourceId'))), createObject('clientId', reference('cseIdentity').clientId), createObject())), createObject())))]"
           }
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "9930934584678265723"
+              "templateHash": "5972745166705801067"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -2283,21 +2699,21 @@
             },
             "forceUpdateTag": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. How the extension handler should be forced to update even if the extension configuration has not changed."
               }
             },
             "settings": {
               "type": "object",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific settings."
               }
             },
             "protectedSettings": {
               "type": "secureObject",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific protected settings."
               }
@@ -2314,12 +2730,38 @@
               "metadata": {
                 "description": "Required. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
               }
+            },
+            "protectedSettingsFromKeyVault": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/protectedSettingsFromKeyVault"
+                },
+                "description": "Optional. The extensions protected settings that are passed by reference, and consumed from key vault."
+              },
+              "nullable": true
+            },
+            "provisionAfterExtensions": {
+              "type": "array",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
+                },
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              },
+              "nullable": true
             }
           },
-          "resources": [
-            {
+          "resources": {
+            "virtualMachineScaleSet": {
+              "existing": true,
+              "type": "Microsoft.Compute/virtualMachineScaleSets",
+              "apiVersion": "2024-11-01",
+              "name": "[parameters('virtualMachineScaleSetName')]"
+            },
+            "extension": {
               "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-              "apiVersion": "2023-09-01",
+              "apiVersion": "2024-11-01",
               "name": "[format('{0}/{1}', parameters('virtualMachineScaleSetName'), parameters('name'))]",
               "properties": {
                 "publisher": "[parameters('publisher')]",
@@ -2327,13 +2769,15 @@
                 "typeHandlerVersion": "[parameters('typeHandlerVersion')]",
                 "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
                 "enableAutomaticUpgrade": "[parameters('enableAutomaticUpgrade')]",
-                "forceUpdateTag": "[if(not(empty(parameters('forceUpdateTag'))), parameters('forceUpdateTag'), null())]",
-                "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
-                "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
-                "suppressFailures": "[parameters('supressFailures')]"
+                "forceUpdateTag": "[parameters('forceUpdateTag')]",
+                "settings": "[parameters('settings')]",
+                "protectedSettings": "[parameters('protectedSettings')]",
+                "suppressFailures": "[parameters('supressFailures')]",
+                "protectedSettingsFromKeyVault": "[parameters('protectedSettingsFromKeyVault')]",
+                "provisionAfterExtensions": "[parameters('provisionAfterExtensions')]"
               }
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",
@@ -2360,6 +2804,7 @@
         }
       },
       "dependsOn": [
+        "cseIdentity",
         "vmss",
         "vmss_desiredStateConfigurationExtension"
       ]
@@ -2403,12 +2848,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "9930934584678265723"
+              "templateHash": "5972745166705801067"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -2452,21 +2898,21 @@
             },
             "forceUpdateTag": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. How the extension handler should be forced to update even if the extension configuration has not changed."
               }
             },
             "settings": {
               "type": "object",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific settings."
               }
             },
             "protectedSettings": {
               "type": "secureObject",
-              "defaultValue": {},
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Any object that contains the extension specific protected settings."
               }
@@ -2483,12 +2929,38 @@
               "metadata": {
                 "description": "Required. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
               }
+            },
+            "protectedSettingsFromKeyVault": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/protectedSettingsFromKeyVault"
+                },
+                "description": "Optional. The extensions protected settings that are passed by reference, and consumed from key vault."
+              },
+              "nullable": true
+            },
+            "provisionAfterExtensions": {
+              "type": "array",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
+                },
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              },
+              "nullable": true
             }
           },
-          "resources": [
-            {
+          "resources": {
+            "virtualMachineScaleSet": {
+              "existing": true,
+              "type": "Microsoft.Compute/virtualMachineScaleSets",
+              "apiVersion": "2024-11-01",
+              "name": "[parameters('virtualMachineScaleSetName')]"
+            },
+            "extension": {
               "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
-              "apiVersion": "2023-09-01",
+              "apiVersion": "2024-11-01",
               "name": "[format('{0}/{1}', parameters('virtualMachineScaleSetName'), parameters('name'))]",
               "properties": {
                 "publisher": "[parameters('publisher')]",
@@ -2496,13 +2968,15 @@
                 "typeHandlerVersion": "[parameters('typeHandlerVersion')]",
                 "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
                 "enableAutomaticUpgrade": "[parameters('enableAutomaticUpgrade')]",
-                "forceUpdateTag": "[if(not(empty(parameters('forceUpdateTag'))), parameters('forceUpdateTag'), null())]",
-                "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
-                "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
-                "suppressFailures": "[parameters('supressFailures')]"
+                "forceUpdateTag": "[parameters('forceUpdateTag')]",
+                "settings": "[parameters('settings')]",
+                "protectedSettings": "[parameters('protectedSettings')]",
+                "suppressFailures": "[parameters('supressFailures')]",
+                "protectedSettingsFromKeyVault": "[parameters('protectedSettingsFromKeyVault')]",
+                "provisionAfterExtensions": "[parameters('provisionAfterExtensions')]"
               }
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",
@@ -2562,14 +3036,14 @@
       "metadata": {
         "description": "The principal ID of the system assigned identity."
       },
-      "value": "[tryGet(tryGet(reference('vmss', '2024-07-01', 'full'), 'identity'), 'principalId')]"
+      "value": "[tryGet(tryGet(reference('vmss', '2024-11-01', 'full'), 'identity'), 'principalId')]"
     },
     "location": {
       "type": "string",
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('vmss', '2024-07-01', 'full').location]"
+      "value": "[reference('vmss', '2024-11-01', 'full').location]"
     }
   }
 }

--- a/avm/res/compute/virtual-machine-scale-set/main.json
+++ b/avm/res/compute/virtual-machine-scale-set/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "11157832261456876697"
+      "templateHash": "6736421211333355117"
     },
     "name": "Virtual Machine Scale Sets",
     "description": "This module deploys a Virtual Machine Scale Set."
@@ -17,9 +17,8 @@
       "properties": {
         "enabled": {
           "type": "bool",
-          "nullable": true,
           "metadata": {
-            "description": "Optional. Enable or disable the Health Config extension. Defaults to `false`."
+            "description": "Required. Enable or disable the Health Config extension."
           }
         },
         "typeHandlerVersion": {
@@ -34,6 +33,13 @@
           "nullable": true,
           "metadata": {
             "description": "Optional. Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true. Defaults to `false`."
+          }
+        },
+        "enableAutomaticUpgrade": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available. Defaults to `true`."
           }
         },
         "protocol": {
@@ -86,6 +92,16 @@
           "maxValue": 14400,
           "metadata": {
             "description": "Optional. The grace period for newly created instances. Defaults to `intervalInSeconds` x `numberOfProbes`."
+          }
+        },
+        "provisionAfterExtensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
           }
         }
       },
@@ -1308,7 +1324,6 @@
               "storageUri": "[if(not(empty(parameters('bootDiagnosticStorageAccountName'))), format('https://{0}{1}', parameters('bootDiagnosticStorageAccountName'), parameters('bootDiagnosticStorageAccountUri')), null())]"
             }
           },
-          "extensionProfile": "[if(coalesce(tryGet(parameters('extensionHealthConfig'), 'enabled'), false()), createObject('extensions', createArray(createObject('name', 'HealthExtension', 'properties', createObject('publisher', 'Microsoft.ManagedServices', 'type', if(equals(parameters('osType'), 'Windows'), 'ApplicationHealthWindows', 'ApplicationHealthLinux'), 'typeHandlerVersion', coalesce(tryGet(parameters('extensionHealthConfig'), 'typeHandlerVersion'), '2.0'), 'autoUpgradeMinorVersion', coalesce(tryGet(parameters('extensionHealthConfig'), 'autoUpgradeMinorVersion'), false()), 'settings', createObject('protocol', coalesce(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'http'), 'port', coalesce(tryGet(parameters('extensionHealthConfig'), 'port'), 80), 'requestPath', coalesce(tryGet(parameters('extensionHealthConfig'), 'requestPath'), if(and(contains(parameters('extensionHealthConfig'), 'protocol'), not(equals(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'tcp'))), '/', '')), 'intervalInSeconds', coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), 'numberOfProbes', coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1), 'gracePeriod', coalesce(tryGet(parameters('extensionHealthConfig'), 'gracePeriod'), mul(coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1)))))))), null())]",
           "licenseType": "[parameters('licenseType')]",
           "priority": "[parameters('vmPriority')]",
           "evictionPolicy": "[if(parameters('enableEvictionPolicy'), 'Deallocate', null())]",
@@ -1417,11 +1432,11 @@
         "vmss"
       ]
     },
-    "vmss_domainJoinExtension": {
-      "condition": "[parameters('extensionDomainJoinConfig').enabled]",
+    "vmss_healthExtension": {
+      "condition": "[parameters('extensionHealthConfig').enabled]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-VMSS-DomainJoin', uniqueString(deployment().name, parameters('location')))]",
+      "name": "[format('{0}-VMSS-Health', uniqueString(deployment().name, parameters('location')))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -1432,30 +1447,33 @@
             "value": "[parameters('name')]"
           },
           "name": {
-            "value": "DomainJoin"
+            "value": "HealthExtension"
           },
           "publisher": {
-            "value": "Microsoft.Compute"
+            "value": "Microsoft.ManagedServices"
           },
-          "type": {
-            "value": "JsonADDomainExtension"
-          },
+          "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'ApplicationHealthWindows'), createObject('value', 'ApplicationHealthLinux'))]",
           "typeHandlerVersion": {
-            "value": "[coalesce(tryGet(parameters('extensionDomainJoinConfig'), 'typeHandlerVersion'), '1.3')]"
+            "value": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'typeHandlerVersion'), '2.0')]"
           },
           "autoUpgradeMinorVersion": {
-            "value": "[coalesce(tryGet(parameters('extensionDomainJoinConfig'), 'autoUpgradeMinorVersion'), true())]"
+            "value": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'autoUpgradeMinorVersion'), false())]"
           },
           "enableAutomaticUpgrade": {
-            "value": "[coalesce(tryGet(parameters('extensionDomainJoinConfig'), 'enableAutomaticUpgrade'), false())]"
+            "value": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'enableAutomaticUpgrade'), true())]"
           },
           "settings": {
-            "value": "[parameters('extensionDomainJoinConfig').settings]"
-          },
-          "protectedSettings": {
             "value": {
-              "Password": "[parameters('extensionDomainJoinPassword')]"
+              "protocol": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'http')]",
+              "port": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'port'), 80)]",
+              "requestPath": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'requestPath'), if(and(contains(parameters('extensionHealthConfig'), 'protocol'), not(equals(tryGet(parameters('extensionHealthConfig'), 'protocol'), 'tcp'))), '/', ''))]",
+              "intervalInSeconds": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5)]",
+              "numberOfProbes": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1)]",
+              "gracePeriod": "[coalesce(tryGet(parameters('extensionHealthConfig'), 'gracePeriod'), mul(coalesce(tryGet(parameters('extensionHealthConfig'), 'intervalInSeconds'), 5), coalesce(tryGet(parameters('extensionHealthConfig'), 'numberOfProbes'), 1)))]"
             }
+          },
+          "provisionAfterExtensions": {
+            "value": "[tryGet(parameters('extensionHealthConfig'), 'provisionAfterExtensions')]"
           }
         },
         "template": {
@@ -1466,7 +1484,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "5972745166705801067"
+              "templateHash": "1457477458264476892"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -1554,13 +1572,217 @@
             },
             "provisionAfterExtensions": {
               "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              }
+            }
+          },
+          "resources": {
+            "virtualMachineScaleSet": {
+              "existing": true,
+              "type": "Microsoft.Compute/virtualMachineScaleSets",
+              "apiVersion": "2024-11-01",
+              "name": "[parameters('virtualMachineScaleSetName')]"
+            },
+            "extension": {
+              "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
+              "apiVersion": "2024-11-01",
+              "name": "[format('{0}/{1}', parameters('virtualMachineScaleSetName'), parameters('name'))]",
+              "properties": {
+                "publisher": "[parameters('publisher')]",
+                "type": "[parameters('type')]",
+                "typeHandlerVersion": "[parameters('typeHandlerVersion')]",
+                "autoUpgradeMinorVersion": "[parameters('autoUpgradeMinorVersion')]",
+                "enableAutomaticUpgrade": "[parameters('enableAutomaticUpgrade')]",
+                "forceUpdateTag": "[parameters('forceUpdateTag')]",
+                "settings": "[parameters('settings')]",
+                "protectedSettings": "[parameters('protectedSettings')]",
+                "suppressFailures": "[parameters('supressFailures')]",
+                "protectedSettingsFromKeyVault": "[parameters('protectedSettingsFromKeyVault')]",
+                "provisionAfterExtensions": "[parameters('provisionAfterExtensions')]"
+              }
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the extension."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The ResourceId of the extension."
+              },
+              "value": "[resourceId('Microsoft.Compute/virtualMachineScaleSets/extensions', parameters('virtualMachineScaleSetName'), parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Resource Group the extension was created in."
+              },
+              "value": "[resourceGroup().name]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "vmss"
+      ]
+    },
+    "vmss_domainJoinExtension": {
+      "condition": "[parameters('extensionDomainJoinConfig').enabled]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('{0}-VMSS-DomainJoin', uniqueString(deployment().name, parameters('location')))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "virtualMachineScaleSetName": {
+            "value": "[parameters('name')]"
+          },
+          "name": {
+            "value": "DomainJoin"
+          },
+          "publisher": {
+            "value": "Microsoft.Compute"
+          },
+          "type": {
+            "value": "JsonADDomainExtension"
+          },
+          "typeHandlerVersion": {
+            "value": "[coalesce(tryGet(parameters('extensionDomainJoinConfig'), 'typeHandlerVersion'), '1.3')]"
+          },
+          "autoUpgradeMinorVersion": {
+            "value": "[coalesce(tryGet(parameters('extensionDomainJoinConfig'), 'autoUpgradeMinorVersion'), true())]"
+          },
+          "enableAutomaticUpgrade": {
+            "value": "[coalesce(tryGet(parameters('extensionDomainJoinConfig'), 'enableAutomaticUpgrade'), false())]"
+          },
+          "settings": {
+            "value": "[parameters('extensionDomainJoinConfig').settings]"
+          },
+          "protectedSettings": {
+            "value": {
+              "Password": "[parameters('extensionDomainJoinPassword')]"
+            }
+          },
+          "provisionAfterExtensions": {
+            "value": "[tryGet(parameters('extensionDomainJoinConfig'), 'provisionAfterExtensions')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.37.4.10188",
+              "templateHash": "1457477458264476892"
+            },
+            "name": "Virtual Machine Scale Set Extensions",
+            "description": "This module deploys a Virtual Machine Scale Set Extension."
+          },
+          "parameters": {
+            "virtualMachineScaleSetName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the parent virtual machine scale set that extension is provisioned for. Required if the template is used in a standalone deployment."
+              }
+            },
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the virtual machine scale set extension."
+              }
+            },
+            "publisher": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the extension handler publisher."
+              }
+            },
+            "type": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Specifies the type of the extension; an example is \"CustomScriptExtension\"."
+              }
+            },
+            "typeHandlerVersion": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Specifies the version of the script handler."
+              }
+            },
+            "autoUpgradeMinorVersion": {
+              "type": "bool",
+              "metadata": {
+                "description": "Required. Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true."
+              }
+            },
+            "forceUpdateTag": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. How the extension handler should be forced to update even if the extension configuration has not changed."
+              }
+            },
+            "settings": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Any object that contains the extension specific settings."
+              }
+            },
+            "protectedSettings": {
+              "type": "secureObject",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Any object that contains the extension specific protected settings."
+              }
+            },
+            "supressFailures": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Indicates whether failures stemming from the extension will be suppressed (Operational failures such as not connecting to the VM will not be suppressed regardless of this value). The default is false."
+              }
+            },
+            "enableAutomaticUpgrade": {
+              "type": "bool",
+              "metadata": {
+                "description": "Required. Indicates whether the extension should be automatically upgraded by the platform if there is a newer version of the extension available."
+              }
+            },
+            "protectedSettingsFromKeyVault": {
+              "type": "object",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
+                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/protectedSettingsFromKeyVault"
                 },
-                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+                "description": "Optional. The extensions protected settings that are passed by reference, and consumed from key vault."
               },
               "nullable": true
+            },
+            "provisionAfterExtensions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              }
             }
           },
           "resources": {
@@ -1652,6 +1874,9 @@
           },
           "settings": {
             "value": "[parameters('extensionAntiMalwareConfig').settings]"
+          },
+          "provisionAfterExtensions": {
+            "value": "[tryGet(parameters('extensionAntiMalwareConfig'), 'provisionAfterExtensions')]"
           }
         },
         "template": {
@@ -1662,7 +1887,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "5972745166705801067"
+              "templateHash": "1457477458264476892"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -1750,13 +1975,13 @@
             },
             "provisionAfterExtensions": {
               "type": "array",
-              "metadata": {
-                "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
-                },
-                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              "items": {
+                "type": "string"
               },
-              "nullable": true
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              }
             }
           },
           "resources": {
@@ -1853,6 +2078,9 @@
             "value": {
               "workspaceKey": "[if(not(empty(parameters('monitoringWorkspaceResourceId'))), listKeys('vmss_logAnalyticsWorkspace', '2025-02-01').primarySharedKey, '')]"
             }
+          },
+          "provisionAfterExtensions": {
+            "value": "[tryGet(parameters('extensionMonitoringAgentConfig'), 'provisionAfterExtensions')]"
           }
         },
         "template": {
@@ -1863,7 +2091,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "5972745166705801067"
+              "templateHash": "1457477458264476892"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -1951,13 +2179,13 @@
             },
             "provisionAfterExtensions": {
               "type": "array",
-              "metadata": {
-                "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
-                },
-                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              "items": {
+                "type": "string"
               },
-              "nullable": true
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              }
             }
           },
           "resources": {
@@ -2046,6 +2274,9 @@
           },
           "enableAutomaticUpgrade": {
             "value": "[coalesce(tryGet(parameters('extensionDependencyAgentConfig'), 'enableAutomaticUpgrade'), true())]"
+          },
+          "provisionAfterExtensions": {
+            "value": "[tryGet(parameters('extensionDependencyAgentConfig'), 'provisionAfterExtensions')]"
           }
         },
         "template": {
@@ -2056,7 +2287,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "5972745166705801067"
+              "templateHash": "1457477458264476892"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -2144,13 +2375,13 @@
             },
             "provisionAfterExtensions": {
               "type": "array",
-              "metadata": {
-                "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
-                },
-                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              "items": {
+                "type": "string"
               },
-              "nullable": true
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              }
             }
           },
           "resources": {
@@ -2238,6 +2469,9 @@
           },
           "enableAutomaticUpgrade": {
             "value": "[coalesce(tryGet(parameters('extensionNetworkWatcherAgentConfig'), 'enableAutomaticUpgrade'), false())]"
+          },
+          "provisionAfterExtensions": {
+            "value": "[tryGet(parameters('extensionNetworkWatcherAgentConfig'), 'provisionAfterExtensions')]"
           }
         },
         "template": {
@@ -2248,7 +2482,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "5972745166705801067"
+              "templateHash": "1457477458264476892"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -2336,13 +2570,13 @@
             },
             "provisionAfterExtensions": {
               "type": "array",
-              "metadata": {
-                "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
-                },
-                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              "items": {
+                "type": "string"
               },
-              "nullable": true
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              }
             }
           },
           "resources": {
@@ -2438,6 +2672,9 @@
           },
           "protectedSettings": {
             "value": "[coalesce(tryGet(parameters('extensionDSCConfig'), 'protectedSettings'), createObject())]"
+          },
+          "provisionAfterExtensions": {
+            "value": "[tryGet(parameters('extensionDSCConfig'), 'provisionAfterExtensions')]"
           }
         },
         "template": {
@@ -2448,7 +2685,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "5972745166705801067"
+              "templateHash": "1457477458264476892"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -2536,13 +2773,13 @@
             },
             "provisionAfterExtensions": {
               "type": "array",
-              "metadata": {
-                "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
-                },
-                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              "items": {
+                "type": "string"
               },
-              "nullable": true
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              }
             }
           },
           "resources": {
@@ -2656,7 +2893,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "5972745166705801067"
+              "templateHash": "1457477458264476892"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -2744,13 +2981,13 @@
             },
             "provisionAfterExtensions": {
               "type": "array",
-              "metadata": {
-                "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
-                },
-                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              "items": {
+                "type": "string"
               },
-              "nullable": true
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              }
             }
           },
           "resources": {
@@ -2845,6 +3082,9 @@
           },
           "settings": {
             "value": "[parameters('extensionAzureDiskEncryptionConfig').settings]"
+          },
+          "provisionAfterExtensions": {
+            "value": "[tryGet(parameters('extensionAzureDiskEncryptionConfig'), 'provisionAfterExtensions')]"
           }
         },
         "template": {
@@ -2855,7 +3095,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "5972745166705801067"
+              "templateHash": "1457477458264476892"
             },
             "name": "Virtual Machine Scale Set Extensions",
             "description": "This module deploys a Virtual Machine Scale Set Extension."
@@ -2943,13 +3183,13 @@
             },
             "provisionAfterExtensions": {
               "type": "array",
-              "metadata": {
-                "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.Compute/virtualMachineScaleSets/extensions@2024-11-01#properties/properties/properties/provisionAfterExtensions"
-                },
-                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              "items": {
+                "type": "string"
               },
-              "nullable": true
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Collection of extension names after which this extension needs to be provisioned."
+              }
             }
           },
           "resources": {

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.defaults/dependencies.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.defaults/dependencies.bicep
@@ -15,7 +15,7 @@ param sshKeyName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-07-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -35,7 +35,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   }
 }
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
@@ -53,7 +53,7 @@ resource msiRGContrRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: sshDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'
@@ -64,7 +64,7 @@ resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' 
     }
   }
   properties: {
-    azPowerShellVersion: '9.0'
+    azPowerShellVersion: '11.0'
     retentionInterval: 'P1D'
     arguments: '-SSHKeyName "${sshKeyName}" -ResourceGroupName "${resourceGroup().name}"'
     scriptContent: loadTextContent('../../../../../../../utilities/e2e-template-assets/scripts/New-SSHKey.ps1')
@@ -74,7 +74,7 @@ resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' 
   ]
 }
 
-resource sshKey 'Microsoft.Compute/sshPublicKeys@2022-03-01' = {
+resource sshKey 'Microsoft.Compute/sshPublicKeys@2024-11-01' = {
   name: sshKeyName
   location: location
   properties: {

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.defaults/main.test.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.defaults/main.test.bicep
@@ -68,7 +68,7 @@ module testDeployment '../../../main.bicep' = [
       }
       osDisk: {
         createOption: 'fromImage'
-        diskSizeGB: '128'
+        diskSizeGB: 128
         managedDisk: {
           storageAccountType: 'Premium_LRS'
         }

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.defaults/main.test.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.defaults/main.test.bicep
@@ -31,7 +31,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: enforcedLocation
 }
@@ -40,7 +40,6 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
-    location: enforcedLocation
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
     sshDeploymentScriptName: 'dep-${namePrefix}-ds-${serviceShort}'
@@ -58,7 +57,6 @@ module testDeployment '../../../main.bicep' = [
     scope: resourceGroup
     name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-${iteration}'
     params: {
-      location: enforcedLocation
       name: '${namePrefix}${serviceShort}001'
       adminUsername: 'scaleSetAdmin'
       adminPassword: password

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.health/dependencies.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.health/dependencies.bicep
@@ -15,7 +15,7 @@ param sshKeyName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-07-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -35,7 +35,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   }
 }
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
@@ -53,7 +53,7 @@ resource msiRGContrRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: sshDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'
@@ -64,7 +64,7 @@ resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' 
     }
   }
   properties: {
-    azPowerShellVersion: '9.0'
+    azPowerShellVersion: '11.0'
     retentionInterval: 'P1D'
     arguments: '-SSHKeyName "${sshKeyName}" -ResourceGroupName "${resourceGroup().name}"'
     scriptContent: loadTextContent('../../../../../../../utilities/e2e-template-assets/scripts/New-SSHKey.ps1')
@@ -74,7 +74,7 @@ resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' 
   ]
 }
 
-resource sshKey 'Microsoft.Compute/sshPublicKeys@2022-03-01' = {
+resource sshKey 'Microsoft.Compute/sshPublicKeys@2024-11-01' = {
   name: sshKeyName
   location: location
   properties: {

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.health/main.test.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.health/main.test.bicep
@@ -31,7 +31,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: enforcedLocation
 }
@@ -40,7 +40,6 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
-    location: enforcedLocation
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
     sshDeploymentScriptName: 'dep-${namePrefix}-ds-${serviceShort}'
@@ -58,7 +57,6 @@ module testDeployment '../../../main.bicep' = [
     scope: resourceGroup
     name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-${iteration}'
     params: {
-      location: enforcedLocation
       name: '${namePrefix}${serviceShort}001'
       adminUsername: 'scaleSetAdmin'
       adminPassword: password
@@ -70,7 +68,7 @@ module testDeployment '../../../main.bicep' = [
       }
       osDisk: {
         createOption: 'fromImage'
-        diskSizeGB: '128'
+        diskSizeGB: 128
         managedDisk: {
           storageAccountType: 'Premium_LRS'
         }

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/dependencies.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/dependencies.bicep
@@ -25,7 +25,7 @@ param sshKeyName string
 var storageAccountCSEFileName = 'scriptExtensionMasterInstaller.ps1'
 var addressPrefix = '10.0.0.0/16'
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-07-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -45,7 +45,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   }
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
   name: keyVaultName
   location: location
   properties: {
@@ -62,7 +62,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     accessPolicies: []
   }
 
-  resource key 'keys@2022-07-01' = {
+  resource key 'keys@2024-11-01' = {
     name: 'encryptionKey'
     properties: {
       kty: 'RSA'
@@ -70,7 +70,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   }
 }
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
@@ -101,7 +101,7 @@ resource msiKVCryptoUserRoleAssignment 'Microsoft.Authorization/roleAssignments@
   }
 }
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' = {
   name: storageAccountName
   location: location
   sku: {
@@ -109,16 +109,16 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
   }
   kind: 'StorageV2'
 
-  resource blobService 'blobServices@2021-09-01' = {
+  resource blobService 'blobServices@2025-01-01' = {
     name: 'default'
 
-    resource container 'containers@2021-09-01' = {
+    resource container 'containers@2025-01-01' = {
       name: 'scripts'
     }
   }
 }
 
-resource storageUpload 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource storageUpload 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: storageUploadDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'
@@ -129,7 +129,7 @@ resource storageUpload 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
     }
   }
   properties: {
-    azPowerShellVersion: '9.0'
+    azPowerShellVersion: '11.0'
     retentionInterval: 'P1D'
     arguments: '-StorageAccountName "${storageAccount.name}" -ResourceGroupName "${resourceGroup().name}" -ContainerName "${storageAccount::blobService::container.name}" -FileName "${storageAccountCSEFileName}"'
     scriptContent: loadTextContent('../../../../../../../utilities/e2e-template-assets/scripts/Set-BlobContent.ps1')
@@ -139,7 +139,7 @@ resource storageUpload 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   ]
 }
 
-resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: sshDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'
@@ -150,7 +150,7 @@ resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' 
     }
   }
   properties: {
-    azPowerShellVersion: '9.0'
+    azPowerShellVersion: '11.0'
     retentionInterval: 'P1D'
     arguments: '-SSHKeyName "${sshKeyName}" -ResourceGroupName "${resourceGroup().name}"'
     scriptContent: loadTextContent('../../../../../../../utilities/e2e-template-assets/scripts/New-SSHKey.ps1')
@@ -160,7 +160,7 @@ resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' 
   ]
 }
 
-resource sshKey 'Microsoft.Compute/sshPublicKeys@2022-03-01' = {
+resource sshKey 'Microsoft.Compute/sshPublicKeys@2024-11-01' = {
   name: sshKeyName
   location: location
   properties: {

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/dependencies.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/dependencies.bicep
@@ -208,5 +208,8 @@ output storageAccountResourceId string = storageAccount.id
 @description('The URL of the Custom Script Extension in the created Storage Account')
 output storageAccountCSEFileUrl string = '${storageAccount.properties.primaryEndpoints.blob}${storageAccount::blobService::container.name}/${storageAccountCSEFileName}'
 
+@description('The name of the Custom Script Extension in the created Storage Account.')
+output storageAccountCSEFileName string = storageAccountCSEFileName
+
 @description('The Public Key of the created SSH Key.')
 output SSHKeyPublicKey string = sshKey.properties.publicKey

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/dependencies.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/dependencies.bicep
@@ -139,6 +139,19 @@ resource storageUpload 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   ]
 }
 
+resource msiStorageReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, 'Storage Blob Data Reader', managedIdentity.id)
+  scope: storageAccount::blobService::container
+  properties: {
+    principalId: managedIdentity.properties.principalId
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
+    ) // Storage Blob Data Reader
+    principalType: 'ServicePrincipal'
+  }
+}
+
 resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: sshDeploymentScriptName
   location: location

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/main.test.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/main.test.bicep
@@ -85,7 +85,7 @@ module testDeployment '../../../main.bicep' = [
       }
       osDisk: {
         createOption: 'fromImage'
-        diskSizeGB: '128'
+        diskSizeGB: 128
         managedDisk: {
           storageAccountType: 'Premium_LRS'
         }
@@ -99,17 +99,19 @@ module testDeployment '../../../main.bicep' = [
       bootDiagnosticStorageAccountName: nestedDependencies.outputs.storageAccountName
       dataDisks: [
         {
+          lun: 1
           caching: 'ReadOnly'
           createOption: 'Empty'
-          diskSizeGB: '256'
+          diskSizeGB: 256
           managedDisk: {
             storageAccountType: 'Premium_LRS'
           }
         }
         {
+          lun: 2
           caching: 'ReadOnly'
           createOption: 'Empty'
-          diskSizeGB: '128'
+          diskSizeGB: 128
           managedDisk: {
             storageAccountType: 'Premium_LRS'
           }
@@ -132,14 +134,15 @@ module testDeployment '../../../main.bicep' = [
       disablePasswordAuthentication: true
       encryptionAtHost: false
       extensionCustomScriptConfig: {
-        fileData: [
-          {
-            storageAccountId: nestedDependencies.outputs.storageAccountResourceId
-            uri: nestedDependencies.outputs.storageAccountCSEFileUrl
-          }
-        ]
-        protectedSettings: {
+        settings: {
           commandToExecute: 'sudo apt-get update'
+          fileUris: [
+            nestedDependencies.outputs.storageAccountCSEFileUrl
+          ]
+        }
+        protectedSettings: {
+          // Needs 'Storage Blob Data Reader' role on the storage account
+          managedIdentityResourceId: nestedDependencies.outputs.managedIdentityResourceId
         }
       }
       extensionDependencyAgentConfig: {

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/main.test.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/main.test.bicep
@@ -31,7 +31,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: enforcedLocation
 }
@@ -40,7 +40,6 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
-    location: enforcedLocation
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
     keyVaultName: 'dep-${namePrefix}-kv-${serviceShort}'
@@ -61,7 +60,6 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
     logAnalyticsWorkspaceName: 'dep-${namePrefix}-law-${serviceShort}'
     eventHubNamespaceEventHubName: 'dep-${namePrefix}-evh-${serviceShort}'
     eventHubNamespaceName: 'dep-${namePrefix}-evhns-${serviceShort}'
-    location: enforcedLocation
   }
 }
 
@@ -134,7 +132,6 @@ module testDeployment '../../../main.bicep' = [
       disablePasswordAuthentication: true
       encryptionAtHost: false
       extensionCustomScriptConfig: {
-        enabled: true
         fileData: [
           {
             storageAccountId: nestedDependencies.outputs.storageAccountResourceId

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/main.test.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.max/main.test.bicep
@@ -135,7 +135,7 @@ module testDeployment '../../../main.bicep' = [
       encryptionAtHost: false
       extensionCustomScriptConfig: {
         settings: {
-          commandToExecute: 'sudo apt-get update'
+          commandToExecute: 'bash ${nestedDependencies.outputs.storageAccountCSEFileUrl}'
           fileUris: [
             nestedDependencies.outputs.storageAccountCSEFileUrl
           ]

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.ssecmk/dependencies.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.ssecmk/dependencies.bicep
@@ -21,7 +21,7 @@ param location string = resourceGroup().location
 
 var addressPrefix = '10.0.0.0/16'
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-07-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -41,7 +41,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   }
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
   name: keyVaultName
   location: location
   properties: {
@@ -59,7 +59,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     accessPolicies: []
   }
 
-  resource key 'keys@2022-07-01' = {
+  resource key 'keys@2024-11-01' = {
     name: 'keyEncryptionKey'
     properties: {
       kty: 'RSA'
@@ -67,7 +67,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   }
 }
 
-resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2021-04-01' = {
+resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2025-01-02' = {
   name: diskEncryptionSetName
   location: location
   identity: {
@@ -97,7 +97,7 @@ resource keyPermissions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
 }
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
@@ -115,7 +115,7 @@ resource msiRGContrRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: sshDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'
@@ -126,7 +126,7 @@ resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' 
     }
   }
   properties: {
-    azPowerShellVersion: '9.0'
+    azPowerShellVersion: '11.0'
     retentionInterval: 'P1D'
     arguments: '-SSHKeyName "${sshKeyName}" -ResourceGroupName "${resourceGroup().name}"'
     scriptContent: loadTextContent('../../../../../../../utilities/e2e-template-assets/scripts/New-SSHKey.ps1')
@@ -136,7 +136,7 @@ resource sshDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' 
   ]
 }
 
-resource sshKey 'Microsoft.Compute/sshPublicKeys@2022-03-01' = {
+resource sshKey 'Microsoft.Compute/sshPublicKeys@2024-11-01' = {
   name: sshKeyName
   location: location
   properties: {

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.ssecmk/main.test.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/linux.ssecmk/main.test.bicep
@@ -34,7 +34,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: enforcedLocation
 }
@@ -43,7 +43,6 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
-    location: enforcedLocation
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
     // Adding base time to make the name unique as purge protection must be enabled (but may not be longer than 24 characters total)
     keyVaultName: 'dep${namePrefix}kv${serviceShort}-${substring(uniqueString(baseTime), 0, 3)}'
@@ -67,7 +66,6 @@ module testDeployment '../../../main.bicep' = [
         enabled: true
         autoUpgradeMinorVersion: true
       }
-      location: enforcedLocation
       name: '${namePrefix}${serviceShort}001'
       adminUsername: 'scaleSetAdmin'
       adminPassword: password
@@ -97,7 +95,7 @@ module testDeployment '../../../main.bicep' = [
       ]
       osDisk: {
         createOption: 'fromImage'
-        diskSizeGB: '128'
+        diskSizeGB: 128
         managedDisk: {
           storageAccountType: 'Premium_LRS'
           diskEncryptionSet: {
@@ -107,9 +105,10 @@ module testDeployment '../../../main.bicep' = [
       }
       dataDisks: [
         {
+          lun: 1
           caching: 'ReadOnly'
           createOption: 'Empty'
-          diskSizeGB: '128'
+          diskSizeGB: 128
           managedDisk: {
             storageAccountType: 'Premium_LRS'
             diskEncryptionSet: {

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/windows.defaults/dependencies.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/windows.defaults/dependencies.bicep
@@ -6,7 +6,7 @@ param virtualNetworkName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-07-01' = {
   name: virtualNetworkName
   location: location
   properties: {

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/windows.defaults/main.test.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/windows.defaults/main.test.bicep
@@ -31,7 +31,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: enforcedLocation
 }
@@ -40,7 +40,6 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
-    location: enforcedLocation
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
   }
 }
@@ -67,7 +66,7 @@ module testDeployment '../../../main.bicep' = [
       }
       osDisk: {
         createOption: 'fromImage'
-        diskSizeGB: '128'
+        diskSizeGB: 128
         managedDisk: {
           storageAccountType: 'Premium_LRS'
         }

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/windows.uniform/dependencies.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/windows.uniform/dependencies.bicep
@@ -6,7 +6,7 @@ param virtualNetworkName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-07-01' = {
   name: virtualNetworkName
   location: location
   properties: {

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/windows.uniform/main.test.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/windows.uniform/main.test.bicep
@@ -31,7 +31,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: enforcedLocation
 }
@@ -40,7 +40,6 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
-    location: enforcedLocation
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
   }
 }
@@ -55,7 +54,6 @@ module testDeployment '../../../main.bicep' = [
     scope: resourceGroup
     name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-${iteration}'
     params: {
-      location: enforcedLocation
       name: '${namePrefix}${serviceShort}001'
       adminUsername: 'localAdminUser'
       adminPassword: password
@@ -67,7 +65,7 @@ module testDeployment '../../../main.bicep' = [
       }
       osDisk: {
         createOption: 'fromImage'
-        diskSizeGB: '128'
+        diskSizeGB: 128
         managedDisk: {
           storageAccountType: 'Premium_LRS'
         }

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/windows.waf-aligned/main.test.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/windows.waf-aligned/main.test.bicep
@@ -82,7 +82,7 @@ module testDeployment '../../../main.bicep' = [
       }
       osDisk: {
         createOption: 'fromImage'
-        diskSizeGB: '128'
+        diskSizeGB: 128
         managedDisk: {
           storageAccountType: 'Premium_LRS'
         }

--- a/avm/res/compute/virtual-machine-scale-set/tests/e2e/windows.waf-aligned/main.test.bicep
+++ b/avm/res/compute/virtual-machine-scale-set/tests/e2e/windows.waf-aligned/main.test.bicep
@@ -31,7 +31,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: enforcedLocation
 }
@@ -40,7 +40,6 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
-    location: enforcedLocation
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
     keyVaultName: 'dep-${namePrefix}-kv-${serviceShort}'
@@ -59,7 +58,6 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
     logAnalyticsWorkspaceName: 'dep-${namePrefix}-law-${serviceShort}'
     eventHubNamespaceEventHubName: 'dep-${namePrefix}-evh-${serviceShort}'
     eventHubNamespaceName: 'dep-${namePrefix}-evhns-${serviceShort}'
-    location: enforcedLocation
   }
 }
 
@@ -126,15 +124,15 @@ module testDeployment '../../../main.bicep' = [
         }
       }
       extensionCustomScriptConfig: {
-        enabled: true
-        fileData: [
-          {
-            storageAccountId: nestedDependencies.outputs.storageAccountResourceId
-            uri: nestedDependencies.outputs.storageAccountCSEFileUrl
-          }
-        ]
-        protectedSettings: {
+        settings: {
           commandToExecute: 'powershell -ExecutionPolicy Unrestricted -Command "& ./${nestedDependencies.outputs.storageAccountCSEFileName}"'
+          // Needs 'Storage Blob Data Reader' role on the storage account
+          fileUris: [
+            nestedDependencies.outputs.storageAccountCSEFileUrl
+          ]
+        }
+        protectedSettings: {
+          managedIdentityResourceId: nestedDependencies.outputs.managedIdentityResourceId
         }
       }
       extensionDependencyAgentConfig: {

--- a/avm/res/compute/virtual-machine-scale-set/version.json
+++ b/avm/res/compute/virtual-machine-scale-set/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.10"
+  "version": "0.11"
 }


### PR DESCRIPTION
## Description

### Changes

- Updated tests
- Introduced user-defined type for `extensionCustomScriptConfig` parameter that is aligned with its [official documentation](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-windows).
- Added parameters `provisionAfterExtensions` & `provisionAfterExtensions`  to 'extension' child module.
- Added types for parameters `osDisk`, `dataDisks`, `nicConfigurations`, `extensionHealthConfig`, `winRM` & `publicKeys`
- Fixed incorrect default value of `extensionHealthConfig` parameter
- Added optional `name` property to `nicConfigurations` parameter
- Moved Health-Extension to its own deployment block
- Added `provisionAfterExtensions` property support to all extensions

### Breaking Changes

- Merged `extensionCustomScriptProtectedSetting` parameter into `extensionCustomScriptConfig`
- Removed support for the CustomScriptExtension extension to automatically append SAS-Keys to file specified via the `extensionCustomScriptConfig.fileData` property. Instead, the SAS token must either be pre-provided with the URL, or either the settings `extensionCustomScriptConfig.protectedSettings.storageAccountKey` & `extensionCustomScriptConfig.protectedSettings.storageAccountName` or (recommended) `extensionCustomScriptConfig.protectedSettings.managedIdentityResourceId`. For the latter, you can provide either the full resource ID - or set it to `''` if you want it to use the VM's system-assigned identity (if enabled) instead. Note, in either case, the Identity must be granted access to correct Storage Account scope.
- The updated `osDisk` parameter requires an integer for its `diskSizeGB` property
- The updated `dataDisks` parameter requires an integer for its `diskSizeGB` property & the `lun` property (which specifies the logical unit number of the data disk. Can be an incremental number)

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.compute.virtual-machine-scale-set](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine-scale-set.yml/badge.svg?branch=users%2Falsehr%2FvmssAlignment202509&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine-scale-set.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
