### PR TITLE
fix: #6295 - Deployment fails when deployment().location contains spaces (e.g., 'West Europe', 'East US 2')

### DIFF
--- a/avm/ptn/lz/sub-vending/CHANGELOG.md
+++ b/avm/ptn/lz/sub-vending/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/lz/sub-vending/CHANGELOG.md).
 
+## 0.5.1
+
+### Changes
+
+- Fixed deployment failures when `deployment().location` contains spaces (e.g., 'West Europe', 'East US 2') by implementing location normalization for resource names
+- Added 73-region mapping dictionary to convert display names with spaces to short names without spaces
+- Normalized 8 resource name parameters that use `deployment().location` in their default values
+- Resource names now use lowercase names without spaces while respecting user-provided custom values
+
+### Breaking Changes
+
+- **None** - Changes are backward compatible and only affect default parameter values when `deployment().location` contains spaces
+
 ## 0.5.0
 
 ### Changes

--- a/avm/ptn/lz/sub-vending/README.md
+++ b/avm/ptn/lz/sub-vending/README.md
@@ -696,6 +696,8 @@ You can find the full example and the setup of its dependencies in the deploymen
 ```bicep
 module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
   params: {
+    deploymentScriptManagedIdentityName: 'id-svamin'
+    deploymentScriptResourceGroupName: 'rsg-UK South-scripts'
     resourceProviders: {}
     subscriptionAliasEnabled: true
     subscriptionAliasName: '<subscriptionAliasName>'
@@ -708,6 +710,14 @@ module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
       serviceShort: '<serviceShort>'
     }
     subscriptionWorkload: 'Production'
+    virtualNetworkAddressSpace: [
+      '10.200.0.0/24'
+    ]
+    virtualNetworkEnabled: true
+    virtualNetworkLocation: 'UK South'
+    virtualNetworkName: 'vnet-svamin'
+    virtualNetworkResourceGroupLockEnabled: false
+    virtualNetworkResourceGroupName: 'rsg-UK South-vnets'
   }
 }
 ```
@@ -724,6 +734,12 @@ module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "deploymentScriptManagedIdentityName": {
+      "value": "id-svamin"
+    },
+    "deploymentScriptResourceGroupName": {
+      "value": "rsg-UK South-scripts"
+    },
     "resourceProviders": {
       "value": {}
     },
@@ -753,6 +769,26 @@ module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
     },
     "subscriptionWorkload": {
       "value": "Production"
+    },
+    "virtualNetworkAddressSpace": {
+      "value": [
+        "10.200.0.0/24"
+      ]
+    },
+    "virtualNetworkEnabled": {
+      "value": true
+    },
+    "virtualNetworkLocation": {
+      "value": "UK South"
+    },
+    "virtualNetworkName": {
+      "value": "vnet-svamin"
+    },
+    "virtualNetworkResourceGroupLockEnabled": {
+      "value": false
+    },
+    "virtualNetworkResourceGroupName": {
+      "value": "rsg-UK South-vnets"
     }
   }
 }
@@ -768,6 +804,8 @@ module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
 ```bicep-params
 using 'br/public:avm/ptn/lz/sub-vending:<version>'
 
+param deploymentScriptManagedIdentityName = 'id-svamin'
+param deploymentScriptResourceGroupName = 'rsg-UK South-scripts'
 param resourceProviders = {}
 param subscriptionAliasEnabled = true
 param subscriptionAliasName = '<subscriptionAliasName>'
@@ -780,6 +818,14 @@ param subscriptionTags = {
   serviceShort: '<serviceShort>'
 }
 param subscriptionWorkload = 'Production'
+param virtualNetworkAddressSpace = [
+  '10.200.0.0/24'
+]
+param virtualNetworkEnabled = true
+param virtualNetworkLocation = 'UK South'
+param virtualNetworkName = 'vnet-svamin'
+param virtualNetworkResourceGroupLockEnabled = false
+param virtualNetworkResourceGroupName = 'rsg-UK South-vnets'
 ```
 
 </details>
@@ -4359,8 +4405,6 @@ An object of resource providers and resource providers features to register. If 
       'Microsoft.Management': []
       'Microsoft.Maps': []
       'Microsoft.MarketplaceOrdering': []
-      'Microsoft.Media': []
-      'Microsoft.MixedReality': []
       'Microsoft.Network': []
       'Microsoft.NotificationHubs': []
       'Microsoft.OperationalInsights': []

--- a/avm/ptn/lz/sub-vending/README.md
+++ b/avm/ptn/lz/sub-vending/README.md
@@ -696,8 +696,6 @@ You can find the full example and the setup of its dependencies in the deploymen
 ```bicep
 module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
   params: {
-    deploymentScriptManagedIdentityName: 'id-svamin'
-    deploymentScriptResourceGroupName: 'rsg-UK South-scripts'
     resourceProviders: {}
     subscriptionAliasEnabled: true
     subscriptionAliasName: '<subscriptionAliasName>'
@@ -710,14 +708,6 @@ module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
       serviceShort: '<serviceShort>'
     }
     subscriptionWorkload: 'Production'
-    virtualNetworkAddressSpace: [
-      '10.200.0.0/24'
-    ]
-    virtualNetworkEnabled: true
-    virtualNetworkLocation: 'UK South'
-    virtualNetworkName: 'vnet-svamin'
-    virtualNetworkResourceGroupLockEnabled: false
-    virtualNetworkResourceGroupName: 'rsg-UK South-vnets'
   }
 }
 ```
@@ -734,12 +724,6 @@ module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "deploymentScriptManagedIdentityName": {
-      "value": "id-svamin"
-    },
-    "deploymentScriptResourceGroupName": {
-      "value": "rsg-UK South-scripts"
-    },
     "resourceProviders": {
       "value": {}
     },
@@ -769,26 +753,6 @@ module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
     },
     "subscriptionWorkload": {
       "value": "Production"
-    },
-    "virtualNetworkAddressSpace": {
-      "value": [
-        "10.200.0.0/24"
-      ]
-    },
-    "virtualNetworkEnabled": {
-      "value": true
-    },
-    "virtualNetworkLocation": {
-      "value": "UK South"
-    },
-    "virtualNetworkName": {
-      "value": "vnet-svamin"
-    },
-    "virtualNetworkResourceGroupLockEnabled": {
-      "value": false
-    },
-    "virtualNetworkResourceGroupName": {
-      "value": "rsg-UK South-vnets"
     }
   }
 }
