### PR TITLE
fix: Update cdn/profile secretVersion to handle optional values (follow up to #6097)

### DIFF
--- a/avm/res/cdn/profile/CHANGELOG.md
+++ b/avm/res/cdn/profile/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/CHANGELOG.md).
 
+## 0.16.1
+
+### Changes
+
+- Fixed bug when using `secrets` that treats the `secretVersion` as a mandatory property even though it is not.
+
+### Breaking Changes
+
+- None
+
 ## 0.16.0
 
 ### Changes

--- a/avm/res/cdn/profile/main.bicep
+++ b/avm/res/cdn/profile/main.bicep
@@ -232,7 +232,7 @@ module profile_secrets 'secret/main.bicep' = [
       secretSourceResourceId: secret.secretSourceResourceId
       subjectAlternativeNames: secret.?subjectAlternativeNames
       useLatestVersion: secret.?useLatestVersion
-      secretVersion: secret.secretVersion
+      secretVersion: secret.?secretVersion
     }
   }
 ]

--- a/avm/res/cdn/profile/main.json
+++ b/avm/res/cdn/profile/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.38.33.27573",
-      "templateHash": "17365480520348784928"
+      "templateHash": "15130791660840705978"
     },
     "name": "CDN Profiles",
     "description": "This module deploys a CDN Profile."
@@ -1648,7 +1648,7 @@
             "value": "[tryGet(coalesce(parameters('secrets'), createArray())[copyIndex()], 'useLatestVersion')]"
           },
           "secretVersion": {
-            "value": "[coalesce(parameters('secrets'), createArray())[copyIndex()].secretVersion]"
+            "value": "[tryGet(coalesce(parameters('secrets'), createArray())[copyIndex()], 'secretVersion')]"
           }
         },
         "template": {


### PR DESCRIPTION
## Description

> This PR replaces #6097 to allow for upstream testing. Original author: @jupacaza

Original description:
If secretVersion is not passed in the type, it fails with error:

``` text
'The language expression property 'secretVersion' doesn't exist, available properties are 'name, type, useLatestVersion, secretSourceResourceId'.'
```

By checking for null in the optional value and defaulting to '' we no longer are required to pass the secretVersion property.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.cdn.profile](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml/badge.svg?branch=users%2Falsehr%2F6097_CDN&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [X] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` (`bicep build`) locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
