### PR TITLE
fix: sub-vending - fixed routingConfiguration when creating additional virtual Wan connections

### DIFF
--- a/avm/ptn/lz/sub-vending/CHANGELOG.md
+++ b/avm/ptn/lz/sub-vending/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/lz/sub-vending/CHANGELOG.md).
 
+## 0.4.1
+
+### Changes
+
+- Fixed routingConfiguration when creating additional virtual Wan connection to use correct vHub resource Id when virtualNetworkVwanAssociatedRouteTableResourceId is not provided.
+
+### Breaking Changes
+
+- **None**
+
 ## 0.4.0
 
 ### Changes

--- a/avm/ptn/lz/sub-vending/main.json
+++ b/avm/ptn/lz/sub-vending/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "11036118962451026960"
+      "version": "0.38.33.27573",
+      "templateHash": "7550082996471672170"
     },
     "name": "Sub-vending",
     "description": "This module deploys a subscription to accelerate deployment of landing zones. For more information on how to use it, please visit this [Wiki](https://github.com/Azure/bicep-lz-vending/wiki).",
@@ -1867,7 +1867,7 @@
     "createSubscription": {
       "condition": "[and(parameters('subscriptionAliasEnabled'), empty(parameters('existingSubscriptionId')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[variables('deploymentNames').createSubscription]",
       "location": "[deployment().location]",
       "properties": {
@@ -1901,8 +1901,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "2432840958642647721"
+              "version": "0.38.33.27573",
+              "templateHash": "16574186634835473532"
             }
           },
           "parameters": {
@@ -1992,7 +1992,7 @@
     "createSubscriptionResources": {
       "condition": "[or(parameters('subscriptionAliasEnabled'), not(empty(parameters('existingSubscriptionId'))))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[variables('deploymentNames').createSubscriptionResources]",
       "location": "[deployment().location]",
       "properties": {
@@ -2157,8 +2157,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "12076241841135701361"
+              "version": "0.38.33.27573",
+              "templateHash": "999263166460876108"
             },
             "name": "`/subResourcesWrapper/deploy.bicep` Parameters",
             "description": "This module is used by the [`bicep-lz-vending`](https://aka.ms/sub-vending/bicep) module to help orchestrate the deployment",
@@ -4027,10 +4027,10 @@
             "virtualWanHubResourceGroupName": "[if(not(empty(variables('virtualHubResourceIdChecked'))), split(variables('virtualHubResourceIdChecked'), '/')[4], '')]",
             "virtualWanHubConnectionName": "[format('vhc-{0}-{1}', parameters('virtualNetworkName'), substring(guid(variables('virtualHubResourceIdChecked'), parameters('virtualNetworkName'), parameters('virtualNetworkResourceGroupName'), parameters('virtualNetworkLocation'), parameters('subscriptionId')), 0, 5))]",
             "virtualWanHubConnectionAssociatedRouteTable": "[if(not(empty(parameters('virtualNetworkVwanAssociatedRouteTableResourceId'))), parameters('virtualNetworkVwanAssociatedRouteTableResourceId'), format('{0}/hubRouteTables/defaultRouteTable', variables('virtualHubResourceIdChecked')))]",
-            "virutalWanHubDefaultRouteTableId": {
+            "virtualWanHubDefaultRouteTableId": {
               "id": "[format('{0}/hubRouteTables/defaultRouteTable', variables('virtualHubResourceIdChecked'))]"
             },
-            "virtualWanHubConnectionPropogatedRouteTables": "[if(not(empty(parameters('virtualNetworkVwanPropagatedRouteTablesResourceIds'))), parameters('virtualNetworkVwanPropagatedRouteTablesResourceIds'), array(variables('virutalWanHubDefaultRouteTableId')))]",
+            "virtualWanHubConnectionPropogatedRouteTables": "[if(not(empty(parameters('virtualNetworkVwanPropagatedRouteTablesResourceIds'))), parameters('virtualNetworkVwanPropagatedRouteTablesResourceIds'), array(variables('virtualWanHubDefaultRouteTableId')))]",
             "virtualWanHubConnectionPropogatedLabels": "[if(not(empty(parameters('virtualNetworkVwanPropagatedLabels'))), parameters('virtualNetworkVwanPropagatedLabels'), createArray('default'))]",
             "resourceProvidersFormatted": "[replace(string(parameters('resourceProviders')), '\"', '\\\"')]",
             "nsgArrayFormatted": "[if(not(empty(parameters('additionalVirtualNetworks'))), flatten(map(parameters('additionalVirtualNetworks'), lambda('vnet', map(coalesce(tryGet(lambdaVariables('vnet'), 'subnets'), createArray()), lambda('subnet', createObject('vnetResourceGroupName', lambdaVariables('vnet').resourceGroupName, 'subnetName', lambdaVariables('subnet').name, 'nsgName', coalesce(tryGet(tryGet(lambdaVariables('subnet'), 'networkSecurityGroup'), 'name'), format('nsg-{0}-{1}-{2}', lambdaVariables('subnet').name, lambdaVariables('vnet').name, substring(guid(coalesce(lambdaVariables('vnet').name, 'vnet'), lambdaVariables('vnet').resourceGroupName, lambdaVariables('subnet').name), 0, 4))), 'nsgLocation', coalesce(tryGet(tryGet(lambdaVariables('subnet'), 'networkSecurityGroup'), 'location'), lambdaVariables('vnet').location), 'nsgRules', coalesce(tryGet(tryGet(lambdaVariables('subnet'), 'networkSecurityGroup'), 'securityRules'), null()), 'nsgTags', coalesce(tryGet(tryGet(lambdaVariables('subnet'), 'networkSecurityGroup'), 'tags'), null()))))))), createArray())]",
@@ -4062,7 +4062,7 @@
             "moveSubscriptionToManagementGroup": {
               "condition": "[and(parameters('subscriptionManagementGroupAssociationEnabled'), not(empty(parameters('subscriptionManagementGroupId'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').moveSubscriptionToManagementGroup]",
               "scope": "[format('Microsoft.Management/managementGroups/{0}', parameters('subscriptionManagementGroupId'))]",
               "location": "[deployment().location]",
@@ -4085,8 +4085,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "10119532997954158148"
+                      "version": "0.38.33.27573",
+                      "templateHash": "18107819872752296910"
                     }
                   },
                   "parameters": {
@@ -4121,7 +4121,7 @@
             "tagSubscription": {
               "condition": "[not(empty(parameters('subscriptionTags')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').tagSubscription]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "location": "[deployment().location]",
@@ -4147,8 +4147,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "15753993745852490416"
+                      "version": "0.38.33.27573",
+                      "templateHash": "2654933692570559783"
                     }
                   },
                   "parameters": {
@@ -4185,7 +4185,7 @@
                     {
                       "condition": "[and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName')))]",
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2022-09-01",
+                      "apiVersion": "2025-04-01",
                       "name": "[format('{0}-Tags-Sub', deployment().name)]",
                       "location": "[deployment().location]",
                       "properties": {
@@ -4207,8 +4207,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "17777929966904635893"
+                              "version": "0.38.33.27573",
+                              "templateHash": "1661292190117326471"
                             }
                           },
                           "parameters": {
@@ -4240,7 +4240,7 @@
                               "apiVersion": "2025-04-01",
                               "name": "[parameters('name')]",
                               "properties": {
-                                "tags": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2022-09-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
+                                "tags": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2025-04-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
                               },
                               "dependsOn": [
                                 "[subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name))]"
@@ -4249,7 +4249,7 @@
                             {
                               "condition": "[parameters('onlyUpdate')]",
                               "type": "Microsoft.Resources/deployments",
-                              "apiVersion": "2022-09-01",
+                              "apiVersion": "2025-04-01",
                               "name": "[format('{0}-ReadTags', deployment().name)]",
                               "location": "[deployment().location]",
                               "properties": {
@@ -4263,8 +4263,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.37.4.10188",
-                                      "templateHash": "17895554561530196302"
+                                      "version": "0.38.33.27573",
+                                      "templateHash": "12489795648043380518"
                                     }
                                   },
                                   "parameters": {
@@ -4303,7 +4303,7 @@
                               "metadata": {
                                 "description": "The applied tags."
                               },
-                              "value": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2022-09-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
+                              "value": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2025-04-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
                             },
                             "resourceId": {
                               "type": "string",
@@ -4319,7 +4319,7 @@
                     {
                       "condition": "[and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId'))))]",
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2022-09-01",
+                      "apiVersion": "2025-04-01",
                       "name": "[format('{0}-Tags-RG', deployment().name)]",
                       "resourceGroup": "[parameters('resourceGroupName')]",
                       "properties": {
@@ -4341,8 +4341,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "2329361910473224649"
+                              "version": "0.38.33.27573",
+                              "templateHash": "7727222932365568939"
                             }
                           },
                           "parameters": {
@@ -4374,7 +4374,7 @@
                               "apiVersion": "2025-04-01",
                               "name": "[parameters('name')]",
                               "properties": {
-                                "tags": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(resourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2022-09-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
+                                "tags": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(resourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2025-04-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
                               },
                               "dependsOn": [
                                 "[resourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name))]"
@@ -4383,7 +4383,7 @@
                             {
                               "condition": "[parameters('onlyUpdate')]",
                               "type": "Microsoft.Resources/deployments",
-                              "apiVersion": "2022-09-01",
+                              "apiVersion": "2025-04-01",
                               "name": "[format('{0}-ReadTags', deployment().name)]",
                               "properties": {
                                 "expressionEvaluationOptions": {
@@ -4396,8 +4396,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.37.4.10188",
-                                      "templateHash": "17671496048922498595"
+                                      "version": "0.38.33.27573",
+                                      "templateHash": "1625562912621355821"
                                     }
                                   },
                                   "parameters": {
@@ -4450,7 +4450,7 @@
                               "metadata": {
                                 "description": "The applied tags."
                               },
-                              "value": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(resourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2022-09-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
+                              "value": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(resourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2025-04-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
                             }
                           }
                         }
@@ -4463,21 +4463,21 @@
                       "metadata": {
                         "description": "The name of the tags resource."
                       },
-                      "value": "[if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), coalesce(tryGet(if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-Tags-RG', deployment().name)), '2022-09-01'), null()), 'outputs', 'name', 'value'), ''), coalesce(tryGet(if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Tags-Sub', deployment().name)), '2022-09-01'), null()), 'outputs', 'name', 'value'), ''))]"
+                      "value": "[if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), coalesce(tryGet(if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-Tags-RG', deployment().name)), '2025-04-01'), null()), 'outputs', 'name', 'value'), ''), coalesce(tryGet(if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Tags-Sub', deployment().name)), '2025-04-01'), null()), 'outputs', 'name', 'value'), ''))]"
                     },
                     "tags": {
                       "type": "object",
                       "metadata": {
                         "description": "The applied tags."
                       },
-                      "value": "[if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), coalesce(tryGet(if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-Tags-RG', deployment().name)), '2022-09-01'), null()), 'outputs', 'tags', 'value'), createObject()), coalesce(tryGet(if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Tags-Sub', deployment().name)), '2022-09-01'), null()), 'outputs', 'tags', 'value'), createObject()))]"
+                      "value": "[if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), coalesce(tryGet(if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-Tags-RG', deployment().name)), '2025-04-01'), null()), 'outputs', 'tags', 'value'), createObject()), coalesce(tryGet(if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Tags-Sub', deployment().name)), '2025-04-01'), null()), 'outputs', 'tags', 'value'), createObject()))]"
                     },
                     "resourceId": {
                       "type": "string",
                       "metadata": {
                         "description": "The resource ID of the applied tags."
                       },
-                      "value": "[if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), coalesce(tryGet(if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-Tags-RG', deployment().name)), '2022-09-01'), null()), 'outputs', 'resourceId', 'value'), ''), coalesce(tryGet(if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Tags-Sub', deployment().name)), '2022-09-01'), null()), 'outputs', 'resourceId', 'value'), ''))]"
+                      "value": "[if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), coalesce(tryGet(if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-Tags-RG', deployment().name)), '2025-04-01'), null()), 'outputs', 'resourceId', 'value'), ''), coalesce(tryGet(if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Tags-Sub', deployment().name)), '2025-04-01'), null()), 'outputs', 'resourceId', 'value'), ''))]"
                     }
                   }
                 }
@@ -4486,7 +4486,7 @@
             "createResourceGroupForLzNetworking": {
               "condition": "[and(and(parameters('virtualNetworkEnabled'), not(empty(parameters('virtualNetworkLocation')))), not(empty(parameters('virtualNetworkResourceGroupName'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createResourceGroupForLzNetworking]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "location": "[deployment().location]",
@@ -4983,7 +4983,7 @@
             "createResourceGroupForIdentities": {
               "condition": "[not(empty(parameters('userAssignedManagedIdentities')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createResourceGroupForIdentities]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "location": "[deployment().location]",
@@ -5480,7 +5480,7 @@
             "tagResourceGroup": {
               "condition": "[and(and(and(parameters('virtualNetworkEnabled'), not(empty(parameters('virtualNetworkLocation')))), not(empty(parameters('virtualNetworkResourceGroupName')))), not(empty(parameters('virtualNetworkResourceGroupTags'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').tagResoruceGroupForLzNetworking]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "location": "[deployment().location]",
@@ -5509,8 +5509,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "15753993745852490416"
+                      "version": "0.38.33.27573",
+                      "templateHash": "2654933692570559783"
                     }
                   },
                   "parameters": {
@@ -5547,7 +5547,7 @@
                     {
                       "condition": "[and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName')))]",
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2022-09-01",
+                      "apiVersion": "2025-04-01",
                       "name": "[format('{0}-Tags-Sub', deployment().name)]",
                       "location": "[deployment().location]",
                       "properties": {
@@ -5569,8 +5569,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "17777929966904635893"
+                              "version": "0.38.33.27573",
+                              "templateHash": "1661292190117326471"
                             }
                           },
                           "parameters": {
@@ -5602,7 +5602,7 @@
                               "apiVersion": "2025-04-01",
                               "name": "[parameters('name')]",
                               "properties": {
-                                "tags": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2022-09-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
+                                "tags": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2025-04-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
                               },
                               "dependsOn": [
                                 "[subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name))]"
@@ -5611,7 +5611,7 @@
                             {
                               "condition": "[parameters('onlyUpdate')]",
                               "type": "Microsoft.Resources/deployments",
-                              "apiVersion": "2022-09-01",
+                              "apiVersion": "2025-04-01",
                               "name": "[format('{0}-ReadTags', deployment().name)]",
                               "location": "[deployment().location]",
                               "properties": {
@@ -5625,8 +5625,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.37.4.10188",
-                                      "templateHash": "17895554561530196302"
+                                      "version": "0.38.33.27573",
+                                      "templateHash": "12489795648043380518"
                                     }
                                   },
                                   "parameters": {
@@ -5665,7 +5665,7 @@
                               "metadata": {
                                 "description": "The applied tags."
                               },
-                              "value": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2022-09-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
+                              "value": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2025-04-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
                             },
                             "resourceId": {
                               "type": "string",
@@ -5681,7 +5681,7 @@
                     {
                       "condition": "[and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId'))))]",
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2022-09-01",
+                      "apiVersion": "2025-04-01",
                       "name": "[format('{0}-Tags-RG', deployment().name)]",
                       "resourceGroup": "[parameters('resourceGroupName')]",
                       "properties": {
@@ -5703,8 +5703,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "2329361910473224649"
+                              "version": "0.38.33.27573",
+                              "templateHash": "7727222932365568939"
                             }
                           },
                           "parameters": {
@@ -5736,7 +5736,7 @@
                               "apiVersion": "2025-04-01",
                               "name": "[parameters('name')]",
                               "properties": {
-                                "tags": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(resourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2022-09-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
+                                "tags": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(resourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2025-04-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
                               },
                               "dependsOn": [
                                 "[resourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name))]"
@@ -5745,7 +5745,7 @@
                             {
                               "condition": "[parameters('onlyUpdate')]",
                               "type": "Microsoft.Resources/deployments",
-                              "apiVersion": "2022-09-01",
+                              "apiVersion": "2025-04-01",
                               "name": "[format('{0}-ReadTags', deployment().name)]",
                               "properties": {
                                 "expressionEvaluationOptions": {
@@ -5758,8 +5758,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.37.4.10188",
-                                      "templateHash": "17671496048922498595"
+                                      "version": "0.38.33.27573",
+                                      "templateHash": "1625562912621355821"
                                     }
                                   },
                                   "parameters": {
@@ -5812,7 +5812,7 @@
                               "metadata": {
                                 "description": "The applied tags."
                               },
-                              "value": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(resourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2022-09-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
+                              "value": "[if(parameters('onlyUpdate'), union(coalesce(tryGet(if(parameters('onlyUpdate'), reference(resourceId('Microsoft.Resources/deployments', format('{0}-ReadTags', deployment().name)), '2025-04-01'), null()), 'outputs', 'existingTags', 'value'), createObject()), parameters('tags')), parameters('tags'))]"
                             }
                           }
                         }
@@ -5825,21 +5825,21 @@
                       "metadata": {
                         "description": "The name of the tags resource."
                       },
-                      "value": "[if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), coalesce(tryGet(if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-Tags-RG', deployment().name)), '2022-09-01'), null()), 'outputs', 'name', 'value'), ''), coalesce(tryGet(if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Tags-Sub', deployment().name)), '2022-09-01'), null()), 'outputs', 'name', 'value'), ''))]"
+                      "value": "[if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), coalesce(tryGet(if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-Tags-RG', deployment().name)), '2025-04-01'), null()), 'outputs', 'name', 'value'), ''), coalesce(tryGet(if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Tags-Sub', deployment().name)), '2025-04-01'), null()), 'outputs', 'name', 'value'), ''))]"
                     },
                     "tags": {
                       "type": "object",
                       "metadata": {
                         "description": "The applied tags."
                       },
-                      "value": "[if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), coalesce(tryGet(if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-Tags-RG', deployment().name)), '2022-09-01'), null()), 'outputs', 'tags', 'value'), createObject()), coalesce(tryGet(if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Tags-Sub', deployment().name)), '2022-09-01'), null()), 'outputs', 'tags', 'value'), createObject()))]"
+                      "value": "[if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), coalesce(tryGet(if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-Tags-RG', deployment().name)), '2025-04-01'), null()), 'outputs', 'tags', 'value'), createObject()), coalesce(tryGet(if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Tags-Sub', deployment().name)), '2025-04-01'), null()), 'outputs', 'tags', 'value'), createObject()))]"
                     },
                     "resourceId": {
                       "type": "string",
                       "metadata": {
                         "description": "The resource ID of the applied tags."
                       },
-                      "value": "[if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), coalesce(tryGet(if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-Tags-RG', deployment().name)), '2022-09-01'), null()), 'outputs', 'resourceId', 'value'), ''), coalesce(tryGet(if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Tags-Sub', deployment().name)), '2022-09-01'), null()), 'outputs', 'resourceId', 'value'), ''))]"
+                      "value": "[if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), coalesce(tryGet(if(and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId')))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', format('{0}-Tags-RG', deployment().name)), '2025-04-01'), null()), 'outputs', 'resourceId', 'value'), ''), coalesce(tryGet(if(and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('{0}-Tags-Sub', deployment().name)), '2025-04-01'), null()), 'outputs', 'resourceId', 'value'), ''))]"
                     }
                   }
                 }
@@ -5851,7 +5851,7 @@
             "createLzVnet": {
               "condition": "[and(and(and(and(parameters('virtualNetworkEnabled'), not(empty(parameters('virtualNetworkName')))), not(empty(parameters('virtualNetworkAddressSpace')))), not(empty(parameters('virtualNetworkLocation')))), not(empty(parameters('virtualNetworkResourceGroupName'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createLzVnet]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('virtualNetworkResourceGroupName')]",
@@ -7523,7 +7523,7 @@
             "createBastionNsg": {
               "condition": "[and(and(and(and(parameters('virtualNetworkDeployBastion'), not(empty(parameters('virtualNetworkName')))), not(empty(parameters('virtualNetworkAddressSpace')))), not(empty(parameters('virtualNetworkLocation')))), not(empty(parameters('virtualNetworkResourceGroupName'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createBastionNsg]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('virtualNetworkResourceGroupName')]",
@@ -8322,7 +8322,7 @@
               },
               "condition": "[not(empty(parameters('virtualNetworkSubnets')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-{1}', variables('deploymentNames').createLzNsg, copyIndex())]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('virtualNetworkResourceGroupName')]",
@@ -8981,7 +8981,7 @@
               },
               "condition": "[and(not(empty(parameters('networkSecurityGroups'))), not(empty(parameters('networkSecurityGroupResourceGroupName'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-{1}', variables('deploymentNames').createLzNsg, copyIndex())]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('networkSecurityGroupResourceGroupName')]",
@@ -9640,7 +9640,7 @@
               },
               "condition": "[and(not(empty(parameters('routeTables'))), not(empty(parameters('routeTablesResourceGroupName'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-{1}', variables('deploymentNames').createLzRouteTable, copyIndex())]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('routeTablesResourceGroupName')]",
@@ -9985,7 +9985,7 @@
               },
               "condition": "[not(empty(parameters('additionalVirtualNetworks')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('createAdditionalVnetNsgs-{0}-{1}', copyIndex(), uniqueString('createAdditionalVnetNsgs', deployment().name))]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[variables('nsgArrayFormatted')[copyIndex()].vnetResourceGroupName]",
@@ -10643,7 +10643,7 @@
             "createLzVirtualWanConnection": {
               "condition": "[and(and(and(and(and(and(and(and(parameters('virtualNetworkEnabled'), parameters('virtualNetworkPeeringEnabled')), not(empty(variables('virtualHubResourceIdChecked')))), not(empty(parameters('virtualNetworkName')))), not(empty(parameters('virtualNetworkAddressSpace')))), not(empty(parameters('virtualNetworkLocation')))), not(empty(parameters('virtualNetworkResourceGroupName')))), not(empty(variables('virtualWanHubResourceGroupName')))), not(empty(variables('virtualWanHubSubscriptionId'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createLzVirtualWanConnection]",
               "subscriptionId": "[variables('virtualWanHubSubscriptionId')]",
               "resourceGroup": "[variables('virtualWanHubResourceGroupName')]",
@@ -10673,8 +10673,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "17543656022324673718"
+                      "version": "0.38.33.27573",
+                      "templateHash": "6279059423618909743"
                     }
                   },
                   "parameters": {
@@ -10762,7 +10762,7 @@
               },
               "condition": "[and(parameters('roleAssignmentEnabled'), not(empty(variables('roleAssignmentsSubscription'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}-{1}', variables('deploymentNames').createLzRoleAssignmentsSub, uniqueString(variables('roleAssignmentsSubscription')[copyIndex()].principalId, variables('roleAssignmentsSubscription')[copyIndex()].definition, variables('roleAssignmentsSubscription')[copyIndex()].relativeScope)), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -11463,7 +11463,7 @@
               },
               "condition": "[and(parameters('roleAssignmentEnabled'), not(empty(variables('roleAssignmentsResourceGroupSelf'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}-{1}', variables('deploymentNames').createLzRoleAssignmentsRsgsSelf, uniqueString(variables('roleAssignmentsResourceGroupSelf')[copyIndex()].principalId, variables('roleAssignmentsResourceGroupSelf')[copyIndex()].definition, variables('roleAssignmentsResourceGroupSelf')[copyIndex()].relativeScope)), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -12170,7 +12170,7 @@
               },
               "condition": "[and(parameters('roleAssignmentEnabled'), not(empty(variables('roleAssignmentsResourceGroupNotSelf'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}-{1}', variables('deploymentNames').createLzRoleAssignmentsRsgsNotSelf, uniqueString(variables('roleAssignmentsResourceGroupNotSelf')[copyIndex()].principalId, variables('roleAssignmentsResourceGroupNotSelf')[copyIndex()].definition, variables('roleAssignmentsResourceGroupNotSelf')[copyIndex()].relativeScope)), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -12874,7 +12874,7 @@
               },
               "condition": "[and(parameters('roleAssignmentEnabled'), not(empty(variables('umiRoleAssignmentsSubscriptionFlattened'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}-{1}', variables('deploymentNames').createLzUMIRoleAssignmentsSub, uniqueString(format('{0}-{1}', variables('deploymentNames').createUserAssignedIdentities, copyIndex()), variables('umiRoleAssignmentsSubscriptionFlattened')[copyIndex()].definition, variables('umiRoleAssignmentsSubscriptionFlattened')[copyIndex()].relativeScope)), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -13579,7 +13579,7 @@
               },
               "condition": "[and(parameters('roleAssignmentEnabled'), not(empty(variables('umiRoleAssignmentsResourceGroupSelfFlattened'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}-{1}', variables('deploymentNames').createLzUMIRoleAssignmentsRsgsSelf, uniqueString(format('{0}-{1}', variables('deploymentNames').createUserAssignedIdentities, copyIndex()), variables('umiRoleAssignmentsResourceGroupSelfFlattened')[copyIndex()].definition, variables('umiRoleAssignmentsResourceGroupSelfFlattened')[copyIndex()].relativeScope)), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -14287,7 +14287,7 @@
               },
               "condition": "[and(parameters('roleAssignmentEnabled'), not(empty(variables('umiRoleAssignmentsResourceGroupNotSelfFlattened'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}-{1}', variables('deploymentNames').createLzUMIRoleAssignmentsRsgsNotSelf, uniqueString(format('{0}-{1}', variables('deploymentNames').createUserAssignedIdentities, copyIndex()), variables('umiRoleAssignmentsResourceGroupNotSelfFlattened')[copyIndex()].definition, variables('umiRoleAssignmentsResourceGroupNotSelfFlattened')[copyIndex()].relativeScope)), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -14995,7 +14995,7 @@
               },
               "condition": "[and(and(parameters('roleAssignmentEnabled'), not(empty(variables('pimRoleAssignmentsSubscription')))), equals(variables('pimRoleAssignmentsSubscription')[copyIndex()].roleAssignmentType, 'Active'))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}-{1}', variables('deploymentNames').createLzPimRoleAssignmentsSub, uniqueString(variables('pimRoleAssignmentsSubscription')[copyIndex()].principalId, variables('pimRoleAssignmentsSubscription')[copyIndex()].definition, variables('pimRoleAssignmentsSubscription')[copyIndex()].relativeScope)), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -16830,7 +16830,7 @@
               },
               "condition": "[and(and(parameters('roleAssignmentEnabled'), not(empty(variables('pimRoleAssignmentsSubscription')))), equals(variables('pimRoleAssignmentsSubscription')[copyIndex()].roleAssignmentType, 'Eligible'))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}-{1}', variables('deploymentNames').createLzPimRoleAssignmentsSub, uniqueString(variables('pimRoleAssignmentsSubscription')[copyIndex()].principalId, variables('pimRoleAssignmentsSubscription')[copyIndex()].definition, variables('pimRoleAssignmentsSubscription')[copyIndex()].relativeScope)), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -18665,7 +18665,7 @@
               },
               "condition": "[and(and(parameters('roleAssignmentEnabled'), not(empty(variables('pimRoleAssignmentsResourceGroupSelf')))), equals(variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()].roleAssignmentType, 'Eligible'))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}-{1}', variables('deploymentNames').createLzPimRoleAssignmentsRsgsSelf, uniqueString(variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()].principalId, variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()].definition, variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()].relativeScope)), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -20506,7 +20506,7 @@
               },
               "condition": "[and(and(parameters('roleAssignmentEnabled'), not(empty(variables('pimRoleAssignmentsResourceGroupSelf')))), equals(variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()].roleAssignmentType, 'Active'))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}-{1}', variables('deploymentNames').createLzPimRoleAssignmentsRsgsSelf, uniqueString(variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()].principalId, variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()].definition, variables('pimRoleAssignmentsResourceGroupSelf')[copyIndex()].relativeScope)), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -22347,7 +22347,7 @@
               },
               "condition": "[and(and(parameters('roleAssignmentEnabled'), not(empty(variables('pimRoleAssignmentsResourceGroupNotSelf')))), equals(variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()].roleAssignmentType, 'Eligible'))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}-{1}', variables('deploymentNames').createLzPimRoleAssignmentsRsgsNotSelf, uniqueString(variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()].principalId, variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()].definition, variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()].relativeScope)), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -24182,7 +24182,7 @@
               },
               "condition": "[and(and(parameters('roleAssignmentEnabled'), not(empty(variables('pimRoleAssignmentsResourceGroupNotSelf')))), equals(variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()].roleAssignmentType, 'Active'))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}-{1}', variables('deploymentNames').createLzPimRoleAssignmentsRsgsNotSelf, uniqueString(variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()].principalId, variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()].definition, variables('pimRoleAssignmentsResourceGroupNotSelf')[copyIndex()].relativeScope)), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -26013,7 +26013,7 @@
             "createResourceGroupForDeploymentScript": {
               "condition": "[not(empty(parameters('resourceProviders')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createResourceGroupForDeploymentScript]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "location": "[deployment().location]",
@@ -26509,7 +26509,7 @@
             "createResourceGroupForRouteTables": {
               "condition": "[and(not(empty(parameters('routeTablesResourceGroupName'))), not(empty(parameters('routeTables'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createResourceGroupForRouteTables]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "location": "[deployment().location]",
@@ -27005,7 +27005,7 @@
             "createResourceGroupForNetworkSecurityGroups": {
               "condition": "[and(not(empty(parameters('networkSecurityGroupResourceGroupName'))), not(empty(parameters('networkSecurityGroups'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createResourceGroupForNetworkSecurityGroups]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "location": "[deployment().location]",
@@ -27501,7 +27501,7 @@
             "createManagedIdentityForDeploymentScript": {
               "condition": "[not(empty(parameters('resourceProviders')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createDeploymentScriptManagedIdentity]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('deploymentScriptResourceGroupName')]",
@@ -27986,7 +27986,7 @@
             "createRoleAssignmentsDeploymentScript": {
               "condition": "[not(empty(parameters('resourceProviders')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}', variables('deploymentNames').createRoleAssignmentsDeploymentScript), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -28679,7 +28679,7 @@
             "createRoleAssignmentsDeploymentScriptStorageAccount": {
               "condition": "[not(empty(parameters('resourceProviders')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('{0}', variables('deploymentNames').createRoleAssignmentsDeploymentScriptStorageAccount), 64)]",
               "location": "[deployment().location]",
               "properties": {
@@ -29378,7 +29378,7 @@
             "createDsNsg": {
               "condition": "[not(empty(parameters('resourceProviders')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createDsNsg]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('deploymentScriptResourceGroupName')]",
@@ -30030,7 +30030,7 @@
             "dsFilePrivateDNSZone": {
               "condition": "[not(empty(parameters('resourceProviders')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createDsFilePrivateDnsZone]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('deploymentScriptResourceGroupName')]",
@@ -33402,7 +33402,7 @@
             "createDsStorageAccount": {
               "condition": "[not(empty(parameters('resourceProviders')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createDsStorageAccount]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('deploymentScriptResourceGroupName')]",
@@ -39319,7 +39319,7 @@
             "createDsVnet": {
               "condition": "[not(empty(parameters('resourceProviders')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createdsVnet]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('deploymentScriptResourceGroupName')]",
@@ -40971,7 +40971,7 @@
             "registerResourceProviders": {
               "condition": "[not(empty(parameters('resourceProviders')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').registerResourceProviders]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('deploymentScriptResourceGroupName')]",
@@ -41552,7 +41552,7 @@
             "createNatGateway": {
               "condition": "[and(parameters('virtualNetworkDeployNatGateway'), and(and(and(and(parameters('virtualNetworkEnabled'), not(empty(parameters('virtualNetworkName')))), not(empty(parameters('virtualNetworkAddressSpace')))), not(empty(parameters('virtualNetworkLocation')))), not(empty(parameters('virtualNetworkResourceGroupName')))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createNatGateway]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('virtualNetworkResourceGroupName')]",
@@ -43229,7 +43229,7 @@
               },
               "condition": "[and(not(empty(coalesce(tryGet(parameters('additionalVirtualNetworks')[copyIndex()], 'subnets'), createArray()))), coalesce(tryGet(parameters('additionalVirtualNetworks')[copyIndex()], 'deployNatGateway'), false()))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('createAdditonalNatGateway-{0}-{1}', copyIndex(), uniqueString('createAdditonalNatGateway', deployment().name))]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('additionalVirtualNetworks')[copyIndex()].resourceGroupName]",
@@ -44902,7 +44902,7 @@
             "createBastionHost": {
               "condition": "[and(parameters('virtualNetworkDeployBastion'), and(and(and(and(parameters('virtualNetworkEnabled'), not(empty(parameters('virtualNetworkName')))), not(empty(parameters('virtualNetworkAddressSpace')))), not(empty(parameters('virtualNetworkLocation')))), not(empty(parameters('virtualNetworkResourceGroupName')))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[variables('deploymentNames').createBastionHost]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('virtualNetworkResourceGroupName')]",
@@ -46621,7 +46621,7 @@
               },
               "condition": "[not(empty(parameters('userAssignedManagedIdentities')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-{1}', variables('deploymentNames').createUserAssignedIdentities, copyIndex())]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('userAssignedIdentityResourceGroupName')]",
@@ -47119,7 +47119,7 @@
               },
               "condition": "[and(parameters('virtualNetworkEnabled'), not(empty(parameters('additionalVirtualNetworks'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('createResourceGroupForAdditionalLzNetworking-{0}-{1}', copyIndex(), uniqueString('createResourceGroupForAdditionalLzNetworking', deployment().name))]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "location": "[deployment().location]",
@@ -47620,7 +47620,7 @@
               },
               "condition": "[and(parameters('virtualNetworkEnabled'), not(empty(parameters('additionalVirtualNetworks'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('createAdditionalVnets-{0}-{1}', copyIndex(), uniqueString('createAdditionalVnets', deployment().name))]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[parameters('additionalVirtualNetworks')[copyIndex()].resourceGroupName]",
@@ -49296,7 +49296,7 @@
               },
               "condition": "[and(and(parameters('virtualNetworkEnabled'), not(empty(parameters('additionalVirtualNetworks')))), or(not(empty(coalesce(tryGet(parameters('additionalVirtualNetworks')[copyIndex()], 'alternativeVwanHubResourceId'), ''))), not(empty(variables('virtualHubResourceIdChecked')))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('createAdditionalLzVirtualWanConnection-{0}-{1}', copyIndex(), uniqueString('createAdditionalLzVirtualWanConnection', deployment().name))]",
               "subscriptionId": "[split(coalesce(tryGet(parameters('additionalVirtualNetworks')[copyIndex()], 'alternativeVwanHubResourceId'), variables('virtualHubResourceIdChecked')), '/')[2]]",
               "resourceGroup": "[split(coalesce(tryGet(parameters('additionalVirtualNetworks')[copyIndex()], 'alternativeVwanHubResourceId'), variables('virtualHubResourceIdChecked')), '/')[4]]",
@@ -49318,7 +49318,7 @@
                   "enableInternetSecurity": {
                     "value": "[parameters('virtualNetworkVwanEnableInternetSecurity')]"
                   },
-                  "routingConfiguration": "[if(not(parameters('vHubRoutingIntentEnabled')), createObject('value', createObject('associatedRouteTable', createObject('id', variables('virtualWanHubConnectionAssociatedRouteTable')), 'propagatedRouteTables', createObject('ids', variables('virtualWanHubConnectionPropogatedRouteTables'), 'labels', variables('virtualWanHubConnectionPropogatedLabels')))), createObject('value', createObject()))]"
+                  "routingConfiguration": "[if(not(parameters('vHubRoutingIntentEnabled')), createObject('value', createObject('associatedRouteTable', createObject('id', if(not(empty(parameters('virtualNetworkVwanAssociatedRouteTableResourceId'))), parameters('virtualNetworkVwanAssociatedRouteTableResourceId'), format('{0}/hubRouteTables/defaultRouteTable', coalesce(tryGet(parameters('additionalVirtualNetworks')[copyIndex()], 'alternativeVwanHubResourceId'), variables('virtualHubResourceIdChecked'))))), 'propagatedRouteTables', createObject('ids', if(not(empty(parameters('virtualNetworkVwanPropagatedRouteTablesResourceIds'))), parameters('virtualNetworkVwanPropagatedRouteTablesResourceIds'), array(createObject('id', format('{0}/hubRouteTables/defaultRouteTable', coalesce(tryGet(parameters('additionalVirtualNetworks')[copyIndex()], 'alternativeVwanHubResourceId'), variables('virtualHubResourceIdChecked')))))), 'labels', variables('virtualWanHubConnectionPropogatedLabels')))), createObject('value', createObject()))]"
                 },
                 "template": {
                   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -49326,8 +49326,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "17543656022324673718"
+                      "version": "0.38.33.27573",
+                      "templateHash": "6279059423618909743"
                     }
                   },
                   "parameters": {
@@ -49415,7 +49415,7 @@
               },
               "condition": "[and(and(parameters('peerAllVirtualNetworks'), not(empty(parameters('additionalVirtualNetworks')))), not(equals(variables('peeringCombinations')[copyIndex()].sourceResourceGroupName, parameters('virtualNetworkResourceGroupName'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('meshPeerAdditionalVnets-{0}-{1}', copyIndex(), uniqueString('meshPeerAdditionalVnets', deployment().name))]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[variables('peeringCombinations')[copyIndex()].sourceResourceGroupName]",
@@ -49441,8 +49441,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "8720977001389603483"
+                      "version": "0.38.33.27573",
+                      "templateHash": "13939377559324876183"
                     }
                   },
                   "parameters": {
@@ -49485,7 +49485,7 @@
               },
               "condition": "[and(and(parameters('peerAllVirtualNetworks'), and(and(and(and(parameters('virtualNetworkEnabled'), not(empty(parameters('virtualNetworkName')))), not(empty(parameters('virtualNetworkAddressSpace')))), not(empty(parameters('virtualNetworkLocation')))), not(empty(parameters('virtualNetworkResourceGroupName'))))), equals(variables('peeringCombinations')[copyIndex()].sourceResourceGroupName, parameters('virtualNetworkResourceGroupName')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('meshPeerFromPrimaryVnet-{0}-{1}', copyIndex(), uniqueString('meshPeerFromPrimaryVnet', deployment().name))]",
               "subscriptionId": "[parameters('subscriptionId')]",
               "resourceGroup": "[variables('peeringCombinations')[copyIndex()].sourceResourceGroupName]",
@@ -49511,8 +49511,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "8720977001389603483"
+                      "version": "0.38.33.27573",
+                      "templateHash": "13939377559324876183"
                     }
                   },
                   "parameters": {

--- a/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
+++ b/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
@@ -469,12 +469,12 @@ var virtualWanHubConnectionName = 'vhc-${virtualNetworkName}-${substring(guid(vi
 var virtualWanHubConnectionAssociatedRouteTable = !empty(virtualNetworkVwanAssociatedRouteTableResourceId)
   ? virtualNetworkVwanAssociatedRouteTableResourceId
   : '${virtualHubResourceIdChecked}/hubRouteTables/defaultRouteTable'
-var virutalWanHubDefaultRouteTableId = {
+var virtualWanHubDefaultRouteTableId = {
   id: '${virtualHubResourceIdChecked}/hubRouteTables/defaultRouteTable'
 }
 var virtualWanHubConnectionPropogatedRouteTables = !empty(virtualNetworkVwanPropagatedRouteTablesResourceIds)
   ? virtualNetworkVwanPropagatedRouteTablesResourceIds
-  : array(virutalWanHubDefaultRouteTableId)
+  : array(virtualWanHubDefaultRouteTableId)
 var virtualWanHubConnectionPropogatedLabels = !empty(virtualNetworkVwanPropagatedLabels)
   ? virtualNetworkVwanPropagatedLabels
   : ['default']
@@ -1801,10 +1801,16 @@ module createAdditionalLzVirtualWanConnection 'hubVirtualNetworkConnections.bice
       routingConfiguration: !vHubRoutingIntentEnabled
         ? {
             associatedRouteTable: {
-              id: virtualWanHubConnectionAssociatedRouteTable
+              id: !empty(virtualNetworkVwanAssociatedRouteTableResourceId)
+                ? virtualNetworkVwanAssociatedRouteTableResourceId
+                : '${vnet.?alternativeVwanHubResourceId ?? virtualHubResourceIdChecked}/hubRouteTables/defaultRouteTable'
             }
             propagatedRouteTables: {
-              ids: virtualWanHubConnectionPropogatedRouteTables
+              ids: !empty(virtualNetworkVwanPropagatedRouteTablesResourceIds)
+                    ? virtualNetworkVwanPropagatedRouteTablesResourceIds
+                    : array({
+                        id: '${vnet.?alternativeVwanHubResourceId ?? virtualHubResourceIdChecked}/hubRouteTables/defaultRouteTable'
+                      })
               labels: virtualWanHubConnectionPropogatedLabels
             }
           }


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #123
-->

Fixed routingConfiguration when creating additional virtual Wan connection to use vHub resource Id if defined for that instance when virtualNetworkVwanAssociatedRouteTableResourceId is not provided.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
