### PR TITLE
feat: APIM - Added support for `publicNetworkAccess` parameter

### DIFF
--- a/avm/res/api-management/service/CHANGELOG.md
+++ b/avm/res/api-management/service/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/api-management/service/CHANGELOG.md).
 
+## 0.11.2
+
+### Changes
+
+- Added support for `publicNetworkAccess` parameter
+
+### Breaking Changes
+
+- None
+
 ## 0.11.1
 
 ### Changes

--- a/avm/res/api-management/service/README.md
+++ b/avm/res/api-management/service/README.md
@@ -466,6 +466,7 @@ module service 'br/public:avm/res/api-management/service:<version>' = {
       }
     ]
     publicIpAddressResourceId: '<publicIpAddressResourceId>'
+    publicNetworkAccess: 'Enabled'
     roleAssignments: [
       {
         name: '6352c3e3-ac6b-43d5-ac43-1077ff373721'
@@ -732,6 +733,9 @@ module service 'br/public:avm/res/api-management/service:<version>' = {
     "publicIpAddressResourceId": {
       "value": "<publicIpAddressResourceId>"
     },
+    "publicNetworkAccess": {
+      "value": "Enabled"
+    },
     "roleAssignments": {
       "value": [
         {
@@ -964,6 +968,7 @@ param products = [
   }
 ]
 param publicIpAddressResourceId = '<publicIpAddressResourceId>'
+param publicNetworkAccess = 'Enabled'
 param roleAssignments = [
   {
     name: '6352c3e3-ac6b-43d5-ac43-1077ff373721'
@@ -1784,6 +1789,7 @@ param tags = {
 | [`portalsettings`](#parameter-portalsettings) | array | Portal settings. |
 | [`products`](#parameter-products) | array | Products. |
 | [`publicIpAddressResourceId`](#parameter-publicipaddressresourceid) | string | Public Standard SKU IP V4 based IP address to be associated with Virtual Network deployed service in the region. Supported only for Developer and Premium SKU being deployed in Virtual Network. |
+| [`publicNetworkAccess`](#parameter-publicnetworkaccess) | string | Whether or not public endpoint access is allowed for this API Management service. If set to 'Disabled', private endpoints are the exclusive access method. MUST be enabled during service creation. |
 | [`restore`](#parameter-restore) | bool | Undelete API Management Service if it was previously soft-deleted. If this flag is specified and set to True all other properties will be ignored. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`sku`](#parameter-sku) | string | The pricing tier of this API Management service. |
@@ -4030,6 +4036,13 @@ Product terms of use. Developers trying to subscribe to the product will be pres
 ### Parameter: `publicIpAddressResourceId`
 
 Public Standard SKU IP V4 based IP address to be associated with Virtual Network deployed service in the region. Supported only for Developer and Premium SKU being deployed in Virtual Network.
+
+- Required: No
+- Type: string
+
+### Parameter: `publicNetworkAccess`
+
+Whether or not public endpoint access is allowed for this API Management service. If set to 'Disabled', private endpoints are the exclusive access method. MUST be enabled during service creation.
 
 - Required: No
 - Type: string

--- a/avm/res/api-management/service/main.bicep
+++ b/avm/res/api-management/service/main.bicep
@@ -160,6 +160,9 @@ param enableDeveloperPortal bool = false
 
 var enableReferencedModulesTelemetry bool = false
 
+@description('Optional. Whether or not public endpoint access is allowed for this API Management service. If set to \'Disabled\', private endpoints are the exclusive access method. MUST be enabled during service creation.')
+param publicNetworkAccess resourceInput<'Microsoft.ApiManagement/service@2024-05-01'>.properties.publicNetworkAccess?
+
 var formattedUserAssignedIdentities = reduce(
   map((managedIdentities.?userAssignedResourceIds ?? []), (id) => { '${id}': {} }),
   {},
@@ -250,6 +253,7 @@ resource service 'Microsoft.ApiManagement/service@2024-05-01' = {
     publisherName: publisherName
     notificationSenderEmail: notificationSenderEmail
     hostnameConfigurations: hostnameConfigurations
+    publicNetworkAccess: publicNetworkAccess
     additionalLocations: contains(sku, 'Premium') && !empty(additionalLocations)
       ? map((additionalLocations ?? []), additLoc => {
           location: additLoc.location

--- a/avm/res/api-management/service/main.json
+++ b/avm/res/api-management/service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "1806672109703220641"
+      "version": "0.38.33.27573",
+      "templateHash": "16661535065041252933"
     },
     "name": "API Management Services",
     "description": "This module deploys an API Management Service. The default deployment is set to use a Premium SKU to align with Microsoft WAF-aligned best practices. In most cases, non-prod deployments should use a lower-tier SKU."
@@ -2256,6 +2256,16 @@
       "metadata": {
         "description": "Optional. Enable the Developer Portal. The developer portal is not supported on the Consumption SKU."
       }
+    },
+    "publicNetworkAccess": {
+      "type": "string",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.ApiManagement/service@2024-05-01#properties/properties/properties/publicNetworkAccess"
+        },
+        "description": "Optional. Whether or not public endpoint access is allowed for this API Management service. If set to 'Disabled', private endpoints are the exclusive access method. MUST be enabled during service creation."
+      },
+      "nullable": true
     }
   },
   "variables": {
@@ -2319,6 +2329,7 @@
         "publisherName": "[parameters('publisherName')]",
         "notificationSenderEmail": "[parameters('notificationSenderEmail')]",
         "hostnameConfigurations": "[parameters('hostnameConfigurations')]",
+        "publicNetworkAccess": "[parameters('publicNetworkAccess')]",
         "additionalLocations": "[if(and(contains(parameters('sku'), 'Premium'), not(empty(parameters('additionalLocations')))), map(coalesce(parameters('additionalLocations'), createArray()), lambda('additLoc', createObject('location', lambdaVariables('additLoc').location, 'sku', lambdaVariables('additLoc').sku, 'disableGateway', tryGet(lambdaVariables('additLoc'), 'disableGateway'), 'natGatewayState', tryGet(lambdaVariables('additLoc'), 'natGatewayState'), 'publicIpAddressId', tryGet(lambdaVariables('additLoc'), 'publicIpAddressResourceId'), 'virtualNetworkConfiguration', tryGet(lambdaVariables('additLoc'), 'virtualNetworkConfiguration'), 'zones', map(coalesce(tryGet(lambdaVariables('additLoc'), 'availabilityZones'), createArray()), lambda('zone', string(lambdaVariables('zone'))))))), createArray())]",
         "customProperties": "[if(contains(parameters('sku'), 'Consumption'), null(), parameters('customProperties'))]",
         "certificates": "[parameters('certificates')]",
@@ -2415,7 +2426,7 @@
         "count": "[length(coalesce(parameters('apis'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-Api-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -2509,8 +2520,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "18116979725417472212"
+              "version": "0.38.33.27573",
+              "templateHash": "2623235378768134723"
             },
             "name": "API Management Service APIs",
             "description": "This module deploys an API Management Service API."
@@ -3076,7 +3087,7 @@
                 "count": "[length(coalesce(parameters('policies'), createArray()))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-Policy-{1}', deployment().name, copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3106,8 +3117,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "6713053293232206479"
+                      "version": "0.38.33.27573",
+                      "templateHash": "564087190067818909"
                     },
                     "name": "API Management Service APIs Policies",
                     "description": "This module deploys an API Management Service API Policy."
@@ -3225,7 +3236,7 @@
                 "count": "[length(coalesce(parameters('diagnostics'), createArray()))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-diagnostics-{1}', deployment().name, copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3283,8 +3294,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "18295485777200437093"
+                      "version": "0.38.33.27573",
+                      "templateHash": "5554806910326294464"
                     },
                     "name": "API Management Service APIs Diagnostics.",
                     "description": "This module deploys an API Management Service API Diagnostics."
@@ -3506,7 +3517,7 @@
                 "count": "[length(coalesce(parameters('operations'), createArray()))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-operation-{1}', deployment().name, copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3555,8 +3566,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "2321178038283517825"
+                      "version": "0.38.33.27573",
+                      "templateHash": "16910130262363182156"
                     },
                     "name": "API Management Service APIs Operations",
                     "description": "This module deploys an API Management Service API Operation."
@@ -3714,7 +3725,7 @@
                         "count": "[length(coalesce(parameters('policies'), createArray()))]"
                       },
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2022-09-01",
+                      "apiVersion": "2025-04-01",
                       "name": "[format('{0}-Policy-{1}', deployment().name, copyIndex())]",
                       "properties": {
                         "expressionEvaluationOptions": {
@@ -3747,8 +3758,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "17700550507187528779"
+                              "version": "0.38.33.27573",
+                              "templateHash": "5236050172800488885"
                             },
                             "name": "API Management Service API Operation Policies",
                             "description": "This module deploys an API Management Service API Operation Policy."
@@ -3904,7 +3915,7 @@
         "count": "[length(coalesce(parameters('apiVersionSets'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-ApiVersionSet-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -3944,8 +3955,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "8432939163648433289"
+              "version": "0.38.33.27573",
+              "templateHash": "9386717746629017522"
             },
             "name": "API Management Service API Version Sets",
             "description": "This module deploys an API Management Service API Version Set."
@@ -4091,7 +4102,7 @@
         "count": "[length(coalesce(parameters('authorizationServers'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-AuthorizationServer-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -4164,8 +4175,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "3719777024451822510"
+              "version": "0.38.33.27573",
+              "templateHash": "6909453157980881819"
             },
             "name": "API Management Service Authorization Servers",
             "description": "This module deploys an API Management Service Authorization Server."
@@ -4418,7 +4429,7 @@
         "count": "[length(coalesce(parameters('backends'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-Backend-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -4470,8 +4481,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "702614170296865172"
+              "version": "0.38.33.27573",
+              "templateHash": "10941349874015991272"
             },
             "name": "API Management Service Backends",
             "description": "This module deploys an API Management Service Backend."
@@ -4655,7 +4666,7 @@
         "count": "[length(coalesce(parameters('caches'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-Cache-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -4692,8 +4703,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "18421200341941067261"
+              "version": "0.38.33.27573",
+              "templateHash": "16885247957185905746"
             },
             "name": "API Management Service Caches",
             "description": "This module deploys an API Management Service Cache."
@@ -4819,7 +4830,7 @@
         "count": "[length(coalesce(parameters('apiDiagnostics'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-Api-Diagnostic-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -4877,8 +4888,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "18295485777200437093"
+              "version": "0.38.33.27573",
+              "templateHash": "5554806910326294464"
             },
             "name": "API Management Service APIs Diagnostics.",
             "description": "This module deploys an API Management Service API Diagnostics."
@@ -5102,7 +5113,7 @@
         "count": "[length(coalesce(parameters('identityProviders'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-IdentityProvider-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -5160,8 +5171,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "488153495468500989"
+              "version": "0.38.33.27573",
+              "templateHash": "6678229070440573363"
             },
             "name": "API Management Service Identity Providers",
             "description": "This module deploys an API Management Service Identity Provider."
@@ -5363,7 +5374,7 @@
         "count": "[length(coalesce(parameters('loggers'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-Logger-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -5403,8 +5414,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "4781753017990092454"
+              "version": "0.38.33.27573",
+              "templateHash": "16749168844612521666"
             },
             "name": "API Management Service Loggers",
             "description": "This module deploys an API Management Service Logger."
@@ -5548,7 +5559,7 @@
         "count": "[length(coalesce(parameters('namedValues'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-NamedValue-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -5588,8 +5599,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "1217065249823917300"
+              "version": "0.38.33.27573",
+              "templateHash": "11879365843187389745"
             },
             "name": "API Management Service Named Values",
             "description": "This module deploys an API Management Service Named Value."
@@ -5730,7 +5741,7 @@
         "count": "[length(coalesce(parameters('portalsettings'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-PortalSetting-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -5757,8 +5768,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "507546033383811759"
+              "version": "0.38.33.27573",
+              "templateHash": "12874552357445438330"
             },
             "name": "API Management Service Portal Settings",
             "description": "This module deploys an API Management Service Portal Setting."
