### PR TITLE
fix: AVM-RES: Update ipamPoolPrefixAllocations type in virtual-network module

### DIFF
--- a/avm/res/network/virtual-network/main.bicep
+++ b/avm/res/network/virtual-network/main.bicep
@@ -363,6 +363,16 @@ type peeringType = {
   remotePeeringUseRemoteGateways: bool?
 }
 
+type ipamPoolPrefixAllocationsType = {
+  @description('Required. The IPAM pool.')
+  pool: {
+    @description('Required. The Resource ID of the IPAM pool.')
+    id: string
+  }
+  @description('Required. Number of IP addresses allocated from the pool.')
+  numberOfIpAddresses: string
+}
+
 @export()
 type subnetType = {
   @description('Required. The Name of the subnet resource.')
@@ -375,17 +385,7 @@ type subnetType = {
   addressPrefixes: string[]?
 
   @description('Conditional. The address space for the subnet, deployed from IPAM Pool. Required if `addressPrefixes` and `addressPrefix` is empty and the VNet address space configured to use IPAM Pool.')
-  ipamPoolPrefixAllocations: [
-    {
-      @description('Required. The Resource ID of the IPAM pool.')
-      pool: {
-        @description('Required. The Resource ID of the IPAM pool.')
-        id: string
-      }
-      @description('Required. Number of IP addresses allocated from the pool.')
-      numberOfIpAddresses: string
-    }
-  ]?
+  ipamPoolPrefixAllocations: ipamPoolPrefixAllocationsType[]?
 
   @description('Optional. Application gateway IP configurations of virtual network resource.')
   applicationGatewayIPConfigurations: object[]?


### PR DESCRIPTION
- Added new type `ipamPoolPrefixAllocationsType` for IPAM pool prefix allocations.
- Updated `subnetType` to use the new `ipamPoolPrefixAllocationsType` instead of the previous inline definition.
- fixed issue with bicep-docs that failed due to the way ipamPoolPrefixAllocationsType was defined

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #123
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
