### PR TITLE
fix: ruleSets depend on originGroups to avoid deployment errors during first run with multiple originGroups

### DIFF
--- a/avm/res/cdn/profile/CHANGELOG.md
+++ b/avm/res/cdn/profile/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/CHANGELOG.md).
 
+## 0.17.0
+
+### Changes
+
+- Added a dependency on the profile_originGroups module for ruleSets to ensure proper deployment order.
+
+### Breaking Changes
+
+- None
+
+
 ## 0.16.1
 
 ### Changes

--- a/avm/res/cdn/profile/CHANGELOG.md
+++ b/avm/res/cdn/profile/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/CHANGELOG.md).
 
+## 0.17
+
+### Changes
+
+- Added a dependency on the profile_originGroups module for ruleSets to ensure proper deployment order.
+- Updated output for systemAssignedMIPrincipalId to handle null values gracefully in the test module.
+
+### Breaking Changes
+
+- None
+
 ## 0.16.1
 
 ### Changes

--- a/avm/res/cdn/profile/CHANGELOG.md
+++ b/avm/res/cdn/profile/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/CHANGELOG.md).
 
-## 0.17
+## 0.17.0
 
 ### Changes
 

--- a/avm/res/cdn/profile/CHANGELOG.md
+++ b/avm/res/cdn/profile/CHANGELOG.md
@@ -2,17 +2,6 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/CHANGELOG.md).
 
-## 0.17.0
-
-### Changes
-
-- Added a dependency on the profile_originGroups module for ruleSets to ensure proper deployment order.
-- Updated output for systemAssignedMIPrincipalId to handle null values gracefully in the test module.
-
-### Breaking Changes
-
-- None
-
 ## 0.16.1
 
 ### Changes

--- a/avm/res/cdn/profile/README.md
+++ b/avm/res/cdn/profile/README.md
@@ -911,6 +911,11 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
       }
     ]
     location: 'global'
