### PR TITLE
feat: CI - Updated `Set-AVMModule` function to latest specs

### DIFF
--- a/utilities/tools/Set-AVMModule.ps1
+++ b/utilities/tools/Set-AVMModule.ps1
@@ -85,7 +85,7 @@ function Set-AVMModule {
     # # Load helper scripts
     . (Join-Path $PSScriptRoot 'helper' 'Set-ModuleFileAndFolderSetup.ps1')
 
-    $resolvedPath = (Resolve-Path $ModuleFolderPath).Path
+    $resolvedPath = (Test-Path $ModuleFolderPath) ? (Resolve-Path $ModuleFolderPath).Path : $ModuleFolderPath
 
     # Build up module file & folder structure if not yet existing. Should only run if an actual module path was provided (and not any of their parent paths)
     if (-not $SkipFileAndFolderSetup -and (($resolvedPath -split '[\\|\/]avm[\\|\/](res|ptn|utl)[\\|\/].+?[\\|\/].+').count -gt 1)) {

--- a/utilities/tools/helper/src/CHANGELOG.md
+++ b/utilities/tools/helper/src/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/<modulePath>/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/utilities/tools/helper/src/src.main.bicep
+++ b/utilities/tools/helper/src/src.main.bicep
@@ -19,7 +19,7 @@ param enableTelemetry bool = true
 // ============== //
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.[[REPLACE WITH TELEMETRY IDENTIFIER]].${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'

--- a/utilities/tools/helper/src/src.main.test.bicep
+++ b/utilities/tools/helper/src/src.main.test.bicep
@@ -1,5 +1,8 @@
 targetScope = 'subscription'
 
+metadata name = '<TestName>'
+metadata description = '<TestDescription>'
+
 // ========== //
 // Parameters //
 // ========== //
@@ -25,7 +28,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }


### PR DESCRIPTION
## Description

- Replaced min test suffix with `min`
- Added test file metadata
- Updated default API versions
- Improved robustness when invoked for new modules

## Example invocation

> `Set-avmModule -ModuleFolderPath 'C:\avm\res\compute\disk-access'  -ThrottleLimit 10 -SkipBuild -SkipReadMe;`

<img width="1574" height="495" alt="image" src="https://github.com/user-attachments/assets/f1353f3d-5d53-49f8-b46a-496deb5f5231" />

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
