### PR TITLE
feat: Updated Session-Pool module to latest & added `ORPHANED.md`

### DIFF
--- a/avm/res/app/session-pool/CHANGELOG.md
+++ b/avm/res/app/session-pool/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/app/session-pool/CHANGELOG.md).
 
+## 0.3.0
+
+### Changes
+
+- Updated resource API version from `2024-10-02-preview` to `2025-07-01`
+- Added support for the parameter `secrets`
+- Updated all references of the `avm-common-types` module to the latest version `0.6.1`
+
+### Breaking Changes
+
+- Removed all exported types in favor of imported types (resource-derived types)
+- Replaced parameters `cooldownPeriodInSeconds`, `registryCredentials`, `targetIngressPort`, `containers` in favor of the combined parameter `customContainerTemplate`
+- Replaced parameter `cooldownPeriodInSeconds` with combined parameter `dynamicPoolConfiguration.lifecycleConfiguration`
+- Replaced parameter `sessionNetworkStatus` in favor of the combined parameter `sessionNetworkConfiguration`
+- Replaced parameters `maxConcurrentSessions` & `readySessionInstances` in favor of the combined parameter `scaleConfiguration`
+- Changed type of `systemAssignedMIPrincipalId` output from empty string to an more accurate `null`
+
 ## 0.2.0
 
 ### Changes

--- a/avm/res/app/session-pool/ORPHANED.md
+++ b/avm/res/app/session-pool/ORPHANED.md
@@ -1,0 +1,4 @@
+⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️
+
+- Only security and bug fixes are being handled by the AVM core team at present.
+- If interested in becoming the module owner of this orphaned module (must be Microsoft FTE), please look for the related "orphaned module" GitHub issue [here](https://aka.ms/AVM/OrphanedModules)!

--- a/avm/res/app/session-pool/README.md
+++ b/avm/res/app/session-pool/README.md
@@ -433,6 +433,7 @@ The pool configuration if the poolManagementType is dynamic.
   ```Bicep
   {
       lifecycleConfiguration: {
+        cooldownPeriodInSeconds: 300
         lifecycleType: 'Timed'
       }
   }

--- a/avm/res/app/session-pool/README.md
+++ b/avm/res/app/session-pool/README.md
@@ -429,6 +429,14 @@ The pool configuration if the poolManagementType is dynamic.
 
 - Required: No
 - Type: object
+- Default:
+  ```Bicep
+  {
+      lifecycleConfiguration: {
+        lifecycleType: 'Timed'
+      }
+  }
+  ```
 
 ### Parameter: `enableTelemetry`
 

--- a/avm/res/app/session-pool/README.md
+++ b/avm/res/app/session-pool/README.md
@@ -1,5 +1,10 @@
 # Container App Session Pool `[Microsoft.App/sessionPools]`
 
+> ⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️
+> 
+> - Only security and bug fixes are being handled by the AVM core team at present.
+> - If interested in becoming the module owner of this orphaned module (must be Microsoft FTE), please look for the related "orphaned module" GitHub issue [here](https://aka.ms/AVM/OrphanedModules)!
+
 This module deploys a Container App Session Pool.
 
 You can reference the module as follows:
@@ -23,7 +28,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.App/sessionPools` | 2024-10-02-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.app_sessionpools.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/2024-10-02-preview/sessionPools)</li></ul> |
+| `Microsoft.App/sessionPools` | 2025-07-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.app_sessionpools.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/2025-07-01/sessionPools)</li></ul> |
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
 
@@ -56,8 +61,6 @@ module sessionPool 'br/public:avm/res/app/session-pool:<version>' = {
     // Required parameters
     containerType: 'PythonLTS'
     name: 'aspmin001'
-    // Non-required parameters
-    location: '<location>'
   }
 }
 ```
@@ -80,10 +83,6 @@ module sessionPool 'br/public:avm/res/app/session-pool:<version>' = {
     },
     "name": {
       "value": "aspmin001"
-    },
-    // Non-required parameters
-    "location": {
-      "value": "<location>"
     }
   }
 }
@@ -102,8 +101,6 @@ using 'br/public:avm/res/app/session-pool:<version>'
 // Required parameters
 param containerType = 'PythonLTS'
 param name = 'aspmin001'
-// Non-required parameters
-param location = '<location>'
 ```
 
 </details>
