### PR TITLE
feat: CI - Adjusted workflow conditions to avoid auto-triggering workflows in `main`

### DIFF
--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    # Only run if not cancelled, in upstream, or in forks on workflow_dispatch
     if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -49,6 +49,12 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: |
+      !cancelled() &&
+      github.repository == 'Azure/bicep-registry-modules' ||
+      (github.repository != 'Azure/bicep-registry-modules' &&
+      github.event_name == 'push' &&
+      github.ref != 'refs/heads/main')
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -42,14 +42,6 @@ env:
 concurrency:
   group: ${{ github.workflow }}
 
-# Test
-# x In fork (in main) push to main should not trigger the workflow
-# x        (in main) workflow dispatch should trigger the workflow
-#         (in branch after merged to main) push to branch should not trigger the workflow
-#         (in branch after merged to main) workflow dispatch should trigger the workflow
-# Upstream (in main) push to main should trigger the workflow
-#          (in main) workflow dispatch should trigger the workflow
-# Test change 1
 jobs:
   ###########################
   #   Initialize pipeline   #
@@ -62,12 +54,6 @@ jobs:
       !(github.repository != 'Azure/bicep-registry-modules' &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main')
-    # if: |
-    #   !cancelled() &&
-    #   github.repository == 'Azure/bicep-registry-modules' ||
-    #   (github.repository != 'Azure/bicep-registry-modules' &&
-    #   github.event_name == 'push' &&
-    #   github.ref != 'refs/heads/main')
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -50,7 +50,7 @@ concurrency:
 #         (in branch after merged to main) workflow dispatch should trigger the workflow
 # Upstream (in main) push to main should trigger the workflow
 #          (in main) workflow dispatch should trigger the workflow
-
+# Test change
 jobs:
   ###########################
   #   Initialize pipeline   #

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -46,8 +46,8 @@ concurrency:
 # Test
 # In fork (in main) push to main should not trigger the workflow
 #         (in main) workflow dispatch should not trigger the workflow
-#         (in branch) push to branch should not trigger the workflow
-#         (in branch) workflow dispatch should trigger the workflow
+#         (in branch after merged to main) push to branch should not trigger the workflow
+#         (in branch after merged to main) workflow dispatch should trigger the workflow
 # Upstream (in main) push to main should trigger the workflow
 #          (in main) workflow dispatch should trigger the workflow
 

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -49,7 +49,6 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    # Only run if not cancelled, in upstream, or in forks on workflow_dispatch
     if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -75,9 +75,9 @@ jobs:
       psRuleModuleTestFilePaths: ${{ steps.get-module-test-file-paths.outputs.psRuleModuleTestFilePaths }}
       modulePath: "${{ env.modulePath }}"
 
-  # #############################
+  ##############################
   #   Call reusable workflow   #
-  # #############################
+  ##############################
   call-workflow-passing-data:
     name: "Run"
     permissions:

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -49,7 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -75,20 +75,20 @@ jobs:
       psRuleModuleTestFilePaths: ${{ steps.get-module-test-file-paths.outputs.psRuleModuleTestFilePaths }}
       modulePath: "${{ env.modulePath }}"
 
-  ##############################
+  # #############################
   #   Call reusable workflow   #
-  ##############################
-  # call-workflow-passing-data:
-  #   name: "Run"
-  #   permissions:
-  #     id-token: write # For OIDC
-  #     contents: write # For release tags
-  #   needs:
-  #     - job_initialize_pipeline
-  #   uses: ./.github/workflows/avm.template.module.yml
-  #   with:
-  #     workflowInput: "${{ needs.job_initialize_pipeline.outputs.workflowInput }}"
-  #     moduleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.moduleTestFilePaths }}"
-  #     psRuleModuleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.psRuleModuleTestFilePaths }}"
-  #     modulePath: "${{ needs.job_initialize_pipeline.outputs.modulePath}}"
-  #   secrets: inherit
+  # #############################
+  call-workflow-passing-data:
+    name: "Run"
+    permissions:
+      id-token: write # For OIDC
+      contents: write # For release tags
+    needs:
+      - job_initialize_pipeline
+    uses: ./.github/workflows/avm.template.module.yml
+    with:
+      workflowInput: "${{ needs.job_initialize_pipeline.outputs.workflowInput }}"
+      moduleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.moduleTestFilePaths }}"
+      psRuleModuleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.psRuleModuleTestFilePaths }}"
+      modulePath: "${{ needs.job_initialize_pipeline.outputs.modulePath}}"
+    secrets: inherit

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -60,10 +60,15 @@ jobs:
     name: "Initialize pipeline"
     if: |
       !cancelled() &&