+    lock: {
+      kind: 'CanNotDelete'
+      name: 'myCustomLockName'
+      notes: 'This resource cannot be deleted for security reasons.'
+    }
     managedIdentities: {
       systemAssigned: true
       userAssignedResourceIds: [
@@ -1133,6 +1138,13 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
     "location": {
       "value": "global"
     },
+    "lock": {
+      "value": {
+        "kind": "CanNotDelete",
+        "name": "myCustomLockName",
+        "notes": "This resource cannot be deleted for security reasons."
+      }
+    },
     "managedIdentities": {
       "value": {
         "systemAssigned": true,
@@ -1353,6 +1365,11 @@ param diagnosticSettings = [
   }
 ]
 param location = 'global'
+param lock = {
+  kind: 'CanNotDelete'
+  name: 'myCustomLockName'
+  notes: 'This resource cannot be deleted for security reasons.'
+}
 param managedIdentities = {
   systemAssigned: true
   userAssignedResourceIds: [

--- a/avm/res/cdn/profile/README.md
+++ b/avm/res/cdn/profile/README.md
@@ -911,11 +911,6 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
       }
     ]
     location: 'global'
-    lock: {
-      kind: 'CanNotDelete'
-      name: 'myCustomLockName'
-      notes: 'This resource cannot be deleted for security reasons.'
-    }
     managedIdentities: {
       systemAssigned: true
       userAssignedResourceIds: [
@@ -1138,13 +1133,6 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
     "location": {
       "value": "global"
     },
-    "lock": {
-      "value": {
-        "kind": "CanNotDelete",
-        "name": "myCustomLockName",
-        "notes": "This resource cannot be deleted for security reasons."
-      }
-    },
     "managedIdentities": {
       "value": {
         "systemAssigned": true,
@@ -1365,11 +1353,6 @@ param diagnosticSettings = [
   }
 ]
 param location = 'global'
-param lock = {
-  kind: 'CanNotDelete'
-  name: 'myCustomLockName'
-  notes: 'This resource cannot be deleted for security reasons.'
-}
 param managedIdentities = {
   systemAssigned: true
   userAssignedResourceIds: [

--- a/avm/res/cdn/profile/afd-endpoint/main.json
+++ b/avm/res/cdn/profile/afd-endpoint/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "635278703027409548"
+      "version": "0.39.26.7824",
+      "templateHash": "10829811014138580747"
     },
     "name": "CDN Profiles AFD Endpoints",
     "description": "This module deploys a CDN Profile AFD Endpoint."
@@ -280,8 +280,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "12120030800403870984"
+              "version": "0.39.26.7824",
+              "templateHash": "15140994850914151675"
             },
             "name": "CDN Profiles AFD Endpoint Route",
             "description": "This module deploys a CDN Profile AFD Endpoint route."

--- a/avm/res/cdn/profile/afd-endpoint/route/main.json
+++ b/avm/res/cdn/profile/afd-endpoint/route/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "12120030800403870984"
+      "version": "0.39.26.7824",
+      "templateHash": "15140994850914151675"
     },
     "name": "CDN Profiles AFD Endpoint Route",
     "description": "This module deploys a CDN Profile AFD Endpoint route."

--- a/avm/res/cdn/profile/custom-domain/main.json
+++ b/avm/res/cdn/profile/custom-domain/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "7210601349095147888"
+      "version": "0.39.26.7824",
+      "templateHash": "7912636093958858348"
     },
     "name": "CDN Profiles Custom Domains",
     "description": "This module deploys a CDN Profile Custom Domains."

--- a/avm/res/cdn/profile/endpoint/main.json
+++ b/avm/res/cdn/profile/endpoint/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "6059760264549740383"
+      "version": "0.39.26.7824",
+      "templateHash": "1592787511285395284"
     },
     "name": "CDN Profiles Endpoints",
     "description": "This module deploys a CDN Profile Endpoint."
@@ -127,8 +127,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "9952737084200971148"
+              "version": "0.39.26.7824",
+              "templateHash": "6330077596434134380"
             },
             "name": "CDN Profiles Endpoints Origins",
             "description": "This module deploys a CDN Profile Endpoint Origin."

--- a/avm/res/cdn/profile/endpoint/origin/main.json
+++ b/avm/res/cdn/profile/endpoint/origin/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "9952737084200971148"
+      "version": "0.39.26.7824",
+      "templateHash": "6330077596434134380"
     },
     "name": "CDN Profiles Endpoints Origins",
     "description": "This module deploys a CDN Profile Endpoint Origin."

--- a/avm/res/cdn/profile/main.bicep
+++ b/avm/res/cdn/profile/main.bicep
@@ -277,6 +277,9 @@ module profile_originGroups 'origin-group/main.bicep' = [
 module profile_ruleSets 'rule-set/main.bicep' = [
   for (ruleSet, index) in (ruleSets ?? []): {
     name: '${uniqueString(deployment().name)}-Profile-RuleSet-${index}'
+    dependsOn: [
+      profile_originGroups
+    ]
     params: {
       name: ruleSet.name
       profileName: profile.name

--- a/avm/res/cdn/profile/main.json
+++ b/avm/res/cdn/profile/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "15130791660840705978"
+      "version": "0.39.26.7824",
+      "templateHash": "11315343395547404406"
     },
     "name": "CDN Profiles",
     "description": "This module deploys a CDN Profile."
@@ -1290,8 +1290,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "6059760264549740383"
+              "version": "0.39.26.7824",
+              "templateHash": "1592787511285395284"
             },
             "name": "CDN Profiles Endpoints",
             "description": "This module deploys a CDN Profile Endpoint."
@@ -1412,8 +1412,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.38.33.27573",
-                      "templateHash": "9952737084200971148"
+                      "version": "0.39.26.7824",
+                      "templateHash": "6330077596434134380"
                     },
                     "name": "CDN Profiles Endpoints Origins",
                     "description": "This module deploys a CDN Profile Endpoint Origin."
@@ -1658,8 +1658,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "409998718938454126"
+              "version": "0.39.26.7824",
+              "templateHash": "3018475601592641001"
             },
             "name": "CDN Profiles Secret",
             "description": "This module deploys a CDN Profile Secret."
@@ -1822,8 +1822,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "7210601349095147888"
+              "version": "0.39.26.7824",
+              "templateHash": "7912636093958858348"
             },
             "name": "CDN Profiles Custom Domains",
             "description": "This module deploys a CDN Profile Custom Domains."
