### PR TITLE
feat: NetworkWatcher - Address retired NSG-FlowLogs & update module

### DIFF
--- a/avm/res/network/network-watcher/CHANGELOG.md
+++ b/avm/res/network/network-watcher/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/network-watcher/CHANGELOG.md).
 
-## 0.4.2
+## 0.5.0
 
 ### Changes
 
-- Added type for `tags` parameter
+- Added types for `tags`, `connectionMonitors` & `flowLogs` parameters
 - Updated LockType to 'avm-common-types version' `0.6.0`, enabling custom notes for locks.
 
 ### Breaking Changes
 
-- None
+- Renamed `flowLogs.storageId` to AVM-aligned `flowLogs.storageResourceId`
 
 ## 0.4.1
 

--- a/avm/res/network/network-watcher/CHANGELOG.md
+++ b/avm/res/network/network-watcher/CHANGELOG.md
@@ -8,6 +8,14 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 - Added types for `tags`, `connectionMonitors` & `flowLogs` parameters
 - Updated LockType to 'avm-common-types version' `0.6.0`, enabling custom notes for locks.
+- Updated the API Versions to latest `2024-10-01`
+- Added support for
+  - `connectionMonitors.autoStart`
+  - `connectionMonitors.destination`
+  - `connectionMonitors.monitoringIntervalInSeconds`
+  - `connectionMonitors.notes`
+  - `connectionMonitors.source`
+  - `flowLogs.enabledFilteringCriteria`
 
 ### Breaking Changes
 

--- a/avm/res/network/network-watcher/README.md
+++ b/avm/res/network/network-watcher/README.md
@@ -17,9 +17,9 @@ This module deploys a Network Watcher.
 | :-- | :-- | :-- |
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
-| `Microsoft.Network/networkWatchers` | 2024-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_networkwatchers.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/networkWatchers)</li></ul> |
-| `Microsoft.Network/networkWatchers/connectionMonitors` | 2024-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_networkwatchers_connectionmonitors.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/networkWatchers/connectionMonitors)</li></ul> |
-| `Microsoft.Network/networkWatchers/flowLogs` | 2024-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_networkwatchers_flowlogs.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/networkWatchers/flowLogs)</li></ul> |
+| `Microsoft.Network/networkWatchers` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_networkwatchers.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/networkWatchers)</li></ul> |
+| `Microsoft.Network/networkWatchers/connectionMonitors` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_networkwatchers_connectionmonitors.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/networkWatchers/connectionMonitors)</li></ul> |
+| `Microsoft.Network/networkWatchers/flowLogs` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_networkwatchers_flowlogs.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/networkWatchers/flowLogs)</li></ul> |
 
 ## Usage examples
 
