### PR TITLE
fix: Tags Parameter API Version Fix in `avm/res/insights/component`

### DIFF
--- a/avm/res/insights/component/CHANGELOG.md
+++ b/avm/res/insights/component/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/insights/component/CHANGELOG.md).
 
+## 0.7.1
+
+### Changes
+
+- Fixed API version for `tags` parameter type
+
+### Breaking Changes
+
+- None
+
 ## 0.7.0
 
 ### Changes

--- a/avm/res/insights/component/README.md
+++ b/avm/res/insights/component/README.md
@@ -116,7 +116,7 @@ module component 'br/public:avm/res/insights/component:<version>' = {
   name: 'componentDeployment'
   params: {
     // Required parameters
-    name: 'icmax001'
+    name: 'icpmax001'
     workspaceResourceId: '<workspaceResourceId>'
     // Non-required parameters
     diagnosticSettings: [
@@ -187,7 +187,7 @@ module component 'br/public:avm/res/insights/component:<version>' = {
   "parameters": {
     // Required parameters
     "name": {
-      "value": "icmax001"
+      "value": "icpmax001"
     },
     "workspaceResourceId": {
       "value": "<workspaceResourceId>"
@@ -282,7 +282,7 @@ module component 'br/public:avm/res/insights/component:<version>' = {
 using 'br/public:avm/res/insights/component:<version>'
 
 // Required parameters
-param name = 'icmax001'
+param name = 'icpmax001'
 param workspaceResourceId = '<workspaceResourceId>'
 // Non-required parameters
 param diagnosticSettings = [

--- a/avm/res/insights/component/linked-storage-account/main.json
+++ b/avm/res/insights/component/linked-storage-account/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "9567302051678045750"
+      "version": "0.39.26.7824",
+      "templateHash": "5059808225314360251"
     },
     "name": "Application Insights Linked Storage Account",
     "description": "This component deploys an Application Insights Linked Storage Account."

--- a/avm/res/insights/component/main.bicep
+++ b/avm/res/insights/component/main.bicep
@@ -91,7 +91,7 @@ import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6
 param roleAssignments roleAssignmentType[]?
 
 @description('Optional. Tags of the resource.')
-param tags resourceInput<'Microsoft.Insights/components@2020-10-01'>.tags?
+param tags resourceInput<'Microsoft.Insights/components@2020-02-02'>.tags?
 
 @description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true

--- a/avm/res/insights/component/main.json
+++ b/avm/res/insights/component/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "8576356756053854729"
+      "version": "0.39.26.7824",
+      "templateHash": "3585942119874432771"
     },
     "name": "Application Insights",
     "description": "This component deploys an Application Insights instance."
@@ -416,7 +416,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.Insights/components@2020-10-01#properties/tags"
+          "source": "Microsoft.Insights/components@2020-02-02#properties/tags"
         },
         "description": "Optional. Tags of the resource."
       },
@@ -605,8 +605,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "9567302051678045750"
+              "version": "0.39.26.7824",
+              "templateHash": "5059808225314360251"
             },
             "name": "Application Insights Linked Storage Account",
             "description": "This component deploys an Application Insights Linked Storage Account."

--- a/avm/res/insights/component/tests/e2e/max/main.test.bicep
+++ b/avm/res/insights/component/tests/e2e/max/main.test.bicep
@@ -15,7 +15,7 @@ param resourceGroupName string = 'dep-${namePrefix}-insights.components-${servic
 param resourceLocation string = deployment().location
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
-param serviceShort string = 'icmax'
+param serviceShort string = 'icpmax'
 
 @description('Optional. A token to inject into the name of each resource.')
 param namePrefix string = '#_namePrefix_#'


### PR DESCRIPTION
## Description

Fixed tags parameter API version reference to Microsoft.Insights/components@2020-02-02

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.insights.component](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.insights.component.yml/badge.svg?branch=users%2Fkrbar%2FappInsightsTagsFix)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.insights.component.yml) |

Fixes #6237 

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
