### PR TITLE
fix: Remove '(Preview)' label from role name in `avm/res/management/service-group`

### DIFF
--- a/avm/res/management/service-group/CHANGELOG.md
+++ b/avm/res/management/service-group/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/management/service-group/CHANGELOG.md).
 
+## 0.1.1
+
+### Changes
+
+- Removed the "Preview" label from the role `Role Based Access Control Administrator`.
+
+### Breaking Changes
+
+- None
+
 ## 0.1.0
 
 ### Changes

--- a/avm/res/management/service-group/README.md
+++ b/avm/res/management/service-group/README.md
@@ -382,7 +382,7 @@ Array of role assignments to create.
   - `'Contributor'`
   - `'Owner'`
   - `'Reader'`
-  - `'Role Based Access Control Administrator (Preview)'`
+  - `'Role Based Access Control Administrator'`
   - `'User Access Administrator'`
   - `'Service Group Administrator'`
   - `'Service Group Contributor'`

--- a/avm/res/management/service-group/main.bicep
+++ b/avm/res/management/service-group/main.bicep
@@ -33,7 +33,7 @@ var builtInRoleNames = {
   Contributor: tenantResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
   Owner: tenantResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
   Reader: tenantResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
-  'Role Based Access Control Administrator (Preview)': tenantResourceId(
+  'Role Based Access Control Administrator': tenantResourceId(
     'Microsoft.Authorization/roleDefinitions',
     'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
   )

--- a/avm/res/management/service-group/main.json
+++ b/avm/res/management/service-group/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "2483188741245687532"
+      "version": "0.39.26.7824",
+      "templateHash": "12703642976321309495"
     },
     "name": "Service Groups",
     "description": "This module will allow you to create a service group and also associate resource to this service group, if you have permissions upon those resources."
@@ -203,7 +203,7 @@
       "Contributor": "[tenantResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
       "Owner": "[tenantResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
       "Reader": "[tenantResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
-      "Role Based Access Control Administrator (Preview)": "[tenantResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+      "Role Based Access Control Administrator": "[tenantResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
       "User Access Administrator": "[tenantResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
       "Service Group Administrator": "[tenantResourceId('Microsoft.Authorization/roleDefinitions', '4e50c84c-c78e-4e37-b47e-e60ffea0a775')]",
       "Service Group Contributor": "[tenantResourceId('Microsoft.Authorization/roleDefinitions', '32e6a4ec-6095-4e37-b54b-12aa350ba81f')]",
@@ -285,7 +285,7 @@
         "count": "[length(coalesce(parameters('subscriptionIdsToAssociateToServiceGroup'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('serviceGroup_subscriptionMember-{0}-{1}', copyIndex(), uniqueString('serviceGroup_subscriptionMember', deployment().name))]",
       "subscriptionId": "[coalesce(parameters('subscriptionIdsToAssociateToServiceGroup'), createArray())[copyIndex()]]",
       "location": "[deployment().location]",
@@ -305,8 +305,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "16921417674676465264"
+              "version": "0.39.26.7824",
+              "templateHash": "14742369208074015874"
             }
           },
           "parameters": {
@@ -342,7 +342,7 @@
         "count": "[length(coalesce(parameters('resourceGroupResourceIdsToAssociateToServiceGroup'), createArray()))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('serviceGroup_resourceGroupMember-{0}-{1}', copyIndex(), uniqueString('serviceGroup_resourceGroupMember', deployment().name))]",
       "subscriptionId": "[split(coalesce(parameters('resourceGroupResourceIdsToAssociateToServiceGroup'), createArray())[copyIndex()], '/')[2]]",
       "resourceGroup": "[split(coalesce(parameters('resourceGroupResourceIdsToAssociateToServiceGroup'), createArray())[copyIndex()], '/')[4]]",
@@ -362,8 +362,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "10634720568086308362"
+              "version": "0.39.26.7824",
+              "templateHash": "2908038107727204465"
             }
           },
           "parameters": {


### PR DESCRIPTION
## Description

Removed the `Preview` label from the role 'Role Based Access Control Administrator' as per https://github.com/Azure/bicep-registry-modules/issues/3112

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.management.service-group](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.management.service-group.yml/badge.svg?branch=users%2Fkrbar%2FserviceGroupUpdate)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.management.service-group.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
