### PR TITLE
fix: Updated checks

### DIFF
--- a/utilities/pipelines/staticValidation/compliance/module.tests.ps1
+++ b/utilities/pipelines/staticValidation/compliance/module.tests.ps1
@@ -2368,7 +2368,7 @@ Describe 'API version tests' -Tag 'ApiCheck' {
             foreach ($resource in $nestedResources) {
 
                 switch ($resource.type) {
-                    { $PSItem -like '*diagnosticsettings*' } {
+                    { $PSItem -match '[\\|\/]diagnosticSettings$' } {
                         $testCases += @{
                             moduleName                     = $moduleFolderName
                             resourceType                   = 'diagnosticSettings'
@@ -2379,7 +2379,7 @@ Describe 'API version tests' -Tag 'ApiCheck' {
                         }
                         break
                     }
-                    { $PSItem -like '*locks' } {
+                    { $PSItem -match '[\\|\/]locks$' } {
                         $testCases += @{
                             moduleName                     = $moduleFolderName
                             resourceType                   = 'locks'
@@ -2390,7 +2390,7 @@ Describe 'API version tests' -Tag 'ApiCheck' {
                         }
                         break
                     }
-                    { $PSItem -like '*roleAssignments' } {
+                    { $PSItem -match '[\\|\/]roleAssignments$' } {
                         $testCases += @{
                             moduleName                     = $moduleFolderName
                             resourceType                   = 'roleAssignments'
@@ -2401,7 +2401,7 @@ Describe 'API version tests' -Tag 'ApiCheck' {
                         }
                         break
                     }
-                    { $PSItem -like '*privateEndpoints' -and ($PSItem -notlike '*managedPrivateEndpoints') } {
+                    { $PSItem -match '[\\|\/]privateEndpoints$' } {
                         $testCases += @{
                             moduleName                     = $moduleFolderName
                             resourceType                   = 'privateEndpoints'


### PR DESCRIPTION
## Description

In the current implementation, a parameter like `sql-role-assignment` is detected like `roleAssignments` which is incorrect and lead to incorrect warnings. Hence refined all checks to use regex `-match` instead of a classic `-like`  to be more explicit

Example before the fix ([ref](https://github.com/Azure/bicep-registry-modules/actions/runs/18469402506)):
<img width="1517" height="253" alt="image" src="https://github.com/user-attachments/assets/fb5d04d3-9351-45b7-958e-465166e3e7aa" />

Example after the fix ([ref](https://github.com/Azure/bicep-registry-modules/actions/runs/18678346376)):
<img width="206" height="70" alt="image" src="https://github.com/user-attachments/assets/a455ab67-e27d-4d08-b9ab-1fd2fd63814d" />

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.ptn.aca-lza.hosting-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.aca-lza.hosting-environment.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.aca-lza.hosting-environment.yml) (unrelated)
[![avm.ptn.ai-platform.baseline](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.ai-platform.baseline.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.ai-platform.baseline.yml) (unrelated PSRule)
[![avm.ptn.app-service-lza.hosting-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app-service-lza.hosting-environment.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app-service-lza.hosting-environment.yml) (unrelated)
[![avm.ptn.app.container-job-toolkit.yml](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app.container-job-toolkit.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app.container-job-toolkit.yml) (unrelated)
[![avm.ptn.app.cosmos-db-account-container-app](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app.cosmos-db-account-container-app.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.app.cosmos-db-account-container-app.yml)
[![avm.ptn.authorization.role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-assignment.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-assignment.yml) (unrelated)
[![avm.ptn.azd.aks](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.aks.yml) (unrelated PSRule)
[![avm.ptn.azd.apim-api](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.apim-api.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.apim-api.yml)
[![avm.ptn.azd.container-app-upsert](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-app-upsert.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-app-upsert.yml) 
[![avm.ptn.azd.container-apps-stack](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-apps-stack.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.container-apps-stack.yml) 
[![avm.ptn.azd.insights-dashboard](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.insights-dashboard.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.insights-dashboard.yml)       
[![avm.ptn.azd.monitoring](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.monitoring.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.azd.monitoring.yml)
[![avm.ptn.data.private-analytical-workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.data.private-analytical-workspace.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.data.private-analytical-workspace.yml) (unrelated - PSRule)
[![avm.ptn.deployment-script.import-image-to-acr](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.deployment-script.import-image-to-acr.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.deployment-script.import-image-to-acr.yml)
[![avm.ptn.dev-ops.cicd-agents-and-runners](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.dev-ops.cicd-agents-and-runners.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.dev-ops.cicd-agents-and-runners.yml)
[![avm.ptn.finops-toolkit.finops-hub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.finops-toolkit.finops-hub.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.finops-toolkit.finops-hub.yml) (unrelated)
[![avm.ptn.lz.sub-vending](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.lz.sub-vending.yml) (unrelated)
[![avm.ptn.mgmt-groups.subscription-placement](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.mgmt-groups.subscription-placement.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.mgmt-groups.subscription-placement.yml)
[![avm.ptn.network.hub-networking](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.hub-networking.yml)       
[![avm.ptn.network.private-link-private-dns-zones](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.private-link-private-dns-zones.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.network.private-link-private-dns-zones.yml)
[![avm.ptn.policy-insights.remediation](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.policy-insights.remediation.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.policy-insights.remediation.yml)
[![avm.ptn.sa.build-your-own-copilot](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.build-your-own-copilot.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.build-your-own-copilot.yml) (unrelated)
[![avm.ptn.sa.chat-with-your-data](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.chat-with-your-data.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.chat-with-your-data.yml) (unrelated)       
[![avm.ptn.sa.content-processing](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.content-processing.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.content-processing.yml) (unrelated)
[![avm.ptn.sa.conversation-knowledge-mining](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.conversation-knowledge-mining.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.conversation-knowledge-mining.yml) (unrelated)
[![avm.ptn.sa.document-knowledge-mining](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.document-knowledge-mining.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.document-knowledge-mining.yml) (unrelated)
[![avm.ptn.sa.modernize-your-code](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.modernize-your-code.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.modernize-your-code.yml) (unrelated)    
[![avm.ptn.sa.multi-agent-custom-automation-engine](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.multi-agent-custom-automation-engine.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.sa.multi-agent-custom-automation-engine.yml)
[![avm.ptn.security.security-center](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.security.security-center.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.security.security-center.yml) (unrelated)
[![avm.ptn.subscription.service-health-alerts](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.subscription.service-health-alerts.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.subscription.service-health-alerts.yml)
[![avm.ptn.virtual-machine-images.azure-image-builder](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml)
[![avm.res.aad.domain-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.aad.domain-service.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.aad.domain-service.yml)
[![avm.res.alerts-management.action-rule](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.alerts-management.action-rule.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.alerts-management.action-rule.yml)
[![avm.res.analysis-services.server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.analysis-services.server.yml) 
[![avm.res.api-management.service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.api-management.service.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.api-management.service.yml)       
[![avm.res.app-configuration.configuration-store](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app-configuration.configuration-store.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app-configuration.configuration-store.yml)
[![avm.res.app.container-app](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.container-app.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.container-app.yml)
[![avm.res.app.job](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.job.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.job.yml)
[![avm.res.app.managed-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.managed-environment.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.managed-environment.yml)    
[![avm.res.app.session-pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.session-pool.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.session-pool.yml)
[![avm.res.authorization.policy-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.authorization.policy-assignment.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.authorization.policy-assignment.yml) (unrelated)
[![avm.res.authorization.role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.authorization.role-assignment.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.authorization.role-assignment.yml)
[![avm.res.automation.automation-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.automation.automation-account.yml)
[![avm.res.azure-stack-hci.cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.cluster.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.cluster.yml)    
[![avm.res.azure-stack-hci.logical-network](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.logical-network.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.logical-network.yml)
[![avm.res.azure-stack-hci.marketplace-gallery-image](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.marketplace-gallery-image.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.marketplace-gallery-image.yml) (unrelated)
[![avm.res.azure-stack-hci.network-interface](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.network-interface.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.network-interface.yml)
[![avm.res.azure-stack-hci.virtual-hard-disk](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.virtual-hard-disk.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.virtual-hard-disk.yml)
[![avm.res.azure-stack-hci.virtual-machine-instance](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.virtual-machine-instance.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.azure-stack-hci.virtual-machine-instance.yml)
[![avm.res.batch.batch-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.batch.batch-account.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.batch.batch-account.yml)
[![avm.res.cache.redis-enterprise](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cache.redis-enterprise.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cache.redis-enterprise.yml)       
[![avm.res.cache.redis](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cache.redis.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cache.redis.yml)
[![avm.res.cdn.profile](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml)
[![avm.res.cognitive-services.account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml)
[![avm.res.communication.communication-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.communication-service.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.communication-service.yml)
[![avm.res.communication.email-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.email-service.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.email-service.yml)
[![avm.res.compute.availability-set](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.availability-set.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.availability-set.yml) 
[![avm.res.compute.disk-encryption-set](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk-encryption-set.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk-encryption-set.yml)
[![avm.res.compute.disk](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk.yml)
[![avm.res.compute.gallery](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml)
[![avm.res.compute.image](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.image.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.image.yml)
[![avm.res.compute.proximity-placement-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.proximity-placement-group.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.proximity-placement-group.yml)
[![avm.res.compute.ssh-public-key](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.ssh-public-key.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.ssh-public-key.yml)       
[![avm.res.compute.virtual-machine-scale-set](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine-scale-set.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine-scale-set.yml)
[![avm.res.compute.virtual-machine](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.virtual-machine.yml)    
[![avm.res.consumption.budget](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.consumption.budget.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.consumption.budget.yml)
[![avm.res.container-instance.container-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-instance.container-group.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-instance.container-group.yml)
[![avm.res.container-registry.registry](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-registry.registry.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-registry.registry.yml) (unrelated)
[![avm.res.container-service.managed-cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-service.managed-cluster.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-service.managed-cluster.yml)
[![avm.res.data-factory.factory](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.data-factory.factory.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.data-factory.factory.yml) (unrelated)
[![avm.res.data-protection.backup-vault](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.data-protection.backup-vault.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.data-protection.backup-vault.yml)
[![avm.res.databricks.access-connector](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.access-connector.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.access-connector.yml) (unrelated)
[![avm.res.databricks.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.workspace.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.databricks.workspace.yml) (unrelated)
[![avm.res.db-for-my-sql.flexible-server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.db-for-my-sql.flexible-server.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.db-for-my-sql.flexible-server.yml)
[![avm.res.db-for-postgre-sql.flexible-server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.db-for-postgre-sql.flexible-server.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.db-for-postgre-sql.flexible-server.yml)
[![avm.res.desktop-virtualization.application-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.application-group.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.application-group.yml)
[![avm.res.desktop-virtualization.host-pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.host-pool.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.host-pool.yml)
[![avm.res.desktop-virtualization.scaling-plan](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.scaling-plan.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.scaling-plan.yml)
[![avm.res.desktop-virtualization.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.workspace.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.workspace.yml)
[![avm.res.dev-center.devcenter](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.devcenter.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.devcenter.yml)
[![avm.res.dev-center.network-connection](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.network-connection.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.network-connection.yml)
[![avm.res.dev-center.project](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.project.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.project.yml)
[![avm.res.dev-ops-infrastructure.pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-ops-infrastructure.pool.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-ops-infrastructure.pool.yml)
[![avm.res.dev-test-lab.lab](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-test-lab.lab.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-test-lab.lab.yml)
[![avm.res.digital-twins.digital-twins-instance](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.digital-twins.digital-twins-instance.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.digital-twins.digital-twins-instance.yml)
[![avm.res.document-db.database-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.document-db.database-account.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.document-db.database-account.yml)
[![avm.res.document-db.mongo-cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.document-db.mongo-cluster.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.document-db.mongo-cluster.yml)
[![avm.res.elastic-san.elastic-san](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.elastic-san.elastic-san.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.elastic-san.elastic-san.yml)    
[![avm.res.event-grid.domain](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.domain.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.domain.yml)
[![avm.res.event-grid.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.namespace.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.namespace.yml)
[![avm.res.event-grid.system-topic](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.system-topic.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.system-topic.yml)    
[![avm.res.event-grid.topic](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.topic.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-grid.topic.yml)
[![avm.res.event-hub.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-hub.namespace.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.event-hub.namespace.yml)
[![avm.res.fabric.capacity](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.fabric.capacity.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.fabric.capacity.yml)
[![avm.res.health-bot.health-bot](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.health-bot.health-bot.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.health-bot.health-bot.yml)
[![avm.res.healthcare-apis.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.healthcare-apis.workspace.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.healthcare-apis.workspace.yml)
[![avm.res.hybrid-compute.gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.gateway.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.gateway.yml)       
[![avm.res.hybrid-compute.license](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.license.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.license.yml)       
[![avm.res.hybrid-compute.machine](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.machine.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-compute.machine.yml)       
[![avm.res.hybrid-container-service.provisioned-cluster-instance](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-container-service.provisioned-cluster-instance.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.hybrid-container-service.provisioned-cluster-instance.yml)
[![avm.res.insights.action-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.action-group.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.action-group.yml)
[![avm.res.insights.activity-log-alert](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.activity-log-alert.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.activity-log-alert.yml)
[![avm.res.insights.component](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.component.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.component.yml)
[![avm.res.insights.data-collection-endpoint](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-endpoint.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-endpoint.yml)
[![avm.res.insights.data-collection-rule](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-rule.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.data-collection-rule.yml)
[![avm.res.insights.diagnostic-setting](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.diagnostic-setting.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.diagnostic-setting.yml)
[![avm.res.insights.metric-alert](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.metric-alert.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.metric-alert.yml)
[![avm.res.insights.private-link-scope](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.private-link-scope.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.private-link-scope.yml)
[![avm.res.insights.scheduled-query-rule](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.scheduled-query-rule.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.scheduled-query-rule.yml)
[![avm.res.insights.webtest](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.webtest.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.webtest.yml)
[![avm.res.key-vault.vault](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml)
[![avm.res.kubernetes-configuration.extension](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-configuration.extension.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-configuration.extension.yml)
[![avm.res.kubernetes-configuration.flux-configuration](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-configuration.flux-configuration.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-configuration.flux-configuration.yml)
[![avm.res.kubernetes-runtime.load-balancer](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-runtime.load-balancer.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes-runtime.load-balancer.yml)
[![avm.res.kubernetes.connected-cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes.connected-cluster.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kubernetes.connected-cluster.yml)
[![avm.res.kusto.cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kusto.cluster.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.kusto.cluster.yml)
[![avm.res.load-test-service.load-test](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.load-test-service.load-test.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.load-test-service.load-test.yml)
[![avm.res.logic.workflow](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.logic.workflow.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.logic.workflow.yml)
[![avm.res.machine-learning-services.registry](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.machine-learning-services.registry.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.machine-learning-services.registry.yml)
[![avm.res.machine-learning-services.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.machine-learning-services.workspace.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.machine-learning-services.workspace.yml)
[![avm.res.maintenance.configuration-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.configuration-assignment.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.configuration-assignment.yml)
[![avm.res.maintenance.maintenance-configuration](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.maintenance-configuration.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.maintenance-configuration.yml)
[![avm.res.managed-identity.user-assigned-identity](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-identity.user-assigned-identity.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-identity.user-assigned-identity.yml)
[![avm.res.managed-services.registration-definition](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-services.registration-definition.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.managed-services.registration-definition.yml)
[![avm.res.management.management-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.management.management-group.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.management.management-group.yml)
[![avm.res.management.service-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.management.service-group.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.management.service-group.yml) 
[![avm.res.maps.account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maps.account.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maps.account.yml)
[![avm.res.net-app.net-app-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.net-app.net-app-account.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.net-app.net-app-account.yml)    
[![avm.res.network.application-gateway-web-application-firewall-policy](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-gateway-web-application-firewall-policy.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-gateway-web-application-firewall-policy.yml)
[![avm.res.network.application-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-gateway.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-gateway.yml)
[![avm.res.network.application-security-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-security-group.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.application-security-group.yml)
[![avm.res.network.azure-firewall](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.azure-firewall.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.azure-firewall.yml)       
[![avm.res.network.bastion-host](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.bastion-host.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.bastion-host.yml)
[![avm.res.network.connection](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.connection.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.connection.yml)
[![avm.res.network.ddos-protection-plan](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ddos-protection-plan.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ddos-protection-plan.yml)
[![avm.res.network.dns-forwarding-ruleset](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-forwarding-ruleset.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-forwarding-ruleset.yml)
[![avm.res.network.dns-resolver](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-resolver.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-resolver.yml)
[![avm.res.network.dns-zone](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-zone.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.dns-zone.yml)
[![avm.res.network.express-route-circuit](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-circuit.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-circuit.yml)
[![avm.res.network.express-route-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-gateway.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-gateway.yml)
[![avm.res.network.express-route-port](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-port.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.express-route-port.yml)
[![avm.res.network.firewall-policy](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.firewall-policy.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.firewall-policy.yml)    
[![avm.res.network.front-door-web-application-firewall-policy](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.front-door-web-application-firewall-policy.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.front-door-web-application-firewall-policy.yml)
[![avm.res.network.ip-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ip-group.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.ip-group.yml)
[![avm.res.network.load-balancer](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.load-balancer.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.load-balancer.yml)
[![avm.res.network.local-network-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.local-network-gateway.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.local-network-gateway.yml)
[![avm.res.network.nat-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml)
[![avm.res.network.network-interface](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-interface.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-interface.yml)
[![avm.res.network.network-manager](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-manager.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-manager.yml)    
[![avm.res.network.network-security-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-security-group.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-security-group.yml)
[![avm.res.network.network-security-perimeter](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-security-perimeter.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-security-perimeter.yml)
[![avm.res.network.network-watcher](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-watcher.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.network-watcher.yml)    
[![avm.res.network.p2s-vpn-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.p2s-vpn-gateway.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.p2s-vpn-gateway.yml)    
[![avm.res.network.private-dns-zone](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-dns-zone.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-dns-zone.yml) 
[![avm.res.network.private-endpoint](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-endpoint.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-endpoint.yml) 
[![avm.res.network.private-link-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-link-service.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-link-service.yml)
[![avm.res.network.public-ip-address](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml)
[![avm.res.network.public-ip-prefix](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-prefix.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-prefix.yml) 
[![avm.res.network.route-table](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.route-table.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.route-table.yml)
[![avm.res.network.service-endpoint-policy](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.service-endpoint-policy.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.service-endpoint-policy.yml)
[![avm.res.network.trafficmanagerprofile](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.trafficmanagerprofile.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.trafficmanagerprofile.yml)
[![avm.res.network.virtual-hub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-hub.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-hub.yml)
[![avm.res.network.virtual-network-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network-gateway.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network-gateway.yml)
[![avm.res.network.virtual-network](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network.yml)    
[![avm.res.network.virtual-wan](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-wan.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-wan.yml)
[![avm.res.network.vpn-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-gateway.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-gateway.yml)
[![avm.res.network.vpn-server-configuration](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-server-configuration.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-server-configuration.yml)
[![avm.res.network.vpn-site](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-site.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.vpn-site.yml)
[![avm.res.operational-insights.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml)
[![avm.res.operations-management.solution](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.operations-management.solution.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.operations-management.solution.yml)
[![avm.res.portal.dashboard](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.portal.dashboard.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.portal.dashboard.yml)
[![avm.res.power-bi-dedicated.capacity](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.power-bi-dedicated.capacity.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.power-bi-dedicated.capacity.yml)
[![avm.res.purview.account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.purview.account.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.purview.account.yml)
[![avm.res.recovery-services.vault](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.recovery-services.vault.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.recovery-services.vault.yml)    
[![avm.res.relay.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.relay.namespace.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.relay.namespace.yml)
[![avm.res.resource-graph.query](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resource-graph.query.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resource-graph.query.yml)
[![avm.res.resources.deployment-script](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.deployment-script.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.deployment-script.yml)
[![avm.res.resources.resource-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.resource-group.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.resources.resource-group.yml) 
[![avm.res.search.search-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.search.search-service.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.search.search-service.yml)
[![avm.res.security-insights.data-connector](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.security-insights.data-connector.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.security-insights.data-connector.yml)
[![avm.res.security-insights.setting](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.security-insights.setting.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.security-insights.setting.yml)
[![avm.res.service-bus.namespace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-bus.namespace.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-bus.namespace.yml)
[![avm.res.service-fabric.cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-fabric.cluster.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-fabric.cluster.yml)       
[![avm.res.service-networking.traffic-controller](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-networking.traffic-controller.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.service-networking.traffic-controller.yml)
[![avm.res.signal-r-service.signal-r](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.signal-r.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.signal-r.yml)
[![avm.res.signal-r-service.web-pub-sub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.web-pub-sub.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.signal-r-service.web-pub-sub.yml)
[![avm.res.sql.instance-pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.instance-pool.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.instance-pool.yml)
[![avm.res.sql.managed-instance](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.managed-instance.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.managed-instance.yml)
[![avm.res.sql.server](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.sql.server.yml)
[![avm.res.storage.storage-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml)    
[![avm.res.synapse.private-link-hub](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.synapse.private-link-hub.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.synapse.private-link-hub.yml) 
[![avm.res.synapse.workspace](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.synapse.workspace.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.synapse.workspace.yml)
[![avm.res.virtual-machine-images.image-template](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.virtual-machine-images.image-template.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.virtual-machine-images.image-template.yml)
[![avm.res.web.connection](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.connection.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.connection.yml)
[![avm.res.web.hosting-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.hosting-environment.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.hosting-environment.yml)    
[![avm.res.web.serverfarm](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.serverfarm.yml)
[![avm.res.web.site](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.site.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.site.yml)
[![avm.res.web.static-site](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.static-site.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.static-site.yml)
[![avm.utl.types.avm-common-types](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml/badge.svg?branch=users%2Falsehr%2FroleDetect&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml)       


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