-      github.repository == 'Azure/bicep-registry-modules' ||
-      (github.repository != 'Azure/bicep-registry-modules' &&
+      !(github.repository != 'Azure/bicep-registry-modules' &&
       github.event_name == 'push' &&
-      github.ref != 'refs/heads/main')
+      github.ref == 'refs/heads/main')
+    # if: |
+    #   !cancelled() &&
+    #   github.repository == 'Azure/bicep-registry-modules' ||
+    #   (github.repository != 'Azure/bicep-registry-modules' &&
+    #   github.event_name == 'push' &&
+    #   github.ref != 'refs/heads/main')
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -43,8 +43,8 @@ concurrency:
   group: ${{ github.workflow }}
 
 # Test
-# In fork (in main) push to main should not trigger the workflow
-#         (in main) workflow dispatch should not trigger the workflow
+# x In fork (in main) push to main should not trigger the workflow
+# x        (in main) workflow dispatch should trigger the workflow
 #         (in branch after merged to main) push to branch should not trigger the workflow
 #         (in branch after merged to main) workflow dispatch should trigger the workflow
 # Upstream (in main) push to main should trigger the workflow

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -49,11 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: |
-      !cancelled() &&
-      !(github.repository != 'Azure/bicep-registry-modules' &&
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/main')
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -24,7 +24,8 @@ on:
         required: false
   push:
     branches:
-      - main
+      # - main
+      - users/alsehr/forkCond
     paths:
       - ".github/actions/templates/avm-**"
       - ".github/workflows/avm.template.module.yml"
@@ -41,6 +42,14 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}
+
+# Test
+# In fork (in main) push to main should not trigger the workflow
+#         (in main) workflow dispatch should not trigger the workflow
+#         (in branch) push to branch should not trigger the workflow
+#         (in branch) workflow dispatch should trigger the workflow
+# Upstream (in main) push to main should trigger the workflow
+#          (in main) workflow dispatch should trigger the workflow
 
 jobs:
   ###########################
@@ -79,17 +88,17 @@ jobs:
   ##############################
   #   Call reusable workflow   #
   ##############################
-  call-workflow-passing-data:
-    name: "Run"
-    permissions:
-      id-token: write # For OIDC
-      contents: write # For release tags
-    needs:
-      - job_initialize_pipeline
-    uses: ./.github/workflows/avm.template.module.yml
-    with:
-      workflowInput: "${{ needs.job_initialize_pipeline.outputs.workflowInput }}"
-      moduleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.moduleTestFilePaths }}"
-      psRuleModuleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.psRuleModuleTestFilePaths }}"
-      modulePath: "${{ needs.job_initialize_pipeline.outputs.modulePath}}"
-    secrets: inherit
+  # call-workflow-passing-data:
+  #   name: "Run"
+  #   permissions:
+  #     id-token: write # For OIDC
+  #     contents: write # For release tags
+  #   needs:
+  #     - job_initialize_pipeline
+  #   uses: ./.github/workflows/avm.template.module.yml
+  #   with:
+  #     workflowInput: "${{ needs.job_initialize_pipeline.outputs.workflowInput }}"
+  #     moduleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.moduleTestFilePaths }}"
+  #     psRuleModuleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.psRuleModuleTestFilePaths }}"
+  #     modulePath: "${{ needs.job_initialize_pipeline.outputs.modulePath}}"
+  #   secrets: inherit

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -49,7 +49,7 @@ concurrency:
 #         (in branch after merged to main) workflow dispatch should trigger the workflow
 # Upstream (in main) push to main should trigger the workflow
 #          (in main) workflow dispatch should trigger the workflow
