### PR TITLE
fix: `avm/ptn/azd/acr-container-app` and `avm/ptn/azd/aks-automatic-cluster` pattern modules

### DIFF
--- a/avm/ptn/azd/acr-container-app/CHANGELOG.md
+++ b/avm/ptn/azd/acr-container-app/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/acr-container-app/CHANGELOG.md).
 
+## 0.3.0
+
+### Changes
+
+- Update module dependencies to latest versions
+
+### Breaking Changes
+
+- None
+
 ## 0.2.0
 
 ### Changes

--- a/avm/ptn/azd/acr-container-app/README.md
+++ b/avm/ptn/azd/acr-container-app/README.md
@@ -25,8 +25,8 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.App/containerApps` | 2025-01-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.app_containerapps.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/2025-01-01/containerApps)</li></ul> |
-| `Microsoft.App/containerApps/authConfigs` | 2025-01-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.app_containerapps_authconfigs.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/2025-01-01/containerApps/authConfigs)</li></ul> |
+| `Microsoft.App/containerApps` | 2025-02-02-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.app_containerapps.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/2025-02-02-preview/containerApps)</li></ul> |
+| `Microsoft.App/containerApps/authConfigs` | 2025-02-02-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.app_containerapps_authconfigs.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/2025-02-02-preview/containerApps/authConfigs)</li></ul> |
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
 | `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.insights_diagnosticsettings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)</li></ul> |