@@ -5861,7 +5872,7 @@
         "count": "[length(coalesce(parameters('policies'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-Policy-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -5888,8 +5899,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "1890042083326760913"
+              "version": "0.38.33.27573",
+              "templateHash": "17795209216786328713"
             },
             "name": "API Management Service Policies",
             "description": "This module deploys an API Management Service Policy."
@@ -6001,7 +6012,7 @@
         "count": "[length(coalesce(parameters('products'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-Product-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -6053,8 +6064,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "16064108269009620660"
+              "version": "0.38.33.27573",
+              "templateHash": "16511334214286635558"
             },
             "name": "API Management Service Products",
             "description": "This module deploys an API Management Service Product."
@@ -6199,7 +6210,7 @@
                 "count": "[length(coalesce(parameters('apis'), createArray()))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-Api-{1}', deployment().name, copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -6226,8 +6237,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "5465704654489665391"
+                      "version": "0.38.33.27573",
+                      "templateHash": "8823922274640931436"
                     },
                     "name": "API Management Service Products APIs",
                     "description": "This module deploys an API Management Service Product API."
@@ -6318,7 +6329,7 @@
                 "count": "[length(coalesce(parameters('groups'), createArray()))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-Group-{1}', deployment().name, copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -6345,8 +6356,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "13523839423669576454"
