### PR TITLE
fix: ReadMe-Gen - Fixed issue where logic would show an error if running for a single module

### DIFF
--- a/utilities/tools/Set-AVMModule.ps1
+++ b/utilities/tools/Set-AVMModule.ps1
@@ -107,7 +107,7 @@ function Set-AVMModule {
     if ($InvokeForDiff) {
         $resolvedPath = (Test-Path $ModuleFolderPath) ? (Resolve-Path $ModuleFolderPath).Path : $ModuleFolderPath
 
-        $relevantTemplatePaths = Get-GitDiff -PathOnly -SkipStats | Where-Object { $_ -match '[\/|\\]main\.bicep$' }
+        $relevantTemplatePaths = @() + (Get-GitDiff -PathOnly -SkipStats | Where-Object { $_ -match '[\/|\\]main\.bicep$' })
         Write-Verbose ('Found [{0}] files in diff' -f $relevantTemplatePaths.Count) -Verbose
 
         # Handling relevant parent modules that would be affected by a diff in a child


### PR DESCRIPTION
## Description

For single modules, one variable is interpreted as a FileInfo object instead an array, causing subsequent erros when trying to add more items to it

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.insights.scheduled-query-rule](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.scheduled-query-rule.yml/badge.svg?branch=users%2Falsehr%2FreadmeFix20260108&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.insights.scheduled-query-rule.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
