### PR TITLE
feat: Align public IP module params with 2025-01-01 API types

### DIFF
--- a/avm/res/network/public-ip-address/CHANGELOG.md
+++ b/avm/res/network/public-ip-address/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/public-ip-address/CHANGELOG.md).
 
+## 0.11.0
+
+### Changes
+
+- Replaced custom types for `ipTags`, `dnsSettings` and `ddosSettings` with direct references to the resource input types from the `Microsoft.Network/publicIPAddresses@2025-01-01` API version.
+
+### Breaking Changes
+
+- Parameters `ipTags`, `dnsSettings`, and `ddosSettings` now use resource input types from the `Microsoft.Network/publicIPAddresses@2025-01-01` API version instead of custom-defined types.
+
 ## 0.10.0
 
 ### Changes

--- a/avm/res/network/public-ip-address/README.md
+++ b/avm/res/network/public-ip-address/README.md
@@ -663,51 +663,6 @@ The DDoS protection plan configuration associated with the public IP address.
 - Required: No
 - Type: object
 
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`protectionMode`](#parameter-ddossettingsprotectionmode) | string | The DDoS protection policy customizations. |
-
-**Optional parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`ddosProtectionPlan`](#parameter-ddossettingsddosprotectionplan) | object | The DDoS protection plan associated with the public IP address. |
-
-### Parameter: `ddosSettings.protectionMode`
-
-The DDoS protection policy customizations.
-
-- Required: Yes
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'Enabled'
-  ]
-  ```
-
-### Parameter: `ddosSettings.ddosProtectionPlan`
-
-The DDoS protection plan associated with the public IP address.
-
-- Required: No
-- Type: object
-
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`id`](#parameter-ddossettingsddosprotectionplanid) | string | The resource ID of the DDOS protection plan associated with the public IP address. |
-
-### Parameter: `ddosSettings.ddosProtectionPlan.id`
-
-The resource ID of the DDOS protection plan associated with the public IP address.
-
-- Required: Yes
-- Type: string
-
 ### Parameter: `deleteOption`
 
 The delete option for the public IP address.
@@ -875,57 +830,6 @@ The DNS settings of the public IP address.
 - Required: No
 - Type: object
 
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`domainNameLabel`](#parameter-dnssettingsdomainnamelabel) | string | The domain name label. The concatenation of the domain name label and the regionalized DNS zone make up the fully qualified domain name associated with the public IP address. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system. |
-
-**Optional parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`domainNameLabelScope`](#parameter-dnssettingsdomainnamelabelscope) | string | The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN. |
-| [`fqdn`](#parameter-dnssettingsfqdn) | string | The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone. |
-| [`reverseFqdn`](#parameter-dnssettingsreversefqdn) | string | The reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN. |
-
-### Parameter: `dnsSettings.domainNameLabel`
-
-The domain name label. The concatenation of the domain name label and the regionalized DNS zone make up the fully qualified domain name associated with the public IP address. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `dnsSettings.domainNameLabelScope`
-
-The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN.
-
-- Required: No
-- Type: string
-- Allowed:
-  ```Bicep
-  [
-    'NoReuse'
-    'ResourceGroupReuse'
-    'SubscriptionReuse'
-    'TenantReuse'
-  ]
-  ```
-
-### Parameter: `dnsSettings.fqdn`
-
-The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone.
-
-- Required: No
-- Type: string
-
-### Parameter: `dnsSettings.reverseFqdn`
-
-The reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN.
-
-- Required: No
-- Type: string
-
 ### Parameter: `enableTelemetry`
 
 Enable/Disable usage telemetry for module.
@@ -948,27 +852,6 @@ The list of tags associated with the public IP address.
 
 - Required: No
 - Type: array
-
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`ipTagType`](#parameter-iptagsiptagtype) | string | The IP tag type. |
-| [`tag`](#parameter-iptagstag) | string | The IP tag. |
-
-### Parameter: `ipTags.ipTagType`
-
-The IP tag type.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `ipTags.tag`
-
-The IP tag.
-
-- Required: Yes
-- Type: string
 
 ### Parameter: `location`
 

--- a/avm/res/network/public-ip-address/main.bicep
+++ b/avm/res/network/public-ip-address/main.bicep
@@ -34,10 +34,10 @@ param availabilityZones int[] = [
 param publicIPAddressVersion string = 'IPv4'
 
 @description('Optional. The DNS settings of the public IP address.')
-param dnsSettings dnsSettingsType?
+param dnsSettings resourceInput<'Microsoft.Network/publicIPAddresses@2025-01-01'>.properties.dnsSettings?
 
 @description('Optional. The list of tags associated with the public IP address.')
-param ipTags ipTagType[]?
+param ipTags resourceInput<'Microsoft.Network/publicIPAddresses@2025-01-01'>.properties.ipTags?
 
 import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The lock settings of the service.')
@@ -58,7 +58,7 @@ param skuName string = 'Standard'
 param skuTier string = 'Regional'
 
 @description('Optional. The DDoS protection plan configuration associated with the public IP address.')
-param ddosSettings ddosSettingsType?
+param ddosSettings resourceInput<'Microsoft.Network/publicIPAddresses@2025-01-01'>.properties.ddosSettings?
 
 @description('Optional. The delete option for the public IP address.')
 @allowed([
@@ -246,42 +246,3 @@ output ipAddress string = publicIpAddress.properties.?ipAddress ?? ''
 
 @description('The location the resource was deployed into.')
 output location string = publicIpAddress.location
-
-// ================ //
-// Definitions      //
-// ================ //
-
-@export()
-type dnsSettingsType = {
-  @description('Required. The domain name label. The concatenation of the domain name label and the regionalized DNS zone make up the fully qualified domain name associated with the public IP address. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system.')
-  domainNameLabel: string
-
-  @description('Optional. The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN.')
-  domainNameLabelScope: ('NoReuse' | 'ResourceGroupReuse' | 'SubscriptionReuse' | 'TenantReuse')?
-
-  @description('Optional. The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone.')
-  fqdn: string?
-
-  @description('Optional. The reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN.')
-  reverseFqdn: string?
-}
-
-@export()
-type ddosSettingsType = {
-  @description('Optional. The DDoS protection plan associated with the public IP address.')
-  ddosProtectionPlan: {
-    @description('Required. The resource ID of the DDOS protection plan associated with the public IP address.')
-    id: string
-  }?
-  @description('Required. The DDoS protection policy customizations.')
-  protectionMode: 'Enabled'
-}
-
-@export()
-type ipTagType = {
-  @description('Required. The IP tag type.')
-  ipTagType: string
-
-  @description('Required. The IP tag.')
-  tag: string
-}

--- a/avm/res/network/public-ip-address/main.json
+++ b/avm/res/network/public-ip-address/main.json
@@ -6,105 +6,12 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "2127232527712631807"
+      "templateHash": "4769782033235146336"
     },
     "name": "Public IP Addresses",
     "description": "This module deploys a Public IP Address."
   },
   "definitions": {
-    "dnsSettingsType": {
-      "type": "object",
-      "properties": {
-        "domainNameLabel": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. The domain name label. The concatenation of the domain name label and the regionalized DNS zone make up the fully qualified domain name associated with the public IP address. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system."
-          }
-        },
-        "domainNameLabelScope": {
-          "type": "string",
-          "allowedValues": [
-            "NoReuse",
-            "ResourceGroupReuse",
-            "SubscriptionReuse",
-            "TenantReuse"
-          ],
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN."
-          }
-        },
-        "fqdn": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone."
-          }
-        },
-        "reverseFqdn": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN."
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true
-      }
-    },
-    "ddosSettingsType": {
-      "type": "object",
-      "properties": {
-        "ddosProtectionPlan": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "metadata": {
-                "description": "Required. The resource ID of the DDOS protection plan associated with the public IP address."
-              }
-            }
-          },
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The DDoS protection plan associated with the public IP address."
-          }
-        },
-        "protectionMode": {
-          "type": "string",
-          "allowedValues": [
-            "Enabled"
-          ],
-          "metadata": {
-            "description": "Required. The DDoS protection policy customizations."
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true
-      }
-    },
-    "ipTagType": {
-      "type": "object",
-      "properties": {
-        "ipTagType": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. The IP tag type."
-          }
-        },
-        "tag": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. The IP tag."
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true
-      }
-    },
     "diagnosticSettingFullType": {
       "type": "object",
       "properties": {
@@ -396,21 +303,24 @@
       }
     },
     "dnsSettings": {
-      "$ref": "#/definitions/dnsSettingsType",
-      "nullable": true,
+      "type": "object",
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/publicIPAddresses@2025-01-01#properties/properties/properties/dnsSettings"
+        },
         "description": "Optional. The DNS settings of the public IP address."
-      }
+      },
+      "nullable": true
     },
     "ipTags": {
       "type": "array",
-      "items": {
-        "$ref": "#/definitions/ipTagType"
-      },
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/publicIPAddresses@2025-01-01#properties/properties/properties/ipTags"
+        },
         "description": "Optional. The list of tags associated with the public IP address."
-      }
+      },
+      "nullable": true
     },
     "lock": {
       "$ref": "#/definitions/lockType",
@@ -442,11 +352,14 @@
       }
     },
     "ddosSettings": {
-      "$ref": "#/definitions/ddosSettingsType",
-      "nullable": true,
+      "type": "object",
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/publicIPAddresses@2025-01-01#properties/properties/properties/ddosSettings"
+        },
         "description": "Optional. The DDoS protection plan configuration associated with the public IP address."
-      }
+      },
+      "nullable": true
     },
     "deleteOption": {
       "type": "string",

--- a/avm/res/network/public-ip-address/version.json
+++ b/avm/res/network/public-ip-address/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.10"
+  "version": "0.11"
 }


### PR DESCRIPTION
## Description

Parameters `ipTags`, `dnsSettings`, and `ddosSettings` now use resource input types from the `Microsoft.Network/publicIPAddresses@2025-01-01` API version instead of custom-defined types.

#Resolves #6358

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.network.public-ip-address](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml/badge.svg?branch=users%2Fkrbar%2FpipTypes)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