@@ -2068,8 +2068,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "2492165368267580144"
+              "version": "0.39.26.7824",
+              "templateHash": "11465443729464123039"
             },
             "name": "CDN Profiles Origin Group",
             "description": "This module deploys a CDN Profile Origin Group."
@@ -2368,8 +2368,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.38.33.27573",
-                      "templateHash": "10601624887272794842"
+                      "version": "0.39.26.7824",
+                      "templateHash": "17900393745335221241"
                     },
                     "name": "CDN Profiles Origin",
                     "description": "This module deploys a CDN Profile Origin."
@@ -2590,8 +2590,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "592453402231164630"
+              "version": "0.39.26.7824",
+              "templateHash": "2701401049211175818"
             },
             "name": "CDN Profiles Rule Sets",
             "description": "This module deploys a CDN Profile rule set."
@@ -2729,8 +2729,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.38.33.27573",
-                      "templateHash": "6984936093254190035"
+                      "version": "0.39.26.7824",
+                      "templateHash": "15746008404835349617"
                     },
                     "name": "CDN Profiles Rules",
                     "description": "This module deploys a CDN Profile rule."
@@ -2870,7 +2870,8 @@
         }
       },
       "dependsOn": [
-        "profile"
+        "profile",
+        "profile_originGroups"
       ]
     },
     "profile_afdEndpoints": {
@@ -2916,8 +2917,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "635278703027409548"
+              "version": "0.39.26.7824",
+              "templateHash": "10829811014138580747"
             },
             "name": "CDN Profiles AFD Endpoints",
             "description": "This module deploys a CDN Profile AFD Endpoint."
@@ -3191,8 +3192,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.38.33.27573",
-                      "templateHash": "12120030800403870984"
+                      "version": "0.39.26.7824",
+                      "templateHash": "15140994850914151675"
                     },
                     "name": "CDN Profiles AFD Endpoint Route",
                     "description": "This module deploys a CDN Profile AFD Endpoint route."
@@ -3520,8 +3521,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "12979914515638992236"
+              "version": "0.39.26.7824",
+              "templateHash": "5838105506608549969"
             },
             "name": "CDN Profiles Security Policy",
             "description": "This module deploys a CDN Profile Security Policy."

--- a/avm/res/cdn/profile/origin-group/main.json
+++ b/avm/res/cdn/profile/origin-group/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "2492165368267580144"
+      "version": "0.39.26.7824",
+      "templateHash": "11465443729464123039"
     },
     "name": "CDN Profiles Origin Group",
     "description": "This module deploys a CDN Profile Origin Group."
@@ -305,8 +305,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "10601624887272794842"
+              "version": "0.39.26.7824",
+              "templateHash": "17900393745335221241"
             },
             "name": "CDN Profiles Origin",
             "description": "This module deploys a CDN Profile Origin."

--- a/avm/res/cdn/profile/origin-group/origin/main.json
+++ b/avm/res/cdn/profile/origin-group/origin/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "10601624887272794842"
+      "version": "0.39.26.7824",
+      "templateHash": "17900393745335221241"
     },
     "name": "CDN Profiles Origin",
     "description": "This module deploys a CDN Profile Origin."

--- a/avm/res/cdn/profile/rule-set/main.json
+++ b/avm/res/cdn/profile/rule-set/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "592453402231164630"
+      "version": "0.39.26.7824",
+      "templateHash": "2701401049211175818"
     },
     "name": "CDN Profiles Rule Sets",
     "description": "This module deploys a CDN Profile rule set."
@@ -144,8 +144,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "6984936093254190035"
+              "version": "0.39.26.7824",
+              "templateHash": "15746008404835349617"
             },
             "name": "CDN Profiles Rules",
             "description": "This module deploys a CDN Profile rule."

--- a/avm/res/cdn/profile/rule-set/rule/main.json
+++ b/avm/res/cdn/profile/rule-set/rule/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "6984936093254190035"
+      "version": "0.39.26.7824",
+      "templateHash": "15746008404835349617"
     },
     "name": "CDN Profiles Rules",
     "description": "This module deploys a CDN Profile rule."

