### PR TITLE
feat: Added support for Lab Secrets for DevTest Labs `avm/res/dev-test-lab/lab`

### DIFF
--- a/avm/res/dev-test-lab/lab/CHANGELOG.md
+++ b/avm/res/dev-test-lab/lab/CHANGELOG.md
@@ -6,6 +6,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Changes
 
+- Added support for Lab Secrets in DevTest Labs.
 - Updated LockType to 'avm-common-types version' `0.6.0`, enabling custom notes for locks.
 
 ### Breaking Changes

--- a/avm/res/dev-test-lab/lab/README.md
+++ b/avm/res/dev-test-lab/lab/README.md
@@ -23,6 +23,7 @@ This module deploys a DevTest Lab.
 | `Microsoft.DevTestLab/labs/notificationchannels` | 2018-09-15 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.devtestlab_labs_notificationchannels.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DevTestLab/2018-09-15/labs/notificationchannels)</li></ul> |
 | `Microsoft.DevTestLab/labs/policysets/policies` | 2018-09-15 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.devtestlab_labs_policysets_policies.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DevTestLab/2018-09-15/labs/policysets/policies)</li></ul> |
 | `Microsoft.DevTestLab/labs/schedules` | 2018-09-15 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.devtestlab_labs_schedules.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DevTestLab/2018-09-15/labs/schedules)</li></ul> |
+| `Microsoft.DevTestLab/labs/secrets` | 2018-10-15-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.devtestlab_labs_secrets.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DevTestLab/labs)</li></ul> |
 | `Microsoft.DevTestLab/labs/virtualnetworks` | 2018-09-15 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.devtestlab_labs_virtualnetworks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DevTestLab/2018-09-15/labs/virtualnetworks)</li></ul> |
 
 ## Usage examples
@@ -320,6 +321,12 @@ module lab 'br/public:avm/res/dev-test-lab/lab:<version>' = {
             'Wednesday'
           ]
         }
+      }
+    ]
+    secrets: [
+      {
+        name: 'labSecret1'
+        value: '<value>'
       }
     ]
     support: {
@@ -645,6 +652,14 @@ module lab 'br/public:avm/res/dev-test-lab/lab:<version>' = {
         }
       ]
     },
+    "secrets": {
+      "value": [
+        {
+          "name": "labSecret1",
+          "value": "<value>"
+        }
+      ]
+    },
     "support": {
       "value": {
         "enabled": "Enabled",
@@ -930,6 +945,12 @@ param schedules = [
     }
   }
 ]