-# Test change
+# Test change 1
 jobs:
   ###########################
   #   Initialize pipeline   #

--- a/.github/workflows/avm.res.analysis-services.server.yml
+++ b/.github/workflows/avm.res.analysis-services.server.yml
@@ -24,8 +24,7 @@ on:
         required: false
   push:
     branches:
-      # - main
-      - users/alsehr/forkCond
+      - main
     paths:
       - ".github/actions/templates/avm-**"
       - ".github/workflows/avm.template.module.yml"

--- a/.github/workflows/platform.check.psrule.yml
+++ b/.github/workflows/platform.check.psrule.yml
@@ -40,7 +40,7 @@ jobs:
   job_init_psrule_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/platform.check.psrule.yml
+++ b/.github/workflows/platform.check.psrule.yml
@@ -40,6 +40,7 @@ jobs:
   job_init_psrule_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: github.repository == 'Azure/bicep-registry-modules'
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/platform.check.psrule.yml
+++ b/.github/workflows/platform.check.psrule.yml
@@ -40,7 +40,7 @@ jobs:
   job_init_psrule_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: github.repository == 'Azure/bicep-registry-modules'
+    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/platform.check.psrule.yml
+++ b/.github/workflows/platform.check.psrule.yml
@@ -40,7 +40,7 @@ jobs:
   job_init_psrule_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/platform.ci-tests.yml
+++ b/.github/workflows/platform.ci-tests.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: "The regex of the test file(s) to run"
         required: false
-        default: '.*'
+        default: ".*"
   push:
     branches:
       - main
@@ -21,7 +21,6 @@ on:
 env:
   workflowPath: ".github/workflows/platform.ci-tests.yml"
 
-
 jobs:
   ###########################
   #   Initialize pipeline   #
@@ -29,6 +28,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: github.repository == 'Azure/bicep-registry-modules'
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.ci-tests.yml
+++ b/.github/workflows/platform.ci-tests.yml
@@ -28,7 +28,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: github.repository == 'Azure/bicep-registry-modules'
+    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.ci-tests.yml
+++ b/.github/workflows/platform.ci-tests.yml
@@ -28,7 +28,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.ci-tests.yml
+++ b/.github/workflows/platform.ci-tests.yml
@@ -28,7 +28,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.ci-tests.yml
+++ b/.github/workflows/platform.ci-tests.yml
@@ -28,7 +28,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.manage-workflow-issue.yml
+++ b/.github/workflows/platform.manage-workflow-issue.yml
@@ -19,7 +19,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: github.repository == 'Azure/bicep-registry-modules'
+    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.manage-workflow-issue.yml
+++ b/.github/workflows/platform.manage-workflow-issue.yml
@@ -19,6 +19,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: github.repository == 'Azure/bicep-registry-modules'
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.manage-workflow-issue.yml
+++ b/.github/workflows/platform.manage-workflow-issue.yml
@@ -19,7 +19,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.manage-workflow-issue.yml
+++ b/.github/workflows/platform.manage-workflow-issue.yml
@@ -19,7 +19,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.manage-workflow-issue.yml
+++ b/.github/workflows/platform.manage-workflow-issue.yml
@@ -19,7 +19,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.ossf-scorecard.yml
+++ b/.github/workflows/platform.ossf-scorecard.yml
@@ -21,7 +21,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
-    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/platform.ossf-scorecard.yml
+++ b/.github/workflows/platform.ossf-scorecard.yml
@@ -10,9 +10,9 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '17 17 * * 1'
+    - cron: "17 17 * * 1"
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -21,6 +21,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    if: github.repository == 'Azure/bicep-registry-modules'
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/platform.ossf-scorecard.yml
+++ b/.github/workflows/platform.ossf-scorecard.yml
@@ -21,7 +21,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
-    if: github.repository == 'Azure/bicep-registry-modules'
+    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/platform.ossf-scorecard.yml
+++ b/.github/workflows/platform.ossf-scorecard.yml
@@ -21,7 +21,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
+    if: ${{ github.repository == 'Azure/bicep-registry-modules' }}
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/platform.publish-module-index-json.yml
+++ b/.github/workflows/platform.publish-module-index-json.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   upload-index-data:
     runs-on: ubuntu-latest
