### PR TITLE
documentation: Update GitHub Copilot prompts, chatmode and add Microsoft Learn MCP

### DIFF
--- a/.github/chatmodes/azure-verified-modules-bicep.chatmode.md
+++ b/.github/chatmodes/azure-verified-modules-bicep.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Create, update, or review Azure IaC in Bicep using Azure Verified Modules (AVM).'
-tools: ['edit', 'search', 'new', 'runCommands', 'runTasks', 'usages', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'extensions', 'todos', 'runTests', 'documentation', 'search', 'github']
+tools: ['edit', 'search', 'new', 'runCommands', 'runTasks', 'Azure MCP/documentation', 'Azure MCP/search', 'Azure MCP/documentation', 'Azure MCP/search', 'Microsoft Learn/*', 'github/*', 'usages', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'extensions', 'todos']
 ---
 # Azure AVM Bicep Mode
 

--- a/.github/prompts/create-plan-update-ARM-API.prompt.md
+++ b/.github/prompts/create-plan-update-ARM-API.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Analyze Azure Verified Module (AVM) Bicep files for ARM API version updates and create implementation plans.'
-tools: ['search', 'runCommands', 'runTasks', 'usages', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'todos', 'runTests', 'documentation', 'search']
+tools: ['edit', 'search', 'new', 'runCommands', 'runTasks', 'Azure MCP/documentation', 'Azure MCP/search', 'Azure MCP/documentation', 'Azure MCP/search', 'Microsoft Learn/*', 'usages', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'todos']
 ---
 
 # Analyze ARM API Version Updates for Resource Module

--- a/.github/prompts/create-plan-update-ARM-API.prompt.md
+++ b/.github/prompts/create-plan-update-ARM-API.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-description: 'Analyze Azure Verified Module (AVM) Bicep files for ARM API version updates and create implementation plans.'
+description: 'Analyze AVM Bicep files for ARM API version updates and create implementation plans.'
 tools: ['edit', 'search', 'new', 'runCommands', 'runTasks', 'Azure MCP/documentation', 'Azure MCP/search', 'Azure MCP/documentation', 'Azure MCP/search', 'Microsoft Learn/*', 'usages', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'todos']
 ---
 

--- a/.github/prompts/tech-debt-analysis-ARM-API.prompt.md
+++ b/.github/prompts/tech-debt-analysis-ARM-API.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-description: 'Analyze Azure Verified Module (AVM) Bicep files and examples for technical debt, inconsistencies, documentation gaps, and quality issues.'
+description: 'Analyze AVM Bicep files and examples for technical debt, inconsistencies, documentation gaps, and quality issues.'
 tools: ['search', 'runCommands', 'runTasks', 'Azure MCP/search', 'Azure MCP/search', 'Microsoft Learn/*', 'usages', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'todos']
 ---
 

--- a/.github/prompts/tech-debt-analysis-ARM-API.prompt.md
+++ b/.github/prompts/tech-debt-analysis-ARM-API.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Analyze Azure Verified Module (AVM) Bicep files and examples for technical debt, inconsistencies, documentation gaps, and quality issues.'
-tools: ['search', 'runCommands', 'runTasks', 'usages', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'todos', 'runTests', 'documentation', 'search']
+tools: ['search', 'runCommands', 'runTasks', 'Azure MCP/search', 'Azure MCP/search', 'Microsoft Learn/*', 'usages', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'todos']
 ---
 
 # Technical Debt Analysis for Azure Verified Module

--- a/.github/prompts/triage-github-issues-for-resource-module.prompt.md
+++ b/.github/prompts/triage-github-issues-for-resource-module.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Triage Open GitHub Issues related to the specific resource module.'
-tools: ['search', 'runCommands', 'runTasks', 'usages', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'todos', 'documentation', 'search', 'get_issue', 'get_issue_comments', 'get_pull_request', 'get_pull_request_comments', 'list_issues', 'search_issues', 'search_pull_requests']
+tools: ['search', 'runCommands', 'runTasks', 'Azure MCP/search', 'Azure MCP/search', 'Microsoft Learn/*', 'github/assign_copilot_to_issue', 'github/issue_read', 'github/list_issue_types', 'github/list_issues', 'github/search_issues', 'github/search_pull_requests', 'usages', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'todos']
 ---
 
 # Triage Open GitHub Issues for Resource Module

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -4,6 +4,10 @@
     "github": {
       "url": "https://api.githubcopilot.com/mcp/",
       "type": "http"
+    },
+    "Microsoft Learn": {
+      "url": "https://learn.microsoft.com/api/mcp",
+      "type": "sse"
     }
   }
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -7,7 +7,7 @@
     },
     "Microsoft Learn": {
       "url": "https://learn.microsoft.com/api/mcp",
-      "type": "sse"
+      "type": "http"
     }
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,10 @@
     {
       "text": "The first line should be a summary of no more than 50 characters, starting with one of: `AVM-RES:` (resource module), `AVM-PTN:` (pattern module), `AVM-UTL:` (utility module), or `CHORE:`|`NEW:`|`FIX:`|`CHANGE:`|`BREAKING CHANGE:`|`TESTS:`|`SECURITY:`|`COMPLEX:`|`DOCS:`|`ACTIONS:` for other updates. The second line should be blank. The following lines should be a detailed summary, each item starting with a `-`. Any summary item that is security related should start with `SECURITY:`. Any summary item that causes a breaking change to a feature/interface/dependency should start with `BREAKING CHANGE:`. For AVM module changes, specify the module path (e.g., avm/res/storage/storage-account)."
     }
-  ]
+  ],
+  "chat.promptFilesRecommendations": {
+    "create-plan-update-ARM-API": true,
+    "tech-debt-analysis-ARM-API": true,
+    "triage-github-issues-for-resource-module": true
+  }
 }


### PR DESCRIPTION
## Description

Update GitHub Copilot prompts, chatmode and add Microsoft Learn MCP server:

- Reviewed and updated descriptions for GitHub Copilot prompts to ensure latest tools available in VS Code.
- Added Microsoft Learn MCP Server and added to prompts and chatmode to ensure usage.
- Added VS Code suggestions to improve discoverability of prompts and reduced prompt description length to make it easier to see purpose.
<img width="852" height="389" alt="image" src="https://github.com/user-attachments/assets/47599075-a84d-4474-b33d-0968238225a9" />


## Pipeline Reference

| Pipeline |
| -------- |
| ??? |

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files. N/A
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