+param secrets = [
+  {
+    name: 'labSecret1'
+    value: '<value>'
+  }
+]
 param support = {
   enabled: 'Enabled'
   markdown: 'DevTest Lab support text. <br> New line. It also supports Markdown'
@@ -1112,6 +1133,7 @@ param tags = {
 | [`premiumDataDisks`](#parameter-premiumdatadisks) | string | The setting to enable usage of premium data disks. When its value is "Enabled", creation of standard or premium data disks is allowed. When its value is "Disabled", only creation of standard data disks is allowed. Default is "Disabled". |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`schedules`](#parameter-schedules) | array | Schedules to create for the lab. |
+| [`secrets`](#parameter-secrets) | array | Secrets to create for the lab. With Lab Secrets, you can store sensitive data once at the lab level and make it available wherever it's needed. |
 | [`support`](#parameter-support) | object | The properties of any lab support message associated with this lab. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`virtualnetworks`](#parameter-virtualnetworks) | array | Virtual networks to create for the lab. |
@@ -2232,6 +2254,55 @@ The days of the week for which the schedule is set (e.g. Sunday, Monday, Tuesday
 
 - Required: Yes
 - Type: array
+
+### Parameter: `secrets`
+
+Secrets to create for the lab. With Lab Secrets, you can store sensitive data once at the lab level and make it available wherever it's needed.
+
+- Required: No
+- Type: array
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-secretsname) | string | The name of the secret. |
+| [`value`](#parameter-secretsvalue) | securestring | The value of the secret. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`enabledForArtifacts`](#parameter-secretsenabledforartifacts) | bool | Set a secret for your artifacts (e.g., a personal access token to clone your Git repository via an artifact). At least one of the following must be true: enabledForArtifacts, enabledForVmCreation. |
+| [`enabledForVmCreation`](#parameter-secretsenabledforvmcreation) | bool | Set a user password or provide an SSH public key to access your Windows or Linux virtual machines. At least one of the following must be true: enabledForArtifacts, enabledForVmCreation. |
+
+### Parameter: `secrets.name`
+
+The name of the secret.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `secrets.value`
+
+The value of the secret.
+
+- Required: Yes
+- Type: securestring
+
+### Parameter: `secrets.enabledForArtifacts`
+
+Set a secret for your artifacts (e.g., a personal access token to clone your Git repository via an artifact). At least one of the following must be true: enabledForArtifacts, enabledForVmCreation.
+
+- Required: No
+- Type: bool
+
+### Parameter: `secrets.enabledForVmCreation`
+
+Set a user password or provide an SSH public key to access your Windows or Linux virtual machines. At least one of the following must be true: enabledForArtifacts, enabledForVmCreation.
+
+- Required: No
+- Type: bool
 
 ### Parameter: `support`
 

--- a/avm/res/dev-test-lab/lab/artifactsource/main.json
+++ b/avm/res/dev-test-lab/lab/artifactsource/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "17170824417365300700"
+      "version": "0.37.4.10188",
+      "templateHash": "4678850000249407168"
     },
     "name": "DevTest Lab Artifact Sources",
     "description": "This module deploys a DevTest Lab Artifact Source.\n\nAn artifact source allows you to create custom artifacts for the VMs in the lab, or use Azure Resource Manager templates to create a custom test environment. You must add a private Git repository for the artifacts or Resource Manager templates that your team creates. The repository can be hosted on GitHub or on Azure DevOps Services."

--- a/avm/res/dev-test-lab/lab/cost/main.json
+++ b/avm/res/dev-test-lab/lab/cost/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "2470950542253630216"
+      "version": "0.37.4.10188",
+      "templateHash": "12382238122958060703"
     },
     "name": "DevTest Lab Costs",
     "description": "This module deploys a DevTest Lab Cost.\n\nManage lab costs by setting a spending target that can be viewed in the Monthly Estimated Cost Trend chart. DevTest Labs can send a notification when spending reaches the specified target threshold."

--- a/avm/res/dev-test-lab/lab/main.bicep
+++ b/avm/res/dev-test-lab/lab/main.bicep
@@ -348,8 +348,8 @@ module lab_secrets 'secret/main.bicep' = [
       labName: lab.name
       name: secret.name
       value: secret.value
-      enabledForArtifacts: secret.?enabledForArtifacts ?? false
-      enabledForVmCreation: secret.?enabledForVmCreation ?? false
+      enabledForArtifacts: secret.?enabledForArtifacts
+      enabledForVmCreation: secret.?enabledForVmCreation
     }
   }
 ]

--- a/avm/res/dev-test-lab/lab/main.json
+++ b/avm/res/dev-test-lab/lab/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "15889866139986126980"
+      "templateHash": "12831024384586215893"
     },
     "name": "DevTest Labs",
     "description": "This module deploys a DevTest Lab."
@@ -2815,10 +2815,10 @@
             "value": "[coalesce(parameters('secrets'), createArray())[copyIndex()].value]"
           },
           "enabledForArtifacts": {
-            "value": "[coalesce(tryGet(coalesce(parameters('secrets'), createArray())[copyIndex()], 'enabledForArtifacts'), false())]"
+            "value": "[tryGet(coalesce(parameters('secrets'), createArray())[copyIndex()], 'enabledForArtifacts')]"
           },
           "enabledForVmCreation": {
-            "value": "[coalesce(tryGet(coalesce(parameters('secrets'), createArray())[copyIndex()], 'enabledForVmCreation'), false())]"
+            "value": "[tryGet(coalesce(parameters('secrets'), createArray())[copyIndex()], 'enabledForVmCreation')]"
           }
         },
         "template": {

--- a/avm/res/dev-test-lab/lab/main.json
+++ b/avm/res/dev-test-lab/lab/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "4805082130769567335"
+      "templateHash": "15889866139986126980"
     },
     "name": "DevTest Labs",
     "description": "This module deploys a DevTest Lab."