--- a/avm/res/cdn/profile/secret/main.json
+++ b/avm/res/cdn/profile/secret/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "409998718938454126"
+      "version": "0.39.26.7824",
+      "templateHash": "3018475601592641001"
     },
     "name": "CDN Profiles Secret",
     "description": "This module deploys a CDN Profile Secret."

--- a/avm/res/cdn/profile/security-policy/main.json
+++ b/avm/res/cdn/profile/security-policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "12979914515638992236"
+      "version": "0.39.26.7824",
+      "templateHash": "5838105506608549969"
     },
     "name": "CDN Profiles Security Policy",
     "description": "This module deploys a CDN Profile Security Policy."

--- a/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
+++ b/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
@@ -78,13 +78,6 @@ module testDeployment '../../../main.bicep' = [
         ]
       }
 
-      // Lock configuration
-      lock: {
-        kind: 'CanNotDelete'
-        name: 'myCustomLockName'
-        notes: 'This resource cannot be deleted for security reasons.'
-      }
-
       // Tags
       tags: {
         Environment: 'Test'
@@ -315,5 +308,4 @@ output afdEndpointNames array = testDeployment[0].outputs.frontDoorEndpointHostN
 output resourceGroupName string = resourceGroup.name
 
 @description('The system-assigned managed identity principal ID.')
-// Do not try to fix this warning as the test then fails
-output systemAssignedMIPrincipalId string = testDeployment[0].outputs.?systemAssignedMIPrincipalId
+output systemAssignedMIPrincipalId string = testDeployment[0].outputs.?systemAssignedMIPrincipalId ?? ''

--- a/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
+++ b/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
@@ -315,4 +315,5 @@ output afdEndpointNames array = testDeployment[0].outputs.frontDoorEndpointHostN
 output resourceGroupName string = resourceGroup.name
 
 @description('The system-assigned managed identity principal ID.')
-output systemAssignedMIPrincipalId string = testDeployment[0].outputs.?systemAssignedMIPrincipalId ?? ''
+// Do not try to fix this warning as the test then fails
+output systemAssignedMIPrincipalId string = testDeployment[0].outputs.?systemAssignedMIPrincipalId

--- a/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
+++ b/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
@@ -78,6 +78,13 @@ module testDeployment '../../../main.bicep' = [
         ]
       }
 
+      // Lock configuration
+      lock: {
+        kind: 'CanNotDelete'
+        name: 'myCustomLockName'
+        notes: 'This resource cannot be deleted for security reasons.'
+      }
+
       // Tags
       tags: {
         Environment: 'Test'
@@ -308,4 +315,4 @@ output afdEndpointNames array = testDeployment[0].outputs.frontDoorEndpointHostN
 output resourceGroupName string = resourceGroup.name
 
 @description('The system-assigned managed identity principal ID.')
-output systemAssignedMIPrincipalId string = testDeployment[0].outputs.?systemAssignedMIPrincipalId ?? ''
+output systemAssignedMIPrincipalId string? = testDeployment[0].outputs.?systemAssignedMIPrincipalId

--- a/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
+++ b/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
@@ -315,4 +315,4 @@ output afdEndpointNames array = testDeployment[0].outputs.frontDoorEndpointHostN
 output resourceGroupName string = resourceGroup.name
 
 @description('The system-assigned managed identity principal ID.')
-output systemAssignedMIPrincipalId string = testDeployment[0].outputs.?systemAssignedMIPrincipalId
+output systemAssignedMIPrincipalId string = testDeployment[0].outputs.?systemAssignedMIPrincipalId ?? ''

--- a/avm/res/cdn/profile/version.json
+++ b/avm/res/cdn/profile/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.16"
+    "version": "0.17"
 }

--- a/avm/res/cdn/profile/version.json
+++ b/avm/res/cdn/profile/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.17"
+    "version": "0.16"
 }


### PR DESCRIPTION
## Description

- Added a dependency on the profile_originGroups module for ruleSets to ensure proper deployment order
- Updated output for systemAssignedMIPrincipalId to handle null values gracefully in the test module

Closes #6238

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

[![avm.res.cdn.profile](https://github.com/gbeaud/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml/badge.svg?event=workflow_dispatch)](https://github.com/gbeaud/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml)


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