-    if: github.repository == 'Azure/bicep-registry-modules'
+    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/platform.publish-module-index-json.yml
+++ b/.github/workflows/platform.publish-module-index-json.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   upload-index-data:
     runs-on: ubuntu-latest
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/platform.publish-module-index-json.yml
+++ b/.github/workflows/platform.publish-module-index-json.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   upload-index-data:
     runs-on: ubuntu-latest
+    if: github.repository == 'Azure/bicep-registry-modules'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/platform.publish-module-index-json.yml
+++ b/.github/workflows/platform.publish-module-index-json.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   upload-index-data:
     runs-on: ubuntu-latest
-    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/platform.publish-module-index-json.yml
+++ b/.github/workflows/platform.publish-module-index-json.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   upload-index-data:
     runs-on: ubuntu-latest
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/platform.set-avm-github-issue-owner-config.yml
+++ b/.github/workflows/platform.set-avm-github-issue-owner-config.yml
@@ -26,7 +26,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.set-avm-github-issue-owner-config.yml
+++ b/.github/workflows/platform.set-avm-github-issue-owner-config.yml
@@ -26,7 +26,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.set-avm-github-issue-owner-config.yml
+++ b/.github/workflows/platform.set-avm-github-issue-owner-config.yml
@@ -26,7 +26,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: github.repository == 'Azure/bicep-registry-modules'
+    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.set-avm-github-issue-owner-config.yml
+++ b/.github/workflows/platform.set-avm-github-issue-owner-config.yml
@@ -12,7 +12,7 @@ on:
         type: string
         description: "Specific issue to process"
         required: false
-        default: ''
+        default: ""
       whatIf:
         type: boolean
         description: "Simulate execution"
@@ -26,6 +26,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: github.repository == 'Azure/bicep-registry-modules'
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.set-avm-github-issue-owner-config.yml
+++ b/.github/workflows/platform.set-avm-github-issue-owner-config.yml
@@ -26,7 +26,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.set-avm-github-pr-labels.yml
+++ b/.github/workflows/platform.set-avm-github-pr-labels.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   SetAvmGitHubPrLabels:
-    if: github.repository == 'Azure/bicep-registry-modules'
     name: Set-AvmGitHubPrLabels
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/platform.sync-avm-modules-list.yml
+++ b/.github/workflows/platform.sync-avm-modules-list.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   sync-avm-modules-list:
     runs-on: ubuntu-latest
-    if: github.repository == 'Azure/bicep-registry-modules'
+    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
     permissions:
       issues: write
     steps:

--- a/.github/workflows/platform.sync-avm-modules-list.yml
+++ b/.github/workflows/platform.sync-avm-modules-list.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   sync-avm-modules-list:
     runs-on: ubuntu-latest
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     permissions:
       issues: write
     steps:

--- a/.github/workflows/platform.sync-avm-modules-list.yml
+++ b/.github/workflows/platform.sync-avm-modules-list.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   sync-avm-modules-list:
     runs-on: ubuntu-latest
