### PR TITLE
fix: CI - Owner config - Added case handling for deprecated modules / modules without a team

### DIFF
--- a/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
+++ b/utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
@@ -198,14 +198,18 @@ function Set-AvmGitHubIssueOwnerConfig {
         # existing module
         else {
             $ownerTeamMembers = [array](Get-GithubTeamMembersLogin -OrgName $RepositoryOwner -TeamName $moduleCsvData.ModuleOwnersGHTeam)
-            $reply = @"
+            if ($ownerTeamMembers) {
+                $reply = @"
 **@$($issue.user.login), thanks for submitting this issue for the ``$moduleName`` module!**
 
 > [!IMPORTANT]
 > A member of the @Azure/$($moduleCsvData.ModuleOwnersGHTeam) team will review it soon!
 "@
+            } else {
+                Write-Warning ('    ⚠️  Issue [{0}] {1}: No members found in owner team [{2}] or team itself does not exist (e.g., because module was deprecated). Skipping comments & assignment.' -f $issue.number, $shortTitle, $moduleCsvData.ModuleOwnersGHTeam)
+                $statistics.'Issues to review by core team'++
+            }
         }
-
         # Existing assignees
         # ------------------
         $existingAssignees = $issue.assignees.login

--- a/utilities/pipelines/platform/helper/Get-GithubTeamMembersLogin.ps1
+++ b/utilities/pipelines/platform/helper/Get-GithubTeamMembersLogin.ps1
@@ -28,5 +28,10 @@ function Get-GithubTeamMembersLogin {
 
     $teamMembers = (gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /orgs/$OrgName/teams/$TeamName/members) | ConvertFrom-Json -Depth 100
 
+    if ($teamMembers.message -eq 'Not Found') {
+        Write-Warning "Team [$TeamName] not found in organization [$OrgName]"
+        return @()
+    }
+
     return $teamMembers | Select-Object -ExpandProperty login
 }


### PR DESCRIPTION
## Description

Addresses the error issue https://github.com/Azure/bicep-registry-modules/issues/2844 produced: https://github.com/Azure/bicep-registry-modules/actions/runs/17703754119/job/50312649054#step:4:451

The module was deprecated & its team removed, yet issues for it still exist and must be handled by the maintainers.

Log entry instead of error message: https://github.com/Azure/bicep-registry-modules/actions/runs/17709423499/job/50326034658#step:4:438

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![.Platform - Set GitHub issue owner config](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.set-avm-github-issue-owner-config.yml/badge.svg?branch=users%2Falsehr%2FownerConfigErrorHandling&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.set-avm-github-issue-owner-config.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
