### PR TITLE
feat: Add support for StandardV2 SKU in `avm/res/network/public-ip-prefix`

### DIFF
--- a/avm/res/network/public-ip-prefix/CHANGELOG.md
+++ b/avm/res/network/public-ip-prefix/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/public-ip-prefix/CHANGELOG.md).
 
+## 0.8.0
+
+### Changes
+
+- Removed hardcoded `Standard` SKU value and added `skuName` parameter to support configurable SKU selection.
+- Added support for `StandardV2` SKU.
+
+### Breaking Changes
+
+- None
+
 ## 0.7.2
 
 ### Changes

--- a/avm/res/network/public-ip-prefix/README.md
+++ b/avm/res/network/public-ip-prefix/README.md
@@ -398,7 +398,6 @@ module publicIpPrefix 'br/public:avm/res/network/public-ip-prefix:<version>' = {
     name: 'npipv2001'
     prefixLength: 28
     // Non-required parameters
-    location: '<location>'
     skuName: 'StandardV2'
   }
 }
@@ -424,9 +423,6 @@ module publicIpPrefix 'br/public:avm/res/network/public-ip-prefix:<version>' = {
       "value": 28
     },
     // Non-required parameters
-    "location": {
-      "value": "<location>"
-    },
     "skuName": {
       "value": "StandardV2"
     }
@@ -448,7 +444,6 @@ using 'br/public:avm/res/network/public-ip-prefix:<version>'
 param name = 'npipv2001'
 param prefixLength = 28
 // Non-required parameters
-param location = '<location>'
 param skuName = 'StandardV2'
 ```
 

--- a/avm/res/network/public-ip-prefix/README.md
+++ b/avm/res/network/public-ip-prefix/README.md
@@ -38,7 +38,8 @@ The following section provides usage examples for the module, which were used to
 - [Using only defaults](#example-1-using-only-defaults)
 - [IPv6 Public IP Prefix](#example-2-ipv6-public-ip-prefix)
 - [Using large parameter set](#example-3-using-large-parameter-set)
-- [WAF-aligned](#example-4-waf-aligned)
+- [StandardV2 SKU](#example-4-standardv2-sku)
+- [WAF-aligned](#example-5-waf-aligned)
 
 ### Example 1: _Using only defaults_
 
@@ -379,7 +380,82 @@ param tags = {
 </details>
 <p>
 
-### Example 4: _WAF-aligned_
+### Example 4: _StandardV2 SKU_
+
+This instance deploys the module using the StandardV2 SKU.
+
+You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/v2sku]
+
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module publicIpPrefix 'br/public:avm/res/network/public-ip-prefix:<version>' = {
+  params: {
+    // Required parameters
+    name: 'npipv2001'
+    prefixLength: 28
+    // Non-required parameters
+    location: '<location>'
+    skuName: 'StandardV2'
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON parameters file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "name": {
+      "value": "npipv2001"
+    },
+    "prefixLength": {
+      "value": 28
+    },
+    // Non-required parameters
+    "location": {
+      "value": "<location>"
+    },
+    "skuName": {
+      "value": "StandardV2"
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via Bicep parameters file</summary>
+
+```bicep-params
+using 'br/public:avm/res/network/public-ip-prefix:<version>'
+
+// Required parameters
+param name = 'npipv2001'
+param prefixLength = 28
+// Non-required parameters
+param location = '<location>'
+param skuName = 'StandardV2'
+```
+
+</details>
+<p>
+
+### Example 5: _WAF-aligned_
 
 This instance deploys the module in alignment with the best-practices of the Azure Well-Architected Framework.
 
@@ -487,6 +563,7 @@ param tags = {
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`publicIPAddressVersion`](#parameter-publicipaddressversion) | string | The public IP address version. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
+| [`skuName`](#parameter-skuname) | string | Name of the Public IP Prefix SKU. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`tier`](#parameter-tier) | string | Tier of a public IP prefix SKU. If set to `Global`, the `zones` property must be empty. |
 
@@ -740,6 +817,21 @@ The principal type of the assigned principal ID.
     'Group'
     'ServicePrincipal'
     'User'
+  ]
+  ```
+
+### Parameter: `skuName`
+
+Name of the Public IP Prefix SKU.
+
+- Required: No
+- Type: string
+- Default: `'Standard'`
+- Allowed:
+  ```Bicep
+  [
+    'Standard'
+    'StandardV2'
   ]
   ```
 

