### PR TITLE
fix: oras published module validation

### DIFF
--- a/utilities/pipelines/publish/Confirm-ModuleIsPublished.ps1
+++ b/utilities/pipelines/publish/Confirm-ModuleIsPublished.ps1
@@ -22,12 +22,12 @@ Optional. Define how a successful publish should be validated.
 Note: The 'Catalogue' validation method may take longer to complete than the 'Oras' method.
 
 .EXAMPLE
-Confirm-ModuleIsPublished -Version '0.2.0' -PublishedModuleName 'avm/res/key-vault/vault' -Verbose
+Confirm-ModuleIsPublished -Version '0.2.0' -PublishedModuleName 'avm/res/key-vault/vault' -GitTagName 'avm/res/key-vault/vault/0.2.0' -Verbose
 
 Check if module 'key-vault/vault' has been published with version '0.2.0 using Oras, the default validation method
 
 .EXAMPLE
-Confirm-ModuleIsPublished -Version '0.2.0' -PublishedModuleName 'avm/res/key-vault/vault' -ValidationMethod 'Catalogue' -Verbose
+Confirm-ModuleIsPublished -Version '0.2.0' -PublishedModuleName 'avm/res/key-vault/vault' -GitTagName 'avm/res/key-vault/vault/0.2.0' -ValidationMethod 'Catalogue' -Verbose
 
 Check if module 'key-vault/vault' has been published with version '0.2.0 using the 'Catalogue' validation method
 #>
@@ -74,6 +74,11 @@ function Confirm-ModuleIsPublished {
                 oras pull $registryReference --format 'json' 2>$null
 
                 if (Test-Path (Join-Path -Path $PWD 'Compiled ARM template')) {
+                    # Checking if a "main.json" file exist already. If so, delete it
+                    if (Test-Path (Join-Path -Path $PWD 'main.json')){
+                        Write-Verbose "Found 'main.json' file in current path. Removing."
+                        Remove-Item (Join-Path -Path $PWD 'main.json') -Verbose
+                    }
                     # Checking if the file "Compiled ARM template" returned by the oras cmdlet is valid
                     # Rename the file to "main.json", import it and check it has the property $schema
                     $null = Rename-Item 'Compiled ARM template' 'main.json'


### PR DESCRIPTION
## Description

- Delete main.json file if existing, to fix renaming conflicts in case multiple modules have to be validated (e.g. if child modules get published). Ref failed run https://github.com/Azure/bicep-registry-modules/actions/runs/17726070557/job/50368663930
- Minor fixes to usage synopsis

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -- |
| tested locally |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