@@ -58,7 +58,7 @@ module acrContainerApp 'br/public:avm/ptn/azd/acr-container-app:<version>' = {
   params: {
     // Required parameters
     containerAppsEnvironmentName: '<containerAppsEnvironmentName>'
-    name: 'acamin001'
+    name: 'acapmin001'
     // Non-required parameters
     location: '<location>'
   }
@@ -82,7 +82,7 @@ module acrContainerApp 'br/public:avm/ptn/azd/acr-container-app:<version>' = {
       "value": "<containerAppsEnvironmentName>"
     },
     "name": {
-      "value": "acamin001"
+      "value": "acapmin001"
     },
     // Non-required parameters
     "location": {
@@ -104,7 +104,7 @@ using 'br/public:avm/ptn/azd/acr-container-app:<version>'
 
 // Required parameters
 param containerAppsEnvironmentName = '<containerAppsEnvironmentName>'
-param name = 'acamin001'
+param name = 'acapmin001'
 // Non-required parameters
 param location = '<location>'
 ```
@@ -876,7 +876,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 | Reference | Type |
 | :-- | :-- |
 | `br/public:avm/ptn/authorization/resource-role-assignment:0.1.2` | Remote reference |
-| `br/public:avm/res/app/container-app:0.18.1` | Remote reference |
+| `br/public:avm/res/app/container-app:0.19.0` | Remote reference |
 
 ## Data Collection
 

--- a/avm/ptn/azd/acr-container-app/main.bicep
+++ b/avm/ptn/azd/acr-container-app/main.bicep
@@ -94,7 +94,7 @@ param ingressAllowInsecure bool = true
 @description('Optional. Controls how active revisions are handled for the Container app.')
 param revisionMode string = 'Single'
 
-import { secretType } from 'br/public:avm/res/app/container-app:0.18.1'
+import { secretType } from 'br/public:avm/res/app/container-app:0.19.0'
 @description('Optional. The secrets required for the container.')
 param secrets secretType[]?
 
@@ -144,7 +144,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-module containerApp 'br/public:avm/res/app/container-app:0.18.1' = {
+module containerApp 'br/public:avm/res/app/container-app:0.19.0' = {
   name: '${uniqueString(deployment().name, location)}-container-app'
   params: {
     name: name

--- a/avm/ptn/azd/acr-container-app/main.json
+++ b/avm/ptn/azd/acr-container-app/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "16562185646515156881"
+      "version": "0.39.26.7824",
+      "templateHash": "9874279878997797016"
     },
     "name": "Azd ACR Linked Container App",
     "description": "Creates a container app in an Azure Container App environment.\n\n**Note:** This module is not intended for broad, generic use, as it was designed to cater for the requirements of the AZD CLI product. Feature requests and bug fix requests are welcome if they support the development of the AZD CLI but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case"
@@ -250,7 +250,7 @@
       "metadata": {
         "description": "The type for a secret.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/app/container-app:0.18.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/app/container-app:0.19.0"
         }
       }
     }
@@ -555,7 +555,7 @@
     },
     "containerApp": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-container-app', uniqueString(deployment().name, parameters('location')))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -649,91 +649,13 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.177.2456",
-              "templateHash": "13502451048865419001"
+              "version": "0.38.33.27573",
+              "templateHash": "7056981135113238663"
             },
             "name": "Container Apps",
             "description": "This module deploys a Container App."
           },
           "definitions": {
-            "containerType": {
-              "type": "object",
-              "properties": {
-                "args": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Container start command arguments."
-                  }
-                },
-                "command": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Container start command."
-                  }
-                },
-                "env": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/environmentVarType"
-                  },
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Container environment variables."
-                  }
-                },
-                "image": {
-                  "type": "string",
-                  "metadata": {
-                    "description": "Required. Container image tag."
-                  }
-                },
-                "name": {
-                  "type": "string",
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Custom container name."
-                  }
-                },
-                "probes": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/containerAppProbeType"
-                  },
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. List of probes for the container."
-                  }
-                },
-                "resources": {
-                  "type": "object",
-                  "metadata": {
-                    "description": "Required. Container resource requirements."
-                  }
-                },
-                "volumeMounts": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/volumeMountType"
-                  },
-                  "nullable": true,
-                  "metadata": {
-                    "description": "Optional. Container volume mounts."
-                  }
-                }
-              },
-              "metadata": {
-                "__bicep_export!": true,
-                "description": "The type for a container."
-              }
-            },
             "ingressPortMappingType": {
               "type": "object",
               "properties": {
@@ -1208,7 +1130,7 @@
                   "type": "object",
                   "metadata": {
                     "__bicep_resource_derived_type!": {
-                      "source": "Microsoft.App/containerApps/authConfigs@2025-01-01#properties/properties/properties/encryptionSettings"
+                      "source": "Microsoft.App/containerApps/authConfigs@2025-02-02-preview#properties/properties/properties/encryptionSettings"
                     },
                     "description": "Optional. The configuration settings of the secrets references of encryption key and signing key for ContainerApp Service Authentication/Authorization."
                   },
@@ -1218,7 +1140,7 @@
                   "type": "object",
                   "metadata": {
                     "__bicep_resource_derived_type!": {
-                      "source": "Microsoft.App/containerApps/authConfigs@2025-01-01#properties/properties/properties/globalValidation"
+                      "source": "Microsoft.App/containerApps/authConfigs@2025-02-02-preview#properties/properties/properties/globalValidation"
                     },
                     "description": "Optional. The configuration settings that determines the validation flow of users using Service Authentication and/or Authorization."
                   },
@@ -1228,7 +1150,7 @@
                   "type": "object",
                   "metadata": {
                     "__bicep_resource_derived_type!": {
-                      "source": "Microsoft.App/containerApps/authConfigs@2025-01-01#properties/properties/properties/httpSettings"
+                      "source": "Microsoft.App/containerApps/authConfigs@2025-02-02-preview#properties/properties/properties/httpSettings"
                     },
                     "description": "Optional. The configuration settings of the HTTP requests for authentication and authorization requests made against ContainerApp Service Authentication/Authorization."
                   },
@@ -1238,7 +1160,7 @@
                   "type": "object",
                   "metadata": {
                     "__bicep_resource_derived_type!": {
-                      "source": "Microsoft.App/containerApps/authConfigs@2025-01-01#properties/properties/properties/identityProviders"
+                      "source": "Microsoft.App/containerApps/authConfigs@2025-02-02-preview#properties/properties/properties/identityProviders"
                     },
                     "description": "Optional. The configuration settings of each of the identity providers used to configure ContainerApp Service Authentication/Authorization."
                   },
@@ -1248,7 +1170,7 @@
                   "type": "object",
                   "metadata": {
                     "__bicep_resource_derived_type!": {
-                      "source": "Microsoft.App/containerApps/authConfigs@2025-01-01#properties/properties/properties/login"
+                      "source": "Microsoft.App/containerApps/authConfigs@2025-02-02-preview#properties/properties/properties/login"
                     },
                     "description": "Optional. The configuration settings of the login flow of users using ContainerApp Service Authentication/Authorization."
                   },
@@ -1258,7 +1180,7 @@
                   "type": "object",
                   "metadata": {
                     "__bicep_resource_derived_type!": {
-                      "source": "Microsoft.App/containerApps/authConfigs@2025-01-01#properties/properties/properties/platform"
+                      "source": "Microsoft.App/containerApps/authConfigs@2025-02-02-preview#properties/properties/properties/platform"
                     },
                     "description": "Optional. The configuration settings of the platform of ContainerApp Service Authentication/Authorization."
                   },
@@ -1380,12 +1302,19 @@
                   "metadata": {
                     "description": "Optional. Specify the type of lock."
                   }
+                },
+                "notes": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the notes of the lock."
+                  }
                 }
               },
               "metadata": {
                 "description": "An AVM-aligned type for a lock.",
                 "__bicep_imported_from!": {
-                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.4.1"
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
                 }
               }
             },
@@ -1507,6 +1436,18 @@
                 "description": "Optional. Location for all Resources."
               }
             },
+            "kind": {
+              "type": "string",
+              "defaultValue": "containerapps",
+              "allowedValues": [
+                "containerapps",
+                "workflowapp",
+                "functionapp"
+              ],
+              "metadata": {
+                "description": "Optional. Metadata used to render different experiences for resources of the same type."
+              }
+            },
             "disableIngress": {
               "type": "bool",
               "defaultValue": false,
@@ -1568,7 +1509,7 @@
               "type": "object",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps@2025-01-01#properties/properties/properties/configuration/properties/service"
+                  "source": "Microsoft.App/containerApps@2025-02-02-preview#properties/properties/properties/configuration/properties/service"
                 },
                 "description": "Optional. Dev ContainerApp service type."
               },
@@ -1651,16 +1592,19 @@
             },
             "tags": {
               "type": "object",
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.App/containerApps@2025-02-02-preview#properties/tags"
+                },
                 "description": "Optional. Tags of the resource."
-              }
+              },
+              "nullable": true
             },
             "registries": {
               "type": "array",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps@2025-01-01#properties/properties/properties/configuration/properties/registries"
+                  "source": "Microsoft.App/containerApps@2025-02-02-preview#properties/properties/properties/configuration/properties/registries"
                 },
                 "description": "Optional. Collection of private container registry credentials for containers used by the Container app."
               },
@@ -1694,7 +1638,7 @@
               "type": "array",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps@2025-01-01#properties/properties/properties/configuration/properties/ingress/properties/customDomains"
+                  "source": "Microsoft.App/containerApps@2025-02-02-preview#properties/properties/properties/configuration/properties/ingress/properties/customDomains"
                 },
                 "description": "Optional. Custom domain bindings for Container App hostnames."
               },
@@ -1711,7 +1655,7 @@
               "type": "array",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps@2025-01-01#properties/properties/properties/configuration/properties/ingress/properties/ipSecurityRestrictions"
+                  "source": "Microsoft.App/containerApps@2025-02-02-preview#properties/properties/properties/configuration/properties/ingress/properties/ipSecurityRestrictions"
                 },
                 "description": "Optional. Rules to restrict incoming IP address."
               },
@@ -1733,7 +1677,7 @@
             },
             "trafficRevisionName": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Name of a revision."
               }
@@ -1749,7 +1693,7 @@
               "type": "object",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps@2025-01-01#properties/properties/properties/configuration/properties/dapr"
+                  "source": "Microsoft.App/containerApps@2025-02-02-preview#properties/properties/properties/configuration/properties/dapr"
                 },
                 "description": "Optional. Dapr configuration for the Container App."
               },
@@ -1759,7 +1703,7 @@
               "type": "array",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps@2025-01-01#properties/properties/properties/configuration/properties/identitySettings"
+                  "source": "Microsoft.App/containerApps@2025-02-02-preview#properties/properties/properties/configuration/properties/identitySettings"
                 },
                 "description": "Optional. Settings for Managed Identities that are assigned to the Container App. If a Managed Identity is not specified here, default settings will be used."
               },
@@ -1776,7 +1720,7 @@
               "type": "object",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps@2025-01-01#properties/properties/properties/configuration/properties/runtime"
+                  "source": "Microsoft.App/containerApps@2025-02-02-preview#properties/properties/properties/configuration/properties/runtime"
                 },
                 "description": "Optional. Runtime configuration for the Container App."
               },
@@ -1784,18 +1728,25 @@
             },
             "containers": {
               "type": "array",
-              "items": {
-                "$ref": "#/definitions/containerType"
-              },
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.App/containerApps@2025-02-02-preview#properties/properties/properties/template/properties/containers"
+                },
                 "description": "Required. List of container definitions for the Container App."
+              }
+            },
+            "terminationGracePeriodSeconds": {
+              "type": "int",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The termination grace period for the container app."
               }
             },
             "initContainersTemplate": {
               "type": "array",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps@2025-01-01#properties/properties/properties/template/properties/initContainers"
+                  "source": "Microsoft.App/containerApps@2025-02-02-preview#properties/properties/properties/template/properties/initContainers"
                 },
                 "description": "Optional. List of specialized containers that run before app containers."
               },
@@ -1813,7 +1764,7 @@
             },
             "revisionSuffix": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. User friendly suffix that is appended to the revision name."
               }
@@ -1822,7 +1773,7 @@
               "type": "array",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps@2025-01-01#properties/properties/properties/template/properties/volumes"
+                  "source": "Microsoft.App/containerApps@2025-02-02-preview#properties/properties/properties/template/properties/volumes"
                 },
                 "description": "Optional. List of volume definitions for the Container App."
               },
@@ -1830,7 +1781,7 @@
             },
             "workloadProfileName": {
               "type": "string",
-              "defaultValue": "",
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Workload profile name to pin for container app execution."
               }
@@ -1877,7 +1828,7 @@
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2024-03-01",
-              "name": "[format('46d3xbcp.res.app-containerapp.{0}.{1}', replace('0.18.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "name": "[format('46d3xbcp.res.app-containerapp.{0}.{1}', replace('0.19.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -1895,9 +1846,10 @@
             },
             "containerApp": {
               "type": "Microsoft.App/containerApps",
-              "apiVersion": "2025-01-01",
+              "apiVersion": "2025-02-02-preview",
               "name": "[parameters('name')]",
               "tags": "[parameters('tags')]",
+              "kind": "[parameters('kind')]",
               "location": "[parameters('location')]",
               "identity": "[variables('identity')]",
               "properties": {
@@ -1905,6 +1857,7 @@
                 "workloadProfileName": "[parameters('workloadProfileName')]",
                 "template": {
                   "containers": "[parameters('containers')]",
+                  "terminationGracePeriodSeconds": "[parameters('terminationGracePeriodSeconds')]",
                   "initContainers": "[if(not(empty(parameters('initContainersTemplate'))), parameters('initContainersTemplate'), null())]",
                   "revisionSuffix": "[parameters('revisionSuffix')]",
                   "scale": "[parameters('scaleSettings')]",
@@ -1932,7 +1885,7 @@
               "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
               "properties": {
                 "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
-                "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+                "notes": "[coalesce(tryGet(parameters('lock'), 'notes'), if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.'))]"
               },
               "dependsOn": [
                 "containerApp"
@@ -1995,7 +1948,7 @@
             "containerAppAuthConfigs": {
               "condition": "[not(empty(parameters('authConfig')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-auth-config', uniqueString(deployment().name, parameters('location')))]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2032,8 +1985,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.177.2456",
-                      "templateHash": "9975390462196064744"
+                      "version": "0.38.33.27573",
+                      "templateHash": "12480411243596309951"
                     },
                     "name": "Container App Auth Configs",
                     "description": "This module deploys Container App Auth Configs."
@@ -2049,7 +2002,7 @@
                       "type": "object",
                       "metadata": {
                         "__bicep_resource_derived_type!": {
-                          "source": "Microsoft.App/containerApps/authConfigs@2025-01-01#properties/properties/properties/encryptionSettings"
+                          "source": "Microsoft.App/containerApps/authConfigs@2025-02-02-preview#properties/properties/properties/encryptionSettings"
                         },
                         "description": "Optional. The configuration settings of the secrets references of encryption key and signing key for ContainerApp Service Authentication/Authorization."
                       },
@@ -2059,7 +2012,7 @@
                       "type": "object",
                       "metadata": {
                         "__bicep_resource_derived_type!": {
-                          "source": "Microsoft.App/containerApps/authConfigs@2025-01-01#properties/properties/properties/globalValidation"
+                          "source": "Microsoft.App/containerApps/authConfigs@2025-02-02-preview#properties/properties/properties/globalValidation"
                         },
                         "description": "Optional. The configuration settings that determines the validation flow of users using Service Authentication and/or Authorization."
                       },
@@ -2069,7 +2022,7 @@
                       "type": "object",
                       "metadata": {
                         "__bicep_resource_derived_type!": {
-                          "source": "Microsoft.App/containerApps/authConfigs@2025-01-01#properties/properties/properties/httpSettings"
+                          "source": "Microsoft.App/containerApps/authConfigs@2025-02-02-preview#properties/properties/properties/httpSettings"
                         },
                         "description": "Optional. The configuration settings of the HTTP requests for authentication and authorization requests made against ContainerApp Service Authentication/Authorization."
                       },
@@ -2079,7 +2032,7 @@
                       "type": "object",
                       "metadata": {
                         "__bicep_resource_derived_type!": {
-                          "source": "Microsoft.App/containerApps/authConfigs@2025-01-01#properties/properties/properties/identityProviders"
+                          "source": "Microsoft.App/containerApps/authConfigs@2025-02-02-preview#properties/properties/properties/identityProviders"
                         },
                         "description": "Optional. The configuration settings of each of the identity providers used to configure ContainerApp Service Authentication/Authorization."
                       },
@@ -2089,7 +2042,7 @@
                       "type": "object",
                       "metadata": {
                         "__bicep_resource_derived_type!": {
-                          "source": "Microsoft.App/containerApps/authConfigs@2025-01-01#properties/properties/properties/login"
+                          "source": "Microsoft.App/containerApps/authConfigs@2025-02-02-preview#properties/properties/properties/login"
                         },
                         "description": "Optional. The configuration settings of the login flow of users using ContainerApp Service Authentication/Authorization."
                       },
@@ -2099,7 +2052,7 @@
                       "type": "object",
                       "metadata": {
                         "__bicep_resource_derived_type!": {
-                          "source": "Microsoft.App/containerApps/authConfigs@2025-01-01#properties/properties/properties/platform"
+                          "source": "Microsoft.App/containerApps/authConfigs@2025-02-02-preview#properties/properties/properties/platform"
                         },
                         "description": "Optional. The configuration settings of the platform of ContainerApp Service Authentication/Authorization."
                       },
@@ -2110,12 +2063,12 @@
                     "containerApp": {
                       "existing": true,
                       "type": "Microsoft.App/containerApps",
-                      "apiVersion": "2025-01-01",
+                      "apiVersion": "2025-02-02-preview",
                       "name": "[parameters('containerAppName')]"
                     },
                     "containerAppAuthConfigs": {
                       "type": "Microsoft.App/containerApps/authConfigs",
-                      "apiVersion": "2025-01-01",
+                      "apiVersion": "2025-02-02-preview",
                       "name": "[format('{0}/{1}', parameters('containerAppName'), 'current')]",
                       "properties": {
                         "encryptionSettings": "[parameters('encryptionSettings')]",
@@ -2192,14 +2145,14 @@
               "metadata": {
                 "description": "The principal ID of the system assigned identity."
               },
-              "value": "[tryGet(tryGet(reference('containerApp', '2025-01-01', 'full'), 'identity'), 'principalId')]"
+              "value": "[tryGet(tryGet(reference('containerApp', '2025-02-02-preview', 'full'), 'identity'), 'principalId')]"
             },
             "location": {
               "type": "string",
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('containerApp', '2025-01-01', 'full').location]"
+              "value": "[reference('containerApp', '2025-02-02-preview', 'full').location]"
             }
           }
         }
@@ -2211,7 +2164,7 @@
     "containerRegistryAccess": {
       "condition": "[variables('usePrivateRegistry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-registry-access', uniqueString(deployment().name, parameters('location')))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -2233,8 +2186,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "14376840718866683527"
+              "version": "0.39.26.7824",
+              "templateHash": "17052213246113839033"
             },
             "name": "ACR Pull permissions",
             "description": "Assigns ACR Pull permissions to access an Azure Container Registry."
@@ -2266,7 +2219,7 @@
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[guid(subscription().id, resourceGroup().id, parameters('principalId'), variables('acrPullRole'))]",
               "properties": {
                 "expressionEvaluationOptions": {

--- a/avm/ptn/azd/acr-container-app/tests/e2e/defaults/main.test.bicep
+++ b/avm/ptn/azd/acr-container-app/tests/e2e/defaults/main.test.bicep
@@ -15,7 +15,7 @@ param resourceGroupName string = 'dep-${namePrefix}-azd-acrcontainerapp-${servic
 param resourceLocation string = deployment().location
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
-param serviceShort string = 'acamin'
+param serviceShort string = 'acapmin'
 
 @description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
 param namePrefix string = '#_namePrefix_#'

--- a/avm/ptn/azd/acr-container-app/version.json
+++ b/avm/ptn/azd/acr-container-app/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.2"
+  "version": "0.3"
 }

--- a/avm/ptn/azd/aks-automatic-cluster/CHANGELOG.md
+++ b/avm/ptn/azd/aks-automatic-cluster/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/azd/aks-automatic-cluster/CHANGELOG.md).
 
+## 0.3.0
+
+### Changes
+
+- Updated Kubernetes version to 1.33
+- Update module dependencies to latest versions
+
+### Breaking Changes
+
+- None
+
 ## 0.2.0
 
 ### Changes

--- a/avm/ptn/azd/aks-automatic-cluster/README.md
+++ b/avm/ptn/azd/aks-automatic-cluster/README.md
@@ -27,12 +27,12 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | :-- | :-- | :-- |
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
-| `Microsoft.ContainerService/managedClusters` | 2024-09-02-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2024-09-02-preview/managedClusters)</li></ul> |
-| `Microsoft.ContainerService/managedClusters/agentPools` | 2024-09-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters_agentpools.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2024-09-01/managedClusters/agentPools)</li></ul> |
-| `Microsoft.ContainerService/managedClusters/maintenanceConfigurations` | 2023-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters_maintenanceconfigurations.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2023-10-01/managedClusters/maintenanceConfigurations)</li></ul> |
+| `Microsoft.ContainerService/managedClusters` | 2025-05-02-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2025-05-02-preview/managedClusters)</li></ul> |
+| `Microsoft.ContainerService/managedClusters/agentPools` | 2025-05-02-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters_agentpools.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2025-05-02-preview/managedClusters/agentPools)</li></ul> |
+| `Microsoft.ContainerService/managedClusters/maintenanceConfigurations` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters_maintenanceconfigurations.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2025-05-01/managedClusters/maintenanceConfigurations)</li></ul> |
 | `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.insights_diagnosticsettings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)</li></ul> |
-| `Microsoft.KubernetesConfiguration/extensions` | 2022-03-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.kubernetesconfiguration_extensions.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KubernetesConfiguration/2022-03-01/extensions)</li></ul> |
-| `Microsoft.KubernetesConfiguration/fluxConfigurations` | 2023-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.kubernetesconfiguration_fluxconfigurations.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KubernetesConfiguration/2023-05-01/fluxConfigurations)</li></ul> |
+| `Microsoft.KubernetesConfiguration/extensions` | 2024-11-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.kubernetesconfiguration_extensions.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KubernetesConfiguration/2024-11-01/extensions)</li></ul> |
+| `Microsoft.KubernetesConfiguration/fluxConfigurations` | 2025-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.kubernetesconfiguration_fluxconfigurations.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KubernetesConfiguration/2025-04-01/fluxConfigurations)</li></ul> |
 
 ## Usage examples
 
