### PR TITLE
fix: Update role assignment modules for management group

### DIFF
--- a/avm/ptn/authorization/pim-role-assignment/CHANGELOG.md
+++ b/avm/ptn/authorization/pim-role-assignment/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/pim-role-assignment/CHANGELOG.md).
 
+## 0.1.2
+
+### Changes
+
+- Replaced `subscriptionResourceId()` with `managementGroupResourceId()` for built-in role definitions in management group scope module to align with deployment context
+
+### Breaking Changes
+
+- None
+
 ## 0.1.1
 
 ### Changes

--- a/avm/ptn/authorization/pim-role-assignment/main.json
+++ b/avm/ptn/authorization/pim-role-assignment/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "17528569069639196015"
+      "version": "0.39.26.7824",
+      "templateHash": "17391044044629631031"
     },
     "name": "PIM Role Assignments (All scopes)",
     "description": "This module deploys a PIM Role Assignment at a Management Group, Subscription or Resource Group scope."
@@ -393,7 +393,7 @@
     "roleAssignment_mg": {
       "condition": "[and(empty(parameters('subscriptionId')), empty(parameters('resourceGroupName')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-PimRoleAssignment-MG-Module', uniqueString(deployment().name, parameters('location')))]",
       "scope": "[format('Microsoft.Management/managementGroups/{0}', parameters('managementGroupId'))]",
       "location": "[deployment().location]",
@@ -448,8 +448,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "12447664435402346880"
+              "version": "0.39.26.7824",
+              "templateHash": "4433413933094874992"
             },
             "name": " PIM Role Assignments (Management Group scope)",
             "description": "This module deploys a PIM Role Assignment at a Management Group scope."
@@ -770,13 +770,13 @@
           },
           "variables": {
             "builtInRoleNames": {
-              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
-              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
-              "Resource Policy Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
-              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
-              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
-              "Management Group Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ac63b705-f282-497d-ac71-919bf39d939d')]"
+              "Contributor": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+              "Owner": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+              "Reader": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "Resource Policy Contributor": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
+              "Role Based Access Control Administrator": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+              "User Access Administrator": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+              "Management Group Reader": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'ac63b705-f282-497d-ac71-919bf39d939d')]"
             },
             "roleDefinitionIdVar": "[coalesce(tryGet(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), parameters('roleDefinitionIdOrName'))]"
           },
@@ -847,7 +847,7 @@
     "roleAssignment_sub": {
       "condition": "[and(not(empty(parameters('subscriptionId'))), empty(parameters('resourceGroupName')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-PimRoleAssignment-Sub-Module', uniqueString(deployment().name, parameters('location')))]",
       "subscriptionId": "[parameters('subscriptionId')]",
       "location": "[deployment().location]",
@@ -896,8 +896,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "5454496355625652015"
+              "version": "0.39.26.7824",
+              "templateHash": "15963295932027707707"
             },
             "name": "PIM Role Assignments (Subscription scope)",
             "description": "This module deploys a PIM Role Assignment at a Subscription scope."
@@ -1300,7 +1300,7 @@
     "roleAssignment_rg": {
       "condition": "[and(not(empty(parameters('resourceGroupName'))), not(empty(parameters('subscriptionId'))))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-PimRoleAssignment-RG-Module', uniqueString(deployment().name, parameters('location')))]",
       "subscriptionId": "[parameters('subscriptionId')]",
       "resourceGroup": "[parameters('resourceGroupName')]",
@@ -1352,8 +1352,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "969688251715262024"
+              "version": "0.39.26.7824",
+              "templateHash": "11642603087731996523"
             },
             "name": "PIM Role Assignments (Resource Group scope)",
             "description": "This module deploys a PIM Role Assignment at a Resource Group scope."

