### PR TITLE
fix: allow DNS servers to be set without DNS proxy

### DIFF
--- a/avm/res/network/firewall-policy/CHANGELOG.md
+++ b/avm/res/network/firewall-policy/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/firewall-policy/CHANGELOG.md).
 
+## 0.3.3
+
+### Changes
+
+- Allowed DNS servers to be provided and set without enabling DNS proxy. Fixing issue [6071](https://github.com/Azure/bicep-registry-modules/issues/6071).
+
+### Breaking Changes
+
+- None
+
 ## 0.3.2
 
 ### Changes

--- a/avm/res/network/firewall-policy/README.md
+++ b/avm/res/network/firewall-policy/README.md
@@ -17,8 +17,8 @@ This module deploys a Firewall Policy.
 | :-- | :-- | :-- |
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
-| `Microsoft.Network/firewallPolicies` | 2024-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_firewallpolicies.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/firewallPolicies)</li></ul> |
-| `Microsoft.Network/firewallPolicies/ruleCollectionGroups` | 2023-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_firewallpolicies_rulecollectiongroups.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-04-01/firewallPolicies/ruleCollectionGroups)</li></ul> |
+| `Microsoft.Network/firewallPolicies` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_firewallpolicies.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/firewallPolicies)</li></ul> |
+| `Microsoft.Network/firewallPolicies/ruleCollectionGroups` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_firewallpolicies_rulecollectiongroups.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/firewallPolicies/ruleCollectionGroups)</li></ul> |
 
 ## Usage examples
 
@@ -102,6 +102,7 @@ module firewallPolicy 'br/public:avm/res/network/firewall-policy:<version>' = {
     name: 'nfpmax001'
     // Non-required parameters
     allowSqlRedirect: true
+    enableProxy: true
     intrusionDetection: {
       mode: 'Alert'
     }
@@ -172,6 +173,10 @@ module firewallPolicy 'br/public:avm/res/network/firewall-policy:<version>' = {
         ]
       }
     ]
+    servers: [
+      '10.0.0.4'
+      '10.0.0.5'
+    ]
     snat: {
       autoLearnPrivateRanges: 'Enabled'
     }
@@ -203,6 +208,9 @@ module firewallPolicy 'br/public:avm/res/network/firewall-policy:<version>' = {
     },
     // Non-required parameters
     "allowSqlRedirect": {
+      "value": true
+    },
+    "enableProxy": {
       "value": true
     },
     "intrusionDetection": {
@@ -287,6 +295,12 @@ module firewallPolicy 'br/public:avm/res/network/firewall-policy:<version>' = {
         }
       ]
     },
+    "servers": {
+      "value": [
+        "10.0.0.4",
+        "10.0.0.5"
+      ]
+    },
     "snat": {
       "value": {
         "autoLearnPrivateRanges": "Enabled"
@@ -320,6 +334,7 @@ using 'br/public:avm/res/network/firewall-policy:<version>'
 param name = 'nfpmax001'
 // Non-required parameters
 param allowSqlRedirect = true
+param enableProxy = true
 param intrusionDetection = {
   mode: 'Alert'
 }
@@ -389,6 +404,10 @@ param ruleCollectionGroups = [
       }
     ]
   }