@@ -249,7 +249,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/res/container-service/managed-cluster:0.9.0` | Remote reference |
+| `br/public:avm/res/container-service/managed-cluster:0.11.1` | Remote reference |
 
 ## Data Collection
 

--- a/avm/ptn/azd/aks-automatic-cluster/main.bicep
+++ b/avm/ptn/azd/aks-automatic-cluster/main.bicep
@@ -12,7 +12,7 @@ param location string = resourceGroup().location
 @description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
 
-import { aadProfileType } from 'br/public:avm/res/container-service/managed-cluster:0.9.0'
+import { aadProfileType } from 'br/public:avm/res/container-service/managed-cluster:0.11.1'
 @description('Optional. Settigs for the Azure Active Directory integration.')
 param aadProfile aadProfileType?
 
@@ -39,7 +39,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-module aks 'br/public:avm/res/container-service/managed-cluster:0.9.0' = {
+module aks 'br/public:avm/res/container-service/managed-cluster:0.11.1' = {
   name: '${uniqueString(deployment().name, location)}-managed-cluster'
   params: {
     name: name
@@ -50,7 +50,7 @@ module aks 'br/public:avm/res/container-service/managed-cluster:0.9.0' = {
     enableKeyvaultSecretsProvider: true
     enableSecretRotation: true
     kedaAddon: true
-    kubernetesVersion: '1.31'
+    kubernetesVersion: '1.33'
     maintenanceConfigurations: [
       {
         name: 'aksManagedAutoUpgradeSchedule'

--- a/avm/ptn/azd/aks-automatic-cluster/main.json
+++ b/avm/ptn/azd/aks-automatic-cluster/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "6422995579439413789"
+      "version": "0.39.26.7824",
+      "templateHash": "2109477192427067119"
     },
     "name": "Azd AKS Automatic Cluster",
     "description": "Creates an Azure Kubernetes Service (AKS) cluster with a system agent pool.\n\n**Note:** This module is not intended for broad, generic use, as it was designed to cater for the requirements of the AZD CLI product. Feature requests and bug fix requests are welcome if they support the development of the AZD CLI but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case"
@@ -69,7 +69,7 @@
       "metadata": {
         "description": "The type for an AAD profile.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/container-service/managed-cluster:0.9.0"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/res/container-service/managed-cluster:0.11.1"
         }
       }
     }
@@ -126,7 +126,7 @@
     },
     "aks": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-managed-cluster', uniqueString(deployment().name, parameters('location')))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -159,7 +159,7 @@
             "value": true
           },
           "kubernetesVersion": {
-            "value": "1.31"
+            "value": "1.33"
           },
           "maintenanceConfigurations": {
             "value": [
@@ -232,8 +232,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.34.44.8038",
-              "templateHash": "7489731477943219114"
+              "version": "0.38.33.27573",
+              "templateHash": "3684483631558968319"
             },
             "name": "Azure Kubernetes Service (AKS) Managed Clusters",
             "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster."
@@ -327,6 +327,16 @@
                   "metadata": {
                     "description": "Optional. The kubelet disk type of the agent pool."
                   }
+                },
+                "linuxOSConfig": {
+                  "type": "object",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerService/managedClusters/agentPools@2025-05-02-preview#properties/properties/properties/linuxOSConfig"
+                    },
+                    "description": "Optional. The Linux OS configuration of the agent pool."
+                  },
+                  "nullable": true
                 },
                 "maxCount": {
                   "type": "int",
@@ -492,6 +502,17 @@
                     "description": "Optional. vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch."
                   }
                 },
+                "sshAccess": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Disabled",
+                    "LocalUser"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. SSH access method of an agent pool."
+                  }
+                },
                 "spotMaxPrice": {
                   "type": "int",
                   "nullable": true,
@@ -544,6 +565,16 @@
                   "metadata": {
                     "description": "Optional. The workload runtime of the agent pool."
                   }
+                },
+                "windowsProfile": {
+                  "type": "object",
+                  "metadata": {
+                    "__bicep_resource_derived_type!": {
+                      "source": "Microsoft.ContainerService/managedClusters/agentPools@2025-05-02-preview#properties/properties/properties/windowsProfile"
+                    },
+                    "description": "Optional. The Windows profile of the agent pool."
+                  },
+                  "nullable": true
                 },
                 "enableDefaultTelemetry": {
                   "type": "bool",
@@ -880,7 +911,7 @@
               "metadata": {
                 "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
                 "__bicep_imported_from!": {
-                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
                 }
               }
             },
@@ -905,12 +936,19 @@
                   "metadata": {
                     "description": "Optional. Specify the type of lock."
                   }
+                },
+                "notes": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Specify the notes of the lock."
+                  }
                 }
               },
               "metadata": {
                 "description": "An AVM-aligned type for a lock.",
                 "__bicep_imported_from!": {
-                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
                 }
               }
             },
@@ -938,7 +976,7 @@
               "metadata": {
                 "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
                 "__bicep_imported_from!": {
-                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
                 }
               }
             },
@@ -1013,7 +1051,7 @@
               "metadata": {
                 "description": "An AVM-aligned type for a role assignment.",
                 "__bicep_imported_from!": {
-                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
                 }
               }
             }
@@ -1129,6 +1167,40 @@
                 "description": "Optional. Outbound IP Count for the Load balancer."
               }
             },
+            "allocatedOutboundPorts": {
+              "type": "int",
+              "defaultValue": 0,
+              "metadata": {
+                "description": "Optional. The desired number of allocated SNAT ports per VM. Default is 0, which results in Azure dynamically allocating ports."
+              }
+            },
+            "idleTimeoutInMinutes": {
+              "type": "int",
+              "defaultValue": 30,
+              "metadata": {
+                "description": "Optional. Desired outbound flow idle timeout in minutes."
+              }
+            },
+            "outboundPublicIPResourceIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. A list of the resource IDs of the public IP addresses to use for the load balancer outbound rules."
+              }
+            },
+            "outboundPublicIPPrefixResourceIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. A list of the resource IDs of the public IP prefixes to use for the load balancer outbound rules."
+              }
+            },
             "backendPoolType": {
               "type": "string",
               "defaultValue": "NodeIPConfiguration",
@@ -1161,7 +1233,7 @@
                 "Automatic"
               ],
               "metadata": {
-                "description": "Optional. Name of a managed cluster SKU. AUTOMATIC CLUSTER SKU IS A PARAMETER USED FOR A PREVIEW FEATURE, MICROSOFT MAY NOT PROVIDE SUPPORT FOR THIS, PLEASE CHECK THE [PRODUCT DOCS](https://learn.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-automatic-deploy?pivots=bicep#before-you-begin) FOR CLARIFICATION."
+                "description": "Optional. Name of a managed cluster SKU."
               }
             },
             "skuTier": {
@@ -1503,6 +1575,27 @@
                 "description": "Optional. Specifies the balance of similar node groups for the auto-scaler of the AKS cluster."
               }
             },
+            "autoScalerProfileDaemonsetEvictionForEmptyNodes": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Specifies whether to enable daemonset eviction for empty nodes for the auto-scaler of the AKS cluster."
+              }
+            },
+            "autoScalerProfileDaemonsetEvictionForOccupiedNodes": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Specifies whether to enable daemonset eviction for occupied nodes for the auto-scaler of the AKS cluster."
+              }
+            },
+            "autoScalerProfileIgnoreDaemonsetsUtilization": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Specifies whether to ignore daemonsets utilization for the auto-scaler of the AKS cluster."
+              }
+            },
             "autoScalerProfileExpander": {
               "type": "string",
               "defaultValue": "random",
@@ -1608,17 +1701,23 @@
             },
             "podIdentityProfileUserAssignedIdentities": {
               "type": "array",
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.ContainerService/managedClusters@2025-05-02-preview#properties/properties/properties/podIdentityProfile/properties/userAssignedIdentities"
+                },
                 "description": "Optional. The pod identities to use in the cluster."
-              }
+              },
+              "nullable": true
             },
             "podIdentityProfileUserAssignedIdentityExceptions": {
               "type": "array",
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.ContainerService/managedClusters@2025-05-02-preview#properties/properties/properties/podIdentityProfile/properties/userAssignedIdentityExceptions"
+                },
                 "description": "Optional. The pod identity exceptions to allow."
-              }
+              },
+              "nullable": true
             },
             "enableOidcIssuerProfile": {
               "type": "bool",
@@ -1641,11 +1740,35 @@
                 "description": "Optional. Whether to enable Azure Defender."
               }
             },
+            "securityGatingConfig": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.ContainerService/managedClusters@2025-05-02-preview#properties/properties/properties/securityProfile/properties/defender/properties/securityGating"
+                },
+                "description": "Optional. Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards."
+              },
+              "nullable": true
+            },
             "enableImageCleaner": {
               "type": "bool",
               "defaultValue": false,
               "metadata": {
-                "description": "Optional. Whether to enable Image Cleaner for Kubernetes."
+                "description": "Optional. Whether to enable Image Cleaner."
+              }
+            },
+            "enableImageIntegrity": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Whether to enable Image Integrity. Image integrity is a feature that works with Azure Policy to verify image integrity by signature. This will not have any effect unless Azure Policy is applied to enforce image signatures. See https://aka.ms/aks/image-integrity for how to use this feature via policy."
+              }
+            },
+            "enableNodeRestriction": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Whether to enable Node Restriction."
               }
             },
             "imageCleanerIntervalHours": {
@@ -1654,13 +1777,6 @@
               "minValue": 24,
               "metadata": {
                 "description": "Optional. The interval in hours Image Cleaner will run. The maximum value is three months."
-              }
-            },
-            "enablePodSecurityPolicy": {
-              "type": "bool",
-              "defaultValue": false,
-              "metadata": {
-                "description": "Optional. Whether to enable Kubernetes pod security policy. Requires enabling the pod security policy feature flag on the subscription."
               }
             },
             "enableStorageProfileBlobCSIDriver": {
@@ -1759,16 +1875,19 @@
             },
             "tags": {
               "type": "object",
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.ContainerService/managedClusters@2025-05-02-preview#properties/tags"
+                },
                 "description": "Optional. Tags of the resource."
-              }
+              },
+              "nullable": true
             },
             "diskEncryptionSetResourceId": {
               "type": "string",
               "nullable": true,
               "metadata": {
-                "description": "Optional. The resource ID of the disc encryption set to apply to the cluster. For security reasons, this value should be provided."
+                "description": "Optional. The Resource ID of the disk encryption set to use for enabling encryption at rest. For security reasons, this value should be provided."
               }
             },
             "fluxExtension": {
@@ -1780,17 +1899,23 @@
             },
             "httpProxyConfig": {
               "type": "object",
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.ContainerService/managedClusters@2025-05-02-preview#properties/properties/properties/httpProxyConfig"
+                },
                 "description": "Optional. Configurations for provisioning the cluster with HTTP proxy servers."
-              }
+              },
+              "nullable": true
             },
             "identityProfile": {
               "type": "object",
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.ContainerService/managedClusters@2025-05-02-preview#properties/properties/properties/identityProfile"
+                },
                 "description": "Optional. Identities associated with the cluster."
-              }
+              },
+              "nullable": true
             },
             "kedaAddon": {
               "type": "bool",
@@ -1812,6 +1937,16 @@
               "metadata": {
                 "description": "Optional. Whether the metric state of the kubenetes cluster is enabled."
               }
+            },
+            "appMonitoring": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.ContainerService/managedClusters@2025-05-02-preview#properties/properties/properties/azureMonitorProfile/properties/appMonitoring"
+                },
+                "description": "Optional. Application Monitoring Profile for Kubernetes Application Container. Collects application logs, metrics and traces through auto-instrumentation of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview."
+              },
+              "nullable": true
             },
             "enableContainerInsights": {
               "type": "bool",
@@ -1929,7 +2064,7 @@
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2024-03-01",
-              "name": "[format('46d3xbcp.res.containerservice-managedcluster.{0}.{1}', replace('0.9.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "name": "[format('46d3xbcp.res.containerservice-managedcluster.{0}.{1}', replace('0.11.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -1947,7 +2082,7 @@
             },
             "managedCluster": {
               "type": "Microsoft.ContainerService/managedClusters",
-              "apiVersion": "2024-09-02-preview",
+              "apiVersion": "2025-05-02-preview",
               "name": "[parameters('name')]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
@@ -2014,7 +2149,6 @@
                 "nodeResourceGroup": "[parameters('nodeResourceGroup')]",
                 "nodeResourceGroupProfile": "[parameters('nodeResourceGroupProfile')]",
                 "nodeProvisioningProfile": "[if(not(empty(parameters('nodeProvisioningProfileMode'))), createObject('mode', parameters('nodeProvisioningProfileMode')), null())]",
-                "enablePodSecurityPolicy": "[parameters('enablePodSecurityPolicy')]",
                 "workloadAutoScalerProfile": {
                   "keda": {
                     "enabled": "[parameters('kedaAddon')]"
@@ -2033,17 +2167,16 @@
                   "dnsServiceIP": "[parameters('dnsServiceIP')]",
                   "outboundType": "[parameters('outboundType')]",
                   "loadBalancerSku": "[parameters('loadBalancerSku')]",
-                  "loadBalancerProfile": {
-                    "managedOutboundIPs": "[if(not(equals(parameters('managedOutboundIPCount'), 0)), createObject('count', parameters('managedOutboundIPCount')), null())]",
-                    "effectiveOutboundIPs": [],
-                    "backendPoolType": "[parameters('backendPoolType')]"
-                  }
+                  "loadBalancerProfile": "[if(not(equals(parameters('outboundType'), 'userDefinedRouting')), createObject('allocatedOutboundPorts', parameters('allocatedOutboundPorts'), 'idleTimeoutInMinutes', parameters('idleTimeoutInMinutes'), 'managedOutboundIPs', if(not(equals(parameters('managedOutboundIPCount'), 0)), createObject('count', parameters('managedOutboundIPCount')), null()), 'backendPoolType', parameters('backendPoolType'), 'outboundIPPrefixes', if(not(empty(parameters('outboundPublicIPPrefixResourceIds'))), createObject('publicIPPrefixes', map(coalesce(parameters('outboundPublicIPPrefixResourceIds'), createArray()), lambda('id', createObject('id', lambdaVariables('id'))))), null()), 'outboundIPs', if(not(empty(parameters('outboundPublicIPResourceIds'))), createObject('publicIPs', map(coalesce(parameters('outboundPublicIPResourceIds'), createArray()), lambda('id', createObject('id', lambdaVariables('id'))))), null())), null())]"
                 },
                 "publicNetworkAccess": "[parameters('publicNetworkAccess')]",
                 "aadProfile": "[if(not(empty(parameters('aadProfile'))), createObject('clientAppID', tryGet(parameters('aadProfile'), 'aadProfileClientAppID'), 'serverAppID', tryGet(parameters('aadProfile'), 'aadProfileServerAppID'), 'serverAppSecret', tryGet(parameters('aadProfile'), 'aadProfileServerAppSecret'), 'managed', tryGet(parameters('aadProfile'), 'aadProfileManaged'), 'enableAzureRBAC', tryGet(parameters('aadProfile'), 'aadProfileEnableAzureRBAC'), 'adminGroupObjectIDs', tryGet(parameters('aadProfile'), 'aadProfileAdminGroupObjectIDs'), 'tenantID', tryGet(parameters('aadProfile'), 'aadProfileTenantId')), null())]",
                 "autoScalerProfile": {
                   "balance-similar-node-groups": "[toLower(string(parameters('autoScalerProfileBalanceSimilarNodeGroups')))]",
+                  "daemonset-eviction-for-empty-nodes": "[parameters('autoScalerProfileDaemonsetEvictionForEmptyNodes')]",
+                  "daemonset-eviction-for-occupied-nodes": "[parameters('autoScalerProfileDaemonsetEvictionForOccupiedNodes')]",
                   "expander": "[parameters('autoScalerProfileExpander')]",
+                  "ignore-daemonsets-utilization": "[parameters('autoScalerProfileIgnoreDaemonsetsUtilization')]",
                   "max-empty-bulk-delete": "[format('{0}', parameters('autoScalerProfileMaxEmptyBulkDelete'))]",
                   "max-graceful-termination-sec": "[format('{0}', parameters('autoScalerProfileMaxGracefulTerminationSec'))]",
                   "max-node-provision-time": "[parameters('autoScalerProfileMaxNodeProvisionTime')]",
@@ -2072,6 +2205,7 @@
                   "privateDNSZone": "[parameters('privateDNSZone')]"
                 },
                 "azureMonitorProfile": {
+                  "appMonitoring": "[parameters('appMonitoring')]",
                   "containerInsights": "[if(parameters('enableContainerInsights'), createObject('enabled', parameters('enableContainerInsights'), 'logAnalyticsWorkspaceResourceId', if(not(empty(parameters('monitoringWorkspaceResourceId'))), parameters('monitoringWorkspaceResourceId'), null()), 'disableCustomMetrics', parameters('disableCustomMetrics'), 'disablePrometheusMetricsScraping', parameters('disablePrometheusMetricsScraping'), 'syslogPort', parameters('syslogPort')), null())]",
                   "metrics": "[if(parameters('enableAzureMonitorProfileMetrics'), createObject('enabled', parameters('enableAzureMonitorProfileMetrics'), 'kubeStateMetrics', createObject('metricLabelsAllowlist', parameters('metricLabelsAllowlist'), 'metricAnnotationsAllowList', parameters('metricAnnotationsAllowList'))), null())]"
                 },
@@ -2082,9 +2216,11 @@
                   "userAssignedIdentityExceptions": "[parameters('podIdentityProfileUserAssignedIdentityExceptions')]"
                 },
                 "securityProfile": {
-                  "defender": "[if(parameters('enableAzureDefender'), createObject('securityMonitoring', createObject('enabled', parameters('enableAzureDefender')), 'logAnalyticsWorkspaceResourceId', parameters('monitoringWorkspaceResourceId')), null())]",
-                  "workloadIdentity": "[if(parameters('enableWorkloadIdentity'), createObject('enabled', parameters('enableWorkloadIdentity')), null())]",
-                  "imageCleaner": "[if(parameters('enableImageCleaner'), createObject('enabled', parameters('enableImageCleaner'), 'intervalHours', parameters('imageCleanerIntervalHours')), null())]"
+                  "defender": "[if(parameters('enableAzureDefender'), createObject('securityGating', parameters('securityGatingConfig'), 'securityMonitoring', createObject('enabled', parameters('enableAzureDefender')), 'logAnalyticsWorkspaceResourceId', parameters('monitoringWorkspaceResourceId')), null())]",
+                  "imageCleaner": "[if(parameters('enableImageCleaner'), createObject('enabled', parameters('enableImageCleaner'), 'intervalHours', parameters('imageCleanerIntervalHours')), null())]",
+                  "imageIntegrity": "[if(parameters('enableImageIntegrity'), createObject('enabled', parameters('enableImageIntegrity')), null())]",
+                  "nodeRestriction": "[if(parameters('enableNodeRestriction'), createObject('enabled', parameters('enableNodeRestriction')), null())]",
+                  "workloadIdentity": "[if(parameters('enableWorkloadIdentity'), createObject('enabled', parameters('enableWorkloadIdentity')), null())]"
                 },
                 "storageProfile": {
                   "blobCSIDriver": {
@@ -2112,7 +2248,7 @@
               "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
               "properties": {
                 "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
-                "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+                "notes": "[coalesce(tryGet(parameters('lock'), 'notes'), if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.'))]"
               },
               "dependsOn": [
                 "managedCluster"
@@ -2182,18 +2318,40 @@
               ]
             },
             "dnsZone": {
-              "condition": "[and(and(equals(parameters('enableDnsZoneContributorRoleAssignment'), true()), not(equals(parameters('dnsZoneResourceId'), null()))), parameters('webApplicationRoutingEnabled'))]",
+              "condition": "[and(and(and(not(equals(parameters('publicNetworkAccess'), 'Disabled')), equals(parameters('enableDnsZoneContributorRoleAssignment'), true())), not(equals(parameters('dnsZoneResourceId'), null()))), parameters('webApplicationRoutingEnabled'))]",
               "existing": true,
               "type": "Microsoft.Network/dnsZones",
               "apiVersion": "2018-05-01",
               "name": "[last(split(if(not(empty(parameters('dnsZoneResourceId'))), parameters('dnsZoneResourceId'), '/dummmyZone'), '/'))]"
             },
+            "privateDnsZone": {
+              "condition": "[and(and(and(equals(parameters('publicNetworkAccess'), 'Disabled'), equals(parameters('enableDnsZoneContributorRoleAssignment'), true())), not(equals(parameters('dnsZoneResourceId'), null()))), parameters('webApplicationRoutingEnabled'))]",
+              "existing": true,
+              "type": "Microsoft.Network/privateDnsZones",
+              "apiVersion": "2024-06-01",
+              "name": "[last(split(if(not(empty(parameters('dnsZoneResourceId'))), parameters('dnsZoneResourceId'), '/dummmyZone'), '/'))]"
+            },
             "dnsZone_roleAssignment": {
-              "condition": "[and(and(equals(parameters('enableDnsZoneContributorRoleAssignment'), true()), not(equals(parameters('dnsZoneResourceId'), null()))), parameters('webApplicationRoutingEnabled'))]",
+              "condition": "[and(and(and(not(equals(parameters('publicNetworkAccess'), 'Disabled')), equals(parameters('enableDnsZoneContributorRoleAssignment'), true())), not(equals(parameters('dnsZoneResourceId'), null()))), parameters('webApplicationRoutingEnabled'))]",
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
               "scope": "[format('Microsoft.Network/dnsZones/{0}', last(split(if(not(empty(parameters('dnsZoneResourceId'))), parameters('dnsZoneResourceId'), '/dummmyZone'), '/')))]",
               "name": "[guid(resourceId('Microsoft.Network/dnsZones', last(split(if(not(empty(parameters('dnsZoneResourceId'))), parameters('dnsZoneResourceId'), '/dummmyZone'), '/'))), subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314'), 'DNS Zone Contributor')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
+                "principalId": "[reference('managedCluster').ingressProfile.webAppRouting.identity.objectId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "managedCluster"
+              ]
+            },
+            "privateDnsZone_roleAssignment": {
+              "condition": "[and(and(and(equals(parameters('publicNetworkAccess'), 'Disabled'), equals(parameters('enableDnsZoneContributorRoleAssignment'), true())), not(equals(parameters('dnsZoneResourceId'), null()))), parameters('webApplicationRoutingEnabled'))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[format('Microsoft.Network/privateDnsZones/{0}', last(split(if(not(empty(parameters('dnsZoneResourceId'))), parameters('dnsZoneResourceId'), '/dummmyZone'), '/')))]",
+              "name": "[guid(resourceId('Microsoft.Network/privateDnsZones', last(split(if(not(empty(parameters('dnsZoneResourceId'))), parameters('dnsZoneResourceId'), '/dummmyZone'), '/'))), subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314'), 'DNS Zone Contributor')]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
                 "principalId": "[reference('managedCluster').ingressProfile.webAppRouting.identity.objectId]",
@@ -2209,7 +2367,7 @@
                 "count": "[length(coalesce(parameters('maintenanceConfigurations'), createArray()))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-ManagedCluster-MaintenanceCfg-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2233,8 +2391,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.34.44.8038",
-                      "templateHash": "13067595449609999928"
+                      "version": "0.38.33.27573",
+                      "templateHash": "8502504771649679490"
                     },
                     "name": "Azure Kubernetes Service (AKS) Managed Cluster Maintenance Configurations",
                     "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Maintenance Configurations."
@@ -2263,7 +2421,7 @@
                   "resources": [
                     {
                       "type": "Microsoft.ContainerService/managedClusters/maintenanceConfigurations",
-                      "apiVersion": "2023-10-01",
+                      "apiVersion": "2025-05-01",
                       "name": "[format('{0}/{1}', parameters('managedClusterName'), parameters('name'))]",
                       "properties": {
                         "maintenanceWindow": "[parameters('maintenanceWindow')]"
@@ -2305,7 +2463,7 @@
                 "count": "[length(coalesce(parameters('agentPools'), createArray()))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-ManagedCluster-AgentPool-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2348,6 +2506,9 @@
                   },
                   "kubeletDiskType": {
                     "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'kubeletDiskType')]"
+                  },
+                  "linuxOSConfig": {
+                    "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'linuxOSConfig')]"
                   },
                   "maxCount": {
                     "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'maxCount')]"
@@ -2400,6 +2561,13 @@
                   "scaleSetPriority": {
                     "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'scaleSetPriority')]"
                   },
+                  "enableSecureBoot": {
+                    "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'enableSecureBoot')]"
+                  },
+                  "enableVTPM": {
+                    "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'enableVTPM')]"
+                  },
+                  "sshAccess": "[if(equals(parameters('skuName'), 'Automatic'), createObject('value', 'Disabled'), createObject('value', 'LocalUser'))]",
                   "spotMaxPrice": {
                     "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'spotMaxPrice')]"
                   },
@@ -2420,6 +2588,9 @@
                   },
                   "workloadRuntime": {
                     "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'workloadRuntime')]"
+                  },
+                  "windowsProfile": {
+                    "value": "[tryGet(coalesce(parameters('agentPools'), createArray())[copyIndex()], 'windowsProfile')]"
                   }
                 },
                 "template": {
@@ -2429,8 +2600,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.34.44.8038",
-                      "templateHash": "3651532122518241859"
+                      "version": "0.38.33.27573",
+                      "templateHash": "484721355279467692"
                     },
                     "name": "Azure Kubernetes Service (AKS) Managed Cluster Agent Pools",
                     "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Agent Pool."
@@ -2533,6 +2704,16 @@
                       "metadata": {
                         "description": "Optional. Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage."
                       }
+                    },
+                    "linuxOSConfig": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.ContainerService/managedClusters/agentPools@2025-05-02-preview#properties/properties/properties/linuxOSConfig"
+                        },
+                        "description": "Optional. Linux OS configuration."
+                      },
+                      "nullable": true
                     },
                     "maxCount": {
                       "type": "int",
@@ -2694,6 +2875,17 @@
                         "description": "Optional. vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch."
                       }
                     },
+                    "sshAccess": {
+                      "type": "string",
+                      "nullable": true,
+                      "allowedValues": [
+                        "Disabled",
+                        "LocalUser"
+                      ],
+                      "metadata": {
+                        "description": "Optional. SSH access method of an agent pool."
+                      }
+                    },
                     "spotMaxPrice": {
                       "type": "int",
                       "nullable": true,
@@ -2742,18 +2934,28 @@
                       "metadata": {
                         "description": "Optional. Determines the type of workload a node can run."
                       }
+                    },
+                    "windowsProfile": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.ContainerService/managedClusters/agentPools@2025-05-02-preview#properties/properties/properties/windowsProfile"
+                        },
+                        "description": "Optional. Windows OS configuration."
+                      },
+                      "nullable": true
                     }
                   },
                   "resources": {
                     "managedCluster": {
                       "existing": true,
                       "type": "Microsoft.ContainerService/managedClusters",
-                      "apiVersion": "2024-09-01",
+                      "apiVersion": "2025-05-02-preview",
                       "name": "[parameters('managedClusterName')]"
                     },
                     "agentPool": {
                       "type": "Microsoft.ContainerService/managedClusters/agentPools",
-                      "apiVersion": "2024-09-01",
+                      "apiVersion": "2025-05-02-preview",
                       "name": "[format('{0}/{1}', parameters('managedClusterName'), parameters('name'))]",
                       "properties": {
                         "availabilityZones": "[map(coalesce(parameters('availabilityZones'), createArray()), lambda('zone', format('{0}', lambdaVariables('zone'))))]",
@@ -2766,6 +2968,7 @@
                         "enableUltraSSD": "[parameters('enableUltraSSD')]",
                         "gpuInstanceProfile": "[parameters('gpuInstanceProfile')]",
                         "kubeletDiskType": "[parameters('kubeletDiskType')]",
+                        "linuxOSConfig": "[parameters('linuxOSConfig')]",
                         "maxCount": "[parameters('maxCount')]",
                         "maxPods": "[parameters('maxPods')]",
                         "minCount": "[parameters('minCount')]",
@@ -2785,7 +2988,8 @@
                         "scaleSetPriority": "[parameters('scaleSetPriority')]",
                         "securityProfile": {
                           "enableSecureBoot": "[parameters('enableSecureBoot')]",
-                          "enableVTPM": "[parameters('enableVTPM')]"
+                          "enableVTPM": "[parameters('enableVTPM')]",
+                          "sshAccess": "[parameters('sshAccess')]"
                         },
                         "spotMaxPrice": "[parameters('spotMaxPrice')]",
                         "tags": "[parameters('tags')]",
@@ -2795,7 +2999,8 @@
                         },
                         "vmSize": "[parameters('vmSize')]",
                         "vnetSubnetID": "[parameters('vnetSubnetResourceId')]",
-                        "workloadRuntime": "[parameters('workloadRuntime')]"
+                        "workloadRuntime": "[parameters('workloadRuntime')]",
+                        "windowsProfile": "[parameters('windowsProfile')]"
                       }
                     }
                   },
@@ -2831,7 +3036,7 @@
             "managedCluster_extension": {
               "condition": "[not(empty(parameters('fluxExtension')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('{0}-ManagedCluster-FluxExtension', uniqueString(deployment().name, parameters('location')))]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2871,6 +3076,9 @@
                   },
                   "version": {
                     "value": "[tryGet(parameters('fluxExtension'), 'version')]"
+                  },
+                  "targetNamespace": {
+                    "value": "[tryGet(parameters('fluxExtension'), 'targetNamespace')]"
                   }
                 },
                 "template": {
@@ -2880,12 +3088,11 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.32.4.45862",
-                      "templateHash": "9966442976957263225"
+                      "version": "0.37.4.10188",
+                      "templateHash": "9872939647776132218"
                     },
                     "name": "Kubernetes Configuration Extensions",
-                    "description": "This module deploys a Kubernetes Configuration Extension.",
-                    "owner": "Azure/module-maintainers"
+                    "description": "This module deploys a Kubernetes Configuration Extension."
                   },
                   "parameters": {
                     "name": {
@@ -2914,19 +3121,36 @@
                         "description": "Optional. Location for all resources."
                       }
                     },
+                    "clusterType": {
+                      "type": "string",
+                      "defaultValue": "managedCluster",
+                      "allowedValues": [
+                        "managedCluster",
+                        "connectedCluster"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The type of cluster to configure. Choose between AKS managed cluster or Arc-enabled connected cluster."
+                      }
+                    },
                     "configurationProtectedSettings": {
                       "type": "secureObject",
-                      "nullable": true,
                       "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.KubernetesConfiguration/fluxConfigurations@2025-04-01#properties/properties/properties/configurationProtectedSettings"
+                        },
                         "description": "Optional. Configuration settings that are sensitive, as name-value pairs for configuring this extension."
-                      }
+                      },
+                      "nullable": true
                     },
                     "configurationSettings": {
                       "type": "object",
-                      "nullable": true,
                       "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.KubernetesConfiguration/extensions@2024-11-01#properties/properties/properties/configurationSettings"
+                        },
                         "description": "Optional. Configuration settings, as name-value pairs for configuring this extension."
-                      }
+                      },
+                      "nullable": true
                     },
                     "extensionType": {
                       "type": "string",
@@ -2964,10 +3188,33 @@
                     },
                     "fluxConfigurations": {
                       "type": "array",
+                      "items": {
+                        "type": "object",
+                        "metadata": {
+                          "__bicep_resource_derived_type!": {
+                            "source": "Microsoft.KubernetesConfiguration/fluxConfigurations@2025-04-01#properties/properties"
+                          }
+                        }
+                      },
                       "nullable": true,
                       "metadata": {
                         "description": "Optional. A list of flux configuraitons."
                       }
+                    }
+                  },
+                  "variables": {
+                    "enableReferencedModulesTelemetry": false,
+                    "extensionProperties": {
+                      "autoUpgradeMinorVersion": "[if(not(empty(parameters('version'))), false(), true())]",
+                      "configurationProtectedSettings": "[parameters('configurationProtectedSettings')]",
+                      "configurationSettings": "[parameters('configurationSettings')]",
+                      "extensionType": "[parameters('extensionType')]",
+                      "releaseTrain": "[parameters('releaseTrain')]",
+                      "scope": {
+                        "cluster": "[if(not(empty(parameters('releaseNamespace'))), createObject('releaseNamespace', parameters('releaseNamespace')), null())]",
+                        "namespace": "[if(not(empty(parameters('targetNamespace'))), createObject('targetNamespace', parameters('targetNamespace')), null())]"
+                      },
+                      "version": "[parameters('version')]"
                     }
                   },
                   "resources": {
@@ -2975,7 +3222,7 @@
                       "condition": "[parameters('enableTelemetry')]",
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2024-03-01",
-                      "name": "[format('46d3xbcp.res.kubernetesconfiguration-extension.{0}.{1}', replace('0.3.5', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "name": "[format('46d3xbcp.res.kubernetesconfiguration-extension.{0}.{1}', replace('0.3.8', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
                       "properties": {
                         "mode": "Incremental",
                         "template": {
@@ -2992,28 +3239,37 @@
                       }
                     },
                     "managedCluster": {
+                      "condition": "[equals(parameters('clusterType'), 'managedCluster')]",
                       "existing": true,
                       "type": "Microsoft.ContainerService/managedClusters",
-                      "apiVersion": "2022-07-01",
+                      "apiVersion": "2025-05-01",
                       "name": "[parameters('clusterName')]"
                     },
-                    "extension": {
+                    "connectedCluster": {
+                      "condition": "[equals(parameters('clusterType'), 'connectedCluster')]",
+                      "existing": true,
+                      "type": "Microsoft.Kubernetes/connectedClusters",
+                      "apiVersion": "2024-01-01",
+                      "name": "[parameters('clusterName')]"
+                    },
+                    "managedExtension": {
+                      "condition": "[equals(parameters('clusterType'), 'managedCluster')]",
                       "type": "Microsoft.KubernetesConfiguration/extensions",
-                      "apiVersion": "2022-03-01",
+                      "apiVersion": "2024-11-01",
                       "scope": "[format('Microsoft.ContainerService/managedClusters/{0}', parameters('clusterName'))]",
                       "name": "[parameters('name')]",
-                      "properties": {
-                        "autoUpgradeMinorVersion": "[if(not(empty(parameters('version'))), false(), true())]",
-                        "configurationProtectedSettings": "[parameters('configurationProtectedSettings')]",
-                        "configurationSettings": "[parameters('configurationSettings')]",
-                        "extensionType": "[parameters('extensionType')]",
-                        "releaseTrain": "[parameters('releaseTrain')]",
-                        "scope": {
-                          "cluster": "[if(not(empty(coalesce(parameters('releaseNamespace'), ''))), createObject('releaseNamespace', parameters('releaseNamespace')), null())]",
-                          "namespace": "[if(not(empty(coalesce(parameters('targetNamespace'), ''))), createObject('targetNamespace', parameters('targetNamespace')), null())]"
-                        },
-                        "version": "[parameters('version')]"
-                      }
+                      "properties": "[variables('extensionProperties')]"
+                    },
+                    "connectedExtension": {
+                      "condition": "[equals(parameters('clusterType'), 'connectedCluster')]",
+                      "type": "Microsoft.KubernetesConfiguration/extensions",
+                      "apiVersion": "2024-11-01",
+                      "scope": "[format('Microsoft.Kubernetes/connectedClusters/{0}', parameters('clusterName'))]",
+                      "name": "[parameters('name')]",
+                      "identity": {
+                        "type": "SystemAssigned"
+                      },
+                      "properties": "[variables('extensionProperties')]"
                     },
                     "fluxConfiguration": {
                       "copy": {
@@ -3022,7 +3278,7 @@
                       },
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('{0}-ManagedCluster-FluxConfiguration{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "name": "[format('{0}-Cluster-FluxConfiguration{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -3030,7 +3286,7 @@
                         "mode": "Incremental",
                         "parameters": {
                           "enableTelemetry": {
-                            "value": "[coalesce(tryGet(coalesce(parameters('fluxConfigurations'), createArray())[copyIndex()], 'enableTelemetry'), parameters('enableTelemetry'))]"
+                            "value": "[variables('enableReferencedModulesTelemetry')]"
                           },
                           "clusterName": {
                             "value": "[parameters('clusterName')]"
@@ -3040,6 +3296,9 @@
                           },
                           "namespace": {
                             "value": "[coalesce(parameters('fluxConfigurations'), createArray())[copyIndex()].namespace]"
+                          },
+                          "clusterType": {
+                            "value": "[parameters('clusterType')]"
                           },
                           "sourceKind": "[if(contains(coalesce(parameters('fluxConfigurations'), createArray())[copyIndex()], 'gitRepository'), createObject('value', 'GitRepository'), createObject('value', 'Bucket'))]",
                           "name": {
@@ -3068,12 +3327,11 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "885928168160399718"
+                              "version": "0.37.4.10188",
+                              "templateHash": "12743785390507267340"
                             },
                             "name": "Kubernetes Configuration Flux Configurations",
-                            "description": "This module deploys a Kubernetes Configuration Flux Configuration.",
-                            "owner": "Azure/module-maintainers"
+                            "description": "This module deploys a Kubernetes Configuration Flux Configuration."
                           },
                           "parameters": {
                             "name": {
@@ -3102,30 +3360,73 @@
                                 "description": "Optional. Location for all resources."
                               }
                             },
+                            "clusterType": {
+                              "type": "string",
+                              "defaultValue": "managedCluster",
+                              "allowedValues": [
+                                "managedCluster",
+                                "connectedCluster"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The type of cluster to configure. Choose between AKS managed cluster or Arc-enabled connected cluster."
+                              }
+                            },
                             "bucket": {
                               "type": "object",
-                              "nullable": true,
                               "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.KubernetesConfiguration/fluxConfigurations@2025-04-01#properties/properties/properties/bucket"
+                                },
                                 "description": "Conditional. Parameters to reconcile to the GitRepository source kind type. Required if `sourceKind` is `Bucket`."
-                              }
+                              },
+                              "nullable": true
                             },
                             "configurationProtectedSettings": {
                               "type": "secureObject",
-                              "nullable": true,
                               "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.KubernetesConfiguration/fluxConfigurations@2025-04-01#properties/properties/properties/configurationProtectedSettings"
+                                },
                                 "description": "Optional. Key-value pairs of protected configuration settings for the configuration."
-                              }
+                              },
+                              "nullable": true
                             },
                             "gitRepository": {
                               "type": "object",
-                              "nullable": true,
                               "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.KubernetesConfiguration/fluxConfigurations@2025-04-01#properties/properties/properties/gitRepository"
+                                },
                                 "description": "Conditional. Parameters to reconcile to the GitRepository source kind type. Required if `sourceKind` is `GitRepository`."
-                              }
+                              },
+                              "nullable": true
+                            },
+                            "ociRepository": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.KubernetesConfiguration/fluxConfigurations@2025-04-01#properties/properties/properties/ociRepository"
+                                },
+                                "description": "Conditional. Parameters to reconcile to the GitRepository source kind type. Required if `sourceKind` is `OciRepository`."
+                              },
+                              "nullable": true
+                            },
+                            "azureBlob": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.KubernetesConfiguration/fluxConfigurations@2025-04-01#properties/properties/properties/azureBlob"
+                                },
+                                "description": "Conditional. Parameters to reconcile to the GitRepository source kind type. Required if `sourceKind` is `AzureBlob`."
+                              },
+                              "nullable": true
                             },
                             "kustomizations": {
                               "type": "object",
                               "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.KubernetesConfiguration/fluxConfigurations@2025-04-01#properties/properties/properties/kustomizations"
+                                },
                                 "description": "Required. Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster."
                               }
                             },
@@ -3137,22 +3438,27 @@
                             },
                             "scope": {
                               "type": "string",
-                              "allowedValues": [
-                                "cluster",
-                                "namespace"
-                              ],
                               "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.KubernetesConfiguration/fluxConfigurations@2025-04-01#properties/properties/properties/scope"
+                                },
                                 "description": "Required. Scope at which the configuration will be installed."
                               }
                             },
                             "sourceKind": {
                               "type": "string",
-                              "allowedValues": [
-                                "Bucket",
-                                "GitRepository"
-                              ],
                               "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.KubernetesConfiguration/fluxConfigurations@2025-04-01#properties/properties/properties/sourceKind"
+                                },
                                 "description": "Required. Source Kind to pull the configuration data from."
+                              }
+                            },
+                            "reconciliationWaitDuration": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Reconciliation wait duration (ISO 8601 format)."
                               }
                             },
                             "suspend": {
@@ -3163,12 +3469,27 @@
                               }
                             }
                           },
+                          "variables": {
+                            "fluxConfigProperties": {
+                              "scope": "[parameters('scope')]",
+                              "namespace": "[parameters('namespace')]",
+                              "sourceKind": "[parameters('sourceKind')]",
+                              "suspend": "[parameters('suspend')]",
+                              "reconciliationWaitDuration": "[parameters('reconciliationWaitDuration')]",
+                              "gitRepository": "[parameters('gitRepository')]",
+                              "azureBlob": "[parameters('azureBlob')]",
+                              "bucket": "[parameters('bucket')]",
+                              "configurationProtectedSettings": "[parameters('configurationProtectedSettings')]",
+                              "ociRepository": "[parameters('ociRepository')]",
+                              "kustomizations": "[parameters('kustomizations')]"
+                            }
+                          },
                           "resources": {
                             "avmTelemetry": {
                               "condition": "[parameters('enableTelemetry')]",
                               "type": "Microsoft.Resources/deployments",
-                              "apiVersion": "2023-07-01",
-                              "name": "[format('46d3xbcp.res.kubernetesconfiguration-fluxconfig.{0}.{1}', replace('0.3.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                              "apiVersion": "2024-03-01",
+                              "name": "[format('46d3xbcp.res.kubernetesconfiguration-fluxconfig.{0}.{1}', replace('0.3.8', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
                               "properties": {
                                 "mode": "Incremental",
                                 "template": {
@@ -3185,29 +3506,34 @@
                               }
                             },
                             "managedCluster": {
+                              "condition": "[equals(parameters('clusterType'), 'managedCluster')]",
                               "existing": true,
                               "type": "Microsoft.ContainerService/managedClusters",
-                              "apiVersion": "2022-07-01",
+                              "apiVersion": "2025-04-01",
                               "name": "[parameters('clusterName')]"
                             },
-                            "fluxConfiguration": {
+                            "connectedCluster": {
+                              "condition": "[equals(parameters('clusterType'), 'connectedCluster')]",
+                              "existing": true,
+                              "type": "Microsoft.Kubernetes/connectedClusters",
+                              "apiVersion": "2024-01-01",
+                              "name": "[parameters('clusterName')]"
+                            },
+                            "fluxConfigurationManaged": {
+                              "condition": "[equals(parameters('clusterType'), 'managedCluster')]",
                               "type": "Microsoft.KubernetesConfiguration/fluxConfigurations",
-                              "apiVersion": "2023-05-01",
+                              "apiVersion": "2025-04-01",
                               "scope": "[format('Microsoft.ContainerService/managedClusters/{0}', parameters('clusterName'))]",
                               "name": "[parameters('name')]",
-                              "properties": {
-                                "bucket": "[parameters('bucket')]",
-                                "configurationProtectedSettings": "[parameters('configurationProtectedSettings')]",
-                                "gitRepository": "[parameters('gitRepository')]",
-                                "kustomizations": "[parameters('kustomizations')]",
-                                "namespace": "[parameters('namespace')]",
-                                "scope": "[parameters('scope')]",
-                                "sourceKind": "[parameters('sourceKind')]",
-                                "suspend": "[parameters('suspend')]"
-                              },
-                              "dependsOn": [
-                                "managedCluster"
-                              ]
+                              "properties": "[variables('fluxConfigProperties')]"
+                            },
+                            "fluxConfigurationConnected": {
+                              "condition": "[equals(parameters('clusterType'), 'connectedCluster')]",
+                              "type": "Microsoft.KubernetesConfiguration/fluxConfigurations",
+                              "apiVersion": "2025-04-01",
+                              "scope": "[format('Microsoft.Kubernetes/connectedClusters/{0}', parameters('clusterName'))]",
+                              "name": "[parameters('name')]",
+                              "properties": "[variables('fluxConfigProperties')]"
                             }
                           },
                           "outputs": {
@@ -3216,14 +3542,14 @@
                               "metadata": {
                                 "description": "The name of the flux configuration."
                               },
-                              "value": "[parameters('name')]"
+                              "value": "[if(equals(parameters('clusterType'), 'managedCluster'), parameters('name'), parameters('name'))]"
                             },
                             "resourceId": {
                               "type": "string",
                               "metadata": {
                                 "description": "The resource ID of the flux configuration."
                               },
-                              "value": "[extensionResourceId(resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/fluxConfigurations', parameters('name'))]"
+                              "value": "[if(equals(parameters('clusterType'), 'managedCluster'), extensionResourceId(resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/fluxConfigurations', parameters('name')), extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/fluxConfigurations', parameters('name')))]"
                             },
                             "resourceGroupName": {
                               "type": "string",
@@ -3236,7 +3562,8 @@
                         }
                       },
                       "dependsOn": [
-                        "extension"
+                        "connectedExtension",
+                        "managedExtension"
                       ]
                     }
                   },
@@ -3246,14 +3573,14 @@
                       "metadata": {
                         "description": "The name of the extension."
                       },
-                      "value": "[parameters('name')]"
+                      "value": "[if(equals(parameters('clusterType'), 'managedCluster'), parameters('name'), parameters('name'))]"
                     },
                     "resourceId": {
                       "type": "string",
                       "metadata": {
                         "description": "The resource ID of the extension."
                       },
-                      "value": "[extensionResourceId(resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', parameters('name'))]"
+                      "value": "[if(equals(parameters('clusterType'), 'managedCluster'), extensionResourceId(resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', parameters('name')), extensionResourceId(resourceId('Microsoft.Kubernetes/connectedClusters', parameters('clusterName')), 'Microsoft.KubernetesConfiguration/extensions', parameters('name')))]"
                     },
                     "resourceGroupName": {
                       "type": "string",
@@ -3305,7 +3632,7 @@
               "metadata": {
                 "description": "The principal ID of the system assigned identity."
               },
-              "value": "[tryGet(tryGet(reference('managedCluster', '2024-09-02-preview', 'full'), 'identity'), 'principalId')]"
+              "value": "[tryGet(tryGet(reference('managedCluster', '2025-05-02-preview', 'full'), 'identity'), 'principalId')]"
             },
             "kubeletIdentityClientId": {
               "type": "string",
@@ -3368,7 +3695,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('managedCluster', '2024-09-02-preview', 'full').location]"
+              "value": "[reference('managedCluster', '2025-05-02-preview', 'full').location]"
             },
             "oidcIssuerUrl": {
               "type": "string",

--- a/avm/ptn/azd/aks-automatic-cluster/version.json
+++ b/avm/ptn/azd/aks-automatic-cluster/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.2"
+    "version": "0.3"
 }


### PR DESCRIPTION
## Description

Fixes #6373 
Fixes #6372 

### avm/ptn/azd/aks-automatic-cluster
- Bump default Kubernetes version
- Bump dependency versions

### avm/ptn/azd/acr-container-app
- Fix `default` test due to `serviceShort` collision with another AVM
- Bump dependency versions

## Pipeline Reference

`Test-ModuleLocally` passes:

<img width="734" height="116" alt="image" src="https://github.com/user-attachments/assets/60545ff6-a819-4ea9-ba60-f88586df52e6" />

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