--- a/avm/res/network/public-ip-prefix/main.bicep
+++ b/avm/res/network/public-ip-prefix/main.bicep
@@ -5,6 +5,13 @@ metadata description = 'This module deploys a Public IP Prefix.'
 @minLength(1)
 param name string
 
+@description('Optional. Name of the Public IP Prefix SKU.')
+@allowed([
+  'Standard'
+  'StandardV2'
+])
+param skuName string = 'Standard'
+
 @description('Optional. Tier of a public IP prefix SKU. If set to `Global`, the `zones` property must be empty.')
 @allowed([
   'Global'
@@ -112,7 +119,7 @@ resource publicIpPrefix 'Microsoft.Network/publicIPPrefixes@2025-01-01' = {
   location: location
   tags: tags
   sku: {
-    name: 'Standard'
+    name: skuName
     tier: tier
   }
   zones: map(availabilityZones, zone => string(zone))

--- a/avm/res/network/public-ip-prefix/main.json
+++ b/avm/res/network/public-ip-prefix/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "13434987165594337456"
+      "templateHash": "11754524888577846069"
     },
     "name": "Public IP Prefixes",
     "description": "This module deploys a Public IP Prefix."
@@ -151,6 +151,17 @@
       "minLength": 1,
       "metadata": {
         "description": "Required. The name of the Public IP Prefix."
+      }
+    },
+    "skuName": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "allowedValues": [
+        "Standard",
+        "StandardV2"
+      ],
+      "metadata": {
+        "description": "Optional. Name of the Public IP Prefix SKU."
       }
     },
     "tier": {
@@ -309,7 +320,7 @@
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
       "sku": {
-        "name": "Standard",
+        "name": "[parameters('skuName')]",
         "tier": "[parameters('tier')]"
       },
       "zones": "[map(parameters('availabilityZones'), lambda('zone', string(lambdaVariables('zone'))))]",

--- a/avm/res/network/public-ip-prefix/tests/e2e/v2sku/main.test.bicep
+++ b/avm/res/network/public-ip-prefix/tests/e2e/v2sku/main.test.bicep
@@ -42,7 +42,6 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
       skuName: 'StandardV2'
       prefixLength: 28
     }

--- a/avm/res/network/public-ip-prefix/tests/e2e/v2sku/main.test.bicep
+++ b/avm/res/network/public-ip-prefix/tests/e2e/v2sku/main.test.bicep
@@ -1,7 +1,7 @@
 targetScope = 'subscription'
 
-metadata name = 'Using only defaults'
-metadata description = 'This instance deploys the module with the minimum set of required parameters.'
+metadata name = 'StandardV2 SKU'
+metadata description = 'This instance deploys the module using the StandardV2 SKU.'
 
 // ========== //
 // Parameters //
@@ -15,7 +15,7 @@ param resourceGroupName string = 'dep-${namePrefix}-network.publicipprefixes-${s
 param resourceLocation string = deployment().location
 
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
-param serviceShort string = 'npipmin'
+param serviceShort string = 'npipv2'
 
 @description('Optional. A token to inject into the name of each resource.')
 param namePrefix string = '#_namePrefix_#'
@@ -43,6 +43,7 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: resourceLocation
+      skuName: 'StandardV2'
       prefixLength: 28
     }
   }

--- a/avm/res/network/public-ip-prefix/version.json
+++ b/avm/res/network/public-ip-prefix/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.7"
+  "version": "0.8"
 }


### PR DESCRIPTION
## Description

- Added `skuName` parameter to support configurable SKU selection.
- Added support for `StandardV2` SKU.
- Removed hardcoded `Standard` SKU value.
- Added new test case for `StandardV2` SKU.

Fixes #6456 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.network.public-ip-prefix](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-prefix.yml/badge.svg?branch=users%2Fkrbar%2FpippfxV2)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-prefix.yml) |



## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
