### PR TITLE
feat: Update public IP module to use RP input types and add `StandardV2` sku

### DIFF
--- a/avm/res/network/public-ip-address/CHANGELOG.md
+++ b/avm/res/network/public-ip-address/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/public-ip-address/CHANGELOG.md).
 
+## 0.12.0
+
+### Changes
+
+- Switched parameters `publicIPAllocationMethod`, `publicIPAddressVersion`, `skuName`, `skuTier`, and `deleteOption` to use resource input types from `Microsoft.Network/publicIPAddresses@2025-01-01` for consistency with the RP schema and built-in validation. This adds support for the `StandardV2` SKU.
+
+### Breaking Changes
+
+- Parameter types for `publicIPAllocationMethod`, `publicIPAddressVersion`, `skuName`, `skuTier`, and `deleteOption` now use resource input types instead of string literals.
+
 ## 0.11.0
 
 ### Changes

--- a/avm/res/network/public-ip-address/README.md
+++ b/avm/res/network/public-ip-address/README.md
@@ -38,7 +38,8 @@ The following section provides usage examples for the module, which were used to
 
 - [Using only defaults](#example-1-using-only-defaults)
 - [Using large parameter set](#example-2-using-large-parameter-set)
-- [WAF-aligned](#example-3-waf-aligned)
+- [Using only defaults](#example-3-using-only-defaults)
+- [WAF-aligned](#example-4-waf-aligned)
 
 ### Example 1: _Using only defaults_
 
@@ -355,7 +356,72 @@ param tags = {
 </details>
 <p>
 
-### Example 3: _WAF-aligned_
+### Example 3: _Using only defaults_
+
+This instance deploys the module with the minimum set of required parameters.
+
+You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/v2sku]
+
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' = {
+  params: {
+    // Required parameters
+    name: 'npiav2001'
+    // Non-required parameters
+    skuName: 'StandardV2'
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON parameters file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "name": {
+      "value": "npiav2001"
+    },
+    // Non-required parameters
+    "skuName": {
+      "value": "StandardV2"
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via Bicep parameters file</summary>
+
+```bicep-params
+using 'br/public:avm/res/network/public-ip-address:<version>'
+
+// Required parameters
+param name = 'npiav2001'
+// Non-required parameters
+param skuName = 'StandardV2'
+```
+
+</details>
+<p>
+
+### Example 4: _WAF-aligned_
 
 This instance deploys the module in alignment with the best-practices of the Azure Well-Architected Framework.
 
@@ -392,7 +458,7 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
     publicIPAddressVersion: 'IPv4'
     publicIPAllocationMethod: 'Static'
     publicIpPrefixResourceId: '<publicIpPrefixResourceId>'
-    skuName: 'StandardV2'
+    skuName: 'Standard'
     skuTier: 'Regional'
     tags: {
       Environment: 'Non-Prod'
@@ -457,7 +523,7 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
       "value": "<publicIpPrefixResourceId>"
     },
     "skuName": {
-      "value": "StandardV2"
+      "value": "Standard"
     },
     "skuTier": {
       "value": "Regional"
@@ -506,7 +572,7 @@ param location = '<location>'
 param publicIPAddressVersion = 'IPv4'
 param publicIPAllocationMethod = 'Static'
 param publicIpPrefixResourceId = '<publicIpPrefixResourceId>'
-param skuName = 'StandardV2'
+param skuName = 'Standard'
 param skuTier = 'Regional'
 param tags = {
   Environment: 'Non-Prod'

--- a/avm/res/network/public-ip-address/README.md
+++ b/avm/res/network/public-ip-address/README.md
@@ -54,10 +54,7 @@ You can find the full example and the setup of its dependencies in the deploymen
 ```bicep
 module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' = {
   params: {
-    // Required parameters
     name: 'npiamin001'
-    // Non-required parameters
-    location: '<location>'
   }
 }
 ```
@@ -74,13 +71,8 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    // Required parameters
     "name": {
       "value": "npiamin001"
-    },
-    // Non-required parameters
-    "location": {
-      "value": "<location>"
     }
   }
 }
@@ -96,10 +88,7 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
 ```bicep-params
 using 'br/public:avm/res/network/public-ip-address:<version>'
 
-// Required parameters
 param name = 'npiamin001'
-// Non-required parameters
-param location = '<location>'
 ```
 
 </details>
@@ -400,31 +389,10 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
     ]
     dnsSettings: '<dnsSettings>'
     location: '<location>'
-    lock: {
-      kind: 'CanNotDelete'
-      name: 'myCustomLockName'
-    }
     publicIPAddressVersion: 'IPv4'
     publicIPAllocationMethod: 'Static'
     publicIpPrefixResourceId: '<publicIpPrefixResourceId>'
-    roleAssignments: [
-      {
-        principalId: '<principalId>'
-        principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: 'Owner'
-      }
-      {
-        principalId: '<principalId>'
-        principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-      }
-      {
-        principalId: '<principalId>'
-        principalType: 'ServicePrincipal'
-        roleDefinitionIdOrName: '<roleDefinitionIdOrName>'
-      }
-    ]
-    skuName: 'Standard'
+    skuName: 'StandardV2'
     skuTier: 'Regional'
     tags: {
       Environment: 'Non-Prod'
@@ -479,12 +447,6 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
     "location": {
       "value": "<location>"
     },
-    "lock": {
-      "value": {
-        "kind": "CanNotDelete",
-        "name": "myCustomLockName"
-      }
-    },
     "publicIPAddressVersion": {
       "value": "IPv4"
     },
@@ -494,27 +456,8 @@ module publicIpAddress 'br/public:avm/res/network/public-ip-address:<version>' =
     "publicIpPrefixResourceId": {
       "value": "<publicIpPrefixResourceId>"
     },
-    "roleAssignments": {
-      "value": [
-        {
-          "principalId": "<principalId>",
-          "principalType": "ServicePrincipal",
-          "roleDefinitionIdOrName": "Owner"
-        },
-        {
-          "principalId": "<principalId>",
-          "principalType": "ServicePrincipal",
-          "roleDefinitionIdOrName": "b24988ac-6180-42a0-ab88-20f7382dd24c"
-        },
-        {
-          "principalId": "<principalId>",
-          "principalType": "ServicePrincipal",
-          "roleDefinitionIdOrName": "<roleDefinitionIdOrName>"
-        }
-      ]
-    },
     "skuName": {
-      "value": "Standard"
+      "value": "StandardV2"
     },
     "skuTier": {
       "value": "Regional"
@@ -560,31 +503,10 @@ param diagnosticSettings = [
 ]
 param dnsSettings = '<dnsSettings>'
 param location = '<location>'
-param lock = {
-  kind: 'CanNotDelete'
-  name: 'myCustomLockName'
-}
 param publicIPAddressVersion = 'IPv4'
 param publicIPAllocationMethod = 'Static'
 param publicIpPrefixResourceId = '<publicIpPrefixResourceId>'
-param roleAssignments = [
-  {
-    principalId: '<principalId>'
-    principalType: 'ServicePrincipal'
-    roleDefinitionIdOrName: 'Owner'
-  }
-  {
-    principalId: '<principalId>'
-    principalType: 'ServicePrincipal'
-    roleDefinitionIdOrName: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-  }
-  {
-    principalId: '<principalId>'
-    principalType: 'ServicePrincipal'
-    roleDefinitionIdOrName: '<roleDefinitionIdOrName>'
-  }
-]
-param skuName = 'Standard'
+param skuName = 'StandardV2'
 param skuTier = 'Regional'
 param tags = {
   Environment: 'Non-Prod'
@@ -669,13 +591,6 @@ The delete option for the public IP address.
 
 - Required: No
 - Type: string
-- Allowed:
-  ```Bicep
-  [
-    'Delete'
-    'Detach'
-  ]
-  ```
 
 ### Parameter: `diagnosticSettings`
 
@@ -912,13 +827,6 @@ IP address version.
 - Required: No
 - Type: string
 - Default: `'IPv4'`
-- Allowed:
-  ```Bicep
-  [
-    'IPv4'
-    'IPv6'
-  ]
-  ```
 
 ### Parameter: `publicIPAllocationMethod`
 
@@ -927,13 +835,6 @@ The public IP address allocation method.
 - Required: No
 - Type: string
 - Default: `'Static'`
-- Allowed:
-  ```Bicep
-  [
-    'Dynamic'
-    'Static'
-  ]
-  ```
 
 ### Parameter: `publicIpPrefixResourceId`
 
@@ -1057,13 +958,6 @@ Name of a public IP address SKU.
 - Required: No
 - Type: string
 - Default: `'Standard'`
-- Allowed:
-  ```Bicep
-  [
-    'Basic'
-    'Standard'
-  ]
-  ```
 
 ### Parameter: `skuTier`
 
@@ -1072,13 +966,6 @@ Tier of a public IP address SKU.
 - Required: No
 - Type: string
 - Default: `'Regional'`
-- Allowed:
-  ```Bicep
-  [
-    'Global'
-    'Regional'
-  ]
-  ```
 
 ### Parameter: `tags`
 

--- a/avm/res/network/public-ip-address/main.bicep
+++ b/avm/res/network/public-ip-address/main.bicep
@@ -8,11 +8,7 @@ param name string
 param publicIpPrefixResourceId string?
 
 @description('Optional. The public IP address allocation method.')
-@allowed([
-  'Dynamic'
-  'Static'
-])
-param publicIPAllocationMethod string = 'Static'
+param publicIPAllocationMethod resourceInput<'Microsoft.Network/publicIPAddresses@2025-01-01'>.properties.publicIPAllocationMethod = 'Static'
 
 @description('Optional. A list of availability zones denoting the IP allocated for the resource needs to come from.')
 @allowed([
@@ -27,11 +23,7 @@ param availabilityZones int[] = [
 ]
 
 @description('Optional. IP address version.')
-@allowed([
-  'IPv4'
-  'IPv6'
-])
-param publicIPAddressVersion string = 'IPv4'
+param publicIPAddressVersion resourceInput<'Microsoft.Network/publicIPAddresses@2025-01-01'>.properties.publicIPAddressVersion = 'IPv4'
 
 @description('Optional. The DNS settings of the public IP address.')
 param dnsSettings resourceInput<'Microsoft.Network/publicIPAddresses@2025-01-01'>.properties.dnsSettings?
@@ -44,28 +36,16 @@ import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 param lock lockType?
 
 @description('Optional. Name of a public IP address SKU.')
-@allowed([
-  'Basic'
-  'Standard'
-])
-param skuName string = 'Standard'
+param skuName resourceInput<'Microsoft.Network/publicIPAddresses@2025-01-01'>.sku.name = 'Standard'
 
 @description('Optional. Tier of a public IP address SKU.')
-@allowed([
-  'Global'
-  'Regional'
-])
-param skuTier string = 'Regional'
+param skuTier resourceInput<'Microsoft.Network/publicIPAddresses@2025-01-01'>.sku.tier = 'Regional'
 
 @description('Optional. The DDoS protection plan configuration associated with the public IP address.')
 param ddosSettings resourceInput<'Microsoft.Network/publicIPAddresses@2025-01-01'>.properties.ddosSettings?
 
 @description('Optional. The delete option for the public IP address.')
-@allowed([
-  'Delete'
-  'Detach'
-])
-param deleteOption string?
+param deleteOption resourceInput<'Microsoft.Network/publicIPAddresses@2025-01-01'>.properties.deleteOption?
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location

--- a/avm/res/network/public-ip-address/main.json
+++ b/avm/res/network/public-ip-address/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "4769782033235146336"
+      "templateHash": "4857898430973480137"
     },
     "name": "Public IP Addresses",
     "description": "This module deploys a Public IP Address."
@@ -263,14 +263,13 @@
     },
     "publicIPAllocationMethod": {
       "type": "string",
-      "defaultValue": "Static",
-      "allowedValues": [
-        "Dynamic",
-        "Static"
-      ],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/publicIPAddresses@2025-01-01#properties/properties/properties/publicIPAllocationMethod"
+        },
         "description": "Optional. The public IP address allocation method."
-      }
+      },
+      "defaultValue": "Static"
     },
     "availabilityZones": {
       "type": "array",
@@ -293,14 +292,13 @@
     },
     "publicIPAddressVersion": {
       "type": "string",
-      "defaultValue": "IPv4",
-      "allowedValues": [
-        "IPv4",
-        "IPv6"
-      ],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/publicIPAddresses@2025-01-01#properties/properties/properties/publicIPAddressVersion"
+        },
         "description": "Optional. IP address version."
-      }
+      },
+      "defaultValue": "IPv4"
     },
     "dnsSettings": {
       "type": "object",
@@ -331,25 +329,23 @@
     },
     "skuName": {
       "type": "string",
-      "defaultValue": "Standard",
-      "allowedValues": [
-        "Basic",
-        "Standard"
-      ],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/publicIPAddresses@2025-01-01#properties/sku/properties/name"
+        },
         "description": "Optional. Name of a public IP address SKU."
-      }
+      },
+      "defaultValue": "Standard"
     },
     "skuTier": {
       "type": "string",
-      "defaultValue": "Regional",
-      "allowedValues": [
-        "Global",
-        "Regional"
-      ],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/publicIPAddresses@2025-01-01#properties/sku/properties/tier"
+        },
         "description": "Optional. Tier of a public IP address SKU."
