### PR TITLE
fix: module `avm/res/network/virtual-network-gateway`

### DIFF
--- a/avm/res/network/virtual-network-gateway/CHANGELOG.md
+++ b/avm/res/network/virtual-network-gateway/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-network-gateway/CHANGELOG.md).
 
-## 0.8.1
+## 0.9.0
+
+### Changes
+
+- Updated LockType to 'avm-common-types version' `0.6.0`, enabling custom notes for locks.
+
+### Breaking Changes
+
+- Changed `vpnType` calculatation from `PolicyBased` to `RouteBased` for ExpressRouteGateways. If not an ExpressRouteGateway, the specified `vpnType` will be used
+
+- ## 0.8.1
 
 ### Changes
 

--- a/avm/res/network/virtual-network-gateway/CHANGELOG.md
+++ b/avm/res/network/virtual-network-gateway/CHANGELOG.md
@@ -12,16 +12,6 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 - Changed `vpnType` calculatation from `PolicyBased` to `RouteBased` for ExpressRouteGateways. If not an ExpressRouteGateway, the specified `vpnType` will be used
 
-## 0.8.1
-
-### Changes
-
-- Updated LockType to 'avm-common-types version' `0.6.0`, enabling custom notes for locks.
-
-### Breaking Changes
-
-- None
-
 ## 0.8.0
 
 ### Changes

--- a/avm/res/network/virtual-network-gateway/CHANGELOG.md
+++ b/avm/res/network/virtual-network-gateway/CHANGELOG.md
@@ -12,7 +12,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 - Changed `vpnType` calculatation from `PolicyBased` to `RouteBased` for ExpressRouteGateways. If not an ExpressRouteGateway, the specified `vpnType` will be used
 
-- ## 0.8.1
+## 0.8.1
 
 ### Changes
 

--- a/avm/res/network/virtual-network-gateway/main.bicep
+++ b/avm/res/network/virtual-network-gateway/main.bicep
@@ -586,7 +586,7 @@ resource virtualNetworkGateway 'Microsoft.Network/virtualNetworkGateways@2024-05
       name: skuName
       tier: skuName
     }
-    vpnType: !isExpressRoute ? vpnType : 'PolicyBased'
+    vpnType: isExpressRoute ? 'RouteBased' : vpnType
     vpnClientConfiguration: !empty(vpnClientAddressPoolPrefix) ? vpnClientConfiguration : null
     vpnGatewayGeneration: gatewayType == 'Vpn' ? vpnGatewayGeneration : 'None'
     customRoutes: customRoutes

--- a/avm/res/network/virtual-network-gateway/main.json
+++ b/avm/res/network/virtual-network-gateway/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "17650947843670351841"
+      "templateHash": "4409346047976764894"
     },
     "name": "Virtual Network Gateways",
     "description": "This module deploys a Virtual Network Gateway."
@@ -1136,7 +1136,7 @@
           "name": "[parameters('skuName')]",
           "tier": "[parameters('skuName')]"
         },
-        "vpnType": "[if(not(variables('isExpressRoute')), parameters('vpnType'), 'PolicyBased')]",
+        "vpnType": "[if(variables('isExpressRoute'), 'RouteBased', parameters('vpnType'))]",
         "vpnClientConfiguration": "[if(not(empty(parameters('vpnClientAddressPoolPrefix'))), variables('vpnClientConfiguration'), null())]",
         "vpnGatewayGeneration": "[if(equals(parameters('gatewayType'), 'Vpn'), parameters('vpnGatewayGeneration'), 'None')]",
         "customRoutes": "[parameters('customRoutes')]",

--- a/avm/res/network/virtual-network-gateway/version.json
+++ b/avm/res/network/virtual-network-gateway/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.8"
+  "version": "0.9"
 }


### PR DESCRIPTION
## Description
Fixed the default vpnType to RouteBased for Ezpress Route gateway

Fixes #6023 
Closes #6023


## Pipeline Reference

| Pipeline |
| [![avm.res.network.virtual-network-gateway](https://github.com/fabmas/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network-gateway.yml/badge.svg?branch=vng_carlos)](https://github.com/fabmas/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network-gateway.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
