### PR TITLE
fix: Update RBAC assignment processing for management groups

### DIFF
--- a/avm/ptn/authorization/policy-assignment/CHANGELOG.md
+++ b/avm/ptn/authorization/policy-assignment/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/policy-assignment/CHANGELOG.md).
 
+## 0.5.2
+
+### Changes
+
+- Fixed bug where management groups for RBAC assignments were not being correctly processed and only those management groups specified in the `additionalManagementGroupsIDsToAssignRbacTo` parameter were being used instead of combining them with the management group scope of the policy assignment.
+
+### Breaking Changes
+
+- None
+
 ## 0.5.1
 
 ### Changes

--- a/avm/ptn/authorization/policy-assignment/main.json
+++ b/avm/ptn/authorization/policy-assignment/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "3078997291416932467"
+      "version": "0.39.26.7824",
+      "templateHash": "3845344383933695650"
     },
     "name": "Policy Assignments (All scopes)",
     "description": "This module deploys a Policy Assignment at a Management Group, Subscription or Resource Group scope."
@@ -217,7 +217,7 @@
     "policyAssignment_mg": {
       "condition": "[and(empty(parameters('subscriptionId')), empty(parameters('resourceGroupName')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-PolicyAssignment-MG-Module', uniqueString(deployment().name, parameters('location')))]",
       "scope": "[format('Microsoft.Management/managementGroups/{0}', parameters('managementGroupId'))]",
       "location": "[deployment().location]",
@@ -274,8 +274,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "16696735039358850323"
+              "version": "0.39.26.7824",
+              "templateHash": "3522442314177871322"
             },
             "name": "Policy Assignments (Management Group scope)",
             "description": "This module deploys a Policy Assignment at a Management Group scope."
@@ -454,9 +454,9 @@
                 "name": "managementGroupRoleAssignments",
                 "count": "[length(parameters('roleDefinitionIds'))]"
               },
-              "condition": "[and(and(not(empty(parameters('roleDefinitionIds'))), not(empty(parameters('additionalManagementGroupsIDsToAssignRbacTo')))), equals(parameters('identity'), 'SystemAssigned'))]",
+              "condition": "[and(and(not(empty(parameters('roleDefinitionIds'))), not(empty(variables('finalArrayOfManagementGroupsToAssignRbacTo')))), equals(parameters('identity'), 'SystemAssigned'))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-PolicyAssignment-MG-Module-Additional-RBAC', uniqueString(deployment().name, parameters('location'), parameters('roleDefinitionIds')[copyIndex()], parameters('name')))]",
               "location": "[deployment().location]",
               "properties": {
@@ -484,8 +484,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "6866566455345128487"
+                      "version": "0.39.26.7824",
+                      "templateHash": "11943394730159030733"
                     }
                   },
                   "parameters": {
@@ -530,7 +530,7 @@
                         "count": "[length(parameters('managementGroupsIDsToAssignRbacTo'))]"
                       },
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2022-09-01",
+                      "apiVersion": "2025-04-01",
                       "name": "[format('{0}-PolicyAssignment-MG-Module-Additional-RBAC', uniqueString(deployment().name, parameters('location'), parameters('roleDefinitionId'), parameters('name')))]",
                       "scope": "[format('Microsoft.Management/managementGroups/{0}', parameters('managementGroupsIDsToAssignRbacTo')[copyIndex()])]",
                       "location": "[deployment().location]",
@@ -556,8 +556,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "9372315288124069987"
+                              "version": "0.39.26.7824",
+                              "templateHash": "10827247913795553672"
                             }
                           },
                           "parameters": {
@@ -617,7 +617,7 @@
               },
               "condition": "[and(and(not(empty(parameters('roleDefinitionIds'))), not(empty(parameters('additionalSubscriptionIDsToAssignRbacTo')))), equals(parameters('identity'), 'SystemAssigned'))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-PolicyAssignment-MG-Module-Additional-RBAC-Subs', uniqueString(deployment().name, parameters('location'), parameters('roleDefinitionIds')[copyIndex()], parameters('name')))]",
               "location": "[deployment().location]",
               "properties": {
@@ -645,8 +645,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "14456224861384112444"
+                      "version": "0.39.26.7824",
+                      "templateHash": "5852722490435240271"
                     }
                   },
                   "parameters": {
@@ -691,7 +691,7 @@
                         "count": "[length(parameters('subscriptionIDsToAssignRbacTo'))]"
                       },
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2022-09-01",
+                      "apiVersion": "2025-04-01",
                       "name": "[format('{0}-PolicyAssignment-MG-Module-RBAC-Sub-{1}', uniqueString(deployment().name, parameters('location'), parameters('roleDefinitionId'), parameters('name')), substring(parameters('subscriptionIDsToAssignRbacTo')[copyIndex()], 0, 8))]",
                       "subscriptionId": "[parameters('subscriptionIDsToAssignRbacTo')[copyIndex()]]",
                       "location": "[deployment().location]",