-      }
+      },
+      "defaultValue": "Regional"
     },
     "ddosSettings": {
       "type": "object",
@@ -363,14 +359,13 @@
     },
     "deleteOption": {
       "type": "string",
-      "nullable": true,
-      "allowedValues": [
-        "Delete",
-        "Detach"
-      ],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/publicIPAddresses@2025-01-01#properties/properties/properties/deleteOption"
+        },
         "description": "Optional. The delete option for the public IP address."
-      }
+      },
+      "nullable": true
     },
     "location": {
       "type": "string",

--- a/avm/res/network/public-ip-address/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/network/public-ip-address/tests/e2e/defaults/main.test.bicep
@@ -41,7 +41,6 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
     }
   }
 ]

--- a/avm/res/network/public-ip-address/tests/e2e/v2sku/main.test.bicep
+++ b/avm/res/network/public-ip-address/tests/e2e/v2sku/main.test.bicep
@@ -1,0 +1,47 @@
+targetScope = 'subscription'
+
+metadata name = 'Using only defaults'
+metadata description = 'This instance deploys the module with the minimum set of required parameters.'
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Optional. The name of the resource group to deploy for testing purposes.')
+@maxLength(90)
+param resourceGroupName string = 'dep-${namePrefix}-network.publicipaddresses-${serviceShort}-rg'
+
+@description('Optional. The location to deploy resources to.')
+param resourceLocation string = deployment().location
+
+@description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
+param serviceShort string = 'npiav2'
+
+@description('Optional. A token to inject into the name of each resource.')
+param namePrefix string = '#_namePrefix_#'
+
+// ============ //
+// Dependencies //
+// ============ //
+
+// General resources
+// =================
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
+  name: resourceGroupName
+  location: resourceLocation
+}
+
+// ============== //
+// Test Execution //
+// ============== //
+
+module testDeployment '../../../main.bicep' = [
+  for iteration in ['init', 'idem']: {
+    scope: resourceGroup
+    name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
+    params: {
+      name: '${namePrefix}${serviceShort}001'
+      skuName: 'StandardV2'
+    }
+  }
+]