@@ -551,6 +551,41 @@
       "metadata": {
         "__bicep_export!": true,
         "description": "The type for the schedule."
+      }
+    },
+    "secretType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the secret."
+          }
+        },
+        "value": {
+          "type": "securestring",
+          "metadata": {
+            "description": "Required. The value of the secret."
+          }
+        },
+        "enabledForArtifacts": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Set a secret for your artifacts (e.g., a personal access token to clone your Git repository via an artifact). At least one of the following must be true: enabledForArtifacts, enabledForVmCreation."
+          }
+        },
+        "enabledForVmCreation": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Set a user password or provide an SSH public key to access your Windows or Linux virtual machines. At least one of the following must be true: enabledForArtifacts, enabledForVmCreation."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The type for the secret."
       }
     },
     "allowedSubnetType": {
@@ -1162,6 +1197,16 @@
       "nullable": true,
       "metadata": {
         "description": "Optional. Costs to create for the lab."
+      }
+    },
+    "secrets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/secretType"
+      },
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Secrets to create for the lab. With Lab Secrets, you can store sensitive data once at the lab level and make it available wherever it's needed."
       }
     },
     "enableTelemetry": {
@@ -2736,6 +2781,123 @@
               "type": "string",
               "metadata": {
                 "description": "The name of the resource group the cost was created in."
+              },
+              "value": "[resourceGroup().name]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "lab"
+      ]
+    },
+    "lab_secrets": {
+      "copy": {
+        "name": "lab_secrets",
+        "count": "[length(coalesce(parameters('secrets'), createArray()))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('{0}-Lab-Secrets-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "labName": {
+            "value": "[parameters('name')]"
+          },
+          "name": {
+            "value": "[coalesce(parameters('secrets'), createArray())[copyIndex()].name]"
+          },
+          "value": {
+            "value": "[coalesce(parameters('secrets'), createArray())[copyIndex()].value]"
+          },
+          "enabledForArtifacts": {
+            "value": "[coalesce(tryGet(coalesce(parameters('secrets'), createArray())[copyIndex()], 'enabledForArtifacts'), false())]"
+          },
+          "enabledForVmCreation": {
+            "value": "[coalesce(tryGet(coalesce(parameters('secrets'), createArray())[copyIndex()], 'enabledForVmCreation'), false())]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.37.4.10188",
+              "templateHash": "5679672050000621262"
+            },
+            "name": "DevTest Lab Secrets",
+            "description": "This module deploys a DevTest Lab Secret.\n\nLab secrets will be accessible to all lab users. Depending on their scope, secrets can be used to securely provide credentials when creating formulas, virtual machines, artifacts, or ARM templates."
+          },
+          "parameters": {
+            "labName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the parent lab. Required if the template is used in a standalone deployment."
+              }
+            },
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the secret. Secret names can only contain alphanumeric characters and dashes."
+              }
+            },
+            "value": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Required. The value of the secret."
+              }
+            },
+            "enabledForArtifacts": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Set a secret for your artifacts (e.g., a personal access token to clone your Git repository via an artifact). At least one of the following must be true: enabledForArtifacts, enabledForVmCreation."
+              }
+            },
+            "enabledForVmCreation": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Set a user password or provide an SSH public key to access your Windows or Linux virtual machines. At least one of the following must be true: enabledForArtifacts, enabledForVmCreation."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.DevTestLab/labs/secrets",
+              "apiVersion": "2018-10-15-preview",
+              "name": "[format('{0}/{1}', parameters('labName'), parameters('name'))]",
+              "properties": {
+                "enabledForArtifacts": "[parameters('enabledForArtifacts')]",
+                "enabledForVmCreation": "[parameters('enabledForVmCreation')]",
+                "value": "[parameters('value')]"
+              }
+            }
+          ],
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the secret."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the secret."
+              },
+              "value": "[resourceId('Microsoft.DevTestLab/labs/secrets', parameters('labName'), parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the resource group the secret was created in."
               },
               "value": "[resourceGroup().name]"
             }

--- a/avm/res/dev-test-lab/lab/notificationchannel/main.json
+++ b/avm/res/dev-test-lab/lab/notificationchannel/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "11014266698746418553"
+      "version": "0.37.4.10188",
+      "templateHash": "1103267499871744968"
     },
     "name": "DevTest Lab Notification Channels",
     "description": "This module deploys a DevTest Lab Notification Channel.\n\nNotification channels are used by the schedule resource type in order to send notifications or events to email addresses and/or webhooks."

--- a/avm/res/dev-test-lab/lab/policyset/policy/main.json
+++ b/avm/res/dev-test-lab/lab/policyset/policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "9670645583410999867"
+      "version": "0.37.4.10188",
+      "templateHash": "8873903756685797283"
     },
     "name": "DevTest Lab Policy Sets Policies",
     "description": "This module deploys a DevTest Lab Policy Sets Policy.\n\nDevTest lab policies are used to modify the lab settings such as only allowing certain VM Size SKUs, marketplace image types, number of VMs allowed per user and other settings."

--- a/avm/res/dev-test-lab/lab/schedule/main.json
+++ b/avm/res/dev-test-lab/lab/schedule/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "44867339593492653"
+      "version": "0.37.4.10188",
+      "templateHash": "13883158783796437346"
     },
     "name": "DevTest Lab Schedules",
     "description": "This module deploys a DevTest Lab Schedule.\n\nLab schedules are used to modify the settings for auto-shutdown, auto-start for lab virtual machines."