@@ -717,8 +717,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "3858413328521914948"
+                              "version": "0.39.26.7824",
+                              "templateHash": "297261946822960846"
                             }
                           },
                           "parameters": {
@@ -778,7 +778,7 @@
               },
               "condition": "[and(and(not(empty(parameters('roleDefinitionIds'))), not(empty(parameters('additionalResourceGroupResourceIDsToAssignRbacTo')))), equals(parameters('identity'), 'SystemAssigned'))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-PolicyAssignment-MG-Module-Additional-RBAC-RGs', uniqueString(deployment().name, parameters('location'), parameters('roleDefinitionIds')[copyIndex()], parameters('name')))]",
               "location": "[deployment().location]",
               "properties": {
@@ -806,8 +806,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "14885565573528717585"
+                      "version": "0.39.26.7824",
+                      "templateHash": "905227369220927938"
                     }
                   },
                   "parameters": {
@@ -852,7 +852,7 @@
                         "count": "[length(parameters('resourceGroupResourceIDsToAssignRbacTo'))]"
                       },
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2022-09-01",
+                      "apiVersion": "2025-04-01",
                       "name": "[format('{0}-PolicyAssignment-MG-Module-RBAC-RG-Sub-{1}', uniqueString(deployment().name, parameters('location'), parameters('roleDefinitionId'), parameters('name'), parameters('resourceGroupResourceIDsToAssignRbacTo')[copyIndex()]), substring(split(parameters('resourceGroupResourceIDsToAssignRbacTo')[copyIndex()], '/')[2], 0, 8))]",
                       "subscriptionId": "[split(parameters('resourceGroupResourceIDsToAssignRbacTo')[copyIndex()], '/')[2]]",
                       "resourceGroup": "[split(parameters('resourceGroupResourceIDsToAssignRbacTo')[copyIndex()], '/')[4]]",
@@ -878,8 +878,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.37.4.10188",
-                              "templateHash": "2244198828379535633"
+                              "version": "0.39.26.7824",
+                              "templateHash": "15559047093658721746"
                             }
                           },
                           "parameters": {
@@ -969,7 +969,7 @@
     "policyAssignment_sub": {
       "condition": "[and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-PolicyAssignment-Sub-Module', uniqueString(deployment().name, parameters('location')))]",
       "subscriptionId": "[parameters('subscriptionId')]",
       "location": "[deployment().location]",
@@ -1020,8 +1020,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "7020424788908864147"
+              "version": "0.39.26.7824",
+              "templateHash": "656621665529853593"
             },
             "name": "Policy Assignments (Subscription scope)",
             "description": "This module deploys a Policy Assignment at a Subscription scope."
@@ -1235,7 +1235,7 @@
     "policyAssignment_rg": {
       "condition": "[and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId'))))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-PolicyAssignment-RG-Module', uniqueString(deployment().name, parameters('location')))]",
       "subscriptionId": "[parameters('subscriptionId')]",
       "resourceGroup": "[parameters('resourceGroupName')]",
@@ -1286,8 +1286,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "1655694359990844863"
+              "version": "0.39.26.7824",
+              "templateHash": "12278402966630035063"
             },
             "name": "Policy Assignments (Resource Group scope)",
             "description": "This module deploys a Policy Assignment at a Resource Group scope."

--- a/avm/ptn/authorization/policy-assignment/modules/management-group.bicep
+++ b/avm/ptn/authorization/policy-assignment/modules/management-group.bicep
@@ -108,7 +108,7 @@ resource policyAssignment 'Microsoft.Authorization/policyAssignments@2025-01-01'
 }
 
 module managementGroupRoleAssignments 'management-group-additional-rbac-asi-def-loop.bicep' = [
-  for roleDefinitionId in roleDefinitionIds: if (!empty(roleDefinitionIds) && !empty(additionalManagementGroupsIDsToAssignRbacTo) && identity == 'SystemAssigned') {
+  for roleDefinitionId in roleDefinitionIds: if (!empty(roleDefinitionIds) && !empty(finalArrayOfManagementGroupsToAssignRbacTo) && identity == 'SystemAssigned') {
     name: '${uniqueString(deployment().name, location, roleDefinitionId, name)}-PolicyAssignment-MG-Module-Additional-RBAC'
     params: {
       name: name


### PR DESCRIPTION
## Description

- Fixed bug where management groups for RBAC assignments were not correctly processed.
- Updated logic to combine management groups specified in the `additionalManagementGroupsIDsToAssignRbacTo` parameter with the management group scope of the policy assignment.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.ptn.authorization.policy-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-assignment.yml/badge.svg?branch=users%2Fjtracey93%2Ffix%2Fpol-asi-ptn-rbac)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.policy-assignment.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