+]
+param servers = [
+  '10.0.0.4'
+  '10.0.0.5'
 ]
 param snat = {
   autoLearnPrivateRanges: 'Enabled'

--- a/avm/res/network/firewall-policy/main.bicep
+++ b/avm/res/network/firewall-policy/main.bicep
@@ -144,7 +144,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource firewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
+resource firewallPolicy 'Microsoft.Network/firewallPolicies@2024-10-01' = {
   name: name
   location: location
   tags: tags
@@ -155,7 +155,7 @@ resource firewallPolicy 'Microsoft.Network/firewallPolicies@2024-05-01' = {
           id: basePolicyResourceId
         }
       : null
-    dnsSettings: enableProxy
+    dnsSettings: (enableProxy || servers != null)
       ? {
           enableProxy: enableProxy
           servers: servers ?? []

--- a/avm/res/network/firewall-policy/main.json
+++ b/avm/res/network/firewall-policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.5.1644",
-      "templateHash": "12625537687605288449"
+      "version": "0.38.33.27573",
+      "templateHash": "15434541666482255594"
     },
     "name": "Firewall Policies",
     "description": "This module deploys a Firewall Policy."
@@ -571,14 +571,14 @@
     },
     "firewallPolicy": {
       "type": "Microsoft.Network/firewallPolicies",
-      "apiVersion": "2024-05-01",
+      "apiVersion": "2024-10-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
       "identity": "[variables('identity')]",
       "properties": {
         "basePolicy": "[if(not(empty(parameters('basePolicyResourceId'))), createObject('id', parameters('basePolicyResourceId')), null())]",
-        "dnsSettings": "[if(parameters('enableProxy'), createObject('enableProxy', parameters('enableProxy'), 'servers', coalesce(parameters('servers'), createArray())), null())]",
+        "dnsSettings": "[if(or(parameters('enableProxy'), not(equals(parameters('servers'), null()))), createObject('enableProxy', parameters('enableProxy'), 'servers', coalesce(parameters('servers'), createArray())), null())]",
         "insights": "[if(parameters('insightsIsEnabled'), createObject('isEnabled', parameters('insightsIsEnabled'), 'logAnalyticsResources', createObject('defaultWorkspaceId', createObject('id', parameters('defaultWorkspaceResourceId')), 'workspaces', parameters('workspaces')), 'retentionDays', parameters('retentionDays')), null())]",
         "intrusionDetection": "[parameters('intrusionDetection')]",
         "sku": {
@@ -668,8 +668,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.5.1644",
-              "templateHash": "953429192279816820"
+              "version": "0.38.33.27573",
+              "templateHash": "10020031119765468926"
             },
             "name": "Firewall Policy Rule Collection Groups",
             "description": "This module deploys a Firewall Policy Rule Collection Group."
@@ -705,12 +705,12 @@
             "firewallPolicy": {
               "existing": true,
               "type": "Microsoft.Network/firewallPolicies",
-              "apiVersion": "2023-04-01",
+              "apiVersion": "2024-10-01",
               "name": "[parameters('firewallPolicyName')]"
             },
             "ruleCollectionGroup": {
               "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
-              "apiVersion": "2023-04-01",
+              "apiVersion": "2024-10-01",
               "name": "[format('{0}/{1}', parameters('firewallPolicyName'), parameters('name'))]",
               "properties": {
                 "priority": "[parameters('priority')]",
@@ -775,7 +775,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('firewallPolicy', '2024-05-01', 'full').location]"
+      "value": "[reference('firewallPolicy', '2024-10-01', 'full').location]"
     }
   }
 }

--- a/avm/res/network/firewall-policy/rule-collection-group/README.md
+++ b/avm/res/network/firewall-policy/rule-collection-group/README.md
@@ -12,7 +12,7 @@ This module deploys a Firewall Policy Rule Collection Group.
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.Network/firewallPolicies/ruleCollectionGroups` | 2023-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_firewallpolicies_rulecollectiongroups.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2023-04-01/firewallPolicies/ruleCollectionGroups)</li></ul> |
+| `Microsoft.Network/firewallPolicies/ruleCollectionGroups` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_firewallpolicies_rulecollectiongroups.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/firewallPolicies/ruleCollectionGroups)</li></ul> |
 
 ## Parameters
 

--- a/avm/res/network/firewall-policy/rule-collection-group/main.bicep
+++ b/avm/res/network/firewall-policy/rule-collection-group/main.bicep
@@ -13,11 +13,11 @@ param priority int
 @description('Optional. Group of Firewall Policy rule collections.')
 param ruleCollections array?
 
-resource firewallPolicy 'Microsoft.Network/firewallPolicies@2023-04-01' existing = {
+resource firewallPolicy 'Microsoft.Network/firewallPolicies@2024-10-01' existing = {
   name: firewallPolicyName
 }
 
-resource ruleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2023-04-01' = {
+resource ruleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2024-10-01' = {
   name: name
   parent: firewallPolicy
   properties: {

--- a/avm/res/network/firewall-policy/rule-collection-group/main.json
+++ b/avm/res/network/firewall-policy/rule-collection-group/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "16872244979902179380"
+      "version": "0.38.33.27573",
+      "templateHash": "10020031119765468926"
     },
     "name": "Firewall Policy Rule Collection Groups",
     "description": "This module deploys a Firewall Policy Rule Collection Group."
@@ -42,12 +42,12 @@
     "firewallPolicy": {
       "existing": true,
       "type": "Microsoft.Network/firewallPolicies",
-      "apiVersion": "2023-04-01",
+      "apiVersion": "2024-10-01",
       "name": "[parameters('firewallPolicyName')]"
     },
     "ruleCollectionGroup": {
       "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
-      "apiVersion": "2023-04-01",
+      "apiVersion": "2024-10-01",
       "name": "[format('{0}/{1}', parameters('firewallPolicyName'), parameters('name'))]",
       "properties": {
         "priority": "[parameters('priority')]",

--- a/avm/res/network/firewall-policy/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/firewall-policy/tests/e2e/max/main.test.bicep
@@ -134,6 +134,11 @@ module testDeployment '../../../main.bicep' = [
       intrusionDetection: {
         mode: 'Alert'
       }
+      servers: [
+        '10.0.0.4'
+        '10.0.0.5'
+      ]
+      enableProxy: true
     }
   }
 ]


### PR DESCRIPTION
## Description

Allow DNS servers to be set without DNS proxy

Fixes #6071 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.network.firewall-policy](https://github.com/jtracey93/bicep-registry-modules/actions/workflows/avm.res.network.firewall-policy.yml/badge.svg?branch=feat%2Ffw-pol-dns-isolated)](https://github.com/jtracey93/bicep-registry-modules/actions/workflows/avm.res.network.firewall-policy.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