--- a/avm/res/dev-test-lab/lab/secret/README.md
+++ b/avm/res/dev-test-lab/lab/secret/README.md
@@ -1,0 +1,84 @@
+# DevTest Lab Secrets `[Microsoft.DevTestLab/labs]`
+
+This module deploys a DevTest Lab Secret.
+
+Lab secrets will be accessible to all lab users. Depending on their scope, secrets can be used to securely provide credentials when creating formulas, virtual machines, artifacts, or ARM templates.
+
+## Navigation
+
+- [Resource Types](#Resource-Types)
+- [Parameters](#Parameters)
+- [Outputs](#Outputs)
+
+## Resource Types
+
+| Resource Type | API Version | References |
+| :-- | :-- | :-- |
+| `Microsoft.DevTestLab/labs/secrets` | 2018-10-15-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.devtestlab_labs_secrets.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.DevTestLab/labs)</li></ul> |
+
+## Parameters
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-name) | string | The name of the secret. Secret names can only contain alphanumeric characters and dashes. |
+| [`value`](#parameter-value) | securestring | The value of the secret. |
+
+**Conditional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`labName`](#parameter-labname) | string | The name of the parent lab. Required if the template is used in a standalone deployment. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`enabledForArtifacts`](#parameter-enabledforartifacts) | bool | Set a secret for your artifacts (e.g., a personal access token to clone your Git repository via an artifact). At least one of the following must be true: enabledForArtifacts, enabledForVmCreation. |
+| [`enabledForVmCreation`](#parameter-enabledforvmcreation) | bool | Set a user password or provide an SSH public key to access your Windows or Linux virtual machines. At least one of the following must be true: enabledForArtifacts, enabledForVmCreation. |
+
+### Parameter: `name`
+
+The name of the secret. Secret names can only contain alphanumeric characters and dashes.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `value`
+
+The value of the secret.
+
+- Required: Yes
+- Type: securestring
+
+### Parameter: `labName`
+
+The name of the parent lab. Required if the template is used in a standalone deployment.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `enabledForArtifacts`
+
+Set a secret for your artifacts (e.g., a personal access token to clone your Git repository via an artifact). At least one of the following must be true: enabledForArtifacts, enabledForVmCreation.
+
+- Required: No
+- Type: bool
+- Default: `False`
+
+### Parameter: `enabledForVmCreation`
+
+Set a user password or provide an SSH public key to access your Windows or Linux virtual machines. At least one of the following must be true: enabledForArtifacts, enabledForVmCreation.
+
+- Required: No
+- Type: bool
+- Default: `False`
+
+## Outputs
+
+| Output | Type | Description |
+| :-- | :-- | :-- |
+| `name` | string | The name of the secret. |
+| `resourceGroupName` | string | The name of the resource group the secret was created in. |
+| `resourceId` | string | The resource ID of the secret. |

--- a/avm/res/dev-test-lab/lab/secret/main.bicep
+++ b/avm/res/dev-test-lab/lab/secret/main.bicep
@@ -1,0 +1,43 @@
+metadata name = 'DevTest Lab Secrets'
+metadata description = '''This module deploys a DevTest Lab Secret.
+
+Lab secrets will be accessible to all lab users. Depending on their scope, secrets can be used to securely provide credentials when creating formulas, virtual machines, artifacts, or ARM templates.'''
+
+@sys.description('Conditional. The name of the parent lab. Required if the template is used in a standalone deployment.')
+param labName string
+
+@sys.description('Required. The name of the secret. Secret names can only contain alphanumeric characters and dashes.')
+param name string
+
+@secure()
+@sys.description('Required. The value of the secret.')
+param value string
+
+@sys.description('Optional. Set a secret for your artifacts (e.g., a personal access token to clone your Git repository via an artifact). At least one of the following must be true: enabledForArtifacts, enabledForVmCreation.')
+param enabledForArtifacts bool = false
+
+@sys.description('Optional. Set a user password or provide an SSH public key to access your Windows or Linux virtual machines. At least one of the following must be true: enabledForArtifacts, enabledForVmCreation.')
+param enabledForVmCreation bool = false
+
+resource lab 'Microsoft.DevTestLab/labs@2018-09-15' existing = {
+  name: labName
+}
+
+resource secret 'Microsoft.DevTestLab/labs/secrets@2018-10-15-preview' = {
+  name: name
+  parent: lab
+  properties: {
+    enabledForArtifacts: enabledForArtifacts
+    enabledForVmCreation: enabledForVmCreation
+    value: value
+  }
+}
+
+@sys.description('The name of the secret.')
+output name string = secret.name
+
+@sys.description('The resource ID of the secret.')
+output resourceId string = secret.id
+
+@sys.description('The name of the resource group the secret was created in.')
+output resourceGroupName string = resourceGroup().name

--- a/avm/res/dev-test-lab/lab/secret/main.json
+++ b/avm/res/dev-test-lab/lab/secret/main.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.37.4.10188",
+      "templateHash": "5679672050000621262"
+    },
+    "name": "DevTest Lab Secrets",
+    "description": "This module deploys a DevTest Lab Secret.\n\nLab secrets will be accessible to all lab users. Depending on their scope, secrets can be used to securely provide credentials when creating formulas, virtual machines, artifacts, or ARM templates."
+  },
+  "parameters": {
+    "labName": {
+      "type": "string",
+      "metadata": {
+        "description": "Conditional. The name of the parent lab. Required if the template is used in a standalone deployment."
+      }
+    },
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "Required. The name of the secret. Secret names can only contain alphanumeric characters and dashes."
+      }
+    },
+    "value": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Required. The value of the secret."
+      }
+    },
+    "enabledForArtifacts": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Optional. Set a secret for your artifacts (e.g., a personal access token to clone your Git repository via an artifact). At least one of the following must be true: enabledForArtifacts, enabledForVmCreation."
+      }
+    },
+    "enabledForVmCreation": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Optional. Set a user password or provide an SSH public key to access your Windows or Linux virtual machines. At least one of the following must be true: enabledForArtifacts, enabledForVmCreation."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.DevTestLab/labs/secrets",
+      "apiVersion": "2018-10-15-preview",
+      "name": "[format('{0}/{1}', parameters('labName'), parameters('name'))]",
+      "properties": {
+        "enabledForArtifacts": "[parameters('enabledForArtifacts')]",
+        "enabledForVmCreation": "[parameters('enabledForVmCreation')]",
+        "value": "[parameters('value')]"
+      }
+    }
+  ],
+  "outputs": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the secret."
+      },
+      "value": "[parameters('name')]"
+    },
+    "resourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource ID of the secret."
+      },
+      "value": "[resourceId('Microsoft.DevTestLab/labs/secrets', parameters('labName'), parameters('name'))]"
+    },
+    "resourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the resource group the secret was created in."
+      },
+      "value": "[resourceGroup().name]"
+    }
+  }
+}

