### PR TITLE
fix: IPGroup - Adjusted idempontency test

### DIFF
--- a/avm/res/network/ip-group/CHANGELOG.md
+++ b/avm/res/network/ip-group/CHANGELOG.md
@@ -7,7 +7,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 ### Changes
 
 - Added type for `tags` parameter
-- Updated LockType to 'avm-common-types version' `0.6.0`, enabling custom notes for locks.
+- Updated LockType to 'avm-common-types version' `0.6.1`, enabling custom notes for locks.
 
 ### Breaking Changes
 

--- a/avm/res/network/ip-group/README.md
+++ b/avm/res/network/ip-group/README.md
@@ -45,7 +45,7 @@ module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
   name: 'ipGroupDeployment'
   params: {
     // Required parameters
-    name: 'nigmin002'
+    name: 'nigmin001'
     // Non-required parameters
     location: '<location>'
   }
@@ -66,7 +66,7 @@ module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
   "parameters": {
     // Required parameters
     "name": {
-      "value": "nigmin002"
+      "value": "nigmin001"
     },
     // Non-required parameters
     "location": {
@@ -87,7 +87,7 @@ module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
 using 'br/public:avm/res/network/ip-group:<version>'
 
 // Required parameters
-param name = 'nigmin002'
+param name = 'nigmin001'
 // Non-required parameters
 param location = '<location>'
 ```

--- a/avm/res/network/ip-group/README.md
+++ b/avm/res/network/ip-group/README.md
@@ -578,8 +578,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.5.1` | Remote reference |
-| `br/public:avm/utl/types/avm-common-types:0.6.0` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/network/ip-group/README.md
+++ b/avm/res/network/ip-group/README.md
@@ -45,7 +45,7 @@ module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
   name: 'ipGroupDeployment'
   params: {
     // Required parameters
-    name: 'nigmin001'
+    name: 'nigmin002'
     // Non-required parameters
     location: '<location>'
   }
@@ -66,7 +66,7 @@ module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
   "parameters": {
     // Required parameters
     "name": {
-      "value": "nigmin001"
+      "value": "nigmin002"
     },
     // Non-required parameters
     "location": {
@@ -87,7 +87,7 @@ module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
 using 'br/public:avm/res/network/ip-group:<version>'
 
 // Required parameters
-param name = 'nigmin001'
+param name = 'nigmin002'
 // Non-required parameters
 param location = '<location>'
 ```

--- a/avm/res/network/ip-group/main.bicep
+++ b/avm/res/network/ip-group/main.bicep
@@ -11,11 +11,11 @@ param location string = resourceGroup().location
 @description('Optional. IpAddresses/IpAddressPrefixes in the IP Group resource.')
 param ipAddresses array = []
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The lock settings of the service.')
 param lock lockType?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 

--- a/avm/res/network/ip-group/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/network/ip-group/tests/e2e/defaults/main.test.bicep
@@ -41,7 +41,7 @@ module testDeployment '../../../main.bicep' = [
     scope: resourceGroup
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
-      name: '${namePrefix}${serviceShort}001'
+      name: '${namePrefix}${serviceShort}002'
       location: resourceLocation
     }
   }

--- a/avm/res/network/ip-group/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/network/ip-group/tests/e2e/defaults/main.test.bicep
@@ -35,14 +35,11 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
 // Test Execution //
 // ============== //
 
-@batchSize(1)
-module testDeployment '../../../main.bicep' = [
-  for iteration in ['init', 'idem']: {
-    scope: resourceGroup
-    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
-    params: {
-      name: '${namePrefix}${serviceShort}002'
-      location: resourceLocation
-    }
+module testDeployment '../../../main.bicep' = {
+  scope: resourceGroup
+  name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}'
+  params: {
+    name: '${namePrefix}${serviceShort}001'
+    location: resourceLocation
   }
-]
+}


### PR DESCRIPTION
## Description

Adjusted `defaults` test so that I does not run identifiy on idempotency.
After numerous tests it appears that an IP-Group with non-specified IPs, is **not** idempotent - or least not anymore. I tested also with alternative names and was able to immediately reproduce the issue.

Note: This PR addresses a previously not published module version due to the afrementioned issue. As a result it includes a minor change to the module to trigger publishing.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.network.ip-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ip-group.yml/badge.svg?branch=users%2Falsehr%2FipGroupTest&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ip-group.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
