### PR TITLE
fix: Improve description for child modules in AVM module issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/avm_module_issue.yml
+++ b/.github/ISSUE_TEMPLATE/avm_module_issue.yml
@@ -35,7 +35,10 @@ body:
     id: module-name-dropdown
     attributes:
       label: Module Name
-      description: Which existing AVM module is this issue related to?
+      description: |
+        Which existing AVM module is this issue related to?
+
+        > **NOTE**: Issues related to child modules must be submitted under the corresponding parent module.
       options:
         - ""
         - "avm/ptn/aca-lza/hosting-environment"

--- a/.github/ISSUE_TEMPLATE/avm_module_issue.yml
+++ b/.github/ISSUE_TEMPLATE/avm_module_issue.yml
@@ -38,7 +38,7 @@ body:
       description: |
         Which existing AVM module is this issue related to?
 
-        > **NOTE**: Issues related to child modules must be submitted under the corresponding parent module.
+        > **NOTE**: Issues related to child modules and multi-scope modules must be submitted under the corresponding parent module.
       options:
         - ""
         - "avm/ptn/aca-lza/hosting-environment"


### PR DESCRIPTION
Enhance clarity in the issue template by specifying that issues related to child modules should be submitted under the corresponding parent module.