### PR TITLE
feat: Budgets - Retrigger publishing

### DIFF
--- a/avm/res/consumption/budget/mg-scope/README.md
+++ b/avm/res/consumption/budget/mg-scope/README.md
@@ -1,6 +1,6 @@
 # Consumption Budgets `[Microsoft.Consumption/budgets]`
 
-This module deploys a Consumption Budget for Management Groups.
+This module deploys a Consumption Budget for a Management Group.
 
 ## Navigation
 

--- a/avm/res/consumption/budget/mg-scope/main.bicep
+++ b/avm/res/consumption/budget/mg-scope/main.bicep
@@ -1,5 +1,5 @@
 metadata name = 'Consumption Budgets'
-metadata description = 'This module deploys a Consumption Budget for Management Groups.'
+metadata description = 'This module deploys a Consumption Budget for a Management Group.'
 
 targetScope = 'managementGroup'
 

--- a/avm/res/consumption/budget/mg-scope/main.json
+++ b/avm/res/consumption/budget/mg-scope/main.json
@@ -6,10 +6,10 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "5061934487655631399"
+      "templateHash": "17366379575889294146"
     },
     "name": "Consumption Budgets",
-    "description": "This module deploys a Consumption Budget for Management Groups."
+    "description": "This module deploys a Consumption Budget for a Management Group."
   },
   "parameters": {
     "name": {

--- a/avm/res/consumption/budget/rg-scope/README.md
+++ b/avm/res/consumption/budget/rg-scope/README.md
@@ -1,6 +1,6 @@
 # Consumption Budgets `[Microsoft.Consumption/budgets]`
 
-This module deploys a Consumption Budget for Resource Groups.
+This module deploys a Consumption Budget for a Resource Group.
 
 ## Navigation
 

--- a/avm/res/consumption/budget/rg-scope/main.bicep
+++ b/avm/res/consumption/budget/rg-scope/main.bicep
@@ -1,5 +1,5 @@
 metadata name = 'Consumption Budgets'
-metadata description = 'This module deploys a Consumption Budget for Resource Groups.'
+metadata description = 'This module deploys a Consumption Budget for a Resource Group.'
 
 @description('Required. The name of the budget.')
 param name string

--- a/avm/res/consumption/budget/rg-scope/main.json
+++ b/avm/res/consumption/budget/rg-scope/main.json
@@ -6,10 +6,10 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "9241608749957347525"
+      "templateHash": "8740300349148561856"
     },
     "name": "Consumption Budgets",
-    "description": "This module deploys a Consumption Budget for Resource Groups."
+    "description": "This module deploys a Consumption Budget for a Resource Group."
   },
   "parameters": {
     "name": {

--- a/avm/res/consumption/budget/sub-scope/README.md
+++ b/avm/res/consumption/budget/sub-scope/README.md
@@ -1,6 +1,6 @@
 # Consumption Budgets `[Microsoft.Consumption/budgets]`
 
-This module deploys a Consumption Budget for Subscriptions.
+This module deploys a Consumption Budget for a Subscription.
 
 ## Navigation
 

--- a/avm/res/consumption/budget/sub-scope/main.bicep
+++ b/avm/res/consumption/budget/sub-scope/main.bicep
@@ -1,5 +1,5 @@
 metadata name = 'Consumption Budgets'
-metadata description = 'This module deploys a Consumption Budget for Subscriptions.'
+metadata description = 'This module deploys a Consumption Budget for a Subscription.'
 
 targetScope = 'subscription'
 

--- a/avm/res/consumption/budget/sub-scope/main.json
+++ b/avm/res/consumption/budget/sub-scope/main.json
@@ -6,10 +6,10 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "1783756953834718386"
+      "templateHash": "3166203340171317748"
     },
     "name": "Consumption Budgets",
-    "description": "This module deploys a Consumption Budget for Subscriptions."
+    "description": "This module deploys a Consumption Budget for a Subscription."
   },
   "parameters": {
     "name": {


### PR DESCRIPTION
## Description

Retrigger the publishing of the earlier not published child-modules. An update to the changelog is **not** required as the currently specified version was not published.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.consumption.budget](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.consumption.budget.yml/badge.svg?branch=users%2Falsehr%2FbudgetRepublish&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.consumption.budget.yml)