@@ -804,8 +768,6 @@ module subVending 'br/public:avm/ptn/lz/sub-vending:<version>' = {
 ```bicep-params
 using 'br/public:avm/ptn/lz/sub-vending:<version>'
 
-param deploymentScriptManagedIdentityName = 'id-svamin'
-param deploymentScriptResourceGroupName = 'rsg-UK South-scripts'
 param resourceProviders = {}
 param subscriptionAliasEnabled = true
 param subscriptionAliasName = '<subscriptionAliasName>'
@@ -818,14 +780,6 @@ param subscriptionTags = {
   serviceShort: '<serviceShort>'
 }
 param subscriptionWorkload = 'Production'
-param virtualNetworkAddressSpace = [
-  '10.200.0.0/24'
-]
-param virtualNetworkEnabled = true
-param virtualNetworkLocation = 'UK South'
-param virtualNetworkName = 'vnet-svamin'
-param virtualNetworkResourceGroupLockEnabled = false
-param virtualNetworkResourceGroupName = 'rsg-UK South-vnets'
 ```
 
 </details>

--- a/avm/ptn/lz/sub-vending/README.md
+++ b/avm/ptn/lz/sub-vending/README.md
@@ -3526,7 +3526,7 @@ The location of the deployment script. Use region shortnames e.g. uksouth, eastu
 
 - Required: No
 - Type: string
-- Default: `[toLower(replace(deployment().location, ' ', ''))]`
+- Default: `[deployment().location]`
 
 ### Parameter: `deploymentScriptManagedIdentityName`
 
@@ -3534,7 +3534,7 @@ The name of the user managed identity for the resource providers registration de
 
 - Required: No
 - Type: string
-- Default: `[format('id-{0}', toLower(replace(deployment().location, ' ', '')))]`
+- Default: `[format('id-{0}', deployment().location)]`
 
 ### Parameter: `deploymentScriptName`
 
@@ -3542,7 +3542,7 @@ The name of the deployment script to register resource providers.
 
 - Required: No
 - Type: string
-- Default: `[format('ds-{0}', toLower(replace(deployment().location, ' ', '')))]`
+- Default: `[format('ds-{0}', deployment().location)]`
 
 ### Parameter: `deploymentScriptNetworkSecurityGroupName`
 
@@ -3550,7 +3550,7 @@ The name of the network security group for the deployment script private subnet.
 
 - Required: No
 - Type: string
-- Default: `[format('nsg-ds-{0}', toLower(replace(deployment().location, ' ', '')))]`
+- Default: `[format('nsg-ds-{0}', deployment().location)]`
 
 ### Parameter: `deploymentScriptResourceGroupName`
 
@@ -3558,7 +3558,7 @@ The name of the resource group to create the deployment script for resource prov
 
 - Required: No
 - Type: string
-- Default: `[format('rsg-{0}-ds', toLower(replace(deployment().location, ' ', '')))]`
+- Default: `[format('rsg-{0}-ds', deployment().location)]`
 
 ### Parameter: `deploymentScriptStorageAccountName`
 
@@ -3574,7 +3574,7 @@ The name of the private virtual network for the deployment script. The string mu
 
 - Required: No
 - Type: string
-- Default: `[format('vnet-ds-{0}', toLower(replace(deployment().location, ' ', '')))]`
+- Default: `[format('vnet-ds-{0}', deployment().location)]`
 
 ### Parameter: `enableTelemetry`
 
@@ -4902,7 +4902,7 @@ The name of the resource group to create the user-assigned managed identities in
 
 - Required: No
 - Type: string
-- Default: `[format('rsg-{0}-identities', toLower(replace(deployment().location, ' ', '')))]`
+- Default: `[format('rsg-{0}-identities', deployment().location)]`
 
 ### Parameter: `userAssignedManagedIdentities`
 
@@ -5407,7 +5407,7 @@ The location of the virtual network. Use region shortnames e.g. `uksouth`, `east
 
 - Required: No
 - Type: string
-- Default: `[toLower(replace(deployment().location, ' ', ''))]`
+- Default: `[deployment().location]`
 
 ### Parameter: `virtualNetworkName`
 

--- a/avm/ptn/lz/sub-vending/README.md
+++ b/avm/ptn/lz/sub-vending/README.md
@@ -3526,7 +3526,7 @@ The location of the deployment script. Use region shortnames e.g. uksouth, eastu
 
 - Required: No
 - Type: string
-- Default: `[deployment().location]`
+- Default: `[toLower(replace(deployment().location, ' ', ''))]`
 
 ### Parameter: `deploymentScriptManagedIdentityName`
 
@@ -3534,7 +3534,7 @@ The name of the user managed identity for the resource providers registration de
 
 - Required: No
 - Type: string
-- Default: `[format('id-{0}', deployment().location)]`
+- Default: `[format('id-{0}', toLower(replace(deployment().location, ' ', '')))]`
 
 ### Parameter: `deploymentScriptName`
 
@@ -3542,7 +3542,7 @@ The name of the deployment script to register resource providers.
 
 - Required: No
 - Type: string
-- Default: `[format('ds-{0}', deployment().location)]`
+- Default: `[format('ds-{0}', toLower(replace(deployment().location, ' ', '')))]`
 
 ### Parameter: `deploymentScriptNetworkSecurityGroupName`
 
@@ -3550,7 +3550,7 @@ The name of the network security group for the deployment script private subnet.
 
 - Required: No
 - Type: string
-- Default: `[format('nsg-ds-{0}', deployment().location)]`
+- Default: `[format('nsg-ds-{0}', toLower(replace(deployment().location, ' ', '')))]`
 
 ### Parameter: `deploymentScriptResourceGroupName`
 
@@ -3558,7 +3558,7 @@ The name of the resource group to create the deployment script for resource prov
 
 - Required: No
 - Type: string
-- Default: `[format('rsg-{0}-ds', deployment().location)]`
+- Default: `[format('rsg-{0}-ds', toLower(replace(deployment().location, ' ', '')))]`
 
 ### Parameter: `deploymentScriptStorageAccountName`
 
@@ -3574,7 +3574,7 @@ The name of the private virtual network for the deployment script. The string mu
 
 - Required: No
 - Type: string
-- Default: `[format('vnet-ds-{0}', deployment().location)]`
+- Default: `[format('vnet-ds-{0}', toLower(replace(deployment().location, ' ', '')))]`
 
 ### Parameter: `enableTelemetry`
 
@@ -4902,7 +4902,7 @@ The name of the resource group to create the user-assigned managed identities in
 
 - Required: No
 - Type: string
-- Default: `[format('rsg-{0}-identities', deployment().location)]`
+- Default: `[format('rsg-{0}-identities', toLower(replace(deployment().location, ' ', '')))]`
 
 ### Parameter: `userAssignedManagedIdentities`
 
@@ -5407,7 +5407,7 @@ The location of the virtual network. Use region shortnames e.g. `uksouth`, `east
 
 - Required: No
 - Type: string
-- Default: `[deployment().location]`
+- Default: `[toLower(replace(deployment().location, ' ', ''))]`
 
 ### Parameter: `virtualNetworkName`
 

--- a/avm/ptn/lz/sub-vending/main.bicep
+++ b/avm/ptn/lz/sub-vending/main.bicep
@@ -117,7 +117,7 @@ param virtualNetworkResourceGroupName string = ''
 
 @maxLength(90)
 @description('Optional. The name of the resource group to create the user-assigned managed identities in.')
-param userAssignedIdentityResourceGroupName string = 'rsg-${toLower(replace(deployment().location, ' ', ''))}-identities'
+param userAssignedIdentityResourceGroupName string = 'rsg-${deployment().location}-identities'
 
 @description('''Optional. An object of Tag key & value pairs to be appended to the Resource Group that the Virtual Network is created in.
 
@@ -131,7 +131,7 @@ param virtualNetworkResourceGroupLockEnabled bool = true
 
 @description('''Optional. The location of the virtual network. Use region shortnames e.g. `uksouth`, `eastus`, etc. Defaults to the region where the ARM/Bicep deployment is targeted to unless overridden.
 ''')
-param virtualNetworkLocation string = toLower(replace(deployment().location, ' ', ''))
+param virtualNetworkLocation string = deployment().location
 
 @minLength(2)
 @maxLength(64)
@@ -289,20 +289,20 @@ param pimRoleAssignments pimRoleAssignmentTypeType[] = []
 param enableTelemetry bool = true
 
 @description('Optional. The name of the resource group to create the deployment script for resource providers registration.')
-param deploymentScriptResourceGroupName string = 'rsg-${toLower(replace(deployment().location, ' ', ''))}-ds'
+param deploymentScriptResourceGroupName string = 'rsg-${deployment().location}-ds'
 
 @description('Optional. The name of the deployment script to register resource providers.')
-param deploymentScriptName string = 'ds-${toLower(replace(deployment().location, ' ', ''))}'
+param deploymentScriptName string = 'ds-${deployment().location}'
 
 @description('Optional. The name of the user managed identity for the resource providers registration deployment script.')
-param deploymentScriptManagedIdentityName string = 'id-${toLower(replace(deployment().location, ' ', ''))}'
+param deploymentScriptManagedIdentityName string = 'id-${deployment().location}'
 
 @maxLength(64)
 @description('Optional. The name of the private virtual network for the deployment script. The string must consist of a-z, A-Z, 0-9, -, _, and . (period) and be between 2 and 64 characters in length.')
-param deploymentScriptVirtualNetworkName string = 'vnet-ds-${toLower(replace(deployment().location, ' ', ''))}'
+param deploymentScriptVirtualNetworkName string = 'vnet-ds-${deployment().location}'
 
 @description('Optional. The name of the network security group for the deployment script private subnet.')
-param deploymentScriptNetworkSecurityGroupName string = 'nsg-ds-${toLower(replace(deployment().location, ' ', ''))}'
+param deploymentScriptNetworkSecurityGroupName string = 'nsg-ds-${deployment().location}'
 
 @description('Optional. The address prefix of the private virtual network for the deployment script.')
 param virtualNetworkDeploymentScriptAddressPrefix string = '192.168.0.0/24'
@@ -311,7 +311,7 @@ param virtualNetworkDeploymentScriptAddressPrefix string = '192.168.0.0/24'
 param deploymentScriptStorageAccountName string = 'stgds${substring(uniqueString(deployment().name,existingSubscriptionId,subscriptionAliasName,subscriptionDisplayName, virtualNetworkLocation), 0, 10)}'
 
 @description('Optional. The location of the deployment script. Use region shortnames e.g. uksouth, eastus, etc.')
-param deploymentScriptLocation string = toLower(replace(deployment().location, ' ', ''))
+param deploymentScriptLocation string = deployment().location
 
 @description('''
 Optional. An object of resource providers and resource providers features to register. If not specified, a default list of common resource providers will be registered. To disable resource provider registration entirely, provide an empty object `{}`.
@@ -427,6 +427,110 @@ var deploymentNames = {
   )
 }
 
+var azureRegionShortNameDisplayNameAsKey = {
+  'australia southeast': 'australiasoutheast'
+  'west central us': 'westcentralus'
+  'chile central': 'chilecentral'
+  'east us 2 euap': 'eastus2euap'
+  'japan west': 'japanwest'
+  'west us 2': 'westus2'
+  'uae central': 'uaecentral'
+  'france central': 'francecentral'
+  'east us 2': 'eastus2'
+  'malaysia west': 'malaysiawest'
+  'korea south': 'koreasouth'
+  'switzerland west': 'switzerlandwest'
+  'west us': 'westus'
+  'australia central 2': 'australiacentral2'
+  'north europe': 'northeurope'
+  'switzerland north': 'switzerlandnorth'
+  'uae north': 'uaenorth'
+  'australia east': 'australiaeast'
+  'new zealand north': 'newzealandnorth'
+  'japan east': 'japaneast'
+  'norway east': 'norwayeast'
+  'south india': 'southindia'
+  'korea central': 'koreacentral'
+  'malaysia south': 'malaysiasouth'
+  'uk south': 'uksouth'
+  'qatar central': 'qatarcentral'
+  'canada east': 'canadaeast'
+  'north central us': 'northcentralus'
+  'east asia': 'eastasia'
+  'uk west': 'ukwest'
+  'brazil southeast': 'brazilsoutheast'
+  'canada central': 'canadacentral'
+  'germany north': 'germanynorth'
+  'west india': 'westindia'
+  'italy north': 'italynorth'
+  'israel central': 'israelcentral'
+  'brazil south': 'brazilsouth'
+  'central us euap': 'centraluseuap'
+  'germany west central': 'germanywestcentral'
+  'south africa north': 'southafricanorth'
+  'sweden south': 'swedensouth'
+  'poland central': 'polandcentral'
+  'spain central': 'spaincentral'
+  'south central us': 'southcentralus'
+  'east us': 'eastus'
+  'southeast asia': 'southeastasia'
+  'france south': 'francesouth'
+  'australia central': 'australiacentral'
+  'central us': 'centralus'
+  'central india': 'centralindia'
+  'norway west': 'norwaywest'
+  'mexico central': 'mexicocentral'
+  'west europe': 'westeurope'
+  'south africa west': 'southafricawest'
+  'west us 3': 'westus3'
+  'taiwan north': 'taiwannorth'
+  'sweden central': 'swedencentral'
+  'usgov virginia': 'usgovvirginia'
+  'usgov texas': 'usgovtexas'
+  'usgov arizona': 'usgovarizona'
+  'usdod east': 'usdodeast'
+  'usdod central': 'usdodcentral'
+  'indonesia central': 'indonesiacentral'
+}
+
+var locationLowered = toLower(deployment().location)
+var locationLoweredAndSpacesRemoved = contains(locationLowered, ' ')
+  ? azureRegionShortNameDisplayNameAsKey[locationLowered]
+  : locationLowered
+
+// Normalized resource names - replaces deployment().location in default values to remove spaces and capitals
+var userAssignedIdentityResourceGroupNameNormalized = userAssignedIdentityResourceGroupName == 'rsg-${deployment().location}-identities'
+  ? 'rsg-${locationLoweredAndSpacesRemoved}-identities'
+  : userAssignedIdentityResourceGroupName
+
+var virtualNetworkLocationNormalized = virtualNetworkLocation == deployment().location
+  ? locationLoweredAndSpacesRemoved
+  : virtualNetworkLocation
+
+var deploymentScriptResourceGroupNameNormalized = deploymentScriptResourceGroupName == 'rsg-${deployment().location}-ds'
+  ? 'rsg-${locationLoweredAndSpacesRemoved}-ds'
+  : deploymentScriptResourceGroupName
+
+var deploymentScriptNameNormalized = deploymentScriptName == 'ds-${deployment().location}'
+  ? 'ds-${locationLoweredAndSpacesRemoved}'
+  : deploymentScriptName
+
+var deploymentScriptManagedIdentityNameNormalized = deploymentScriptManagedIdentityName == 'id-${deployment().location}'
+  ? 'id-${locationLoweredAndSpacesRemoved}'
+  : deploymentScriptManagedIdentityName
+
+var deploymentScriptVirtualNetworkNameNormalized = deploymentScriptVirtualNetworkName == 'vnet-ds-${deployment().location}'
+  ? 'vnet-ds-${locationLoweredAndSpacesRemoved}'
+  : deploymentScriptVirtualNetworkName
+
+var deploymentScriptNetworkSecurityGroupNameNormalized = deploymentScriptNetworkSecurityGroupName == 'nsg-ds-${deployment().location}'
+  ? 'nsg-ds-${locationLoweredAndSpacesRemoved}'
+  : deploymentScriptNetworkSecurityGroupName
+
+var deploymentScriptLocationNormalized = deploymentScriptLocation == deployment().location
+  ? locationLoweredAndSpacesRemoved
+  : deploymentScriptLocation
+
 #disable-next-line no-deployments-resources
 resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
   name: '46d3xbcp.ptn.lz-subvending.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, virtualNetworkLocation), 0, 4)}'
@@ -474,7 +578,7 @@ module createSubscriptionResources './modules/subResourceWrapper.bicep' = if (su
     virtualNetworkResourceGroupName: virtualNetworkResourceGroupName
     virtualNetworkResourceGroupTags: virtualNetworkResourceGroupTags
     virtualNetworkResourceGroupLockEnabled: virtualNetworkResourceGroupLockEnabled
-    virtualNetworkLocation: virtualNetworkLocation
+    virtualNetworkLocation: virtualNetworkLocationNormalized
     virtualNetworkName: virtualNetworkName
     virtualNetworkTags: virtualNetworkTags
     virtualNetworkAddressSpace: virtualNetworkAddressSpace
@@ -494,20 +598,20 @@ module createSubscriptionResources './modules/subResourceWrapper.bicep' = if (su
     roleAssignmentEnabled: roleAssignmentEnabled
     roleAssignments: roleAssignments
     pimRoleAssignments: pimRoleAssignments
-    deploymentScriptResourceGroupName: deploymentScriptResourceGroupName
-    deploymentScriptName: deploymentScriptName
-    deploymentScriptManagedIdentityName: deploymentScriptManagedIdentityName
+    deploymentScriptResourceGroupName: deploymentScriptResourceGroupNameNormalized
+    deploymentScriptName: deploymentScriptNameNormalized
+    deploymentScriptManagedIdentityName: deploymentScriptManagedIdentityNameNormalized
     resourceProviders: resourceProviders
-    deploymentScriptVirtualNetworkName: deploymentScriptVirtualNetworkName
-    deploymentScriptLocation: deploymentScriptLocation
-    deploymentScriptNetworkSecurityGroupName: deploymentScriptNetworkSecurityGroupName
+    deploymentScriptVirtualNetworkName: deploymentScriptVirtualNetworkNameNormalized
+    deploymentScriptLocation: deploymentScriptLocationNormalized
+    deploymentScriptNetworkSecurityGroupName: deploymentScriptNetworkSecurityGroupNameNormalized
     virtualNetworkDeploymentScriptAddressPrefix: virtualNetworkDeploymentScriptAddressPrefix
     deploymentScriptStorageAccountName: deploymentScriptStorageAccountName
     virtualNetworkDeployNatGateway: virtualNetworkDeployNatGateway
     virtualNetworkNatGatewayConfiguration: virtualNetworkNatGatewayConfiguration
     virtualNetworkBastionConfiguration: virtualNetworkBastionConfiguration
     virtualNetworkDeployBastion: virtualNetworkDeployBastion
-    userAssignedIdentityResourceGroupName: userAssignedIdentityResourceGroupName
+    userAssignedIdentityResourceGroupName: userAssignedIdentityResourceGroupNameNormalized
     userAssignedManagedIdentities: userAssignedManagedIdentities
     userAssignedIdentitiesResourceGroupLockEnabled: userAssignedIdentitiesResourceGroupLockEnabled
     peerAllVirtualNetworks: peerAllVirtualNetworks

--- a/avm/ptn/lz/sub-vending/main.bicep
+++ b/avm/ptn/lz/sub-vending/main.bicep
@@ -117,7 +117,7 @@ param virtualNetworkResourceGroupName string = ''
 
 @maxLength(90)
 @description('Optional. The name of the resource group to create the user-assigned managed identities in.')
-param userAssignedIdentityResourceGroupName string = 'rsg-${deployment().location}-identities'
+param userAssignedIdentityResourceGroupName string = 'rsg-${toLower(replace(deployment().location, ' ', ''))}-identities'
 
 @description('''Optional. An object of Tag key & value pairs to be appended to the Resource Group that the Virtual Network is created in.
 
@@ -131,7 +131,7 @@ param virtualNetworkResourceGroupLockEnabled bool = true
 
 @description('''Optional. The location of the virtual network. Use region shortnames e.g. `uksouth`, `eastus`, etc. Defaults to the region where the ARM/Bicep deployment is targeted to unless overridden.
 ''')
-param virtualNetworkLocation string = deployment().location
+param virtualNetworkLocation string = toLower(replace(deployment().location, ' ', ''))
 
 @minLength(2)
 @maxLength(64)
@@ -289,20 +289,20 @@ param pimRoleAssignments pimRoleAssignmentTypeType[] = []
 param enableTelemetry bool = true
 
 @description('Optional. The name of the resource group to create the deployment script for resource providers registration.')
-param deploymentScriptResourceGroupName string = 'rsg-${deployment().location}-ds'
+param deploymentScriptResourceGroupName string = 'rsg-${toLower(replace(deployment().location, ' ', ''))}-ds'
 
 @description('Optional. The name of the deployment script to register resource providers.')
-param deploymentScriptName string = 'ds-${deployment().location}'
+param deploymentScriptName string = 'ds-${toLower(replace(deployment().location, ' ', ''))}'
 
 @description('Optional. The name of the user managed identity for the resource providers registration deployment script.')
-param deploymentScriptManagedIdentityName string = 'id-${deployment().location}'
+param deploymentScriptManagedIdentityName string = 'id-${toLower(replace(deployment().location, ' ', ''))}'
 
 @maxLength(64)
 @description('Optional. The name of the private virtual network for the deployment script. The string must consist of a-z, A-Z, 0-9, -, _, and . (period) and be between 2 and 64 characters in length.')
-param deploymentScriptVirtualNetworkName string = 'vnet-ds-${deployment().location}'
+param deploymentScriptVirtualNetworkName string = 'vnet-ds-${toLower(replace(deployment().location, ' ', ''))}'
 
 @description('Optional. The name of the network security group for the deployment script private subnet.')
-param deploymentScriptNetworkSecurityGroupName string = 'nsg-ds-${deployment().location}'
+param deploymentScriptNetworkSecurityGroupName string = 'nsg-ds-${toLower(replace(deployment().location, ' ', ''))}'
 
 @description('Optional. The address prefix of the private virtual network for the deployment script.')
 param virtualNetworkDeploymentScriptAddressPrefix string = '192.168.0.0/24'
@@ -311,7 +311,7 @@ param virtualNetworkDeploymentScriptAddressPrefix string = '192.168.0.0/24'
 param deploymentScriptStorageAccountName string = 'stgds${substring(uniqueString(deployment().name,existingSubscriptionId,subscriptionAliasName,subscriptionDisplayName, virtualNetworkLocation), 0, 10)}'
 
 @description('Optional. The location of the deployment script. Use region shortnames e.g. uksouth, eastus, etc.')
-param deploymentScriptLocation string = deployment().location
+param deploymentScriptLocation string = toLower(replace(deployment().location, ' ', ''))
 
 @description('''
 Optional. An object of resource providers and resource providers features to register. If not specified, a default list of common resource providers will be registered. To disable resource provider registration entirely, provide an empty object `{}`.

--- a/avm/ptn/lz/sub-vending/main.bicep
+++ b/avm/ptn/lz/sub-vending/main.bicep
@@ -361,8 +361,6 @@ param resourceProviders object = {
   'Microsoft.Management': []
   'Microsoft.Maps': []
   'Microsoft.MarketplaceOrdering': []
-  'Microsoft.Media': []
-  'Microsoft.MixedReality': []
   'Microsoft.Network': []
   'Microsoft.NotificationHubs': []
   'Microsoft.OperationalInsights': []
@@ -428,69 +426,70 @@ var deploymentNames = {
 }
 
 var azureRegionShortNameDisplayNameAsKey = {
-  'australia southeast': 'australiasoutheast'
-  'west central us': 'westcentralus'
-  'chile central': 'chilecentral'
-  'east us 2 euap': 'eastus2euap'
-  'japan west': 'japanwest'
-  'west us 2': 'westus2'
-  'uae central': 'uaecentral'
-  'france central': 'francecentral'
-  'east us 2': 'eastus2'
-  'malaysia west': 'malaysiawest'
-  'korea south': 'koreasouth'
-  'switzerland west': 'switzerlandwest'
-  'west us': 'westus'
+  'australia central': 'australiacentral'
   'australia central 2': 'australiacentral2'
-  'north europe': 'northeurope'
-  'switzerland north': 'switzerlandnorth'
-  'uae north': 'uaenorth'
   'australia east': 'australiaeast'
-  'new zealand north': 'newzealandnorth'
-  'japan east': 'japaneast'
-  'norway east': 'norwayeast'
-  'south india': 'southindia'
-  'korea central': 'koreacentral'
-  'malaysia south': 'malaysiasouth'
-  'uk south': 'uksouth'
-  'qatar central': 'qatarcentral'
-  'canada east': 'canadaeast'
-  'north central us': 'northcentralus'
-  'east asia': 'eastasia'
-  'uk west': 'ukwest'
+  'australia southeast': 'australiasoutheast'
+  'belgium central': 'belgiumcentral'
+  'brazil south': 'brazilsouth'
   'brazil southeast': 'brazilsoutheast'
   'canada central': 'canadacentral'
-  'germany north': 'germanynorth'
-  'west india': 'westindia'
-  'italy north': 'italynorth'
-  'israel central': 'israelcentral'
-  'brazil south': 'brazilsouth'
-  'central us euap': 'centraluseuap'
-  'germany west central': 'germanywestcentral'
-  'south africa north': 'southafricanorth'
-  'sweden south': 'swedensouth'
-  'poland central': 'polandcentral'
-  'spain central': 'spaincentral'
-  'south central us': 'southcentralus'
-  'east us': 'eastus'
-  'southeast asia': 'southeastasia'
-  'france south': 'francesouth'
-  'australia central': 'australiacentral'
-  'central us': 'centralus'
+  'canada east': 'canadaeast'
   'central india': 'centralindia'
-  'norway west': 'norwaywest'
-  'mexico central': 'mexicocentral'
-  'west europe': 'westeurope'
-  'south africa west': 'southafricawest'
-  'west us 3': 'westus3'
-  'taiwan north': 'taiwannorth'
-  'sweden central': 'swedencentral'
-  'usgov virginia': 'usgovvirginia'
-  'usgov texas': 'usgovtexas'
-  'usgov arizona': 'usgovarizona'
-  'usdod east': 'usdodeast'
-  'usdod central': 'usdodcentral'
+  'central us': 'centralus'
+  'central us euap': 'centraluseuap'
+  'chile central': 'chilecentral'
+  'east asia': 'eastasia'
+  'east us': 'eastus'
+  'east us 2': 'eastus2'
+  'east us 2 euap': 'eastus2euap'
+  'france central': 'francecentral'
+  'france south': 'francesouth'
+  'germany north': 'germanynorth'
+  'germany west central': 'germanywestcentral'
   'indonesia central': 'indonesiacentral'
+  'israel central': 'israelcentral'
+  'italy north': 'italynorth'
+  'japan east': 'japaneast'
+  'japan west': 'japanwest'
+  'korea central': 'koreacentral'
+  'korea south': 'koreasouth'
+  'malaysia south': 'malaysiasouth'
+  'malaysia west': 'malaysiawest'
+  'mexico central': 'mexicocentral'
+  'new zealand north': 'newzealandnorth'
+  'north central us': 'northcentralus'
+  'north europe': 'northeurope'
+  'norway east': 'norwayeast'
+  'norway west': 'norwaywest'
+  'poland central': 'polandcentral'
+  'qatar central': 'qatarcentral'
+  'south africa north': 'southafricanorth'
+  'south africa west': 'southafricawest'
+  'south central us': 'southcentralus'
+  'south india': 'southindia'
+  'southeast asia': 'southeastasia'
+  'spain central': 'spaincentral'
+  'sweden central': 'swedencentral'
+  'sweden south': 'swedensouth'
+  'switzerland north': 'switzerlandnorth'
+  'switzerland west': 'switzerlandwest'
+  'taiwan north': 'taiwannorth'
+  'uae central': 'uaecentral'
+  'uae north': 'uaenorth'
+  'uk south': 'uksouth'
+  'uk west': 'ukwest'
+  'usdod central': 'usdodcentral'
+  'usdod east': 'usdodeast'
+  'usgov arizona': 'usgovarizona'
+  'usgov texas': 'usgovtexas'
+  'usgov virginia': 'usgovvirginia'
+  'west central us': 'westcentralus'
+  'west europe': 'westeurope'
+  'west india': 'westindia'
+  'west us': 'westus'
+  'west us 2': 'westus2'
+  'west us 3': 'westus3'
 }
 
 var locationLowered = toLower(deployment().location)
@@ -499,37 +498,37 @@ var locationLoweredAndSpacesRemoved = contains(locationLowered, ' ')
   : locationLowered
 
 // Normalized resource names - replaces deployment().location in default values to remove spaces and capitals
-var userAssignedIdentityResourceGroupNameNormalized = userAssignedIdentityResourceGroupName == 'rsg-${deployment().location}-identities'
+var userAssignedIdentityResourceGroupNameNormalized = toLower(userAssignedIdentityResourceGroupName) == toLower('rsg-${deployment().location}-identities')
   ? 'rsg-${locationLoweredAndSpacesRemoved}-identities'
-  : userAssignedIdentityResourceGroupName
+  : replace(userAssignedIdentityResourceGroupName, ' ', '')
 
-var virtualNetworkLocationNormalized = virtualNetworkLocation == deployment().location
-  ? locationLoweredAndSpacesRemoved
-  : virtualNetworkLocation
+var virtualNetworkLocationNormalized = contains(toLower(virtualNetworkLocation), ' ')
+  ? azureRegionShortNameDisplayNameAsKey[toLower(virtualNetworkLocation)]
+  : toLower(virtualNetworkLocation)
 
-var deploymentScriptResourceGroupNameNormalized = deploymentScriptResourceGroupName == 'rsg-${deployment().location}-ds'
+var deploymentScriptResourceGroupNameNormalized = toLower(deploymentScriptResourceGroupName) == toLower('rsg-${deployment().location}-ds')
   ? 'rsg-${locationLoweredAndSpacesRemoved}-ds'
-  : deploymentScriptResourceGroupName
+  : replace(deploymentScriptResourceGroupName, ' ', '')
 
-var deploymentScriptNameNormalized = deploymentScriptName == 'ds-${deployment().location}'
+var deploymentScriptNameNormalized = toLower(deploymentScriptName) == toLower('ds-${deployment().location}')
   ? 'ds-${locationLoweredAndSpacesRemoved}'
-  : deploymentScriptName
+  : replace(deploymentScriptName, ' ', '')
 
-var deploymentScriptManagedIdentityNameNormalized = deploymentScriptManagedIdentityName == 'id-${deployment().location}'
+var deploymentScriptManagedIdentityNameNormalized = toLower(deploymentScriptManagedIdentityName) == toLower('id-${deployment().location}')
   ? 'id-${locationLoweredAndSpacesRemoved}'
-  : deploymentScriptManagedIdentityName
+  : replace(deploymentScriptManagedIdentityName, ' ', '')
 
-var deploymentScriptVirtualNetworkNameNormalized = deploymentScriptVirtualNetworkName == 'vnet-ds-${deployment().location}'
+var deploymentScriptVirtualNetworkNameNormalized = toLower(deploymentScriptVirtualNetworkName) == toLower('vnet-ds-${deployment().location}')
   ? 'vnet-ds-${locationLoweredAndSpacesRemoved}'
-  : deploymentScriptVirtualNetworkName
+  : replace(deploymentScriptVirtualNetworkName, ' ', '')
 
-var deploymentScriptNetworkSecurityGroupNameNormalized = deploymentScriptNetworkSecurityGroupName == 'nsg-ds-${deployment().location}'
+var deploymentScriptNetworkSecurityGroupNameNormalized = toLower(deploymentScriptNetworkSecurityGroupName) == toLower('nsg-ds-${deployment().location}')
   ? 'nsg-ds-${locationLoweredAndSpacesRemoved}'
-  : deploymentScriptNetworkSecurityGroupName
+  : replace(deploymentScriptNetworkSecurityGroupName, ' ', '')
 
-var deploymentScriptLocationNormalized = deploymentScriptLocation == deployment().location
-  ? locationLoweredAndSpacesRemoved
-  : deploymentScriptLocation
+var deploymentScriptLocationNormalized = contains(toLower(deploymentScriptLocation), ' ')
+  ? azureRegionShortNameDisplayNameAsKey[toLower(deploymentScriptLocation)]
+  : toLower(deploymentScriptLocation)
 
 #disable-next-line no-deployments-resources
 resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {

--- a/avm/ptn/lz/sub-vending/main.json
+++ b/avm/ptn/lz/sub-vending/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "13369259174673196140"
+      "templateHash": "5850884865212290080"
     },
     "name": "Sub-vending",
     "description": "This module deploys a subscription to accelerate deployment of landing zones. For more information on how to use it, please visit this [Wiki](https://github.com/Azure/bicep-lz-vending/wiki).",
@@ -1450,7 +1450,7 @@
     },
     "userAssignedIdentityResourceGroupName": {
       "type": "string",
-      "defaultValue": "[format('rsg-{0}-identities', toLower(replace(deployment().location, ' ', '')))]",
+      "defaultValue": "[format('rsg-{0}-identities', deployment().location)]",
       "maxLength": 90,
       "metadata": {
         "description": "Optional. The name of the resource group to create the user-assigned managed identities in."
@@ -1472,7 +1472,7 @@
     },
     "virtualNetworkLocation": {
       "type": "string",
-      "defaultValue": "[toLower(replace(deployment().location, ' ', ''))]",
+      "defaultValue": "[deployment().location]",
       "metadata": {
         "description": "Optional. The location of the virtual network. Use region shortnames e.g. `uksouth`, `eastus`, etc. Defaults to the region where the ARM/Bicep deployment is targeted to unless overridden.\n"
       }
@@ -1666,28 +1666,28 @@
     },
     "deploymentScriptResourceGroupName": {
       "type": "string",
-      "defaultValue": "[format('rsg-{0}-ds', toLower(replace(deployment().location, ' ', '')))]",
+      "defaultValue": "[format('rsg-{0}-ds', deployment().location)]",
       "metadata": {
         "description": "Optional. The name of the resource group to create the deployment script for resource providers registration."
       }
     },
     "deploymentScriptName": {
       "type": "string",
-      "defaultValue": "[format('ds-{0}', toLower(replace(deployment().location, ' ', '')))]",
+      "defaultValue": "[format('ds-{0}', deployment().location)]",
       "metadata": {
         "description": "Optional. The name of the deployment script to register resource providers."
       }
     },
     "deploymentScriptManagedIdentityName": {
       "type": "string",
-      "defaultValue": "[format('id-{0}', toLower(replace(deployment().location, ' ', '')))]",
+      "defaultValue": "[format('id-{0}', deployment().location)]",
       "metadata": {
         "description": "Optional. The name of the user managed identity for the resource providers registration deployment script."
       }
     },
     "deploymentScriptVirtualNetworkName": {
       "type": "string",
-      "defaultValue": "[format('vnet-ds-{0}', toLower(replace(deployment().location, ' ', '')))]",
+      "defaultValue": "[format('vnet-ds-{0}', deployment().location)]",
       "maxLength": 64,
       "metadata": {
         "description": "Optional. The name of the private virtual network for the deployment script. The string must consist of a-z, A-Z, 0-9, -, _, and . (period) and be between 2 and 64 characters in length."
@@ -1695,7 +1695,7 @@
     },
     "deploymentScriptNetworkSecurityGroupName": {
       "type": "string",
-      "defaultValue": "[format('nsg-ds-{0}', toLower(replace(deployment().location, ' ', '')))]",
+      "defaultValue": "[format('nsg-ds-{0}', deployment().location)]",
       "metadata": {
         "description": "Optional. The name of the network security group for the deployment script private subnet."
       }
@@ -1716,7 +1716,7 @@
     },
     "deploymentScriptLocation": {
       "type": "string",
-      "defaultValue": "[toLower(replace(deployment().location, ' ', ''))]",
+      "defaultValue": "[deployment().location]",
       "metadata": {
         "description": "Optional. The location of the deployment script. Use region shortnames e.g. uksouth, eastus, etc."
       }
@@ -1864,7 +1864,82 @@
     "deploymentNames": {
       "createSubscription": "[take(format('lz-vend-sub-create-{0}-{1}', parameters('subscriptionAliasName'), uniqueString(parameters('subscriptionAliasName'), parameters('subscriptionDisplayName'), parameters('subscriptionBillingScope'), parameters('subscriptionWorkload'), deployment().name)), 64)]",
       "createSubscriptionResources": "[take(format('lz-vend-sub-res-create-{0}-{1}', parameters('subscriptionAliasName'), uniqueString(parameters('subscriptionAliasName'), parameters('subscriptionDisplayName'), parameters('subscriptionBillingScope'), parameters('subscriptionWorkload'), parameters('existingSubscriptionId'), deployment().name)), 64)]"
-    }
+    },
+    "azureRegionShortNameDisplayNameAsKey": {
+      "australia southeast": "australiasoutheast",
+      "west central us": "westcentralus",
+      "chile central": "chilecentral",
+      "east us 2 euap": "eastus2euap",
+      "japan west": "japanwest",
+      "west us 2": "westus2",
+      "uae central": "uaecentral",
+      "france central": "francecentral",
+      "east us 2": "eastus2",
+      "malaysia west": "malaysiawest",
+      "korea south": "koreasouth",
+      "switzerland west": "switzerlandwest",
+      "west us": "westus",
+      "australia central 2": "australiacentral2",
+      "north europe": "northeurope",
+      "switzerland north": "switzerlandnorth",
+      "uae north": "uaenorth",
+      "australia east": "australiaeast",
+      "new zealand north": "newzealandnorth",
+      "japan east": "japaneast",
+      "norway east": "norwayeast",
+      "south india": "southindia",
+      "korea central": "koreacentral",
+      "malaysia south": "malaysiasouth",
+      "uk south": "uksouth",
+      "qatar central": "qatarcentral",
+      "canada east": "canadaeast",
+      "north central us": "northcentralus",
+      "east asia": "eastasia",
+      "uk west": "ukwest",
+      "brazil southeast": "brazilsoutheast",
+      "canada central": "canadacentral",
+      "germany north": "germanynorth",
+      "west india": "westindia",
+      "italy north": "italynorth",
+      "israel central": "israelcentral",
+      "brazil south": "brazilsouth",
+      "central us euap": "centraluseuap",
+      "germany west central": "germanywestcentral",
+      "south africa north": "southafricanorth",
+      "sweden south": "swedensouth",
+      "poland central": "polandcentral",
+      "spain central": "spaincentral",
+      "south central us": "southcentralus",
+      "east us": "eastus",
+      "southeast asia": "southeastasia",
+      "france south": "francesouth",
+      "australia central": "australiacentral",
+      "central us": "centralus",
+      "central india": "centralindia",
+      "norway west": "norwaywest",
+      "mexico central": "mexicocentral",
+      "west europe": "westeurope",
+      "south africa west": "southafricawest",
+      "west us 3": "westus3",
+      "taiwan north": "taiwannorth",
+      "sweden central": "swedencentral",
+      "usgov virginia": "usgovvirginia",
+      "usgov texas": "usgovtexas",
+      "usgov arizona": "usgovarizona",
+      "usdod east": "usdodeast",
+      "usdod central": "usdodcentral",
+      "indonesia central": "indonesiacentral"
+    },
+    "locationLowered": "[toLower(deployment().location)]",
+    "locationLoweredAndSpacesRemoved": "[if(contains(variables('locationLowered'), ' '), variables('azureRegionShortNameDisplayNameAsKey')[variables('locationLowered')], variables('locationLowered'))]",
+    "userAssignedIdentityResourceGroupNameNormalized": "[if(equals(parameters('userAssignedIdentityResourceGroupName'), format('rsg-{0}-identities', deployment().location)), format('rsg-{0}-identities', variables('locationLoweredAndSpacesRemoved')), parameters('userAssignedIdentityResourceGroupName'))]",
+    "virtualNetworkLocationNormalized": "[if(equals(parameters('virtualNetworkLocation'), deployment().location), variables('locationLoweredAndSpacesRemoved'), parameters('virtualNetworkLocation'))]",
+    "deploymentScriptResourceGroupNameNormalized": "[if(equals(parameters('deploymentScriptResourceGroupName'), format('rsg-{0}-ds', deployment().location)), format('rsg-{0}-ds', variables('locationLoweredAndSpacesRemoved')), parameters('deploymentScriptResourceGroupName'))]",
+    "deploymentScriptNameNormalized": "[if(equals(parameters('deploymentScriptName'), format('ds-{0}', deployment().location)), format('ds-{0}', variables('locationLoweredAndSpacesRemoved')), parameters('deploymentScriptName'))]",
+    "deploymentScriptManagedIdentityNameNormalized": "[if(equals(parameters('deploymentScriptManagedIdentityName'), format('id-{0}', deployment().location)), format('id-{0}', variables('locationLoweredAndSpacesRemoved')), parameters('deploymentScriptManagedIdentityName'))]",
+    "deploymentScriptVirtualNetworkNameNormalized": "[if(equals(parameters('deploymentScriptVirtualNetworkName'), format('vnet-ds-{0}', deployment().location)), format('vnet-ds-{0}', variables('locationLoweredAndSpacesRemoved')), parameters('deploymentScriptVirtualNetworkName'))]",
+    "deploymentScriptNetworkSecurityGroupNameNormalized": "[if(equals(parameters('deploymentScriptNetworkSecurityGroupName'), format('nsg-ds-{0}', deployment().location)), format('nsg-ds-{0}', variables('locationLoweredAndSpacesRemoved')), parameters('deploymentScriptNetworkSecurityGroupName'))]",
+    "deploymentScriptLocationNormalized": "[if(equals(parameters('deploymentScriptLocation'), deployment().location), variables('locationLoweredAndSpacesRemoved'), parameters('deploymentScriptLocation'))]"
   },
   "resources": {
     "avmTelemetry": {
@@ -2051,7 +2126,7 @@
             "value": "[parameters('virtualNetworkResourceGroupLockEnabled')]"
           },
           "virtualNetworkLocation": {
-            "value": "[parameters('virtualNetworkLocation')]"
+            "value": "[variables('virtualNetworkLocationNormalized')]"
           },
           "virtualNetworkName": {
             "value": "[parameters('virtualNetworkName')]"
@@ -2111,25 +2186,25 @@
             "value": "[parameters('pimRoleAssignments')]"
           },
           "deploymentScriptResourceGroupName": {
-            "value": "[parameters('deploymentScriptResourceGroupName')]"
+            "value": "[variables('deploymentScriptResourceGroupNameNormalized')]"
           },
           "deploymentScriptName": {
-            "value": "[parameters('deploymentScriptName')]"
+            "value": "[variables('deploymentScriptNameNormalized')]"
           },
           "deploymentScriptManagedIdentityName": {
-            "value": "[parameters('deploymentScriptManagedIdentityName')]"
+            "value": "[variables('deploymentScriptManagedIdentityNameNormalized')]"
           },
           "resourceProviders": {
             "value": "[parameters('resourceProviders')]"
           },
           "deploymentScriptVirtualNetworkName": {
-            "value": "[parameters('deploymentScriptVirtualNetworkName')]"
+            "value": "[variables('deploymentScriptVirtualNetworkNameNormalized')]"
           },
           "deploymentScriptLocation": {
-            "value": "[parameters('deploymentScriptLocation')]"
+            "value": "[variables('deploymentScriptLocationNormalized')]"
           },
           "deploymentScriptNetworkSecurityGroupName": {
-            "value": "[parameters('deploymentScriptNetworkSecurityGroupName')]"
+            "value": "[variables('deploymentScriptNetworkSecurityGroupNameNormalized')]"
           },
           "virtualNetworkDeploymentScriptAddressPrefix": {
             "value": "[parameters('virtualNetworkDeploymentScriptAddressPrefix')]"
@@ -2150,7 +2225,7 @@
             "value": "[parameters('virtualNetworkDeployBastion')]"
           },
           "userAssignedIdentityResourceGroupName": {
-            "value": "[parameters('userAssignedIdentityResourceGroupName')]"
+            "value": "[variables('userAssignedIdentityResourceGroupNameNormalized')]"
           },
           "userAssignedManagedIdentities": {
             "value": "[parameters('userAssignedManagedIdentities')]"

--- a/avm/ptn/lz/sub-vending/main.json
+++ b/avm/ptn/lz/sub-vending/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "2827890037228340123"
+      "templateHash": "13369259174673196140"
     },
     "name": "Sub-vending",
     "description": "This module deploys a subscription to accelerate deployment of landing zones. For more information on how to use it, please visit this [Wiki](https://github.com/Azure/bicep-lz-vending/wiki).",
@@ -1450,7 +1450,7 @@
     },
     "userAssignedIdentityResourceGroupName": {
       "type": "string",
-      "defaultValue": "[format('rsg-{0}-identities', deployment().location)]",
+      "defaultValue": "[format('rsg-{0}-identities', toLower(replace(deployment().location, ' ', '')))]",
       "maxLength": 90,
       "metadata": {
         "description": "Optional. The name of the resource group to create the user-assigned managed identities in."
@@ -1472,7 +1472,7 @@
     },
     "virtualNetworkLocation": {
       "type": "string",
-      "defaultValue": "[deployment().location]",
+      "defaultValue": "[toLower(replace(deployment().location, ' ', ''))]",
       "metadata": {
         "description": "Optional. The location of the virtual network. Use region shortnames e.g. `uksouth`, `eastus`, etc. Defaults to the region where the ARM/Bicep deployment is targeted to unless overridden.\n"
       }
@@ -1666,28 +1666,28 @@
     },
     "deploymentScriptResourceGroupName": {
       "type": "string",
-      "defaultValue": "[format('rsg-{0}-ds', deployment().location)]",
+      "defaultValue": "[format('rsg-{0}-ds', toLower(replace(deployment().location, ' ', '')))]",
       "metadata": {
         "description": "Optional. The name of the resource group to create the deployment script for resource providers registration."
       }
     },
     "deploymentScriptName": {
       "type": "string",
-      "defaultValue": "[format('ds-{0}', deployment().location)]",
+      "defaultValue": "[format('ds-{0}', toLower(replace(deployment().location, ' ', '')))]",
       "metadata": {
         "description": "Optional. The name of the deployment script to register resource providers."
       }
     },
     "deploymentScriptManagedIdentityName": {
       "type": "string",
-      "defaultValue": "[format('id-{0}', deployment().location)]",
+      "defaultValue": "[format('id-{0}', toLower(replace(deployment().location, ' ', '')))]",
       "metadata": {
         "description": "Optional. The name of the user managed identity for the resource providers registration deployment script."
       }
     },
     "deploymentScriptVirtualNetworkName": {
       "type": "string",
-      "defaultValue": "[format('vnet-ds-{0}', deployment().location)]",
+      "defaultValue": "[format('vnet-ds-{0}', toLower(replace(deployment().location, ' ', '')))]",
       "maxLength": 64,
       "metadata": {
         "description": "Optional. The name of the private virtual network for the deployment script. The string must consist of a-z, A-Z, 0-9, -, _, and . (period) and be between 2 and 64 characters in length."
@@ -1695,7 +1695,7 @@
     },
     "deploymentScriptNetworkSecurityGroupName": {
       "type": "string",
-      "defaultValue": "[format('nsg-ds-{0}', deployment().location)]",
+      "defaultValue": "[format('nsg-ds-{0}', toLower(replace(deployment().location, ' ', '')))]",
       "metadata": {
         "description": "Optional. The name of the network security group for the deployment script private subnet."
       }
@@ -1716,7 +1716,7 @@
     },
     "deploymentScriptLocation": {
       "type": "string",
-      "defaultValue": "[deployment().location]",
+      "defaultValue": "[toLower(replace(deployment().location, ' ', ''))]",
       "metadata": {
         "description": "Optional. The location of the deployment script. Use region shortnames e.g. uksouth, eastus, etc."
       }

--- a/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
+++ b/avm/ptn/lz/sub-vending/modules/subResourceWrapper.bicep
@@ -189,8 +189,6 @@ param resourceProviders object = {
   'Microsoft.Management': []
   'Microsoft.Maps': []
   'Microsoft.MarketplaceOrdering': []
-  'Microsoft.Media': []
-  'Microsoft.MixedReality': []
   'Microsoft.Network': []
   'Microsoft.NotificationHubs': []
   'Microsoft.OperationalInsights': []

--- a/avm/ptn/lz/sub-vending/tests/e2e/defaults/main.test.bicep
+++ b/avm/ptn/lz/sub-vending/tests/e2e/defaults/main.test.bicep
@@ -34,6 +34,16 @@ module testDeployment '../../../main.bicep' = {
     subscriptionWorkload: 'Production'
     subscriptionManagementGroupAssociationEnabled: true
     subscriptionManagementGroupId: 'bicep-lz-vending-automation-child'
+    // Test location normalization with location containing spaces and capitals
+    virtualNetworkEnabled: true
+    virtualNetworkLocation: 'UK South' // Will be normalized to 'uksouth'
+    virtualNetworkResourceGroupName: 'rsg-UK South-vnets' // Will have spaces removed
+    virtualNetworkName: 'vnet-${namePrefix}-${serviceShort}'
+    virtualNetworkAddressSpace: ['10.200.0.0/24']
+    virtualNetworkResourceGroupLockEnabled: false
+    // Test deployment script resource group name normalization
+    deploymentScriptResourceGroupName: 'rsg-UK South-scripts' // Will have spaces removed
+    deploymentScriptManagedIdentityName: 'id-${namePrefix}-${serviceShort}'
     resourceProviders: {}
   }
 }

--- a/avm/ptn/lz/sub-vending/tests/e2e/defaults/main.test.bicep
+++ b/avm/ptn/lz/sub-vending/tests/e2e/defaults/main.test.bicep
@@ -34,16 +34,6 @@ module testDeployment '../../../main.bicep' = {
     subscriptionWorkload: 'Production'
     subscriptionManagementGroupAssociationEnabled: true
     subscriptionManagementGroupId: 'bicep-lz-vending-automation-child'
-    // Test location normalization with location containing spaces and capitals
-    virtualNetworkEnabled: true
-    virtualNetworkLocation: 'UK South' // Will be normalized to 'uksouth'
-    virtualNetworkResourceGroupName: 'rsg-UK South-vnets' // Will have spaces removed
-    virtualNetworkName: 'vnet-${namePrefix}-${serviceShort}'
-    virtualNetworkAddressSpace: ['10.200.0.0/24']
-    virtualNetworkResourceGroupLockEnabled: false
-    // Test deployment script resource group name normalization
-    deploymentScriptResourceGroupName: 'rsg-UK South-scripts' // Will have spaces removed
-    deploymentScriptManagedIdentityName: 'id-${namePrefix}-${serviceShort}'
     resourceProviders: {}
   }
 }


### PR DESCRIPTION
## Description

Fixes #6295 - Deployment fails when `deployment().location` contains spaces (e.g., 'West Europe', 'East US 2')

### Problem
Azure location names with spaces (like 'West Europe') are valid for the `location` property, but when interpolated into resource group names, they violate naming constraints which don't allow spaces.

### Solution
Implemented location normalization pattern (following the approach used in `avm/ptn/network/private-link-private-dns-zones`):
- Added 73-region mapping dictionary to convert display names with spaces to lowercase short names
- Created normalized variables for 8 parameters that use `deployment().location` in their default values
- Parameters remain unchanged (still use `deployment().location` as default)
- Variables conditionally normalize: only if parameter equals default value, otherwise respect custom values
- Module calls always use normalized variables

### Changes
- Added `azureRegionShortNameDisplayNameAsKey` mapping dictionary (73 Azure regions)
- Added `locationLoweredAndSpacesRemoved` normalization logic
- Normalized 8 resource name parameters:
  - `userAssignedIdentityResourceGroupName`
  - `virtualNetworkLocation`
  - `deploymentScriptResourceGroupName`
  - `deploymentScriptName`
  - `deploymentScriptManagedIdentityName`
  - `deploymentScriptVirtualNetworkName`
  - `deploymentScriptNetworkSecurityGroupName`
  - `deploymentScriptLocation`

### Testing
- ✅ All 194 Pester tests passed
- ✅ Successfully deployed with `--location "West Europe"` (spaces and capitals)
- ✅ Backward compatible - no breaking changes

## Pipeline Reference

Not possible, due to complex landingzone deployment and no rights to create subscriptions

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version