### PR TITLE
feat: `avm/ptn/azd/container-app-upsert` - add `allowedOrigins` param

### DIFF
--- a/avm/ptn/azd/container-app-upsert/CHANGELOG.md
+++ b/avm/ptn/azd/container-app-upsert/CHANGELOG.md
@@ -8,6 +8,10 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 - Add new `allowedOrigins` param to configure allowed origins
 
+### Breaking Changes
+
+- None
+
 ## 0.2.0
 
 ### Changes

--- a/avm/ptn/azd/container-app-upsert/CHANGELOG.md
+++ b/avm/ptn/azd/container-app-upsert/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/container-app-upsert/CHANGELOG.md).
 
+## 0.3.0
+
+### Changes
+
+- Add new `allowedOrigins` param to configure allowed origins
+
 ## 0.2.0
 
 ### Changes

--- a/avm/ptn/azd/container-app-upsert/README.md
+++ b/avm/ptn/azd/container-app-upsert/README.md
@@ -423,7 +423,6 @@ Allowed origins.
 
 - Required: No
 - Type: array
-- Default: `[]`
 
 ### Parameter: `containerCpuCoreCount`
 

--- a/avm/ptn/azd/container-app-upsert/README.md
+++ b/avm/ptn/azd/container-app-upsert/README.md
@@ -130,6 +130,9 @@ module containerAppUpsert 'br/public:avm/ptn/azd/container-app-upsert:<version>'
     containerAppsEnvironmentName: '<containerAppsEnvironmentName>'
     name: '<name>'
     // Non-required parameters