+                      "version": "0.38.33.27573",
+                      "templateHash": "11439917552911166273"
                     },
                     "name": "API Management Service Products Groups",
                     "description": "This module deploys an API Management Service Product Group."
@@ -6488,7 +6499,7 @@
         "count": "[length(coalesce(parameters('subscriptions'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-Apim-Subscription-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -6534,8 +6545,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "8450474183617387575"
+              "version": "0.38.33.27573",
+              "templateHash": "1654486196961904035"
             },
             "name": "API Management Service Subscriptions",
             "description": "This module deploys an API Management Service Subscription."

--- a/avm/res/api-management/service/tests/e2e/max/main.test.bicep
+++ b/avm/res/api-management/service/tests/e2e/max/main.test.bicep
@@ -100,6 +100,7 @@ module testDeployment '../../../main.bicep' = [
       virtualNetworkType: 'Internal'
       subnetResourceId: nestedDependencies.outputs.subnetResourceIdRegion1
       publicIpAddressResourceId: nestedDependencies.outputs.publicIPResourceIdRegion1
+      publicNetworkAccess: 'Enabled'
       apis: [
         {
           displayName: 'Echo API'


### PR DESCRIPTION
## Description

Added support for `publicNetworkAccess` parameter

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.api-management.service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.api-management.service.yml/badge.svg?branch=users%2Falsehr%2FapiManagementPublicAccess&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.api-management.service.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
