### PR TITLE
feat: Add access keys outputs to `avm/res/cognitive-services/account`

### DIFF
--- a/avm/res/cognitive-services/account/CHANGELOG.md
+++ b/avm/res/cognitive-services/account/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cognitive-services/account/CHANGELOG.md).
 
+## 0.14.1
+
+### Changes
+
+- Added `primaryKey` and `primaryKey` outputs
+
+### Breaking Changes
+
+- None
+
 ## 0.14.0
 
 ### Changes

--- a/avm/res/cognitive-services/account/README.md
+++ b/avm/res/cognitive-services/account/README.md
@@ -3403,9 +3403,11 @@ The storage accounts for this resource.
 | `exportedSecrets` |  | A hashtable of references to the secrets exported to the provided Key Vault. The key of each reference is each secret's name. |
 | `location` | string | The location the resource was deployed into. |
 | `name` | string | The name of the cognitive services account. |
+| `primaryKey` | securestring | The primary access key. |
 | `privateEndpoints` | array | The private endpoints of the congitive services account. |
 | `resourceGroupName` | string | The resource group the cognitive services account was deployed into. |
 | `resourceId` | string | The resource ID of the cognitive services account. |
+| `secondaryKey` | securestring | The secondary access key. |
 | `systemAssignedMIPrincipalId` | string | The principal ID of the system assigned identity. |
 
 ## Cross-referenced modules

--- a/avm/res/cognitive-services/account/main.bicep
+++ b/avm/res/cognitive-services/account/main.bicep
@@ -594,6 +594,14 @@ output privateEndpoints privateEndpointOutputType[] = [
   }
 ]
 
+@secure()
+@description('The primary access key.')
+output primaryKey string? = !disableLocalAuth ? cognitiveService.listKeys().key1 : null
+
+@secure()
+@description('The secondary access key.')
+output secondaryKey string? = !disableLocalAuth ? cognitiveService.listKeys().key2 : null
+
 // ================ //
 // Definitions      //
 // ================ //

--- a/avm/res/cognitive-services/account/main.json
+++ b/avm/res/cognitive-services/account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "14919930200951061092"
+      "version": "0.39.26.7824",
+      "templateHash": "15302696710472046095"
     },
     "name": "Cognitive Services",
     "description": "This module deploys a Cognitive Service."
@@ -2232,8 +2232,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "1394089926798493893"
+              "version": "0.39.26.7824",
+              "templateHash": "356315690886888607"
             }
           },
           "definitions": {
@@ -2429,6 +2429,22 @@
           "networkInterfaceResourceIds": "[reference(format('cognitiveService_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceResourceIds.value]"
         }
       }
+    },
+    "primaryKey": {
+      "type": "securestring",
+      "nullable": true,
+      "metadata": {
+        "description": "The primary access key."
+      },
+      "value": "[if(not(parameters('disableLocalAuth')), listKeys('cognitiveService', '2025-06-01').key1, null())]"
+    },
+    "secondaryKey": {
+      "type": "securestring",
+      "nullable": true,
+      "metadata": {
+        "description": "The secondary access key."
+      },
+      "value": "[if(not(parameters('disableLocalAuth')), listKeys('cognitiveService', '2025-06-01').key2, null())]"
     }
   }
 }


### PR DESCRIPTION
## Description

Added secure outputs: `primaryKey` and `secondaryKey`.


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.cognitive-services.account](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml/badge.svg?branch=users%2Fkrbar%2FcognitiveServicesKeys)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