+    allowedOrigins: [
+      'https://www.bing.com'
+    ]
     containerProbes: [
       {
         httpGet: {
@@ -204,6 +207,11 @@ module containerAppUpsert 'br/public:avm/ptn/azd/container-app-upsert:<version>'
       "value": "<name>"
     },
     // Non-required parameters
+    "allowedOrigins": {
+      "value": [
+        "https://www.bing.com"
+      ]
+    },
     "containerProbes": {
       "value": [
         {
@@ -296,6 +304,9 @@ using 'br/public:avm/ptn/azd/container-app-upsert:<version>'
 param containerAppsEnvironmentName = '<containerAppsEnvironmentName>'
 param name = '<name>'
 // Non-required parameters
+param allowedOrigins = [
+  'https://www.bing.com'
+]
 param containerProbes = [
   {
     httpGet: {
@@ -364,6 +375,7 @@ param userAssignedIdentityResourceId = '<userAssignedIdentityResourceId>'
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`allowedOrigins`](#parameter-allowedorigins) | array | Allowed origins. |
 | [`containerCpuCoreCount`](#parameter-containercpucorecount) | string | The number of CPU cores allocated to a single container instance, e.g., 0.5. |
 | [`containerMaxReplicas`](#parameter-containermaxreplicas) | int | The maximum number of replicas to run. Must be at least 1. |
 | [`containerMemory`](#parameter-containermemory) | string | The amount of memory allocated to a single container instance, e.g., 1Gi. |
@@ -404,6 +416,14 @@ The name of the Container App.
 
 - Required: Yes
 - Type: string
+
+### Parameter: `allowedOrigins`
+
+Allowed origins.
+
+- Required: No
+- Type: array
+- Default: `[]`
 
 ### Parameter: `containerCpuCoreCount`
 

--- a/avm/ptn/azd/container-app-upsert/main.bicep
+++ b/avm/ptn/azd/container-app-upsert/main.bicep
@@ -13,7 +13,7 @@ param location string = resourceGroup().location
 param tags object?
 
 @description('Optional. Allowed origins.')
-param allowedOrigins array = []
+param allowedOrigins string[]?
 
 @description('Required. Name of the environment for container apps.')
 param containerAppsEnvironmentName string

--- a/avm/ptn/azd/container-app-upsert/main.bicep
+++ b/avm/ptn/azd/container-app-upsert/main.bicep
@@ -12,6 +12,9 @@ param location string = resourceGroup().location
 @description('Optional. Tags of the resource.')
 param tags object?
 
+@description('Optional. Allowed origins.')
+param allowedOrigins array = []
+
 @description('Required. Name of the environment for container apps.')
 param containerAppsEnvironmentName string
 
@@ -124,6 +127,7 @@ module app 'br/public:avm/ptn/azd/acr-container-app:0.2.0' = {
     tags: tags
     identityType: identityType
     identityName: identityName
+    allowedOrigins: allowedOrigins
     ingressEnabled: ingressEnabled
     containerName: containerName
     containerAppsEnvironmentName: containerAppsEnvironmentName

--- a/avm/ptn/azd/container-app-upsert/main.json
+++ b/avm/ptn/azd/container-app-upsert/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "3283442724055270610"
+      "version": "0.39.26.7824",
+      "templateHash": "6719229987783347714"
     },
     "name": "Azd Container App Upsert",
     "description": "Creates or updates an existing Azure Container App.\n\n**Note:** This module is not intended for broad, generic use, as it was designed to cater for the requirements of the AZD CLI product. Feature requests and bug fix requests are welcome if they support the development of the AZD CLI but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case"
@@ -287,6 +287,13 @@
         "description": "Optional. Tags of the resource."
       }
     },
+    "allowedOrigins": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Optional. Allowed origins."
+      }
+    },
     "containerAppsEnvironmentName": {
       "type": "string",
       "metadata": {
@@ -512,7 +519,7 @@
     },
     "app": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-container-app-update', uniqueString(deployment().name, parameters('location')))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -534,6 +541,9 @@
           },
           "identityName": {
             "value": "[parameters('identityName')]"
+          },
+          "allowedOrigins": {
+            "value": "[parameters('allowedOrigins')]"
           },
           "ingressEnabled": {
             "value": "[parameters('ingressEnabled')]"

--- a/avm/ptn/azd/container-app-upsert/main.json
+++ b/avm/ptn/azd/container-app-upsert/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "6719229987783347714"
+      "templateHash": "12697644751497558406"
     },
     "name": "Azd Container App Upsert",
     "description": "Creates or updates an existing Azure Container App.\n\n**Note:** This module is not intended for broad, generic use, as it was designed to cater for the requirements of the AZD CLI product. Feature requests and bug fix requests are welcome if they support the development of the AZD CLI but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case"
@@ -289,7 +289,10 @@
     },
     "allowedOrigins": {
       "type": "array",
-      "defaultValue": [],
+      "items": {
+        "type": "string"
+      },
+      "nullable": true,
       "metadata": {
         "description": "Optional. Allowed origins."
       }

--- a/avm/ptn/azd/container-app-upsert/tests/e2e/max/main.test.bicep
+++ b/avm/ptn/azd/container-app-upsert/tests/e2e/max/main.test.bicep
@@ -68,6 +68,9 @@ module testDeployment '../../../main.bicep' = [
       location: resourceLocation
       identityType: 'UserAssigned'
       identityName: nestedDependencies.outputs.managedIdentityName
+      allowedOrigins: [
+        'https://www.bing.com'
+      ]
       containerRegistryName: nestedDependencies.outputs.containerRegistryName
       identityPrincipalId: nestedDependencies.outputs.managedIdentityPrincipalId
       userAssignedIdentityResourceId: nestedDependencies.outputs.managedIdentityResourceId

--- a/avm/ptn/azd/container-app-upsert/version.json
+++ b/avm/ptn/azd/container-app-upsert/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.2"
+  "version": "0.3"
 }


### PR DESCRIPTION
## Description

Fixes #6443 

This PR adds a new `allowedOrigins` param as a passthrough

## Pipeline Reference

`Test-ModuleLocally` passes:

<img width="1838" height="110" alt="image" src="https://github.com/user-attachments/assets/43c5ff92-ba94-4a59-8a34-c202ae75658f" />

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