--- a/avm/ptn/authorization/pim-role-assignment/modules/management-group.bicep
+++ b/avm/ptn/authorization/pim-role-assignment/modules/management-group.bicep
@@ -46,22 +46,25 @@ param condition string?
 param conditionVersion string = '2.0'
 
 var builtInRoleNames = {
-  Contributor: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
-  Owner: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
-  Reader: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
-  'Resource Policy Contributor': subscriptionResourceId(
+  Contributor: managementGroupResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'b24988ac-6180-42a0-ab88-20f7382dd24c'
+  )
+  Owner: managementGroupResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
+  Reader: managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+  'Resource Policy Contributor': managementGroupResourceId(
     'Microsoft.Authorization/roleDefinitions',
     '36243c78-bf99-498c-9df9-86d9f8d28608'
   )
-  'Role Based Access Control Administrator': subscriptionResourceId(
+  'Role Based Access Control Administrator': managementGroupResourceId(
     'Microsoft.Authorization/roleDefinitions',
     'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
   )
-  'User Access Administrator': subscriptionResourceId(
+  'User Access Administrator': managementGroupResourceId(
     'Microsoft.Authorization/roleDefinitions',
     '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
   )
-  'Management Group Reader': subscriptionResourceId(
+  'Management Group Reader': managementGroupResourceId(
     'Microsoft.Authorization/roleDefinitions',
     'ac63b705-f282-497d-ac71-919bf39d939d'
   )

--- a/avm/ptn/authorization/pim-role-assignment/tests/e2e/sub.active.permenant/main.test.bicep
+++ b/avm/ptn/authorization/pim-role-assignment/tests/e2e/sub.active.permenant/main.test.bicep
@@ -31,7 +31,7 @@ module testDeployment '../../../main.bicep' = {
   name: '${uniqueString(deployment().name)}-test-${serviceShort}-${namePrefix}'
   params: {
     principalId: testUserObjectId
-    roleDefinitionIdOrName: subscriptionResourceId(
+    roleDefinitionIdOrName: managementGroupResourceId(
       'Microsoft.Authorization/roleDefinitions',
       'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
     )

--- a/avm/ptn/authorization/role-assignment/CHANGELOG.md
+++ b/avm/ptn/authorization/role-assignment/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/authorization/role-assignment/CHANGELOG.md).
 
+## 0.2.4
+
+### Changes
+
+- Replaced `subscriptionResourceId()` with `managementGroupResourceId()` for built-in role definitions in management group scope module to align with deployment context
+
+### Breaking Changes
+
+- None
+
 ## 0.2.3
 
 ### Changes

--- a/avm/ptn/authorization/role-assignment/main.json
+++ b/avm/ptn/authorization/role-assignment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "12630310542384122119"
+      "templateHash": "10171745902607079182"
     },
     "name": "Role Assignments (All scopes)",
     "description": "This module deploys a Role Assignment at a Management Group, Subscription or Resource Group scope."
@@ -164,7 +164,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.39.26.7824",
-              "templateHash": "17757124846757844493"
+              "templateHash": "2644044087598445758"
             },
             "name": "Role Assignments (Management Group scope)",
             "description": "This module deploys a Role Assignment at a Management Group scope."
@@ -238,13 +238,13 @@
           },
           "variables": {
             "builtInRoleNames": {
-              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
-              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
-              "Resource Policy Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
-              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
-              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
-              "Management Group Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ac63b705-f282-497d-ac71-919bf39d939d')]"
+              "Contributor": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+              "Owner": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+              "Reader": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "Resource Policy Contributor": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
+              "Role Based Access Control Administrator": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+              "User Access Administrator": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+              "Management Group Reader": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'ac63b705-f282-497d-ac71-919bf39d939d')]"
             },
             "roleDefinitionIdVar": "[coalesce(tryGet(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), parameters('roleDefinitionIdOrName'))]"
           },

--- a/avm/ptn/authorization/role-assignment/modules/management-group.bicep
+++ b/avm/ptn/authorization/role-assignment/modules/management-group.bicep
@@ -39,22 +39,25 @@ param conditionVersion string = '2.0'
 param principalType string = ''
 
 var builtInRoleNames = {
-  Contributor: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
-  Owner: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
-  Reader: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
-  'Resource Policy Contributor': subscriptionResourceId(
+  Contributor: managementGroupResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'b24988ac-6180-42a0-ab88-20f7382dd24c'
+  )
+  Owner: managementGroupResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
+  Reader: managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+  'Resource Policy Contributor': managementGroupResourceId(
     'Microsoft.Authorization/roleDefinitions',
     '36243c78-bf99-498c-9df9-86d9f8d28608'
   )
-  'Role Based Access Control Administrator': subscriptionResourceId(
+  'Role Based Access Control Administrator': managementGroupResourceId(
     'Microsoft.Authorization/roleDefinitions',
     'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
   )
-  'User Access Administrator': subscriptionResourceId(
+  'User Access Administrator': managementGroupResourceId(
     'Microsoft.Authorization/roleDefinitions',
     '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
   )
-  'Management Group Reader': subscriptionResourceId(
+  'Management Group Reader': managementGroupResourceId(
     'Microsoft.Authorization/roleDefinitions',
     'ac63b705-f282-497d-ac71-919bf39d939d'
   )

--- a/avm/ptn/authorization/role-assignment/tests/e2e/sub.default/main.test.bicep
+++ b/avm/ptn/authorization/role-assignment/tests/e2e/sub.default/main.test.bicep
@@ -58,7 +58,7 @@ module testDeployment '../../../main.bicep' = {
   name: '${uniqueString(deployment().name)}-test-${serviceShort}'
   params: {
     principalId: nestedDependencies.outputs.managedIdentityPrincipalId
-    roleDefinitionIdOrName: subscriptionResourceId(
+    roleDefinitionIdOrName: managementGroupResourceId(
       'Microsoft.Authorization/roleDefinitions',
       'acdd72a7-3385-48ef-bd42-f606fba81ae7'
     )

--- a/avm/res/authorization/role-assignment/mg-scope/CHANGELOG.md
+++ b/avm/res/authorization/role-assignment/mg-scope/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/authorization/role-assignment/mg-scope/CHANGELOG.md).
 
+## 0.1.2
+
+### Changes
+
+- Replaced `subscriptionResourceId()` with `managementGroupResourceId()` for built-in role definitions to align with management group scope deployment context
+
+### Breaking Changes
+
+- None
+
 ## 0.1.1
 
 ### Changes

--- a/avm/res/authorization/role-assignment/mg-scope/main.bicep
+++ b/avm/res/authorization/role-assignment/mg-scope/main.bicep
@@ -47,22 +47,25 @@ param enableTelemetry bool = true
 param location string = deployment().location
 
 var builtInRoleNames = {
-  Contributor: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
-  Owner: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
-  Reader: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
-  'Resource Policy Contributor': subscriptionResourceId(
+  Contributor: managementGroupResourceId(
+    'Microsoft.Authorization/roleDefinitions',
+    'b24988ac-6180-42a0-ab88-20f7382dd24c'
+  )
+  Owner: managementGroupResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
+  Reader: managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+  'Resource Policy Contributor': managementGroupResourceId(
     'Microsoft.Authorization/roleDefinitions',
     '36243c78-bf99-498c-9df9-86d9f8d28608'
   )
-  'Role Based Access Control Administrator': subscriptionResourceId(
+  'Role Based Access Control Administrator': managementGroupResourceId(
     'Microsoft.Authorization/roleDefinitions',
     'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
   )
-  'User Access Administrator': subscriptionResourceId(
+  'User Access Administrator': managementGroupResourceId(
     'Microsoft.Authorization/roleDefinitions',
     '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
   )
-  'Management Group Reader': subscriptionResourceId(
+  'Management Group Reader': managementGroupResourceId(
     'Microsoft.Authorization/roleDefinitions',
     'ac63b705-f282-497d-ac71-919bf39d939d'
   )
@@ -73,7 +76,7 @@ var roleDefinitionIdVar = builtInRoleNames[?roleDefinitionIdOrName] ?? (contains
     '/providers/Microsoft.Authorization/roleDefinitions/'
   )
   ? roleDefinitionIdOrName
-  : subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionIdOrName))
+  : managementGroupResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionIdOrName))
 
 #disable-next-line no-deployments-resources
 resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {

--- a/avm/res/authorization/role-assignment/mg-scope/main.json
+++ b/avm/res/authorization/role-assignment/mg-scope/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.5.1644",
-      "templateHash": "10230597307084981664"
+      "version": "0.39.26.7824",
+      "templateHash": "10750541938111534142"
     },
     "name": "Role Assignments (Management Group scope)",
     "description": "This module deploys a Role Assignment at a Management Group scope."
@@ -100,15 +100,15 @@
   },
   "variables": {
     "builtInRoleNames": {
-      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
-      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
-      "Resource Policy Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
-      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
-      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
-      "Management Group Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ac63b705-f282-497d-ac71-919bf39d939d')]"
+      "Contributor": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+      "Owner": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+      "Reader": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+      "Resource Policy Contributor": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
+      "Role Based Access Control Administrator": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+      "User Access Administrator": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+      "Management Group Reader": "[managementGroupResourceId('Microsoft.Authorization/roleDefinitions', 'ac63b705-f282-497d-ac71-919bf39d939d')]"
     },
-    "roleDefinitionIdVar": "[coalesce(tryGet(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), if(contains(parameters('roleDefinitionIdOrName'), '/providers/Microsoft.Authorization/roleDefinitions/'), parameters('roleDefinitionIdOrName'), subscriptionResourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionIdOrName'))))]"
+    "roleDefinitionIdVar": "[coalesce(tryGet(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), if(contains(parameters('roleDefinitionIdOrName'), '/providers/Microsoft.Authorization/roleDefinitions/'), parameters('roleDefinitionIdOrName'), managementGroupResourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionIdOrName'))))]"
   },
   "resources": {
     "avmTelemetry": {


### PR DESCRIPTION
## Description

- Replaced `subscriptionResourceId()` with `managementGroupResourceId()` for built-in role definitions in management group scope modules to align with deployment context.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.ptn.authorization.role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-assignment.yml/badge.svg?branch=users%2Fjtracey93%2Ffix%2Fincorrect-resource-id-function-usage)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.role-assignment.yml)|
| [![avm.ptn.authorization.pim-role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.pim-role-assignment.yml/badge.svg?branch=users%2Fjtracey93%2Ffix%2Fincorrect-resource-id-function-usage)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.ptn.authorization.pim-role-assignment.yml) |
| [![avm.res.authorization.role-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.authorization.role-assignment.yml/badge.svg?branch=users%2Fjtracey93%2Ffix%2Fincorrect-resource-id-function-usage)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.authorization.role-assignment.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
