### PR TITLE
feat: Revise contribution guidelines for AVM modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ To view all available AVM Bicep modules, go to AVM Bicep Module Index ([https://
 
 ## Contributing
 
-Only [Microsoft employees](https://azure.github.io/Azure-Verified-Modules/faq/#can-i-be-an-avm-module-owner-if-im-not-a-microsoft-fte) can be module owners at this time. Teams within Microsoft can refer to [AVM Bicep Contribution Guide](https://aka.ms/AVM/Contribute/Bicep) for information on contributing modules.
+Everyone in the world can contribute towards the AVM modules wheteher that is by creating [issues](https://aka.ms/AVM/Bicep/ModuleIssue) and/or by creating [pull requests](https://azure.github.io/Azure-Verified-Modules/contributing/bicep/bicep-contribution-flow/) on **any existing AVM Bicep Module.**
 
-External customers can propose new modules via [AVM Module Proposals](https://aka.ms/AVM/ModuleProposal), submit feature requests or report bugs via [AVM Module Issues](https://aka.ms/AVM/Bicep/ModuleIssue) and can also [contribute to modules](https://azure.github.io/Azure-Verified-Modules/faq/#how-can-i-contribute-to-avm-without-being-a-module-owner) via working with a Microsoft module owner.
+However, **only [Microsoft employees](https://azure.github.io/Azure-Verified-Modules/faq/#can-i-be-an-avm-module-owner-if-im-not-a-microsoft-fte) can be module owners at this time**. Teams within Microsoft can refer to [AVM Bicep Contribution Guide](https://aka.ms/AVM/Contribute/Bicep) for information on contributing modules.
+
+External customers can propose new modules via [AVM Module Proposals](https://aka.ms/AVM/ModuleProposal) and can also [contribute to modules](https://azure.github.io/Azure-Verified-Modules/faq/#how-can-i-contribute-to-avm-without-being-a-module-owner) via working with a Microsoft module owner.
 
 ## Data Collection
 


### PR DESCRIPTION
Updated contribution guidelines to clarify that everyone can contribute to AVM modules, while only Microsoft employees can be module owners.

## Description

Revise contribution guidelines for AVM modules

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| N/A |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Other

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