+    if: github.repository == 'Azure/bicep-registry-modules'
     permissions:
       issues: write
     steps:

--- a/.github/workflows/platform.sync-avm-modules-list.yml
+++ b/.github/workflows/platform.sync-avm-modules-list.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   sync-avm-modules-list:
     runs-on: ubuntu-latest
-    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
     permissions:
       issues: write
     steps:

--- a/.github/workflows/platform.sync-avm-modules-list.yml
+++ b/.github/workflows/platform.sync-avm-modules-list.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   sync-avm-modules-list:
     runs-on: ubuntu-latest
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     permissions:
       issues: write
     steps:

--- a/.github/workflows/platform.sync-repo-labels-from-csv.yml
+++ b/.github/workflows/platform.sync-repo-labels-from-csv.yml
@@ -22,6 +22,7 @@ defaults:
 jobs:
   sync-labels:
     runs-on: ubuntu-latest
+    if: github.repository == 'Azure/bicep-registry-modules'
     steps:
       - name: Sync AVM Labels To Repos GitHub Labels
         run: |

--- a/.github/workflows/platform.sync-repo-labels-from-csv.yml
+++ b/.github/workflows/platform.sync-repo-labels-from-csv.yml
@@ -22,7 +22,7 @@ defaults:
 jobs:
   sync-labels:
     runs-on: ubuntu-latest
-    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
     steps:
       - name: Sync AVM Labels To Repos GitHub Labels
         run: |

--- a/.github/workflows/platform.sync-repo-labels-from-csv.yml
+++ b/.github/workflows/platform.sync-repo-labels-from-csv.yml
@@ -22,7 +22,7 @@ defaults:
 jobs:
   sync-labels:
     runs-on: ubuntu-latest
-    if: github.repository == 'Azure/bicep-registry-modules'
+    if: !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule')
     steps:
       - name: Sync AVM Labels To Repos GitHub Labels
         run: |

--- a/.github/workflows/platform.sync-repo-labels-from-csv.yml
+++ b/.github/workflows/platform.sync-repo-labels-from-csv.yml
@@ -22,7 +22,7 @@ defaults:
 jobs:
   sync-labels:
     runs-on: ubuntu-latest
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: Sync AVM Labels To Repos GitHub Labels
         run: |

--- a/.github/workflows/platform.sync-repo-labels-from-csv.yml
+++ b/.github/workflows/platform.sync-repo-labels-from-csv.yml
@@ -4,7 +4,7 @@ name: .Platform - Sync repo labels from CSV
 on:
   schedule:
     - cron: 45 11 * * * # Run daily at 3:45 AM PST
-  workflow_dispatch: {}
+  workflow_dispatch:
 
 # Allow one concurrent deployment
 concurrency:
@@ -22,7 +22,7 @@ defaults:
 jobs:
   sync-labels:
     runs-on: ubuntu-latest
-    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name == 'schedule') }}
+    if: ${{ !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: Sync AVM Labels To Repos GitHub Labels
         run: |


### PR DESCRIPTION
## Description

- Added condition that avoids auto-triggered workflows in forks for pushes into the main branch
- Aligned disabled platform workflows for forks (some had it some didn't). Excluded PR title workflows as one may one to use those in forks

### Tests

In fork
- [x] (in main) push to main should not run the workflow ([ref](https://github.com/AlexanderSehr/bicep-registry-modules/actions/runs/20896155784))
- [x] (in main) workflow dispatch should run the workflow ([ref](https://github.com/AlexanderSehr/bicep-registry-modules/actions/runs/20896060812))
- [x] (in branch after merged to main) push to branch should not run the workflow
- [x] (in branch after merged to main) workflow dispatch should run the workflow ([ref](https://github.com/AlexanderSehr/bicep-registry-modules/actions/runs/20896060812))

Upstream
- [ ] (in main) push to main should run the workflow
- [ ] (in main) workflow dispatch should run the workflow


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
See above

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
