### PR TITLE
docs: update Copilot instructions to reference Bicep MCP tools

### DIFF
--- a/.github/chatmodes/azure-verified-modules-bicep.chatmode.md
+++ b/.github/chatmodes/azure-verified-modules-bicep.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Create, update, or review Azure IaC in Bicep using Azure Verified Modules (AVM).'
-tools: ['edit', 'search', 'new', 'runCommands', 'runTasks', 'usages', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'extensions', 'todos', 'runTests', 'documentation', 'search', 'github']
+tools: ['edit', 'search', 'new', 'runCommands', 'runTasks', 'usages', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'extensions', 'todos', 'runTests', 'documentation', 'search', 'github', 'Bicep (EXPERIMENTAL)/*']
 ---
 # Azure AVM Bicep Mode
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -217,23 +217,32 @@ module keyVault 'br/public:avm/res/key-vault/vault:0.7.1' = {
 ```
 
 ## Fetching Schemas, API versions and existing Published AVM Modules
+You have two options:
+1. Use tools from Bicep VS Code extension: `#list_az_resource_types_for_provider`, `#get_az_resource_type_schema`, `#list_avm_metadata`.
+2. Use the `fetch` tool to get information from related URLs.
 
-### Fetching Bicep Schemas
+> [!IMPORTANT]
+> Use only the tools above to retrieve the schema documentation for Bicep for specific versions. Do not use any other method or tool to do this, because `azure_get_schema_for_Bicep` tool does not reliably return the latest stable version.
+
+### Use Bicep VS Code Extension Tools (Preferred)
+- `#list_az_resource_types_for_provider` takes a resource provider (e.g. `Microsoft.Storage`) as input and outputs a list of resource types including their API versions.
+- `#get_az_resource_type_schema` takes a resource type (e.g. `Microsoft.Storage/storageAccounts`) and an API version (e.g. `2023-01-01`) as input and outputs the schema for that resource type and API version.
+- `#list_avm_metadata` lists up-to-date metadata for all published AVM modules. The return value is a newline-separated list of AVM metadata. Each line includes the module name, description, versions, and documentation URI for a specific module.
+
+### Use Fetch Tool (When Bicep VS Code Extension Tools Are Not Available)
+#### Fetching Bicep Schemas
 Use the `fetch` tool to get the Bicep schema for specific resources:
 
 - **URL for specific version**: `https://learn.microsoft.com/azure/templates/{resourceType}/{resourceName}?pivots=deployment-language-bicep`
 - **Example**: `https://learn.microsoft.com/azure/templates/Microsoft.Storage/storageAccounts?pivots=deployment-language-bicep`
 
-### Fetching Bicep Schemas with API Version
+#### Fetching Bicep Schemas with API Version
 Use the `fetch` tool to get the Bicep schema for specific resources and explicit API version:
 
 - **URL for specific version**: `https://learn.microsoft.com/azure/templates/{resourceType}/{apiVersion}/{resourceName}`
 - **Example**: `https://learn.microsoft.com/azure/templates/Microsoft.Storage/2023-01-01/storageAccounts?pivots=deployment-language-bicep`
 
-> [!IMPORTANT]
-> Use the `fetch` tool to retrieve the schema documentation for Bicep for specific versions. Do not use any other method or tool to do this, because `azure_get_schema_for_Bicep` tool does not reliably return the latest stable version.
-
-### Fetching AVM Resource Module Versions
+#### Fetching AVM Resource Module Versions
 Use the `fetch` tool to get the AVM Resource module versions published in the MCR:
 
 - **URL for specific module**: `https://mcr.microsoft.com/v2/bicep/avm/res/{service}/{resource}/tags/list`
@@ -264,7 +273,10 @@ Use the `fetch` tool to get the AVM Resource module versions published in the MC
 
 - `#azure_get_deployment_best_practices` to ensure meeting deployment best practices.
 - `#microsoft.docs.mcp` to fetch Microsoft documentation.
-- `#fetch` to get schemas and documentation.
+- `#list_az_resource_types_for_provider` to list resource types for an Azure resource provider.
+- `#get_az_resource_type_schema` to get the schema for a resource type.
+- `#list_avm_metadata` to list AVM module metadata.
+- `#fetch` to get related documentation from a URL.
 - `#todos` to track outstanding tasks.
 - `#think` to think more deeply about the problem at hand (especially when making breaking changes or security-related changes).
 


### PR DESCRIPTION
## Description

The update copilot instructions and custom chat mode file to include the usage of MCP tools in Bicep VS Code extension. These tools returns the latest information for Azure resource types and AVM metadata.

## Pipeline Reference

Documentation change only.

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Doc only change

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version