--- a/avm/res/network/public-ip-address/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/public-ip-address/tests/e2e/waf-aligned/main.test.bicep
@@ -65,35 +65,11 @@ module testDeployment '../../../main.bicep' = [
     params: {
       name: '${namePrefix}${serviceShort}001'
       location: resourceLocation
-      lock: {
-        name: 'myCustomLockName'
-        kind: 'CanNotDelete'
-      }
       dnsSettings: null
       ddosSettings: null
       publicIPAllocationMethod: 'Static'
       publicIpPrefixResourceId: null
-      roleAssignments: [
-        {
-          roleDefinitionIdOrName: 'Owner'
-          principalId: nestedDependencies.outputs.managedIdentityPrincipalId
-          principalType: 'ServicePrincipal'
-        }
-        {
-          roleDefinitionIdOrName: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
-          principalId: nestedDependencies.outputs.managedIdentityPrincipalId
-          principalType: 'ServicePrincipal'
-        }
-        {
-          roleDefinitionIdOrName: subscriptionResourceId(
-            'Microsoft.Authorization/roleDefinitions',
-            'acdd72a7-3385-48ef-bd42-f606fba81ae7'
-          )
-          principalId: nestedDependencies.outputs.managedIdentityPrincipalId
-          principalType: 'ServicePrincipal'
-        }
-      ]
-      skuName: 'Standard'
+      skuName: 'StandardV2'
       skuTier: 'Regional'
       publicIPAddressVersion: 'IPv4'
       availabilityZones: [

--- a/avm/res/network/public-ip-address/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/public-ip-address/tests/e2e/waf-aligned/main.test.bicep
@@ -69,7 +69,7 @@ module testDeployment '../../../main.bicep' = [
       ddosSettings: null
       publicIPAllocationMethod: 'Static'
       publicIpPrefixResourceId: null
-      skuName: 'StandardV2'
+      skuName: 'Standard'
       skuTier: 'Regional'
       publicIPAddressVersion: 'IPv4'
       availabilityZones: [

--- a/avm/res/network/public-ip-address/version.json
+++ b/avm/res/network/public-ip-address/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.11"
+  "version": "0.12"
 }


### PR DESCRIPTION
## Description

- Switch key parameters to RP resource input types to align with 2025-01-01 schema and enable `StandardV2` SKU support
- Refresh tests: add `StandardV2` example, trim `waf-aligned`/`defaults` scenarios to rely on module defaults

Fixes #6455 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.network.public-ip-address](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml/badge.svg?branch=users%2Fkrbar%2FpipaddrV2)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.network.public-ip-address.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