@@ -127,7 +124,11 @@ module sessionPool 'br/public:avm/res/app/session-pool:<version>' = {
     containerType: 'PythonLTS'
     name: 'aspmax001'
     // Non-required parameters
-    cooldownPeriodInSeconds: 350
+    dynamicPoolConfiguration: {
+      lifecycleConfiguration: {
+        cooldownPeriodInSeconds: 350
+      }
+    }
     location: '<location>'
     lock: {
       kind: 'CanNotDelete'
@@ -139,9 +140,7 @@ module sessionPool 'br/public:avm/res/app/session-pool:<version>' = {
         lifecycle: 'Main'
       }
     ]
-    maxConcurrentSessions: 6
     poolManagementType: 'Dynamic'
-    readySessionInstances: 1
     roleAssignments: [
       {
         principalId: '<principalId>'
@@ -149,7 +148,13 @@ module sessionPool 'br/public:avm/res/app/session-pool:<version>' = {
         roleDefinitionIdOrName: 'Azure ContainerApps Session Executor'
       }
     ]
-    sessionNetworkStatus: 'EgressDisabled'
+    scaleConfiguration: {
+      maxConcurrentSessions: 6
+      readySessionInstances: 1
+    }
+    sessionNetworkConfiguration: {
+      status: 'EgressDisabled'
+    }
     tags: {
       resourceType: 'Session Pool'
     }
@@ -177,8 +182,12 @@ module sessionPool 'br/public:avm/res/app/session-pool:<version>' = {
       "value": "aspmax001"
     },
     // Non-required parameters
-    "cooldownPeriodInSeconds": {
-      "value": 350
+    "dynamicPoolConfiguration": {
+      "value": {
+        "lifecycleConfiguration": {
+          "cooldownPeriodInSeconds": 350
+        }
+      }
     },
     "location": {
       "value": "<location>"
@@ -197,14 +206,8 @@ module sessionPool 'br/public:avm/res/app/session-pool:<version>' = {
         }
       ]
     },
-    "maxConcurrentSessions": {
-      "value": 6
-    },
     "poolManagementType": {
       "value": "Dynamic"
-    },
-    "readySessionInstances": {
-      "value": 1
     },
     "roleAssignments": {
       "value": [
@@ -215,8 +218,16 @@ module sessionPool 'br/public:avm/res/app/session-pool:<version>' = {
         }
       ]
     },
-    "sessionNetworkStatus": {
-      "value": "EgressDisabled"
+    "scaleConfiguration": {
+      "value": {
+        "maxConcurrentSessions": 6,
+        "readySessionInstances": 1
+      }
+    },
+    "sessionNetworkConfiguration": {
+      "value": {
+        "status": "EgressDisabled"
+      }
     },
     "tags": {
       "value": {
@@ -241,7 +252,11 @@ using 'br/public:avm/res/app/session-pool:<version>'
 param containerType = 'PythonLTS'
 param name = 'aspmax001'
 // Non-required parameters
-param cooldownPeriodInSeconds = 350
+param dynamicPoolConfiguration = {
+  lifecycleConfiguration: {
+    cooldownPeriodInSeconds: 350
+  }
+}
 param location = '<location>'
 param lock = {
   kind: 'CanNotDelete'
@@ -253,9 +268,7 @@ param managedIdentitySettings = [
     lifecycle: 'Main'
   }
 ]
-param maxConcurrentSessions = 6
 param poolManagementType = 'Dynamic'
-param readySessionInstances = 1
 param roleAssignments = [
   {
     principalId: '<principalId>'
@@ -263,7 +276,13 @@ param roleAssignments = [
     roleDefinitionIdOrName: 'Azure ContainerApps Session Executor'
   }
 ]
-param sessionNetworkStatus = 'EgressDisabled'
+param scaleConfiguration = {
+  maxConcurrentSessions: 6
+  readySessionInstances: 1
+}
+param sessionNetworkConfiguration = {
+  status: 'EgressDisabled'
+}
 param tags = {
   resourceType: 'Session Pool'
 }
@@ -290,8 +309,6 @@ module sessionPool 'br/public:avm/res/app/session-pool:<version>' = {
     containerType: 'PythonLTS'
     name: 'aspwaf001'
     // Non-required parameters
-    location: '<location>'
-    sessionNetworkStatus: 'EgressDisabled'
     tags: {
       resourceType: 'Session Pool'
     }
@@ -319,12 +336,6 @@ module sessionPool 'br/public:avm/res/app/session-pool:<version>' = {
       "value": "aspwaf001"
     },
     // Non-required parameters
-    "location": {
-      "value": "<location>"
-    },
-    "sessionNetworkStatus": {
-      "value": "EgressDisabled"
-    },
     "tags": {
       "value": {
         "resourceType": "Session Pool"
@@ -348,8 +359,6 @@ using 'br/public:avm/res/app/session-pool:<version>'
 param containerType = 'PythonLTS'
 param name = 'aspwaf001'
 // Non-required parameters
-param location = '<location>'
-param sessionNetworkStatus = 'EgressDisabled'
 param tags = {
   resourceType: 'Session Pool'
 }
@@ -371,22 +380,20 @@ param tags = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`containers`](#parameter-containers) | array | Custom container definitions. Only required if containerType is CustomContainer. |
-| [`cooldownPeriodInSeconds`](#parameter-cooldownperiodinseconds) | int | The cooldown period of a session in seconds. |
+| [`customContainerTemplate`](#parameter-customcontainertemplate) | object | The custom container configuration if the containerType is CustomContainer. Only set if containerType is CustomContainer. |
+| [`dynamicPoolConfiguration`](#parameter-dynamicpoolconfiguration) | object | The pool configuration if the poolManagementType is dynamic. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`environmentResourceId`](#parameter-environmentresourceid) | string | Resource ID of the session pool's environment. |
 | [`location`](#parameter-location) | string | Location for all Resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. |
 | [`managedIdentitySettings`](#parameter-managedidentitysettings) | array | Settings for a Managed Identity that is assigned to the Session pool. |
-| [`maxConcurrentSessions`](#parameter-maxconcurrentsessions) | int | The maximum count of sessions at the same time. |
 | [`poolManagementType`](#parameter-poolmanagementtype) | string | The pool management type of the session pool. Defaults to Dynamic. |
-| [`readySessionInstances`](#parameter-readysessioninstances) | int | The minimum count of ready session instances. |
-| [`registryCredentials`](#parameter-registrycredentials) | object | Container registry credentials. Only required if containerType is CustomContainer and the container registry requires authentication. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
-| [`sessionNetworkStatus`](#parameter-sessionnetworkstatus) | string | Network status for the sessions. Defaults to EgressDisabled. |
+| [`scaleConfiguration`](#parameter-scaleconfiguration) | object | The scale configuration of the session pool. |
+| [`secrets`](#parameter-secrets) | array | The secrets of the session pool. |
+| [`sessionNetworkConfiguration`](#parameter-sessionnetworkconfiguration) | object | The network configuration of the sessions in the session pool. |
 | [`tags`](#parameter-tags) | object | Tags of the Automation Account resource. |
-| [`targetIngressPort`](#parameter-targetingressport) | int | Required if containerType == 'CustomContainer'. Target port in containers for traffic from ingress. Only required if containerType is CustomContainer. |
 
 ### Parameter: `containerType`
 
@@ -409,133 +416,19 @@ Name of the Container App Session Pool.
 - Required: Yes
 - Type: string
 
-### Parameter: `containers`
+### Parameter: `customContainerTemplate`
 
-Custom container definitions. Only required if containerType is CustomContainer.
+The custom container configuration if the containerType is CustomContainer. Only set if containerType is CustomContainer.
 
 - Required: No
-- Type: array
-
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`image`](#parameter-containersimage) | string | Container image tag. |
-| [`name`](#parameter-containersname) | string | Custom container name. |
-| [`resources`](#parameter-containersresources) | object | Container resource requirements. |
-
-**Optional parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`args`](#parameter-containersargs) | array | Container start command arguments. |
-| [`command`](#parameter-containerscommand) | array | Container start command. |
-| [`env`](#parameter-containersenv) | array | Container environment variables. |
-
-### Parameter: `containers.image`
-
-Container image tag.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `containers.name`
-
-Custom container name.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `containers.resources`
-
-Container resource requirements.
-
-- Required: Yes
 - Type: object
 
-**Required parameters**
+### Parameter: `dynamicPoolConfiguration`
 
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`cpu`](#parameter-containersresourcescpu) | string | Required CPU in cores, e.g. 0.5. |
-| [`memory`](#parameter-containersresourcesmemory) | string | Required memory, e.g. "1.25Gi". |
-
-### Parameter: `containers.resources.cpu`
-
-Required CPU in cores, e.g. 0.5.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `containers.resources.memory`
-
-Required memory, e.g. "1.25Gi".
-
-- Required: Yes
-- Type: string
-
-### Parameter: `containers.args`
-
-Container start command arguments.
+The pool configuration if the poolManagementType is dynamic.
 
 - Required: No
-- Type: array
-
-### Parameter: `containers.command`
-
-Container start command.
-
-- Required: No
-- Type: array
-
-### Parameter: `containers.env`
-
-Container environment variables.
-
-- Required: No
-- Type: array
-
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`name`](#parameter-containersenvname) | string | Environment variable name. |
-
-**Optional parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`secretRef`](#parameter-containersenvsecretref) | string | Required if value is not set. Name of the Container App secret from which to pull the environment variable value. |
-| [`value`](#parameter-containersenvvalue) | string | Required if secretRef is not set. Non-secret environment variable value. |
-
-### Parameter: `containers.env.name`
-
-Environment variable name.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `containers.env.secretRef`
-
-Required if value is not set. Name of the Container App secret from which to pull the environment variable value.
-
-- Required: No
-- Type: string
-
-### Parameter: `containers.env.value`
-
-Required if secretRef is not set. Non-secret environment variable value.
-
-- Required: No
-- Type: string
-
-### Parameter: `cooldownPeriodInSeconds`
-
-The cooldown period of a session in seconds.
-
-- Required: No
-- Type: int
-- Default: `300`
+- Type: object
 
 ### Parameter: `enableTelemetry`
 
@@ -639,35 +532,6 @@ Settings for a Managed Identity that is assigned to the Session pool.
 - Required: No
 - Type: array
 
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`identity`](#parameter-managedidentitysettingsidentity) | string | The resource ID of a user-assigned managed identity that is assigned to the Session Pool, or "system" for system-assigned identity. |
-| [`lifecycle`](#parameter-managedidentitysettingslifecycle) | string | Use to select the lifecycle stages of a Session Pool during which the Managed Identity should be available. Valid values: "All", "Init", "Main", "None". |
-
-### Parameter: `managedIdentitySettings.identity`
-
-The resource ID of a user-assigned managed identity that is assigned to the Session Pool, or "system" for system-assigned identity.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `managedIdentitySettings.lifecycle`
-
-Use to select the lifecycle stages of a Session Pool during which the Managed Identity should be available. Valid values: "All", "Init", "Main", "None".
-
-- Required: Yes
-- Type: string
-
-### Parameter: `maxConcurrentSessions`
-
-The maximum count of sessions at the same time.
-
-- Required: No
-- Type: int
-- Default: `5`
-
 ### Parameter: `poolManagementType`
 
 The pool management type of the session pool. Defaults to Dynamic.
@@ -682,62 +546,6 @@ The pool management type of the session pool. Defaults to Dynamic.
     'Manual'
   ]
   ```
-
-### Parameter: `readySessionInstances`
-
-The minimum count of ready session instances.
-
-- Required: No
-- Type: int
-
-### Parameter: `registryCredentials`
-
-Container registry credentials. Only required if containerType is CustomContainer and the container registry requires authentication.
-
-- Required: No
-- Type: object
-
-**Required parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`server`](#parameter-registrycredentialsserver) | string | Container registry server. |
-| [`username`](#parameter-registrycredentialsusername) | string | Container registry username. |
-
-**Optional parameters**
-
-| Parameter | Type | Description |
-| :-- | :-- | :-- |
-| [`identity`](#parameter-registrycredentialsidentity) | string | A Managed Identity to use to authenticate with Azure Container Registry. For user-assigned identities, use the full user-assigned identity Resource ID. For system-assigned identities, use "system". |
-| [`passwordSecretRef`](#parameter-registrycredentialspasswordsecretref) | string | The name of the secret that contains the registry login password. Not used if identity is specified. |
-
-### Parameter: `registryCredentials.server`
-
-Container registry server.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `registryCredentials.username`
-
-Container registry username.
-
-- Required: Yes
-- Type: string
-
-### Parameter: `registryCredentials.identity`
-
-A Managed Identity to use to authenticate with Azure Container Registry. For user-assigned identities, use the full user-assigned identity Resource ID. For system-assigned identities, use "system".
-
-- Required: No
-- Type: string
-
-### Parameter: `registryCredentials.passwordSecretRef`
-
-The name of the secret that contains the registry login password. Not used if identity is specified.
-
-- Required: No
-- Type: string
 
 ### Parameter: `roleAssignments`
 
@@ -845,19 +653,37 @@ The principal type of the assigned principal ID.
   ]
   ```
 
-### Parameter: `sessionNetworkStatus`
+### Parameter: `scaleConfiguration`
 
-Network status for the sessions. Defaults to EgressDisabled.
+The scale configuration of the session pool.
 
 - Required: No
-- Type: string
-- Default: `'EgressDisabled'`
-- Allowed:
+- Type: object
+- Default:
   ```Bicep
-  [
-    'EgressDisabled'
-    'EgressEnabled'
-  ]
+  {
+      maxConcurrentSessions: 5
+  }
+  ```
+
+### Parameter: `secrets`
+
+The secrets of the session pool.
+
+- Required: No
+- Type: array
+
+### Parameter: `sessionNetworkConfiguration`
+
+The network configuration of the sessions in the session pool.
+
+- Required: No
+- Type: object
+- Default:
+  ```Bicep
+  {
+      status: 'EgressDisabled'
+  }
   ```
 
 ### Parameter: `tags`
@@ -866,13 +692,6 @@ Tags of the Automation Account resource.
 
 - Required: No
 - Type: object
-
-### Parameter: `targetIngressPort`
-
-Required if containerType == 'CustomContainer'. Target port in containers for traffic from ingress. Only required if containerType is CustomContainer.
-
-- Required: No
-- Type: int
 
 ## Outputs
 
@@ -890,8 +709,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.2.1` | Remote reference |
-| `br/public:avm/utl/types/avm-common-types:0.6.0` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/app/session-pool/main.bicep
+++ b/avm/res/app/session-pool/main.bicep
@@ -11,46 +11,43 @@ param location string = resourceGroup().location
 @allowed(['PythonLTS', 'CustomContainer'])
 param containerType string
 
-@description('Optional. Custom container definitions. Only required if containerType is CustomContainer.')
-param containers sessionContainerType[]?
+@description('Optional. The custom container configuration if the containerType is CustomContainer. Only set if containerType is CustomContainer.')
+param customContainerTemplate resourceInput<'Microsoft.App/sessionPools@2025-07-01'>.properties.customContainerTemplate?
 
-@description('Optional. Required if containerType == \'CustomContainer\'. Target port in containers for traffic from ingress. Only required if containerType is CustomContainer.')
-param targetIngressPort int?
+@description('Optional. The pool configuration if the poolManagementType is dynamic.')
+param dynamicPoolConfiguration resourceInput<'Microsoft.App/sessionPools@2025-07-01'>.properties.dynamicPoolConfiguration?
 
-@description('Optional. Container registry credentials. Only required if containerType is CustomContainer and the container registry requires authentication.')
-param registryCredentials sessionRegistryCredentialsType?
+@description('Optional. The scale configuration of the session pool.')
+param scaleConfiguration resourceInput<'Microsoft.App/sessionPools@2025-07-01'>.properties.scaleConfiguration = {
+  maxConcurrentSessions: 5
+}
 
-@description('Optional. The cooldown period of a session in seconds.')
-param cooldownPeriodInSeconds int = 300
-
-@description('Optional. The maximum count of sessions at the same time.')
-param maxConcurrentSessions int = 5
-
-@description('Optional. The minimum count of ready session instances.')
-param readySessionInstances int?
-
-@description('Optional. Network status for the sessions. Defaults to EgressDisabled.')
-@allowed(['EgressEnabled', 'EgressDisabled'])
-param sessionNetworkStatus string = 'EgressDisabled'
+@description('Optional. The network configuration of the sessions in the session pool.')
+param sessionNetworkConfiguration resourceInput<'Microsoft.App/sessionPools@2025-07-01'>.properties.sessionNetworkConfiguration = {
+  status: 'EgressDisabled'
+}
 
 @description('Optional. The pool management type of the session pool. Defaults to Dynamic.')
 @allowed(['Dynamic', 'Manual'])
 param poolManagementType string = 'Dynamic'
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The lock settings of the service.')
 param lock lockType?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.2.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
-import { managedIdentityAllType } from 'br/public:avm/utl/types/avm-common-types:0.2.1'
+import { managedIdentityAllType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The managed identity definition for this resource.')
 param managedIdentities managedIdentityAllType?
 
 @description('Optional. Settings for a Managed Identity that is assigned to the Session pool.')
-param managedIdentitySettings managedIdentitySettingType[]?
+param managedIdentitySettings resourceInput<'Microsoft.App/sessionPools@2025-07-01'>.properties.managedIdentitySettings?
+
+@description('Optional. The secrets of the session pool.')
+param secrets resourceInput<'Microsoft.App/sessionPools@2025-07-01'>.properties.secrets?
 
 @description('Optional. Resource ID of the session pool\'s environment.')
 param environmentResourceId string?
@@ -132,34 +129,19 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource sessionPool 'Microsoft.App/sessionPools@2024-10-02-preview' = {
+resource sessionPool 'Microsoft.App/sessionPools@2025-07-01' = {
   name: name
   location: location
   identity: identity
   properties: {
     containerType: containerType
     environmentId: environmentResourceId
-    customContainerTemplate: containerType == 'CustomContainer'
-      ? {
-          containers: containers
-          ingress: {
-            targetPort: targetIngressPort
-          }
-          registryCredentials: registryCredentials
-        }
-      : null
-    dynamicPoolConfiguration: {
-      cooldownPeriodInSeconds: cooldownPeriodInSeconds
-      executionType: 'Timed'
-    }
+    customContainerTemplate: containerType == 'CustomContainer' ? customContainerTemplate : null
+    dynamicPoolConfiguration: dynamicPoolConfiguration
+    secrets: secrets
     managedIdentitySettings: managedIdentitySettings
-    scaleConfiguration: {
-      maxConcurrentSessions: maxConcurrentSessions
-      readySessionInstances: readySessionInstances
-    }
-    sessionNetworkConfiguration: {
-      status: sessionNetworkStatus
-    }
+    scaleConfiguration: scaleConfiguration
+    sessionNetworkConfiguration: sessionNetworkConfiguration
     poolManagementType: poolManagementType
   }
   tags: tags
@@ -205,79 +187,4 @@ output resourceGroupName string = resourceGroup().name
 output managementEndpoint string = sessionPool.properties.poolManagementEndpoint
 
 @description('The principal ID of the system assigned identity.')
-output systemAssignedMIPrincipalId string = sessionPool.?identity.?principalId ?? ''
-
-// =============== //
-//   Definitions   //
-// =============== //
-
-@export()
-@description('Optional. Custom container definition.')
-type sessionContainerType = {
-  @description('Optional. Container start command arguments.')
-  args: string[]?
-
-  @description('Optional. Container start command.')
-  command: string[]?
-
-  @description('Optional. Container environment variables.')
-  env: sessionContainerEnvType[]?
-
-  @description('Required. Container image tag.')
-  image: string
-
-  @description('Required. Custom container name.')
-  name: string
-
-  @description('Required. Container resource requirements.')
-  resources: sessionContainerResourceType
-}
-
-@export()
-@description('Optional. Environment variable definition for a container. Only used with custom containers.')
-type sessionContainerEnvType = {
-  @description('Required. Environment variable name.')
-  name: string
-
-  @description('Optional. Required if value is not set. Name of the Container App secret from which to pull the environment variable value.')
-  secretRef: string?
-
-  @description('Optional. Required if secretRef is not set. Non-secret environment variable value.')
-  value: string?
-}
-
-@export()
-@description('Optional. Container resource requirements. Only used with custom containers.')
-type sessionContainerResourceType = {
-  @description('Required. Required CPU in cores, e.g. 0.5.')
-  cpu: string
-
-  @description('Required. Required memory, e.g. "1.25Gi".')
-  memory: string
-}
-
-@export()
-@description('Optional. Container registry credentials. Only used with custom containers.')
-type sessionRegistryCredentialsType = {
-  @description('Optional. A Managed Identity to use to authenticate with Azure Container Registry. For user-assigned identities, use the full user-assigned identity Resource ID. For system-assigned identities, use "system".')
-  identity: string?
-
-  @description('Optional. The name of the secret that contains the registry login password. Not used if identity is specified.')
-  passwordSecretRef: string?
-
-  @description('Required. Container registry server.')
-  server: string
-
-  @description('Required. Container registry username.')
-  username: string
-}
-
-@export()
-@description('Optional. Managed Identity settings for the session pool.')
-type managedIdentitySettingType = {
-  @description('Required. The resource ID of a user-assigned managed identity that is assigned to the Session Pool, or "system" for system-assigned identity.')
-  identity: string
-
-  @description('Required. Use to select the lifecycle stages of a Session Pool during which the Managed Identity should be available. Valid values: "All", "Init", "Main", "None".')
-  lifecycle: string
-}
+output systemAssignedMIPrincipalId string? = sessionPool.?identity.?principalId

--- a/avm/res/app/session-pool/main.bicep
+++ b/avm/res/app/session-pool/main.bicep
@@ -17,6 +17,7 @@ param customContainerTemplate resourceInput<'Microsoft.App/sessionPools@2025-07-
 @description('Optional. The pool configuration if the poolManagementType is dynamic.')
 param dynamicPoolConfiguration resourceInput<'Microsoft.App/sessionPools@2025-07-01'>.properties.dynamicPoolConfiguration = {
   lifecycleConfiguration: {
+    cooldownPeriodInSeconds: 300
     lifecycleType: 'Timed'
   }
 }

--- a/avm/res/app/session-pool/main.json
+++ b/avm/res/app/session-pool/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "10637456249855363651"
+      "templateHash": "14248350204192589126"
     },
     "name": "Container App Session Pool",
     "description": "This module deploys a Container App Session Pool."
@@ -195,7 +195,11 @@
         },
         "description": "Optional. The pool configuration if the poolManagementType is dynamic."
       },
-      "nullable": true
+      "defaultValue": {
+        "lifecycleConfiguration": {
+          "lifecycleType": "Timed"
+        }
+      }
     },
     "scaleConfiguration": {
       "type": "object",
@@ -310,7 +314,7 @@
       }
     ],
     "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
-    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned,UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
+    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(variables('formattedUserAssignedIdentities'))), 'SystemAssigned,UserAssigned', 'SystemAssigned'), if(not(empty(variables('formattedUserAssignedIdentities'))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
     "builtInRoleNames": {
       "Azure ContainerApps Session Executor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0fb8eba5-a2bb-4abe-b1c1-49dfad359bb0')]",
       "Container Apps SessionPools Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f7669afb-68b2-44b4-9c5f-6d2a47fddda0')]",
@@ -353,7 +357,7 @@
         "containerType": "[parameters('containerType')]",
         "environmentId": "[parameters('environmentResourceId')]",
         "customContainerTemplate": "[if(equals(parameters('containerType'), 'CustomContainer'), parameters('customContainerTemplate'), null())]",
-        "dynamicPoolConfiguration": "[parameters('dynamicPoolConfiguration')]",
+        "dynamicPoolConfiguration": "[if(equals(parameters('poolManagementType'), 'Dynamic'), parameters('dynamicPoolConfiguration'), null())]",
         "secrets": "[parameters('secrets')]",
         "managedIdentitySettings": "[parameters('managedIdentitySettings')]",
         "scaleConfiguration": "[parameters('scaleConfiguration')]",

--- a/avm/res/app/session-pool/main.json
+++ b/avm/res/app/session-pool/main.json
@@ -5,176 +5,13 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "17337433088192690119"
+      "version": "0.39.26.7824",
+      "templateHash": "10637456249855363651"
     },
     "name": "Container App Session Pool",
     "description": "This module deploys a Container App Session Pool."
   },
   "definitions": {
-    "sessionContainerType": {
-      "type": "object",
-      "properties": {
-        "args": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Container start command arguments."
-          }
-        },
-        "command": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Container start command."
-          }
-        },
-        "env": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/sessionContainerEnvType"
-          },
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Container environment variables."
-          }
-        },
-        "image": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. Container image tag."
-          }
-        },
-        "name": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. Custom container name."
-          }
-        },
-        "resources": {
-          "$ref": "#/definitions/sessionContainerResourceType",
-          "metadata": {
-            "description": "Required. Container resource requirements."
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true,
-        "description": "Optional. Custom container definition."
-      }
-    },
-    "sessionContainerEnvType": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. Environment variable name."
-          }
-        },
-        "secretRef": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Required if value is not set. Name of the Container App secret from which to pull the environment variable value."
-          }
-        },
-        "value": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. Required if secretRef is not set. Non-secret environment variable value."
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true,
-        "description": "Optional. Environment variable definition for a container. Only used with custom containers."
-      }
-    },
-    "sessionContainerResourceType": {
-      "type": "object",
-      "properties": {
-        "cpu": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. Required CPU in cores, e.g. 0.5."
-          }
-        },
-        "memory": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. Required memory, e.g. \"1.25Gi\"."
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true,
-        "description": "Optional. Container resource requirements. Only used with custom containers."
-      }
-    },
-    "sessionRegistryCredentialsType": {
-      "type": "object",
-      "properties": {
-        "identity": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. A Managed Identity to use to authenticate with Azure Container Registry. For user-assigned identities, use the full user-assigned identity Resource ID. For system-assigned identities, use \"system\"."
-          }
-        },
-        "passwordSecretRef": {
-          "type": "string",
-          "nullable": true,
-          "metadata": {
-            "description": "Optional. The name of the secret that contains the registry login password. Not used if identity is specified."
-          }
-        },
-        "server": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. Container registry server."
-          }
-        },
-        "username": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. Container registry username."
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true,
-        "description": "Optional. Container registry credentials. Only used with custom containers."
-      }
-    },
-    "managedIdentitySettingType": {
-      "type": "object",
-      "properties": {
-        "identity": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. The resource ID of a user-assigned managed identity that is assigned to the Session Pool, or \"system\" for system-assigned identity."
-          }
-        },
-        "lifecycle": {
-          "type": "string",
-          "metadata": {
-            "description": "Required. Use to select the lifecycle stages of a Session Pool during which the Managed Identity should be available. Valid values: \"All\", \"Init\", \"Main\", \"None\"."
-          }
-        }
-      },
-      "metadata": {
-        "__bicep_export!": true,
-        "description": "Optional. Managed Identity settings for the session pool."
-      }
-    },
     "lockType": {
       "type": "object",
       "properties": {
@@ -208,7 +45,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a lock.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
         }
       }
     },
@@ -236,7 +73,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.2.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
         }
       }
     },
@@ -311,7 +148,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.2.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
         }
       }
     }
@@ -340,60 +177,48 @@
         "description": "Required. The container type of the sessions."
       }
     },
-    "containers": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/sessionContainerType"
+    "customContainerTemplate": {
+      "type": "object",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.App/sessionPools@2025-07-01#properties/properties/properties/customContainerTemplate"
+        },
+        "description": "Optional. The custom container configuration if the containerType is CustomContainer. Only set if containerType is CustomContainer."
       },
-      "nullable": true,
+      "nullable": true
+    },
+    "dynamicPoolConfiguration": {
+      "type": "object",
       "metadata": {
-        "description": "Optional. Custom container definitions. Only required if containerType is CustomContainer."
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.App/sessionPools@2025-07-01#properties/properties/properties/dynamicPoolConfiguration"
+        },
+        "description": "Optional. The pool configuration if the poolManagementType is dynamic."
+      },
+      "nullable": true
+    },
+    "scaleConfiguration": {
+      "type": "object",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.App/sessionPools@2025-07-01#properties/properties/properties/scaleConfiguration"
+        },
+        "description": "Optional. The scale configuration of the session pool."
+      },
+      "defaultValue": {
+        "maxConcurrentSessions": 5
       }
     },
-    "targetIngressPort": {
-      "type": "int",
-      "nullable": true,
+    "sessionNetworkConfiguration": {
+      "type": "object",
       "metadata": {
-        "description": "Optional. Required if containerType == 'CustomContainer'. Target port in containers for traffic from ingress. Only required if containerType is CustomContainer."
-      }
-    },
-    "registryCredentials": {
-      "$ref": "#/definitions/sessionRegistryCredentialsType",
-      "nullable": true,
-      "metadata": {
-        "description": "Optional. Container registry credentials. Only required if containerType is CustomContainer and the container registry requires authentication."
-      }
-    },
-    "cooldownPeriodInSeconds": {
-      "type": "int",
-      "defaultValue": 300,
-      "metadata": {
-        "description": "Optional. The cooldown period of a session in seconds."
-      }
-    },
-    "maxConcurrentSessions": {
-      "type": "int",
-      "defaultValue": 5,
-      "metadata": {
-        "description": "Optional. The maximum count of sessions at the same time."
-      }
-    },
-    "readySessionInstances": {
-      "type": "int",
-      "nullable": true,
-      "metadata": {
-        "description": "Optional. The minimum count of ready session instances."
-      }
-    },
-    "sessionNetworkStatus": {
-      "type": "string",
-      "defaultValue": "EgressDisabled",
-      "allowedValues": [
-        "EgressEnabled",
-        "EgressDisabled"
-      ],
-      "metadata": {
-        "description": "Optional. Network status for the sessions. Defaults to EgressDisabled."
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.App/sessionPools@2025-07-01#properties/properties/properties/sessionNetworkConfiguration"
+        },
+        "description": "Optional. The network configuration of the sessions in the session pool."
+      },
+      "defaultValue": {
+        "status": "EgressDisabled"
       }
     },
     "poolManagementType": {
@@ -433,13 +258,23 @@
     },
     "managedIdentitySettings": {
       "type": "array",
-      "items": {
-        "$ref": "#/definitions/managedIdentitySettingType"
-      },
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.App/sessionPools@2025-07-01#properties/properties/properties/managedIdentitySettings"
+        },
         "description": "Optional. Settings for a Managed Identity that is assigned to the Session pool."
-      }
+      },
+      "nullable": true
+    },
+    "secrets": {
+      "type": "array",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.App/sessionPools@2025-07-01#properties/properties/properties/secrets"
+        },
+        "description": "Optional. The secrets of the session pool."
+      },
+      "nullable": true
     },
     "environmentResourceId": {
       "type": "string",
@@ -510,26 +345,19 @@
     },
     "sessionPool": {
       "type": "Microsoft.App/sessionPools",
-      "apiVersion": "2024-10-02-preview",
+      "apiVersion": "2025-07-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "identity": "[variables('identity')]",
       "properties": {
         "containerType": "[parameters('containerType')]",
         "environmentId": "[parameters('environmentResourceId')]",
-        "customContainerTemplate": "[if(equals(parameters('containerType'), 'CustomContainer'), createObject('containers', parameters('containers'), 'ingress', createObject('targetPort', parameters('targetIngressPort')), 'registryCredentials', parameters('registryCredentials')), null())]",
-        "dynamicPoolConfiguration": {
-          "cooldownPeriodInSeconds": "[parameters('cooldownPeriodInSeconds')]",
-          "executionType": "Timed"
-        },
+        "customContainerTemplate": "[if(equals(parameters('containerType'), 'CustomContainer'), parameters('customContainerTemplate'), null())]",
+        "dynamicPoolConfiguration": "[parameters('dynamicPoolConfiguration')]",
+        "secrets": "[parameters('secrets')]",
         "managedIdentitySettings": "[parameters('managedIdentitySettings')]",
-        "scaleConfiguration": {
-          "maxConcurrentSessions": "[parameters('maxConcurrentSessions')]",
-          "readySessionInstances": "[parameters('readySessionInstances')]"
-        },
-        "sessionNetworkConfiguration": {
-          "status": "[parameters('sessionNetworkStatus')]"
-        },
+        "scaleConfiguration": "[parameters('scaleConfiguration')]",
+        "sessionNetworkConfiguration": "[parameters('sessionNetworkConfiguration')]",
         "poolManagementType": "[parameters('poolManagementType')]"
       },
       "tags": "[parameters('tags')]"
@@ -602,10 +430,11 @@
     },
     "systemAssignedMIPrincipalId": {
       "type": "string",
+      "nullable": true,
       "metadata": {
         "description": "The principal ID of the system assigned identity."
       },
-      "value": "[coalesce(tryGet(tryGet(reference('sessionPool', '2024-10-02-preview', 'full'), 'identity'), 'principalId'), '')]"
+      "value": "[tryGet(tryGet(reference('sessionPool', '2025-07-01', 'full'), 'identity'), 'principalId')]"
     }
   }
 }

--- a/avm/res/app/session-pool/main.json
+++ b/avm/res/app/session-pool/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "14248350204192589126"
+      "templateHash": "3271245120536758923"
     },
     "name": "Container App Session Pool",
     "description": "This module deploys a Container App Session Pool."
@@ -197,6 +197,7 @@
       },
       "defaultValue": {
         "lifecycleConfiguration": {
+          "cooldownPeriodInSeconds": 300,
           "lifecycleType": "Timed"
         }
       }

--- a/avm/res/app/session-pool/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/app/session-pool/tests/e2e/defaults/main.test.bicep
@@ -27,7 +27,7 @@ param namePrefix string = '#_namePrefix_#'
 // ================= //
 // General resources //
 // ================= //
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -43,7 +43,6 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
       containerType: 'PythonLTS'
     }
   }

--- a/avm/res/app/session-pool/tests/e2e/max/dependencies.bicep
+++ b/avm/res/app/session-pool/tests/e2e/max/dependencies.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 @description('Required. The name of the Managed Identity to be created.')
 param managedIdentityName string
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-07-31-preview' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }

--- a/avm/res/app/session-pool/tests/e2e/max/main.test.bicep
+++ b/avm/res/app/session-pool/tests/e2e/max/main.test.bicep
@@ -27,7 +27,7 @@ param namePrefix string = '#_namePrefix_#'
 // ================= //
 // General resources //
 // ================= //
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -36,7 +36,6 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
   params: {
-    location: resourceLocation
     managedIdentityName: 'dep-${namePrefix}-mi-${serviceShort}'
   }
 }
@@ -57,10 +56,18 @@ module testDeployment '../../../main.bicep' = [
       tags: {
         resourceType: 'Session Pool'
       }
-      cooldownPeriodInSeconds: 350
-      maxConcurrentSessions: 6
-      readySessionInstances: 1
-      sessionNetworkStatus: 'EgressDisabled'
+      dynamicPoolConfiguration: {
+        lifecycleConfiguration: {
+          cooldownPeriodInSeconds: 350
+        }
+      }
+      scaleConfiguration: {
+        maxConcurrentSessions: 6
+        readySessionInstances: 1
+      }
+      sessionNetworkConfiguration: {
+        status: 'EgressDisabled'
+      }
       poolManagementType: 'Dynamic'
       managedIdentitySettings: [
         {

--- a/avm/res/app/session-pool/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/app/session-pool/tests/e2e/waf-aligned/main.test.bicep
@@ -27,7 +27,7 @@ param namePrefix string = '#_namePrefix_#'
 // ================= //
 // General resources //
 // ================= //
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -43,12 +43,10 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
       containerType: 'PythonLTS'
       tags: {
         resourceType: 'Session Pool'
       }
-      sessionNetworkStatus: 'EgressDisabled'
     }
   }
 ]

--- a/avm/res/app/session-pool/version.json
+++ b/avm/res/app/session-pool/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.2"
+  "version": "0.3"
 }


### PR DESCRIPTION
## Description

### Changes

- Updated resource API version from `2024-10-02-preview` to `2025-07-01`
- Added support for the parameter `secrets`
- Updated all references of the `avm-common-types` module to the latest version `0.6.1`

### Breaking Changes

- Removed all exported types in favor of imported types (resource-derived types)
- Replaced parameters `cooldownPeriodInSeconds`, `registryCredentials`, `targetIngressPort`, `containers` in favor of the combined parameter `customContainerTemplate`
- Replaced parameter `cooldownPeriodInSeconds` with combined parameter `dynamicPoolConfiguration.lifecycleConfiguration`
- Replaced parameter `sessionNetworkStatus` in favor of the combined parameter `sessionNetworkConfiguration`
- Replaced parameters `maxConcurrentSessions` & `readySessionInstances` in favor of the combined parameter `scaleConfiguration`
- Changed type of `systemAssignedMIPrincipalId` output from empty string to an more accurate `null`


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.app.session-pool](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.session-pool.yml/badge.svg?branch=users%2Falsehr%2FsessionPoolOrphaned&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.app.session-pool.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