--- a/avm/res/dev-test-lab/lab/tests/e2e/max/main.test.bicep
+++ b/avm/res/dev-test-lab/lab/tests/e2e/max/main.test.bicep
@@ -322,6 +322,12 @@ module testDeployment '../../../main.bicep' = [
         thresholdValue125DisplayOnChart: 'Disabled'
         thresholdValue75DisplayOnChart: 'Enabled'
       }
+      secrets: [
+        {
+          name: 'labSecret1'
+          value: guid(baseTime)
+        }
+      ]
     }
   }
 ]

--- a/avm/res/dev-test-lab/lab/virtualnetwork/main.json
+++ b/avm/res/dev-test-lab/lab/virtualnetwork/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "6830177169160833613"
+      "version": "0.37.4.10188",
+      "templateHash": "8445856704861775730"
     },
     "name": "DevTest Lab Virtual Networks",
     "description": "This module deploys a DevTest Lab Virtual Network.\n\nLab virtual machines must be deployed into a virtual network. This resource type allows configuring the virtual network and subnet settings used for the lab virtual machines."


### PR DESCRIPTION
## Description

- Introduced a new parameter `secrets` to the DevTest Lab module to allow the creation of lab secrets.
- Updated the README and changelog to reflect the new feature.
- Added a new module for managing secrets within the DevTest Lab.
- Updated existing modules and templates to support the integration of lab secrets.

[Release Documentation](https://devblogs.microsoft.com/develop-from-the-cloud/%F0%9F%8E%89enhancing-security-and-streamlining-configuration-with-lab-secrets-in-azure-devtest-labs/)

Closes #5154

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.dev-test-lab.lab](https://github.com/ahmadabdalla/bicep-registry-modules/actions/workflows/avm.res.dev-test-lab.lab.yml/badge.svg?branch=users%2Fahmad%2FDTL_Secrets)](https://github.com/ahmadabdalla/bicep-registry-modules/actions/workflows/avm.res.dev-test-lab.lab.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