@@ -740,8 +740,13 @@ Array that contains the Connection Monitors.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`autoStart`](#parameter-connectionmonitorsautostart) | bool | Determines if the connection monitor will start automatically once created. |
+| [`destination`](#parameter-connectionmonitorsdestination) | object | Describes the destination of connection monitor. |
 | [`endpoints`](#parameter-connectionmonitorsendpoints) | array | List of connection monitor endpoints. |
 | [`location`](#parameter-connectionmonitorslocation) | string | Location for all resources. |
+| [`monitoringIntervalInSeconds`](#parameter-connectionmonitorsmonitoringintervalinseconds) | int | Monitoring interval in seconds. |
+| [`notes`](#parameter-connectionmonitorsnotes) | string | Notes to be associated with the connection monitor. |
+| [`source`](#parameter-connectionmonitorssource) | object | Describes the source of connection monitor. |
 | [`tags`](#parameter-connectionmonitorstags) | object | Tags of the resource. |
 | [`testConfigurations`](#parameter-connectionmonitorstestconfigurations) | array | List of connection monitor test configurations. |
 | [`testGroups`](#parameter-connectionmonitorstestgroups) | array | List of connection monitor test groups. |
@@ -753,6 +758,20 @@ Name of the resource.
 
 - Required: Yes
 - Type: string
+
+### Parameter: `connectionMonitors.autoStart`
+
+Determines if the connection monitor will start automatically once created.
+
+- Required: No
+- Type: bool
+
+### Parameter: `connectionMonitors.destination`
+
+Describes the destination of connection monitor.
+
+- Required: No
+- Type: object
 
 ### Parameter: `connectionMonitors.endpoints`
 
@@ -767,6 +786,29 @@ Location for all resources.
 
 - Required: No
 - Type: string
+
+### Parameter: `connectionMonitors.monitoringIntervalInSeconds`
+
+Monitoring interval in seconds.
+
+- Required: No
+- Type: int
+- MinValue: 30
+- MaxValue: 1800
+
+### Parameter: `connectionMonitors.notes`
+
+Notes to be associated with the connection monitor.
+
+- Required: No
+- Type: string
+
+### Parameter: `connectionMonitors.source`
+
+Describes the source of connection monitor.
+
+- Required: No
+- Type: object
 
 ### Parameter: `connectionMonitors.tags`
 
@@ -823,6 +865,7 @@ Array that contains the Flow Logs.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`enabled`](#parameter-flowlogsenabled) | bool | If the flow log should be enabled. |
+| [`enabledFilteringCriteria`](#parameter-flowlogsenabledfilteringcriteria) | string | Field to filter network traffic logs based on SrcIP, SrcPort, DstIP, DstPort, Protocol, Encryption, Direction and Action. If not specified, all network traffic will be logged. |
 | [`formatVersion`](#parameter-flowlogsformatversion) | int | The flow log format version. |
 | [`location`](#parameter-flowlogslocation) | string | Location for all resources. |
 | [`name`](#parameter-flowlogsname) | string | Name of the resource. |
@@ -851,6 +894,13 @@ If the flow log should be enabled.
 
 - Required: No
 - Type: bool
+
+### Parameter: `flowLogs.enabledFilteringCriteria`
+
+Field to filter network traffic logs based on SrcIP, SrcPort, DstIP, DstPort, Protocol, Encryption, Direction and Action. If not specified, all network traffic will be logged.
+
+- Required: No
+- Type: string
 
 ### Parameter: `flowLogs.formatVersion`
 

--- a/avm/res/network/network-watcher/README.md
+++ b/avm/res/network/network-watcher/README.md
@@ -151,14 +151,14 @@ module networkWatcher 'br/public:avm/res/network/network-watcher:<version>' = {
     flowLogs: [
       {
         enabled: false
-        storageId: '<storageId>'
+        storageResourceId: '<storageResourceId>'
         targetResourceId: '<targetResourceId>'
       }
       {
         formatVersion: 1
         name: 'nnwmax-fl-001'
         retentionInDays: 8
-        storageId: '<storageId>'
+        storageResourceId: '<storageResourceId>'
         targetResourceId: '<targetResourceId>'
         trafficAnalyticsInterval: 10
         workspaceResourceId: '<workspaceResourceId>'
@@ -265,14 +265,14 @@ module networkWatcher 'br/public:avm/res/network/network-watcher:<version>' = {
       "value": [
         {
           "enabled": false,
-          "storageId": "<storageId>",
+          "storageResourceId": "<storageResourceId>",
           "targetResourceId": "<targetResourceId>"
         },
         {
           "formatVersion": 1,
           "name": "nnwmax-fl-001",
           "retentionInDays": 8,
-          "storageId": "<storageId>",
+          "storageResourceId": "<storageResourceId>",
           "targetResourceId": "<targetResourceId>",
           "trafficAnalyticsInterval": 10,
           "workspaceResourceId": "<workspaceResourceId>"
@@ -383,14 +383,14 @@ param connectionMonitors = [
 param flowLogs = [
   {
     enabled: false
-    storageId: '<storageId>'
+    storageResourceId: '<storageResourceId>'
     targetResourceId: '<targetResourceId>'
   }
   {
     formatVersion: 1
     name: 'nnwmax-fl-001'
     retentionInDays: 8
-    storageId: '<storageId>'
+    storageResourceId: '<storageResourceId>'
     targetResourceId: '<targetResourceId>'
     trafficAnalyticsInterval: 10
     workspaceResourceId: '<workspaceResourceId>'
@@ -496,14 +496,14 @@ module networkWatcher 'br/public:avm/res/network/network-watcher:<version>' = {
     flowLogs: [
       {
         enabled: false
-        storageId: '<storageId>'
+        storageResourceId: '<storageResourceId>'
         targetResourceId: '<targetResourceId>'
       }
       {
         formatVersion: 1
         name: 'nnwwaf-fl-001'
         retentionInDays: 8
-        storageId: '<storageId>'
+        storageResourceId: '<storageResourceId>'
         targetResourceId: '<targetResourceId>'
         trafficAnalyticsInterval: 10
         workspaceResourceId: '<workspaceResourceId>'
@@ -590,14 +590,14 @@ module networkWatcher 'br/public:avm/res/network/network-watcher:<version>' = {
       "value": [
         {
           "enabled": false,
-          "storageId": "<storageId>",
+          "storageResourceId": "<storageResourceId>",
           "targetResourceId": "<targetResourceId>"
         },
         {
           "formatVersion": 1,
           "name": "nnwwaf-fl-001",
           "retentionInDays": 8,
-          "storageId": "<storageId>",
+          "storageResourceId": "<storageResourceId>",
           "targetResourceId": "<targetResourceId>",
           "trafficAnalyticsInterval": 10,
           "workspaceResourceId": "<workspaceResourceId>"
@@ -684,14 +684,14 @@ param connectionMonitors = [
 param flowLogs = [
   {
     enabled: false
-    storageId: '<storageId>'
+    storageResourceId: '<storageResourceId>'
     targetResourceId: '<targetResourceId>'
   }
   {
     formatVersion: 1
     name: 'nnwwaf-fl-001'
     retentionInDays: 8
-    storageId: '<storageId>'
+    storageResourceId: '<storageResourceId>'
     targetResourceId: '<targetResourceId>'
     trafficAnalyticsInterval: 10
     workspaceResourceId: '<workspaceResourceId>'
@@ -729,7 +729,72 @@ Array that contains the Connection Monitors.
 
 - Required: No
 - Type: array
-- Default: `[]`
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-connectionmonitorsname) | string | Name of the resource. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`endpoints`](#parameter-connectionmonitorsendpoints) | array | List of connection monitor endpoints. |
+| [`location`](#parameter-connectionmonitorslocation) | string | Location for all resources. |
+| [`tags`](#parameter-connectionmonitorstags) | object | Tags of the resource. |
+| [`testConfigurations`](#parameter-connectionmonitorstestconfigurations) | array | List of connection monitor test configurations. |
+| [`testGroups`](#parameter-connectionmonitorstestgroups) | array | List of connection monitor test groups. |
+| [`workspaceResourceId`](#parameter-connectionmonitorsworkspaceresourceid) | string | Specify the Log Analytics Workspace Resource ID. |
+
+### Parameter: `connectionMonitors.name`
+
+Name of the resource.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `connectionMonitors.endpoints`
+
+List of connection monitor endpoints.
+
+- Required: No
+- Type: array
+
+### Parameter: `connectionMonitors.location`
+
+Location for all resources.
+
+- Required: No
+- Type: string
+
+### Parameter: `connectionMonitors.tags`
+
+Tags of the resource.
+
+- Required: No
+- Type: object
+
+### Parameter: `connectionMonitors.testConfigurations`
+
+List of connection monitor test configurations.
+
+- Required: No
+- Type: array
+
+### Parameter: `connectionMonitors.testGroups`
+
+List of connection monitor test groups.
+
+- Required: No
+- Type: array
+
+### Parameter: `connectionMonitors.workspaceResourceId`
+
+Specify the Log Analytics Workspace Resource ID.
+
+- Required: No
+- Type: string
 
 ### Parameter: `enableTelemetry`
 
@@ -745,7 +810,112 @@ Array that contains the Flow Logs.
 
 - Required: No
 - Type: array
-- Default: `[]`
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`storageResourceId`](#parameter-flowlogsstorageresourceid) | string | Resource ID of the diagnostic storage account. |
+| [`targetResourceId`](#parameter-flowlogstargetresourceid) | string | Resource ID of the NSG that must be enabled for Flow Logs. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`enabled`](#parameter-flowlogsenabled) | bool | If the flow log should be enabled. |
+| [`formatVersion`](#parameter-flowlogsformatversion) | int | The flow log format version. |
+| [`location`](#parameter-flowlogslocation) | string | Location for all resources. |
+| [`name`](#parameter-flowlogsname) | string | Name of the resource. |
+| [`retentionInDays`](#parameter-flowlogsretentionindays) | int | Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely. |
+| [`tags`](#parameter-flowlogstags) | object | Tags of the resource. |
+| [`trafficAnalyticsInterval`](#parameter-flowlogstrafficanalyticsinterval) | int | The interval in minutes which would decide how frequently TA service should do flow analytics. |
+| [`workspaceResourceId`](#parameter-flowlogsworkspaceresourceid) | string | Specify the Log Analytics Workspace Resource ID. |
+
+### Parameter: `flowLogs.storageResourceId`
+
+Resource ID of the diagnostic storage account.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `flowLogs.targetResourceId`
+
+Resource ID of the NSG that must be enabled for Flow Logs.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `flowLogs.enabled`
+
+If the flow log should be enabled.
+
+- Required: No
+- Type: bool
+
+### Parameter: `flowLogs.formatVersion`
+
+The flow log format version.
+
+- Required: No
+- Type: int
+- Allowed:
+  ```Bicep
+  [
+    1
+    2
+  ]
+  ```
+
+### Parameter: `flowLogs.location`
+
+Location for all resources.
+
+- Required: No
+- Type: string
+
+### Parameter: `flowLogs.name`
+
+Name of the resource.
+
+- Required: No
+- Type: string
+
+### Parameter: `flowLogs.retentionInDays`
+
+Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.
+
+- Required: No
+- Type: int
+- MinValue: 0
+- MaxValue: 365
+
+### Parameter: `flowLogs.tags`
+
+Tags of the resource.
+
+- Required: No
+- Type: object
+
+### Parameter: `flowLogs.trafficAnalyticsInterval`
+
+The interval in minutes which would decide how frequently TA service should do flow analytics.
+
+- Required: No
+- Type: int
+- Allowed:
+  ```Bicep
+  [
+    10
+    60
+  ]
+  ```
+
+### Parameter: `flowLogs.workspaceResourceId`
+
+Specify the Log Analytics Workspace Resource ID.
+
+- Required: No
+- Type: string
 
 ### Parameter: `location`
 
@@ -933,8 +1103,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.5.1` | Remote reference |
-| `br/public:avm/utl/types/avm-common-types:0.6.0` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/network/network-watcher/connection-monitor/README.md
+++ b/avm/res/network/network-watcher/connection-monitor/README.md
@@ -12,7 +12,7 @@ This module deploys a Network Watcher Connection Monitor.
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.Network/networkWatchers/connectionMonitors` | 2024-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_networkwatchers_connectionmonitors.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/networkWatchers/connectionMonitors)</li></ul> |
+| `Microsoft.Network/networkWatchers/connectionMonitors` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_networkwatchers_connectionmonitors.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/networkWatchers/connectionMonitors)</li></ul> |
 
 ## Parameters
 
@@ -26,9 +26,14 @@ This module deploys a Network Watcher Connection Monitor.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`autoStart`](#parameter-autostart) | bool | Determines if the connection monitor will start automatically once created. |
+| [`destination`](#parameter-destination) | object | Describes the destination of connection monitor. |
 | [`endpoints`](#parameter-endpoints) | array | List of connection monitor endpoints. |
 | [`location`](#parameter-location) | string | Location for all resources. |
+| [`monitoringIntervalInSeconds`](#parameter-monitoringintervalinseconds) | int | Monitoring interval in seconds. |
 | [`networkWatcherName`](#parameter-networkwatchername) | string | Name of the network watcher resource. Must be in the resource group where the Flow log will be created and same region as the NSG. |
+| [`notes`](#parameter-notes) | string | Notes to be associated with the connection monitor. |
+| [`source`](#parameter-source) | object | Describes the source of connection monitor. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`testConfigurations`](#parameter-testconfigurations) | array | List of connection monitor test configurations. |
 | [`testGroups`](#parameter-testgroups) | array | List of connection monitor test groups. |
@@ -40,6 +45,20 @@ Name of the resource.
 
 - Required: Yes
 - Type: string
+
+### Parameter: `autoStart`
+
+Determines if the connection monitor will start automatically once created.
+
+- Required: No
+- Type: bool
+
+### Parameter: `destination`
+
+Describes the destination of connection monitor.
+
+- Required: No
+- Type: object
 
 ### Parameter: `endpoints`
 
@@ -57,6 +76,15 @@ Location for all resources.
 - Type: string
 - Default: `[resourceGroup().location]`
 
+### Parameter: `monitoringIntervalInSeconds`
+
+Monitoring interval in seconds.
+
+- Required: No
+- Type: int
+- MinValue: 30
+- MaxValue: 1800
+
 ### Parameter: `networkWatcherName`
 
 Name of the network watcher resource. Must be in the resource group where the Flow log will be created and same region as the NSG.
@@ -64,6 +92,20 @@ Name of the network watcher resource. Must be in the resource group where the Fl
 - Required: No
 - Type: string
 - Default: `[format('NetworkWatcher_{0}', resourceGroup().location)]`
+
+### Parameter: `notes`
+
+Notes to be associated with the connection monitor.
+
+- Required: No
+- Type: string
+
+### Parameter: `source`
+
+Describes the source of connection monitor.
+
+- Required: No
+- Type: object
 
 ### Parameter: `tags`
 

--- a/avm/res/network/network-watcher/connection-monitor/README.md
+++ b/avm/res/network/network-watcher/connection-monitor/README.md
@@ -94,7 +94,6 @@ Specify the Log Analytics Workspace Resource ID.
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ## Outputs
 

--- a/avm/res/network/network-watcher/connection-monitor/main.bicep
+++ b/avm/res/network/network-watcher/connection-monitor/main.bicep
@@ -8,22 +8,22 @@ param networkWatcherName string = 'NetworkWatcher_${resourceGroup().location}'
 param name string
 
 @description('Optional. Tags of the resource.')
-param tags object?
+param tags resourceInput<'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01'>.tags?
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
 @description('Optional. List of connection monitor endpoints.')
-param endpoints array = []
+param endpoints resourceInput<'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01'>.properties.endpoints = []
 
 @description('Optional. List of connection monitor test configurations.')
-param testConfigurations array = []
+param testConfigurations resourceInput<'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01'>.properties.testConfigurations = []
 
 @description('Optional. List of connection monitor test groups.')
-param testGroups array = []
+param testGroups resourceInput<'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01'>.properties.testGroups = []
 
 @description('Optional. Specify the Log Analytics Workspace Resource ID.')
-param workspaceResourceId string = ''
+param workspaceResourceId string?
 
 resource networkWatcher 'Microsoft.Network/networkWatchers@2024-05-01' existing = {
   name: networkWatcherName

--- a/avm/res/network/network-watcher/connection-monitor/main.bicep
+++ b/avm/res/network/network-watcher/connection-monitor/main.bicep
@@ -25,11 +25,28 @@ param testGroups resourceInput<'Microsoft.Network/networkWatchers/connectionMoni
 @description('Optional. Specify the Log Analytics Workspace Resource ID.')
 param workspaceResourceId string?
 
-resource networkWatcher 'Microsoft.Network/networkWatchers@2024-05-01' existing = {
+@description('Optional. Determines if the connection monitor will start automatically once created.')
+param autoStart bool?
+
+@description('Optional. Describes the destination of connection monitor.')
+param destination resourceInput<'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01'>.properties.destination?
+
+@description('Optional. Monitoring interval in seconds.')
+@minValue(30)
+@maxValue(1800)
+param monitoringIntervalInSeconds int?
+
+@description('Optional. Notes to be associated with the connection monitor.')
+param notes string?
+
+@description('Optional. Describes the source of connection monitor.')
+param source resourceInput<'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01'>.properties.source?
+
+resource networkWatcher 'Microsoft.Network/networkWatchers@2024-10-01' existing = {
   name: networkWatcherName
 }
 
-resource connectionMonitor 'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01' = {
+resource connectionMonitor 'Microsoft.Network/networkWatchers/connectionMonitors@2024-10-01' = {
   name: name
   parent: networkWatcher
   tags: tags
@@ -38,6 +55,11 @@ resource connectionMonitor 'Microsoft.Network/networkWatchers/connectionMonitors
     endpoints: endpoints
     testConfigurations: testConfigurations
     testGroups: testGroups
+    autoStart: autoStart
+    destination: destination
+    monitoringIntervalInSeconds: monitoringIntervalInSeconds
+    notes: notes
+    source: source
     outputs: !empty(workspaceResourceId)
       ? [
           {

--- a/avm/res/network/network-watcher/connection-monitor/main.json
+++ b/avm/res/network/network-watcher/connection-monitor/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.38.5.1644",
-      "templateHash": "8435110440648926991"
+      "templateHash": "9988153364509308698"
     },
     "name": "Network Watchers Connection Monitors",
     "description": "This module deploys a Network Watcher Connection Monitor."
@@ -78,18 +78,61 @@
       "metadata": {
         "description": "Optional. Specify the Log Analytics Workspace Resource ID."
       }
+    },
+    "autoStart": {
+      "type": "bool",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Determines if the connection monitor will start automatically once created."
+      }
+    },
+    "destination": {
+      "type": "object",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/destination"
+        },
+        "description": "Optional. Describes the destination of connection monitor."
+      },
+      "nullable": true
+    },
+    "monitoringIntervalInSeconds": {
+      "type": "int",
+      "nullable": true,
+      "minValue": 30,
+      "maxValue": 1800,
+      "metadata": {
+        "description": "Optional. Monitoring interval in seconds."
+      }
+    },
+    "notes": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Notes to be associated with the connection monitor."
+      }
+    },
+    "source": {
+      "type": "object",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/source"
+        },
+        "description": "Optional. Describes the source of connection monitor."
+      },
+      "nullable": true
     }
   },
   "resources": {
     "networkWatcher": {
       "existing": true,
       "type": "Microsoft.Network/networkWatchers",
-      "apiVersion": "2024-05-01",
+      "apiVersion": "2024-10-01",
       "name": "[parameters('networkWatcherName')]"
     },
     "connectionMonitor": {
       "type": "Microsoft.Network/networkWatchers/connectionMonitors",
-      "apiVersion": "2024-05-01",
+      "apiVersion": "2024-10-01",
       "name": "[format('{0}/{1}', parameters('networkWatcherName'), parameters('name'))]",
       "tags": "[parameters('tags')]",
       "location": "[parameters('location')]",
@@ -97,6 +140,11 @@
         "endpoints": "[parameters('endpoints')]",
         "testConfigurations": "[parameters('testConfigurations')]",
         "testGroups": "[parameters('testGroups')]",
+        "autoStart": "[parameters('autoStart')]",
+        "destination": "[parameters('destination')]",
+        "monitoringIntervalInSeconds": "[parameters('monitoringIntervalInSeconds')]",
+        "notes": "[parameters('notes')]",
+        "source": "[parameters('source')]",
         "outputs": "[if(not(empty(parameters('workspaceResourceId'))), createArray(createObject('type', 'Workspace', 'workspaceSettings', createObject('workspaceResourceId', parameters('workspaceResourceId')))), null())]"
       }
     }
@@ -128,7 +176,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('connectionMonitor', '2024-05-01', 'full').location]"
+      "value": "[reference('connectionMonitor', '2024-10-01', 'full').location]"
     }
   }
 }

--- a/avm/res/network/network-watcher/connection-monitor/main.json
+++ b/avm/res/network/network-watcher/connection-monitor/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "4843839658644031164"
+      "version": "0.38.5.1644",
+      "templateHash": "8435110440648926991"
     },
     "name": "Network Watchers Connection Monitors",
     "description": "This module deploys a Network Watcher Connection Monitor."
@@ -27,10 +27,13 @@
     },
     "tags": {
       "type": "object",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/tags"
+        },
         "description": "Optional. Tags of the resource."
-      }
+      },
+      "nullable": true
     },
     "location": {
       "type": "string",
@@ -41,28 +44,37 @@
     },
     "endpoints": {
       "type": "array",
-      "defaultValue": [],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/endpoints"
+        },
         "description": "Optional. List of connection monitor endpoints."
-      }
+      },
+      "defaultValue": []
     },
     "testConfigurations": {
       "type": "array",
-      "defaultValue": [],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/testConfigurations"
+        },
         "description": "Optional. List of connection monitor test configurations."
-      }
+      },
+      "defaultValue": []
     },
     "testGroups": {
       "type": "array",
-      "defaultValue": [],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/testGroups"
+        },
         "description": "Optional. List of connection monitor test groups."
-      }
+      },
+      "defaultValue": []
     },
     "workspaceResourceId": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
       "metadata": {
         "description": "Optional. Specify the Log Analytics Workspace Resource ID."
       }

--- a/avm/res/network/network-watcher/flow-log/README.md
+++ b/avm/res/network/network-watcher/flow-log/README.md
@@ -13,7 +13,7 @@ This module controls the Network Security Group Flow Logs and analytics settings
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.Network/networkWatchers/flowLogs` | 2024-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_networkwatchers_flowlogs.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/networkWatchers/flowLogs)</li></ul> |
+| `Microsoft.Network/networkWatchers/flowLogs` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_networkwatchers_flowlogs.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/networkWatchers/flowLogs)</li></ul> |
 
 ## Parameters
 
@@ -29,6 +29,7 @@ This module controls the Network Security Group Flow Logs and analytics settings
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`enabled`](#parameter-enabled) | bool | If the flow log should be enabled. |
+| [`enabledFilteringCriteria`](#parameter-enabledfilteringcriteria) | string | Field to filter network traffic logs based on SrcIP, SrcPort, DstIP, DstPort, Protocol, Encryption, Direction and Action. If not specified, all network traffic will be logged. |
 | [`formatVersion`](#parameter-formatversion) | int | The flow log format version. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`name`](#parameter-name) | string | Name of the resource. |
@@ -59,6 +60,13 @@ If the flow log should be enabled.
 - Required: No
 - Type: bool
 - Default: `True`
+
+### Parameter: `enabledFilteringCriteria`
+
+Field to filter network traffic logs based on SrcIP, SrcPort, DstIP, DstPort, Protocol, Encryption, Direction and Action. If not specified, all network traffic will be logged.
+
+- Required: No
+- Type: string
 
 ### Parameter: `formatVersion`
 

--- a/avm/res/network/network-watcher/flow-log/README.md
+++ b/avm/res/network/network-watcher/flow-log/README.md
@@ -21,7 +21,7 @@ This module controls the Network Security Group Flow Logs and analytics settings
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`storageId`](#parameter-storageid) | string | Resource ID of the diagnostic storage account. |
+| [`storageResourceId`](#parameter-storageresourceid) | string | Resource ID of the diagnostic storage account. |
 | [`targetResourceId`](#parameter-targetresourceid) | string | Resource ID of the NSG that must be enabled for Flow Logs. |
 
 **Optional parameters**
@@ -38,7 +38,7 @@ This module controls the Network Security Group Flow Logs and analytics settings
 | [`trafficAnalyticsInterval`](#parameter-trafficanalyticsinterval) | int | The interval in minutes which would decide how frequently TA service should do flow analytics. |
 | [`workspaceResourceId`](#parameter-workspaceresourceid) | string | Specify the Log Analytics Workspace Resource ID. |
 
-### Parameter: `storageId`
+### Parameter: `storageResourceId`
 
 Resource ID of the diagnostic storage account.
 
@@ -137,7 +137,6 @@ Specify the Log Analytics Workspace Resource ID.
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ## Outputs
 

--- a/avm/res/network/network-watcher/flow-log/main.bicep
+++ b/avm/res/network/network-watcher/flow-log/main.bicep
@@ -45,11 +45,14 @@ param trafficAnalyticsInterval int = 60
 @maxValue(365)
 param retentionInDays int = 365
 
-resource networkWatcher 'Microsoft.Network/networkWatchers@2024-05-01' existing = {
+@description('Optional. Field to filter network traffic logs based on SrcIP, SrcPort, DstIP, DstPort, Protocol, Encryption, Direction and Action. If not specified, all network traffic will be logged.')
+param enabledFilteringCriteria string?
+
+resource networkWatcher 'Microsoft.Network/networkWatchers@2024-10-01' existing = {
   name: networkWatcherName
 }
 
-resource flowLog 'Microsoft.Network/networkWatchers/flowLogs@2024-05-01' = {
+resource flowLog 'Microsoft.Network/networkWatchers/flowLogs@2024-10-01' = {
   name: name
   parent: networkWatcher
   tags: tags
@@ -58,6 +61,7 @@ resource flowLog 'Microsoft.Network/networkWatchers/flowLogs@2024-05-01' = {
     targetResourceId: targetResourceId
     storageId: storageResourceId
     enabled: enabled
+    enabledFilteringCriteria: enabledFilteringCriteria
     retentionPolicy: {
       days: retentionInDays
       enabled: retentionInDays == 0 ? false : true

--- a/avm/res/network/network-watcher/flow-log/main.json
+++ b/avm/res/network/network-watcher/flow-log/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.13.18514",
-      "templateHash": "152927297469547499"
+      "version": "0.38.5.1644",
+      "templateHash": "12532620337201118446"
     },
     "name": "NSG Flow Logs",
     "description": "This module controls the Network Security Group Flow Logs and analytics settings.\n**Note: this module must be run on the Resource Group where Network Watcher is deployed**"
@@ -28,10 +28,13 @@
     },
     "tags": {
       "type": "object",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/networkWatchers/flowLogs@2024-05-01#properties/tags"
+        },
         "description": "Optional. Tags of the resource."
-      }
+      },
+      "nullable": true
     },
     "location": {
       "type": "string",
@@ -46,7 +49,7 @@
         "description": "Required. Resource ID of the NSG that must be enabled for Flow Logs."
       }
     },
-    "storageId": {
+    "storageResourceId": {
       "type": "string",
       "metadata": {
         "description": "Required. Resource ID of the diagnostic storage account."
@@ -72,7 +75,7 @@
     },
     "workspaceResourceId": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
       "metadata": {
         "description": "Optional. Specify the Log Analytics Workspace Resource ID."
       }
@@ -98,9 +101,6 @@
       }
     }
   },
-  "variables": {
-    "flowAnalyticsConfiguration": "[if(and(not(empty(parameters('workspaceResourceId'))), equals(parameters('enabled'), true())), createObject('networkWatcherFlowAnalyticsConfiguration', createObject('enabled', true(), 'workspaceResourceId', parameters('workspaceResourceId'), 'trafficAnalyticsInterval', parameters('trafficAnalyticsInterval'))), createObject('networkWatcherFlowAnalyticsConfiguration', createObject('enabled', false())))]"
-  },
   "resources": {
     "networkWatcher": {
       "existing": true,
@@ -116,7 +116,7 @@
       "location": "[parameters('location')]",
       "properties": {
         "targetResourceId": "[parameters('targetResourceId')]",
-        "storageId": "[parameters('storageId')]",
+        "storageId": "[parameters('storageResourceId')]",
         "enabled": "[parameters('enabled')]",
         "retentionPolicy": {
           "days": "[parameters('retentionInDays')]",
@@ -126,7 +126,7 @@
           "type": "JSON",
           "version": "[parameters('formatVersion')]"
         },
-        "flowAnalyticsConfiguration": "[variables('flowAnalyticsConfiguration')]"
+        "flowAnalyticsConfiguration": "[if(and(not(empty(parameters('workspaceResourceId'))), parameters('enabled')), createObject('networkWatcherFlowAnalyticsConfiguration', createObject('enabled', true(), 'workspaceResourceId', parameters('workspaceResourceId'), 'trafficAnalyticsInterval', parameters('trafficAnalyticsInterval'))), createObject('networkWatcherFlowAnalyticsConfiguration', createObject('enabled', false())))]"
       }
     }
   },

--- a/avm/res/network/network-watcher/flow-log/main.json
+++ b/avm/res/network/network-watcher/flow-log/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.38.5.1644",
-      "templateHash": "12532620337201118446"
+      "templateHash": "7643257579849162716"
     },
     "name": "NSG Flow Logs",
     "description": "This module controls the Network Security Group Flow Logs and analytics settings.\n**Note: this module must be run on the Resource Group where Network Watcher is deployed**"
@@ -99,18 +99,25 @@
       "metadata": {
         "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
       }
+    },
+    "enabledFilteringCriteria": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Field to filter network traffic logs based on SrcIP, SrcPort, DstIP, DstPort, Protocol, Encryption, Direction and Action. If not specified, all network traffic will be logged."
+      }
     }
   },
   "resources": {
     "networkWatcher": {
       "existing": true,
       "type": "Microsoft.Network/networkWatchers",
-      "apiVersion": "2024-05-01",
+      "apiVersion": "2024-10-01",
       "name": "[parameters('networkWatcherName')]"
     },
     "flowLog": {
       "type": "Microsoft.Network/networkWatchers/flowLogs",
-      "apiVersion": "2024-05-01",
+      "apiVersion": "2024-10-01",
       "name": "[format('{0}/{1}', parameters('networkWatcherName'), parameters('name'))]",
       "tags": "[parameters('tags')]",
       "location": "[parameters('location')]",
@@ -118,6 +125,7 @@
         "targetResourceId": "[parameters('targetResourceId')]",
         "storageId": "[parameters('storageResourceId')]",
         "enabled": "[parameters('enabled')]",
+        "enabledFilteringCriteria": "[parameters('enabledFilteringCriteria')]",
         "retentionPolicy": {
           "days": "[parameters('retentionInDays')]",
           "enabled": "[if(equals(parameters('retentionInDays'), 0), false(), true())]"
@@ -157,7 +165,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('flowLog', '2024-05-01', 'full').location]"
+      "value": "[reference('flowLog', '2024-10-01', 'full').location]"
     }
   }
 }

--- a/avm/res/network/network-watcher/main.bicep
+++ b/avm/res/network/network-watcher/main.bicep
@@ -9,16 +9,16 @@ param name string = 'NetworkWatcher_${location}'
 param location string = resourceGroup().location
 
 @description('Optional. Array that contains the Connection Monitors.')
-param connectionMonitors array = []
+param connectionMonitors connectionMonitorType[]?
 
 @description('Optional. Array that contains the Flow Logs.')
-param flowLogs array = []
+param flowLogs flowLogType[]?
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The lock settings of the service.')
 param lock lockType?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
@@ -111,36 +111,36 @@ resource networkWatcher_roleAssignments 'Microsoft.Authorization/roleAssignments
 ]
 
 module networkWatcher_connectionMonitors 'connection-monitor/main.bicep' = [
-  for (connectionMonitor, index) in connectionMonitors: {
+  for (connectionMonitor, index) in (connectionMonitors ?? []): {
     name: '${uniqueString(deployment().name, location)}-NW-ConnectionMonitor-${index}'
     params: {
       tags: tags
-      endpoints: connectionMonitor.?endpoints ?? []
+      endpoints: connectionMonitor.?endpoints
       name: connectionMonitor.name
       location: location
       networkWatcherName: networkWatcher.name
-      testConfigurations: connectionMonitor.?testConfigurations ?? []
-      testGroups: connectionMonitor.?testGroups ?? []
-      workspaceResourceId: connectionMonitor.?workspaceResourceId ?? ''
+      testConfigurations: connectionMonitor.?testConfigurations
+      testGroups: connectionMonitor.?testGroups
+      workspaceResourceId: connectionMonitor.?workspaceResourceId
     }
   }
 ]
 
 module networkWatcher_flowLogs 'flow-log/main.bicep' = [
-  for (flowLog, index) in flowLogs: {
+  for (flowLog, index) in (flowLogs ?? []): {
     name: '${uniqueString(deployment().name, location)}-NW-FlowLog-${index}'
     params: {
       tags: tags
-      enabled: flowLog.?enabled ?? true
-      formatVersion: flowLog.?formatVersion ?? 2
-      location: flowLog.?location ?? location
-      name: flowLog.?name ?? '${last(split(flowLog.targetResourceId, '/'))}-${split(flowLog.targetResourceId, '/')[4]}-flowlog'
+      enabled: flowLog.?enabled
+      formatVersion: flowLog.?formatVersion
+      location: flowLog.?location
+      name: flowLog.?name
       networkWatcherName: networkWatcher.name
-      retentionInDays: flowLog.?retentionInDays ?? 365
-      storageId: flowLog.storageId
+      retentionInDays: flowLog.?retentionInDays
+      storageResourceId: flowLog.storageResourceId
       targetResourceId: flowLog.targetResourceId
-      trafficAnalyticsInterval: flowLog.?trafficAnalyticsInterval ?? 60
-      workspaceResourceId: flowLog.?workspaceResourceId ?? ''
+      trafficAnalyticsInterval: flowLog.?trafficAnalyticsInterval
+      workspaceResourceId: flowLog.?workspaceResourceId
     }
   }
 ]
@@ -156,3 +156,67 @@ output resourceGroupName string = resourceGroup().name
 
 @description('The location the resource was deployed into.')
 output location string = networkWatcher.location
+
+// =============== //
+//   Definitions   //
+// =============== //
+
+@export()
+@description('The type of a flow log.')
+type flowLogType = {
+  @description('Optional. Name of the resource.')
+  name: string?
+  @description('Optional. Tags of the resource.')
+  tags: resourceInput<'Microsoft.Network/networkWatchers/flowLogs@2024-05-01'>.tags?
+
+  @description('Optional. Location for all resources.')
+  location: string?
+
+  @description('Required. Resource ID of the NSG that must be enabled for Flow Logs.')
+  targetResourceId: string
+
+  @description('Required. Resource ID of the diagnostic storage account.')
+  storageResourceId: string
+
+  @description('Optional. If the flow log should be enabled.')
+  enabled: bool?
+
+  @description('Optional. The flow log format version.')
+  formatVersion: (1 | 2)?
+
+  @description('Optional. Specify the Log Analytics Workspace Resource ID.')
+  workspaceResourceId: string?
+
+  @description('Optional. The interval in minutes which would decide how frequently TA service should do flow analytics.')
+  trafficAnalyticsInterval: (10 | 60)?
+
+  @description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
+  @minValue(0)
+  @maxValue(365)
+  retentionInDays: int?
+}
+
+@export()
+@description('The type of a connection monitor.')
+type connectionMonitorType = {
+  @description('Required. Name of the resource.')
+  name: string
+
+  @description('Optional. Tags of the resource.')
+  tags: resourceInput<'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01'>.tags?
+
+  @description('Optional. Location for all resources.')
+  location: string?
+
+  @description('Optional. List of connection monitor endpoints.')
+  endpoints: resourceInput<'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01'>.properties.endpoints?
+
+  @description('Optional. List of connection monitor test configurations.')
+  testConfigurations: resourceInput<'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01'>.properties.testConfigurations?
+
+  @description('Optional. List of connection monitor test groups.')
+  testGroups: resourceInput<'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01'>.properties.testGroups?
+
+  @description('Optional. Specify the Log Analytics Workspace Resource ID.')
+  workspaceResourceId: string?
+}

--- a/avm/res/network/network-watcher/main.bicep
+++ b/avm/res/network/network-watcher/main.bicep
@@ -76,7 +76,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource networkWatcher 'Microsoft.Network/networkWatchers@2024-05-01' = {
+resource networkWatcher 'Microsoft.Network/networkWatchers@2024-10-01' = {
   name: name
   location: location
   tags: tags
@@ -122,6 +122,11 @@ module networkWatcher_connectionMonitors 'connection-monitor/main.bicep' = [
       testConfigurations: connectionMonitor.?testConfigurations
       testGroups: connectionMonitor.?testGroups
       workspaceResourceId: connectionMonitor.?workspaceResourceId
+      autoStart: connectionMonitor.?autoStart
+      destination: connectionMonitor.?destination
+      monitoringIntervalInSeconds: connectionMonitor.?monitoringIntervalInSeconds
+      notes: connectionMonitor.?notes
+      source: connectionMonitor.?source
     }
   }
 ]
@@ -141,6 +146,7 @@ module networkWatcher_flowLogs 'flow-log/main.bicep' = [
       targetResourceId: flowLog.targetResourceId
       trafficAnalyticsInterval: flowLog.?trafficAnalyticsInterval
       workspaceResourceId: flowLog.?workspaceResourceId
+      enabledFilteringCriteria: flowLog.?enabledFilteringCriteria
     }
   }
 ]
@@ -194,6 +200,9 @@ type flowLogType = {
   @minValue(0)
   @maxValue(365)
   retentionInDays: int?
+
+  @description('Optional. Field to filter network traffic logs based on SrcIP, SrcPort, DstIP, DstPort, Protocol, Encryption, Direction and Action. If not specified, all network traffic will be logged.')
+  enabledFilteringCriteria: string?
 }
 
 @export()
@@ -219,4 +228,21 @@ type connectionMonitorType = {
 
   @description('Optional. Specify the Log Analytics Workspace Resource ID.')
   workspaceResourceId: string?
+
+  @description('Optional. Determines if the connection monitor will start automatically once created.')
+  autoStart: bool?
+
+  @description('Optional. Describes the destination of connection monitor.')
+  destination: resourceInput<'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01'>.properties.destination?
+
+  @description('Optional. Monitoring interval in seconds.')
+  @minValue(30)
+  @maxValue(1800)
+  monitoringIntervalInSeconds: int?
+
+  @description('Optional. Notes to be associated with the connection monitor.')
+  notes: string?
+
+  @description('Optional. Describes the source of connection monitor.')
+  source: resourceInput<'Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01'>.properties.source?
 }

--- a/avm/res/network/network-watcher/main.json
+++ b/avm/res/network/network-watcher/main.json
@@ -6,12 +6,171 @@
     "_generator": {
       "name": "bicep",
       "version": "0.38.5.1644",
-      "templateHash": "14971280430650027941"
+      "templateHash": "1398151508538177764"
     },
     "name": "Network Watchers",
     "description": "This module deploys a Network Watcher."
   },
   "definitions": {
+    "flowLogType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Name of the resource."
+          }
+        },
+        "tags": {
+          "type": "object",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/networkWatchers/flowLogs@2024-05-01#properties/tags"
+            },
+            "description": "Optional. Tags of the resource."
+          },
+          "nullable": true
+        },
+        "location": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Location for all resources."
+          }
+        },
+        "targetResourceId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. Resource ID of the NSG that must be enabled for Flow Logs."
+          }
+        },
+        "storageResourceId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. Resource ID of the diagnostic storage account."
+          }
+        },
+        "enabled": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. If the flow log should be enabled."
+          }
+        },
+        "formatVersion": {
+          "type": "int",
+          "allowedValues": [
+            1,
+            2
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The flow log format version."
+          }
+        },
+        "workspaceResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specify the Log Analytics Workspace Resource ID."
+          }
+        },
+        "trafficAnalyticsInterval": {
+          "type": "int",
+          "allowedValues": [
+            10,
+            60
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The interval in minutes which would decide how frequently TA service should do flow analytics."
+          }
+        },
+        "retentionInDays": {
+          "type": "int",
+          "nullable": true,
+          "minValue": 0,
+          "maxValue": 365,
+          "metadata": {
+            "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The type of a flow log."
+      }
+    },
+    "connectionMonitorType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. Name of the resource."
+          }
+        },
+        "tags": {
+          "type": "object",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/tags"
+            },
+            "description": "Optional. Tags of the resource."
+          },
+          "nullable": true
+        },
+        "location": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Location for all resources."
+          }
+        },
+        "endpoints": {
+          "type": "array",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/endpoints"
+            },
+            "description": "Optional. List of connection monitor endpoints."
+          },
+          "nullable": true
+        },
+        "testConfigurations": {
+          "type": "array",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/testConfigurations"
+            },
+            "description": "Optional. List of connection monitor test configurations."
+          },
+          "nullable": true
+        },
+        "testGroups": {
+          "type": "array",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/testGroups"
+            },
+            "description": "Optional. List of connection monitor test groups."
+          },
+          "nullable": true
+        },
+        "workspaceResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Specify the Log Analytics Workspace Resource ID."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The type of a connection monitor."
+      }
+    },
     "lockType": {
       "type": "object",
       "properties": {
@@ -45,7 +204,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a lock.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
         }
       }
     },
@@ -120,7 +279,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
         }
       }
     }
@@ -143,14 +302,20 @@
     },
     "connectionMonitors": {
       "type": "array",
-      "defaultValue": [],
+      "items": {
+        "$ref": "#/definitions/connectionMonitorType"
+      },
+      "nullable": true,
       "metadata": {
         "description": "Optional. Array that contains the Connection Monitors."
       }
     },
     "flowLogs": {
       "type": "array",
-      "defaultValue": [],
+      "items": {
+        "$ref": "#/definitions/flowLogType"
+      },
+      "nullable": true,
       "metadata": {
         "description": "Optional. Array that contains the Flow Logs."
       }
@@ -275,7 +440,7 @@
     "networkWatcher_connectionMonitors": {
       "copy": {
         "name": "networkWatcher_connectionMonitors",
-        "count": "[length(parameters('connectionMonitors'))]"
+        "count": "[length(coalesce(parameters('connectionMonitors'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
@@ -290,10 +455,10 @@
             "value": "[parameters('tags')]"
           },
           "endpoints": {
-            "value": "[coalesce(tryGet(parameters('connectionMonitors')[copyIndex()], 'endpoints'), createArray())]"
+            "value": "[tryGet(coalesce(parameters('connectionMonitors'), createArray())[copyIndex()], 'endpoints')]"
           },
           "name": {
-            "value": "[parameters('connectionMonitors')[copyIndex()].name]"
+            "value": "[coalesce(parameters('connectionMonitors'), createArray())[copyIndex()].name]"
           },
           "location": {
             "value": "[parameters('location')]"
@@ -302,13 +467,13 @@
             "value": "[parameters('name')]"
           },
           "testConfigurations": {
-            "value": "[coalesce(tryGet(parameters('connectionMonitors')[copyIndex()], 'testConfigurations'), createArray())]"
+            "value": "[tryGet(coalesce(parameters('connectionMonitors'), createArray())[copyIndex()], 'testConfigurations')]"
           },
           "testGroups": {
-            "value": "[coalesce(tryGet(parameters('connectionMonitors')[copyIndex()], 'testGroups'), createArray())]"
+            "value": "[tryGet(coalesce(parameters('connectionMonitors'), createArray())[copyIndex()], 'testGroups')]"
           },
           "workspaceResourceId": {
-            "value": "[coalesce(tryGet(parameters('connectionMonitors')[copyIndex()], 'workspaceResourceId'), '')]"
+            "value": "[tryGet(coalesce(parameters('connectionMonitors'), createArray())[copyIndex()], 'workspaceResourceId')]"
           }
         },
         "template": {
@@ -319,7 +484,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.38.5.1644",
-              "templateHash": "5318495614979340661"
+              "templateHash": "8435110440648926991"
             },
             "name": "Network Watchers Connection Monitors",
             "description": "This module deploys a Network Watcher Connection Monitor."
@@ -340,10 +505,13 @@
             },
             "tags": {
               "type": "object",
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/tags"
+                },
                 "description": "Optional. Tags of the resource."
-              }
+              },
+              "nullable": true
             },
             "location": {
               "type": "string",
@@ -354,28 +522,37 @@
             },
             "endpoints": {
               "type": "array",
-              "defaultValue": [],
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/endpoints"
+                },
                 "description": "Optional. List of connection monitor endpoints."
-              }
+              },
+              "defaultValue": []
             },
             "testConfigurations": {
               "type": "array",
-              "defaultValue": [],
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/testConfigurations"
+                },
                 "description": "Optional. List of connection monitor test configurations."
-              }
+              },
+              "defaultValue": []
             },
             "testGroups": {
               "type": "array",
-              "defaultValue": [],
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/testGroups"
+                },
                 "description": "Optional. List of connection monitor test groups."
-              }
+              },
+              "defaultValue": []
             },
             "workspaceResourceId": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Specify the Log Analytics Workspace Resource ID."
               }
@@ -441,7 +618,7 @@
     "networkWatcher_flowLogs": {
       "copy": {
         "name": "networkWatcher_flowLogs",
-        "count": "[length(parameters('flowLogs'))]"
+        "count": "[length(coalesce(parameters('flowLogs'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
@@ -456,34 +633,34 @@
             "value": "[parameters('tags')]"
           },
           "enabled": {
-            "value": "[coalesce(tryGet(parameters('flowLogs')[copyIndex()], 'enabled'), true())]"
+            "value": "[tryGet(coalesce(parameters('flowLogs'), createArray())[copyIndex()], 'enabled')]"
           },
           "formatVersion": {
-            "value": "[coalesce(tryGet(parameters('flowLogs')[copyIndex()], 'formatVersion'), 2)]"
+            "value": "[tryGet(coalesce(parameters('flowLogs'), createArray())[copyIndex()], 'formatVersion')]"
           },
           "location": {
-            "value": "[coalesce(tryGet(parameters('flowLogs')[copyIndex()], 'location'), parameters('location'))]"
+            "value": "[tryGet(coalesce(parameters('flowLogs'), createArray())[copyIndex()], 'location')]"
           },
           "name": {
-            "value": "[coalesce(tryGet(parameters('flowLogs')[copyIndex()], 'name'), format('{0}-{1}-flowlog', last(split(parameters('flowLogs')[copyIndex()].targetResourceId, '/')), split(parameters('flowLogs')[copyIndex()].targetResourceId, '/')[4]))]"
+            "value": "[tryGet(coalesce(parameters('flowLogs'), createArray())[copyIndex()], 'name')]"
           },
           "networkWatcherName": {
             "value": "[parameters('name')]"
           },
           "retentionInDays": {
-            "value": "[coalesce(tryGet(parameters('flowLogs')[copyIndex()], 'retentionInDays'), 365)]"
+            "value": "[tryGet(coalesce(parameters('flowLogs'), createArray())[copyIndex()], 'retentionInDays')]"
           },
-          "storageId": {
-            "value": "[parameters('flowLogs')[copyIndex()].storageId]"
+          "storageResourceId": {
+            "value": "[coalesce(parameters('flowLogs'), createArray())[copyIndex()].storageResourceId]"
           },
           "targetResourceId": {
-            "value": "[parameters('flowLogs')[copyIndex()].targetResourceId]"
+            "value": "[coalesce(parameters('flowLogs'), createArray())[copyIndex()].targetResourceId]"
           },
           "trafficAnalyticsInterval": {
-            "value": "[coalesce(tryGet(parameters('flowLogs')[copyIndex()], 'trafficAnalyticsInterval'), 60)]"
+            "value": "[tryGet(coalesce(parameters('flowLogs'), createArray())[copyIndex()], 'trafficAnalyticsInterval')]"
           },
           "workspaceResourceId": {
-            "value": "[coalesce(tryGet(parameters('flowLogs')[copyIndex()], 'workspaceResourceId'), '')]"
+            "value": "[tryGet(coalesce(parameters('flowLogs'), createArray())[copyIndex()], 'workspaceResourceId')]"
           }
         },
         "template": {
@@ -494,7 +671,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.38.5.1644",
-              "templateHash": "18375550301523839465"
+              "templateHash": "12532620337201118446"
             },
             "name": "NSG Flow Logs",
             "description": "This module controls the Network Security Group Flow Logs and analytics settings.\n**Note: this module must be run on the Resource Group where Network Watcher is deployed**"
@@ -516,10 +693,13 @@
             },
             "tags": {
               "type": "object",
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/networkWatchers/flowLogs@2024-05-01#properties/tags"
+                },
                 "description": "Optional. Tags of the resource."
-              }
+              },
+              "nullable": true
             },
             "location": {
               "type": "string",
@@ -534,7 +714,7 @@
                 "description": "Required. Resource ID of the NSG that must be enabled for Flow Logs."
               }
             },
-            "storageId": {
+            "storageResourceId": {
               "type": "string",
               "metadata": {
                 "description": "Required. Resource ID of the diagnostic storage account."
@@ -560,7 +740,7 @@
             },
             "workspaceResourceId": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Specify the Log Analytics Workspace Resource ID."
               }
@@ -586,9 +766,6 @@
               }
             }
           },
-          "variables": {
-            "flowAnalyticsConfiguration": "[if(and(not(empty(parameters('workspaceResourceId'))), equals(parameters('enabled'), true())), createObject('networkWatcherFlowAnalyticsConfiguration', createObject('enabled', true(), 'workspaceResourceId', parameters('workspaceResourceId'), 'trafficAnalyticsInterval', parameters('trafficAnalyticsInterval'))), createObject('networkWatcherFlowAnalyticsConfiguration', createObject('enabled', false())))]"
-          },
           "resources": {
             "networkWatcher": {
               "existing": true,
@@ -604,7 +781,7 @@
               "location": "[parameters('location')]",
               "properties": {
                 "targetResourceId": "[parameters('targetResourceId')]",
-                "storageId": "[parameters('storageId')]",
+                "storageId": "[parameters('storageResourceId')]",
                 "enabled": "[parameters('enabled')]",
                 "retentionPolicy": {
                   "days": "[parameters('retentionInDays')]",
@@ -614,7 +791,7 @@
                   "type": "JSON",
                   "version": "[parameters('formatVersion')]"
                 },
-                "flowAnalyticsConfiguration": "[variables('flowAnalyticsConfiguration')]"
+                "flowAnalyticsConfiguration": "[if(and(not(empty(parameters('workspaceResourceId'))), parameters('enabled')), createObject('networkWatcherFlowAnalyticsConfiguration', createObject('enabled', true(), 'workspaceResourceId', parameters('workspaceResourceId'), 'trafficAnalyticsInterval', parameters('trafficAnalyticsInterval'))), createObject('networkWatcherFlowAnalyticsConfiguration', createObject('enabled', false())))]"
               }
             }
           },

--- a/avm/res/network/network-watcher/main.json
+++ b/avm/res/network/network-watcher/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.38.5.1644",
-      "templateHash": "1398151508538177764"
+      "templateHash": "10593926005855712519"
     },
     "name": "Network Watchers",
     "description": "This module deploys a Network Watcher."
@@ -95,6 +95,13 @@
           "metadata": {
             "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
           }
+        },
+        "enabledFilteringCriteria": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Field to filter network traffic logs based on SrcIP, SrcPort, DstIP, DstPort, Protocol, Encryption, Direction and Action. If not specified, all network traffic will be logged."
+          }
         }
       },
       "metadata": {
@@ -164,6 +171,49 @@
           "metadata": {
             "description": "Optional. Specify the Log Analytics Workspace Resource ID."
           }
+        },
+        "autoStart": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Determines if the connection monitor will start automatically once created."
+          }
+        },
+        "destination": {
+          "type": "object",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/destination"
+            },
+            "description": "Optional. Describes the destination of connection monitor."
+          },
+          "nullable": true
+        },
+        "monitoringIntervalInSeconds": {
+          "type": "int",
+          "nullable": true,
+          "minValue": 30,
+          "maxValue": 1800,
+          "metadata": {
+            "description": "Optional. Monitoring interval in seconds."
+          }
+        },
+        "notes": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Notes to be associated with the connection monitor."
+          }
+        },
+        "source": {
+          "type": "object",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/source"
+            },
+            "description": "Optional. Describes the source of connection monitor."
+          },
+          "nullable": true
         }
       },
       "metadata": {
@@ -395,7 +445,7 @@
     },
     "networkWatcher": {
       "type": "Microsoft.Network/networkWatchers",
-      "apiVersion": "2024-05-01",
+      "apiVersion": "2024-10-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -474,6 +524,21 @@
           },
           "workspaceResourceId": {
             "value": "[tryGet(coalesce(parameters('connectionMonitors'), createArray())[copyIndex()], 'workspaceResourceId')]"
+          },
+          "autoStart": {
+            "value": "[tryGet(coalesce(parameters('connectionMonitors'), createArray())[copyIndex()], 'autoStart')]"
+          },
+          "destination": {
+            "value": "[tryGet(coalesce(parameters('connectionMonitors'), createArray())[copyIndex()], 'destination')]"
+          },
+          "monitoringIntervalInSeconds": {
+            "value": "[tryGet(coalesce(parameters('connectionMonitors'), createArray())[copyIndex()], 'monitoringIntervalInSeconds')]"
+          },
+          "notes": {
+            "value": "[tryGet(coalesce(parameters('connectionMonitors'), createArray())[copyIndex()], 'notes')]"
+          },
+          "source": {
+            "value": "[tryGet(coalesce(parameters('connectionMonitors'), createArray())[copyIndex()], 'source')]"
           }
         },
         "template": {
@@ -484,7 +549,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.38.5.1644",
-              "templateHash": "8435110440648926991"
+              "templateHash": "9988153364509308698"
             },
             "name": "Network Watchers Connection Monitors",
             "description": "This module deploys a Network Watcher Connection Monitor."
@@ -556,18 +621,61 @@
               "metadata": {
                 "description": "Optional. Specify the Log Analytics Workspace Resource ID."
               }
+            },
+            "autoStart": {
+              "type": "bool",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Determines if the connection monitor will start automatically once created."
+              }
+            },
+            "destination": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/destination"
+                },
+                "description": "Optional. Describes the destination of connection monitor."
+              },
+              "nullable": true
+            },
+            "monitoringIntervalInSeconds": {
+              "type": "int",
+              "nullable": true,
+              "minValue": 30,
+              "maxValue": 1800,
+              "metadata": {
+                "description": "Optional. Monitoring interval in seconds."
+              }
+            },
+            "notes": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Notes to be associated with the connection monitor."
+              }
+            },
+            "source": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/networkWatchers/connectionMonitors@2024-05-01#properties/properties/properties/source"
+                },
+                "description": "Optional. Describes the source of connection monitor."
+              },
+              "nullable": true
             }
           },
           "resources": {
             "networkWatcher": {
               "existing": true,
               "type": "Microsoft.Network/networkWatchers",
-              "apiVersion": "2024-05-01",
+              "apiVersion": "2024-10-01",
               "name": "[parameters('networkWatcherName')]"
             },
             "connectionMonitor": {
               "type": "Microsoft.Network/networkWatchers/connectionMonitors",
-              "apiVersion": "2024-05-01",
+              "apiVersion": "2024-10-01",
               "name": "[format('{0}/{1}', parameters('networkWatcherName'), parameters('name'))]",
               "tags": "[parameters('tags')]",
               "location": "[parameters('location')]",
@@ -575,6 +683,11 @@
                 "endpoints": "[parameters('endpoints')]",
                 "testConfigurations": "[parameters('testConfigurations')]",
                 "testGroups": "[parameters('testGroups')]",
+                "autoStart": "[parameters('autoStart')]",
+                "destination": "[parameters('destination')]",
+                "monitoringIntervalInSeconds": "[parameters('monitoringIntervalInSeconds')]",
+                "notes": "[parameters('notes')]",
+                "source": "[parameters('source')]",
                 "outputs": "[if(not(empty(parameters('workspaceResourceId'))), createArray(createObject('type', 'Workspace', 'workspaceSettings', createObject('workspaceResourceId', parameters('workspaceResourceId')))), null())]"
               }
             }
@@ -606,7 +719,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('connectionMonitor', '2024-05-01', 'full').location]"
+              "value": "[reference('connectionMonitor', '2024-10-01', 'full').location]"
             }
           }
         }
@@ -661,6 +774,9 @@
           },
           "workspaceResourceId": {
             "value": "[tryGet(coalesce(parameters('flowLogs'), createArray())[copyIndex()], 'workspaceResourceId')]"
+          },
+          "enabledFilteringCriteria": {
+            "value": "[tryGet(coalesce(parameters('flowLogs'), createArray())[copyIndex()], 'enabledFilteringCriteria')]"
           }
         },
         "template": {
@@ -671,7 +787,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.38.5.1644",
-              "templateHash": "12532620337201118446"
+              "templateHash": "7643257579849162716"
             },
             "name": "NSG Flow Logs",
             "description": "This module controls the Network Security Group Flow Logs and analytics settings.\n**Note: this module must be run on the Resource Group where Network Watcher is deployed**"
@@ -764,18 +880,25 @@
               "metadata": {
                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
               }
+            },
+            "enabledFilteringCriteria": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Field to filter network traffic logs based on SrcIP, SrcPort, DstIP, DstPort, Protocol, Encryption, Direction and Action. If not specified, all network traffic will be logged."
+              }
             }
           },
           "resources": {
             "networkWatcher": {
               "existing": true,
               "type": "Microsoft.Network/networkWatchers",
-              "apiVersion": "2024-05-01",
+              "apiVersion": "2024-10-01",
               "name": "[parameters('networkWatcherName')]"
             },
             "flowLog": {
               "type": "Microsoft.Network/networkWatchers/flowLogs",
-              "apiVersion": "2024-05-01",
+              "apiVersion": "2024-10-01",
               "name": "[format('{0}/{1}', parameters('networkWatcherName'), parameters('name'))]",
               "tags": "[parameters('tags')]",
               "location": "[parameters('location')]",
@@ -783,6 +906,7 @@
                 "targetResourceId": "[parameters('targetResourceId')]",
                 "storageId": "[parameters('storageResourceId')]",
                 "enabled": "[parameters('enabled')]",
+                "enabledFilteringCriteria": "[parameters('enabledFilteringCriteria')]",
                 "retentionPolicy": {
                   "days": "[parameters('retentionInDays')]",
                   "enabled": "[if(equals(parameters('retentionInDays'), 0), false(), true())]"
@@ -822,7 +946,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('flowLog', '2024-05-01', 'full').location]"
+              "value": "[reference('flowLog', '2024-10-01', 'full').location]"
             }
           }
         }
@@ -859,7 +983,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('networkWatcher', '2024-05-01', 'full').location]"
+      "value": "[reference('networkWatcher', '2024-10-01', 'full').location]"
     }
   }
 }

--- a/avm/res/network/network-watcher/tests/e2e/max/dependencies.bicep
+++ b/avm/res/network/network-watcher/tests/e2e/max/dependencies.bicep
@@ -7,12 +7,6 @@ param virtualNetworkName string
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
-@description('Required. The name of the first Network Security Group to create.')
-param firstNetworkSecurityGroupName string
-
-@description('Required. The name of the second Network Security Group to create.')
-param secondNetworkSecurityGroupName string
-
 @description('Required. The name of the Virtual Machine to create.')
 param virtualMachineName string
 
@@ -22,7 +16,7 @@ param password string = newGuid()
 
 var addressPrefix = '10.0.0.0/16'
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-10-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -42,22 +36,12 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   }
 }
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
 
-resource firstNetworkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
-  name: firstNetworkSecurityGroupName
-  location: location
-}
-
-resource secondNetworkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
-  name: secondNetworkSecurityGroupName
-  location: location
-}
-
-resource networkInterface 'Microsoft.Network/networkInterfaces@2023-04-01' = {
+resource networkInterface 'Microsoft.Network/networkInterfaces@2024-10-01' = {
   name: '${virtualMachineName}-nic'
   location: location
   properties: {
@@ -74,7 +58,7 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2023-04-01' = {
   }
 }
 
-resource virtualMachine 'Microsoft.Compute/virtualMachines@2022-08-01' = {
+resource virtualMachine 'Microsoft.Compute/virtualMachines@2025-04-01' = {
   name: virtualMachineName
   location: location
   properties: {
@@ -115,7 +99,7 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2022-08-01' = {
   }
 }
 
-resource extension 'Microsoft.Compute/virtualMachines/extensions@2021-07-01' = {
+resource extension 'Microsoft.Compute/virtualMachines/extensions@2025-04-01' = {
   name: 'NetworkWatcherAgent'
   parent: virtualMachine
   location: location
@@ -137,8 +121,8 @@ output managedIdentityPrincipalId string = managedIdentity.properties.principalI
 @description('The resource ID of the created Virtual Machine.')
 output virtualMachineResourceId string = virtualMachine.id
 
-@description('The resource ID of the first created Network Security Group.')
-output firstNetworkSecurityGroupResourceId string = firstNetworkSecurityGroup.id
+@description('The resource ID of the created Virtual Network.')
+output virtualNetworkResourceId string = virtualNetwork.id
 
-@description('The resource ID of the second created Network Security Group.')
-output secondNetworkSecurityGroupResourceId string = secondNetworkSecurityGroup.id
+@description('The resource ID of the created Virtual Network Subnet.')
+output virtualNetworkSubnetResourceId string = virtualNetwork.properties.subnets[0].id

--- a/avm/res/network/network-watcher/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/network/network-watcher/tests/e2e/waf-aligned/dependencies.bicep
@@ -7,12 +7,6 @@ param virtualNetworkName string
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
-@description('Required. The name of the first Network Security Group to create.')
-param firstNetworkSecurityGroupName string
-
-@description('Required. The name of the second Network Security Group to create.')
-param secondNetworkSecurityGroupName string
-
 @description('Required. The name of the Virtual Machine to create.')
 param virtualMachineName string
 
@@ -42,22 +36,12 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   }
 }
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
 
-resource firstNetworkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
-  name: firstNetworkSecurityGroupName
-  location: location
-}
-
-resource secondNetworkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
-  name: secondNetworkSecurityGroupName
-  location: location
-}
-
-resource networkInterface 'Microsoft.Network/networkInterfaces@2023-04-01' = {
+resource networkInterface 'Microsoft.Network/networkInterfaces@2024-10-01' = {
   name: '${virtualMachineName}-nic'
   location: location
   properties: {
@@ -74,7 +58,7 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2023-04-01' = {
   }
 }
 
-resource virtualMachine 'Microsoft.Compute/virtualMachines@2022-08-01' = {
+resource virtualMachine 'Microsoft.Compute/virtualMachines@2025-04-01' = {
   name: virtualMachineName
   location: location
   properties: {
@@ -115,7 +99,7 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2022-08-01' = {
   }
 }
 
-resource extension 'Microsoft.Compute/virtualMachines/extensions@2021-07-01' = {
+resource extension 'Microsoft.Compute/virtualMachines/extensions@2025-04-01' = {
   name: 'NetworkWatcherAgent'
   parent: virtualMachine
   location: location
@@ -137,8 +121,8 @@ output managedIdentityPrincipalId string = managedIdentity.properties.principalI
 @description('The resource ID of the created Virtual Machine.')
 output virtualMachineResourceId string = virtualMachine.id
 
-@description('The resource ID of the first created Network Security Group.')
-output firstNetworkSecurityGroupResourceId string = firstNetworkSecurityGroup.id
+@description('The resource ID of the created Virtual Network.')
+output virtualNetworkResourceId string = virtualNetwork.id
 
-@description('The resource ID of the second created Network Security Group.')
-output secondNetworkSecurityGroupResourceId string = secondNetworkSecurityGroup.id
+@description('The resource ID of the created Virtual Network Subnet.')
+output virtualNetworkSubnetResourceId string = virtualNetwork.properties.subnets[0].id

--- a/avm/res/network/network-watcher/version.json
+++ b/avm/res/network/network-watcher/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.4"
+    "version": "0.5"
 }


### PR DESCRIPTION
## Description

Added diverse types & updated tests to cater for the now deprecated NSG-Flow-Logs.

Without this update, the current workflow in main throws the very recent error:
> On September 30, 2027, Network Security Group (NSG) flow logs will be retired. As part of this retirement, creation of new NSG flow logs is blocked starting June 30, 2025, but you will be able to continue using and modifying settings for existing NSG flow logs that are previously deployed/configured until Sept 30th 2027. We recommend migrating to virtual network flow logs, which overcome the limitations of NSG flow logs. For migration, please refer to https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-migrate. (Code: NsgFlowLogCreationBlocked)

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.network.network-watcher](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-watcher.yml/badge.svg?branch=users%2Falsehr%2FflowLogsUpdate&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-watcher.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
