### PR TITLE
feat: CI - Introduced workflow condition that prevents accidental workflow runs in a forks main branch

### DIFF
--- a/.github/workflows/avm.ptn.aca-lza.hosting-environment.yml
+++ b/.github/workflows/avm.ptn.aca-lza.hosting-environment.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.ai-ml.ai-foundry.yml
+++ b/.github/workflows/avm.ptn.ai-ml.ai-foundry.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.ai-platform.baseline.yml
+++ b/.github/workflows/avm.ptn.ai-platform.baseline.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.alz.ama.yml
+++ b/.github/workflows/avm.ptn.alz.ama.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.alz.empty.yml
+++ b/.github/workflows/avm.ptn.alz.empty.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.app-service-lza.hosting-environment.yml
+++ b/.github/workflows/avm.ptn.app-service-lza.hosting-environment.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.app.container-job-toolkit.yml
+++ b/.github/workflows/avm.ptn.app.container-job-toolkit.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.app.iaas-vm-cosmosdb-tier4.yml
+++ b/.github/workflows/avm.ptn.app.iaas-vm-cosmosdb-tier4.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.app.paas-ase-cosmosdb-tier4.yml
+++ b/.github/workflows/avm.ptn.app.paas-ase-cosmosdb-tier4.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.authorization.pim-role-assignment.yml
+++ b/.github/workflows/avm.ptn.authorization.pim-role-assignment.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.authorization.policy-assignment.yml
+++ b/.github/workflows/avm.ptn.authorization.policy-assignment.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.authorization.policy-exemption.yml
+++ b/.github/workflows/avm.ptn.authorization.policy-exemption.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.authorization.resource-role-assignment.yml
+++ b/.github/workflows/avm.ptn.authorization.resource-role-assignment.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.authorization.role-assignment.yml
+++ b/.github/workflows/avm.ptn.authorization.role-assignment.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.authorization.role-definition.yml
+++ b/.github/workflows/avm.ptn.authorization.role-definition.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.azd.acr-container-app.yml
+++ b/.github/workflows/avm.ptn.azd.acr-container-app.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.azd.aks-automatic-cluster.yml
+++ b/.github/workflows/avm.ptn.azd.aks-automatic-cluster.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.azd.aks.yml
+++ b/.github/workflows/avm.ptn.azd.aks.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.azd.container-app-upsert.yml
+++ b/.github/workflows/avm.ptn.azd.container-app-upsert.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.azd.container-apps-stack.yml
+++ b/.github/workflows/avm.ptn.azd.container-apps-stack.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.azd.insights-dashboard.yml
+++ b/.github/workflows/avm.ptn.azd.insights-dashboard.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.azd.monitoring.yml
+++ b/.github/workflows/avm.ptn.azd.monitoring.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.data.private-analytical-workspace.yml
+++ b/.github/workflows/avm.ptn.data.private-analytical-workspace.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.deployment-script.import-image-to-acr.yml
+++ b/.github/workflows/avm.ptn.deployment-script.import-image-to-acr.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.dev-ops.cicd-agents-and-runners.yml
+++ b/.github/workflows/avm.ptn.dev-ops.cicd-agents-and-runners.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.finops-toolkit.finops-hub.yml
+++ b/.github/workflows/avm.ptn.finops-toolkit.finops-hub.yml
@@ -45,6 +45,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.lz.sub-vending.yml
+++ b/.github/workflows/avm.ptn.lz.sub-vending.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.mgmt-groups.subscription-placement.yml
+++ b/.github/workflows/avm.ptn.mgmt-groups.subscription-placement.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.network.hub-networking.yml
+++ b/.github/workflows/avm.ptn.network.hub-networking.yml
@@ -45,6 +45,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.network.private-link-private-dns-zones.yml
+++ b/.github/workflows/avm.ptn.network.private-link-private-dns-zones.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.policy-insights.remediation.yml
+++ b/.github/workflows/avm.ptn.policy-insights.remediation.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/avm.ptn.sa.chat-with-your-data.yml
+++ b/.github/workflows/avm.ptn.sa.chat-with-your-data.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.sa.content-processing.yml
+++ b/.github/workflows/avm.ptn.sa.content-processing.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.sa.conversation-knowledge-mining.yml
+++ b/.github/workflows/avm.ptn.sa.conversation-knowledge-mining.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.sa.document-knowledge-mining.yml
+++ b/.github/workflows/avm.ptn.sa.document-knowledge-mining.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.sa.modernize-your-code.yml
+++ b/.github/workflows/avm.ptn.sa.modernize-your-code.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.sa.multi-agent-custom-automation-engine.yml
+++ b/.github/workflows/avm.ptn.sa.multi-agent-custom-automation-engine.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.security.security-center.yml
+++ b/.github/workflows/avm.ptn.security.security-center.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.subscription.service-health-alerts.yml
+++ b/.github/workflows/avm.ptn.subscription.service-health-alerts.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml
+++ b/.github/workflows/avm.ptn.virtual-machine-images.azure-image-builder.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.aad.domain-service.yml
+++ b/.github/workflows/avm.res.aad.domain-service.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.alerts-management.action-rule.yml
+++ b/.github/workflows/avm.res.alerts-management.action-rule.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.api-management.service.yml
+++ b/.github/workflows/avm.res.api-management.service.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.app-configuration.configuration-store.yml
+++ b/.github/workflows/avm.res.app-configuration.configuration-store.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.app.container-app.yml
+++ b/.github/workflows/avm.res.app.container-app.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.app.job.yml
+++ b/.github/workflows/avm.res.app.job.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.app.managed-environment.yml
+++ b/.github/workflows/avm.res.app.managed-environment.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.app.session-pool.yml
+++ b/.github/workflows/avm.res.app.session-pool.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.authorization.policy-assignment.yml
+++ b/.github/workflows/avm.res.authorization.policy-assignment.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.authorization.role-assignment.yml
+++ b/.github/workflows/avm.res.authorization.role-assignment.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.automation.automation-account.yml
+++ b/.github/workflows/avm.res.automation.automation-account.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.azure-stack-hci.cluster.yml
+++ b/.github/workflows/avm.res.azure-stack-hci.cluster.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.azure-stack-hci.logical-network.yml
+++ b/.github/workflows/avm.res.azure-stack-hci.logical-network.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.azure-stack-hci.marketplace-gallery-image.yml
+++ b/.github/workflows/avm.res.azure-stack-hci.marketplace-gallery-image.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.azure-stack-hci.network-interface.yml
+++ b/.github/workflows/avm.res.azure-stack-hci.network-interface.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.azure-stack-hci.virtual-hard-disk.yml
+++ b/.github/workflows/avm.res.azure-stack-hci.virtual-hard-disk.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.azure-stack-hci.virtual-machine-instance.yml
+++ b/.github/workflows/avm.res.azure-stack-hci.virtual-machine-instance.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.batch.batch-account.yml
+++ b/.github/workflows/avm.res.batch.batch-account.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.cache.redis-enterprise.yml
+++ b/.github/workflows/avm.res.cache.redis-enterprise.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.cache.redis.yml
+++ b/.github/workflows/avm.res.cache.redis.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.cdn.profile.yml
+++ b/.github/workflows/avm.res.cdn.profile.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.cognitive-services.account.yml
+++ b/.github/workflows/avm.res.cognitive-services.account.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.communication.communication-service.yml
+++ b/.github/workflows/avm.res.communication.communication-service.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.communication.email-service.yml
+++ b/.github/workflows/avm.res.communication.email-service.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.compute.availability-set.yml
+++ b/.github/workflows/avm.res.compute.availability-set.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.compute.disk-encryption-set.yml
+++ b/.github/workflows/avm.res.compute.disk-encryption-set.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.compute.disk.yml
+++ b/.github/workflows/avm.res.compute.disk.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.compute.gallery.yml
+++ b/.github/workflows/avm.res.compute.gallery.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.compute.image.yml
+++ b/.github/workflows/avm.res.compute.image.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.compute.proximity-placement-group.yml
+++ b/.github/workflows/avm.res.compute.proximity-placement-group.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.compute.ssh-public-key.yml
+++ b/.github/workflows/avm.res.compute.ssh-public-key.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.compute.virtual-machine-scale-set.yml
+++ b/.github/workflows/avm.res.compute.virtual-machine-scale-set.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.compute.virtual-machine.yml
+++ b/.github/workflows/avm.res.compute.virtual-machine.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.consumption.budget.yml
+++ b/.github/workflows/avm.res.consumption.budget.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.container-instance.container-group.yml
+++ b/.github/workflows/avm.res.container-instance.container-group.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.container-registry.registry.yml
+++ b/.github/workflows/avm.res.container-registry.registry.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.container-service.managed-cluster.yml
+++ b/.github/workflows/avm.res.container-service.managed-cluster.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.data-factory.factory.yml
+++ b/.github/workflows/avm.res.data-factory.factory.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.data-protection.backup-vault.yml
+++ b/.github/workflows/avm.res.data-protection.backup-vault.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.databricks.access-connector.yml
+++ b/.github/workflows/avm.res.databricks.access-connector.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.databricks.workspace.yml
+++ b/.github/workflows/avm.res.databricks.workspace.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.db-for-my-sql.flexible-server.yml
+++ b/.github/workflows/avm.res.db-for-my-sql.flexible-server.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.db-for-postgre-sql.flexible-server.yml
+++ b/.github/workflows/avm.res.db-for-postgre-sql.flexible-server.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.desktop-virtualization.application-group.yml
+++ b/.github/workflows/avm.res.desktop-virtualization.application-group.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.desktop-virtualization.host-pool.yml
+++ b/.github/workflows/avm.res.desktop-virtualization.host-pool.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.desktop-virtualization.scaling-plan.yml
+++ b/.github/workflows/avm.res.desktop-virtualization.scaling-plan.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.desktop-virtualization.workspace.yml
+++ b/.github/workflows/avm.res.desktop-virtualization.workspace.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.dev-center.devcenter.yml
+++ b/.github/workflows/avm.res.dev-center.devcenter.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.dev-center.network-connection.yml
+++ b/.github/workflows/avm.res.dev-center.network-connection.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.dev-center.project.yml
+++ b/.github/workflows/avm.res.dev-center.project.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.dev-ops-infrastructure.pool.yml
+++ b/.github/workflows/avm.res.dev-ops-infrastructure.pool.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.dev-test-lab.lab.yml
+++ b/.github/workflows/avm.res.dev-test-lab.lab.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.digital-twins.digital-twins-instance.yml
+++ b/.github/workflows/avm.res.digital-twins.digital-twins-instance.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.document-db.database-account.yml
+++ b/.github/workflows/avm.res.document-db.database-account.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.document-db.mongo-cluster.yml
+++ b/.github/workflows/avm.res.document-db.mongo-cluster.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.elastic-san.elastic-san.yml
+++ b/.github/workflows/avm.res.elastic-san.elastic-san.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.event-grid.domain.yml
+++ b/.github/workflows/avm.res.event-grid.domain.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.event-grid.namespace.yml
+++ b/.github/workflows/avm.res.event-grid.namespace.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.event-grid.system-topic.yml
+++ b/.github/workflows/avm.res.event-grid.system-topic.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.event-grid.topic.yml
+++ b/.github/workflows/avm.res.event-grid.topic.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.event-hub.namespace.yml
+++ b/.github/workflows/avm.res.event-hub.namespace.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.fabric.capacity.yml
+++ b/.github/workflows/avm.res.fabric.capacity.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.health-bot.health-bot.yml
+++ b/.github/workflows/avm.res.health-bot.health-bot.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.healthcare-apis.workspace.yml
+++ b/.github/workflows/avm.res.healthcare-apis.workspace.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.hybrid-compute.gateway.yml
+++ b/.github/workflows/avm.res.hybrid-compute.gateway.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.hybrid-compute.license.yml
+++ b/.github/workflows/avm.res.hybrid-compute.license.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.hybrid-compute.machine.yml
+++ b/.github/workflows/avm.res.hybrid-compute.machine.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.hybrid-container-service.provisioned-cluster-instance.yml
+++ b/.github/workflows/avm.res.hybrid-container-service.provisioned-cluster-instance.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.insights.action-group.yml
+++ b/.github/workflows/avm.res.insights.action-group.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.insights.activity-log-alert.yml
+++ b/.github/workflows/avm.res.insights.activity-log-alert.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.insights.component.yml
+++ b/.github/workflows/avm.res.insights.component.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.insights.data-collection-endpoint.yml
+++ b/.github/workflows/avm.res.insights.data-collection-endpoint.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.insights.data-collection-rule.yml
+++ b/.github/workflows/avm.res.insights.data-collection-rule.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.insights.diagnostic-setting.yml
+++ b/.github/workflows/avm.res.insights.diagnostic-setting.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.insights.metric-alert.yml
+++ b/.github/workflows/avm.res.insights.metric-alert.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.insights.private-link-scope.yml
+++ b/.github/workflows/avm.res.insights.private-link-scope.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.insights.scheduled-query-rule.yml
+++ b/.github/workflows/avm.res.insights.scheduled-query-rule.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.insights.webtest.yml
+++ b/.github/workflows/avm.res.insights.webtest.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.key-vault.vault.yml
+++ b/.github/workflows/avm.res.key-vault.vault.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.kubernetes-configuration.extension.yml
+++ b/.github/workflows/avm.res.kubernetes-configuration.extension.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.kubernetes-configuration.flux-configuration.yml
+++ b/.github/workflows/avm.res.kubernetes-configuration.flux-configuration.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.kubernetes-runtime.load-balancer.yml
+++ b/.github/workflows/avm.res.kubernetes-runtime.load-balancer.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.kubernetes.connected-cluster.yml
+++ b/.github/workflows/avm.res.kubernetes.connected-cluster.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.kusto.cluster.yml
+++ b/.github/workflows/avm.res.kusto.cluster.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.load-test-service.load-test.yml
+++ b/.github/workflows/avm.res.load-test-service.load-test.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.logic.integration-account.yml
+++ b/.github/workflows/avm.res.logic.integration-account.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/avm.res.logic.workflow.yml
+++ b/.github/workflows/avm.res.logic.workflow.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.machine-learning-services.registry.yml
+++ b/.github/workflows/avm.res.machine-learning-services.registry.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5
@@ -79,8 +80,8 @@ jobs:
   call-workflow-passing-data:
     name: "Run"
     permissions:
-      id-token: write       # For OIDC
-      contents: write       # For release tags
+      id-token: write # For OIDC
+      contents: write # For release tags
     needs:
       - job_initialize_pipeline
     uses: ./.github/workflows/avm.template.module.yml

--- a/.github/workflows/avm.res.machine-learning-services.workspace.yml
+++ b/.github/workflows/avm.res.machine-learning-services.workspace.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.maintenance.configuration-assignment.yml
+++ b/.github/workflows/avm.res.maintenance.configuration-assignment.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.maintenance.maintenance-configuration.yml
+++ b/.github/workflows/avm.res.maintenance.maintenance-configuration.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.managed-identity.user-assigned-identity.yml
+++ b/.github/workflows/avm.res.managed-identity.user-assigned-identity.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.managed-services.registration-definition.yml
+++ b/.github/workflows/avm.res.managed-services.registration-definition.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.management.management-group.yml
+++ b/.github/workflows/avm.res.management.management-group.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.management.service-group.yml
+++ b/.github/workflows/avm.res.management.service-group.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.maps.account.yml
+++ b/.github/workflows/avm.res.maps.account.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.net-app.net-app-account.yml
+++ b/.github/workflows/avm.res.net-app.net-app-account.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.application-gateway-web-application-firewall-policy.yml
+++ b/.github/workflows/avm.res.network.application-gateway-web-application-firewall-policy.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.application-gateway.yml
+++ b/.github/workflows/avm.res.network.application-gateway.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.application-security-group.yml
+++ b/.github/workflows/avm.res.network.application-security-group.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.azure-firewall.yml
+++ b/.github/workflows/avm.res.network.azure-firewall.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.bastion-host.yml
+++ b/.github/workflows/avm.res.network.bastion-host.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.connection.yml
+++ b/.github/workflows/avm.res.network.connection.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.ddos-protection-plan.yml
+++ b/.github/workflows/avm.res.network.ddos-protection-plan.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.dns-forwarding-ruleset.yml
+++ b/.github/workflows/avm.res.network.dns-forwarding-ruleset.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.dns-resolver.yml
+++ b/.github/workflows/avm.res.network.dns-resolver.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.dns-zone.yml
+++ b/.github/workflows/avm.res.network.dns-zone.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.express-route-circuit.yml
+++ b/.github/workflows/avm.res.network.express-route-circuit.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.express-route-gateway.yml
+++ b/.github/workflows/avm.res.network.express-route-gateway.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.express-route-port.yml
+++ b/.github/workflows/avm.res.network.express-route-port.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.firewall-policy.yml
+++ b/.github/workflows/avm.res.network.firewall-policy.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.front-door-web-application-firewall-policy.yml
+++ b/.github/workflows/avm.res.network.front-door-web-application-firewall-policy.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.ip-group.yml
+++ b/.github/workflows/avm.res.network.ip-group.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.load-balancer.yml
+++ b/.github/workflows/avm.res.network.load-balancer.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.local-network-gateway.yml
+++ b/.github/workflows/avm.res.network.local-network-gateway.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.nat-gateway.yml
+++ b/.github/workflows/avm.res.network.nat-gateway.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.network-interface.yml
+++ b/.github/workflows/avm.res.network.network-interface.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.network-manager.yml
+++ b/.github/workflows/avm.res.network.network-manager.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.network-security-group.yml
+++ b/.github/workflows/avm.res.network.network-security-group.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.network-security-perimeter.yml
+++ b/.github/workflows/avm.res.network.network-security-perimeter.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.network-watcher.yml
+++ b/.github/workflows/avm.res.network.network-watcher.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.p2s-vpn-gateway.yml
+++ b/.github/workflows/avm.res.network.p2s-vpn-gateway.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.private-dns-zone.yml
+++ b/.github/workflows/avm.res.network.private-dns-zone.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.private-endpoint.yml
+++ b/.github/workflows/avm.res.network.private-endpoint.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.private-link-service.yml
+++ b/.github/workflows/avm.res.network.private-link-service.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.public-ip-address.yml
+++ b/.github/workflows/avm.res.network.public-ip-address.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.public-ip-prefix.yml
+++ b/.github/workflows/avm.res.network.public-ip-prefix.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.route-table.yml
+++ b/.github/workflows/avm.res.network.route-table.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.service-endpoint-policy.yml
+++ b/.github/workflows/avm.res.network.service-endpoint-policy.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.trafficmanagerprofile.yml
+++ b/.github/workflows/avm.res.network.trafficmanagerprofile.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.virtual-hub.yml
+++ b/.github/workflows/avm.res.network.virtual-hub.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.virtual-network-gateway.yml
+++ b/.github/workflows/avm.res.network.virtual-network-gateway.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.virtual-network.yml
+++ b/.github/workflows/avm.res.network.virtual-network.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.virtual-wan.yml
+++ b/.github/workflows/avm.res.network.virtual-wan.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.vpn-gateway.yml
+++ b/.github/workflows/avm.res.network.vpn-gateway.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.vpn-server-configuration.yml
+++ b/.github/workflows/avm.res.network.vpn-server-configuration.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.network.vpn-site.yml
+++ b/.github/workflows/avm.res.network.vpn-site.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.operational-insights.cluster.yml
+++ b/.github/workflows/avm.res.operational-insights.cluster.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.operational-insights.workspace.yml
+++ b/.github/workflows/avm.res.operational-insights.workspace.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.operations-management.solution.yml
+++ b/.github/workflows/avm.res.operations-management.solution.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.portal.dashboard.yml
+++ b/.github/workflows/avm.res.portal.dashboard.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.power-bi-dedicated.capacity.yml
+++ b/.github/workflows/avm.res.power-bi-dedicated.capacity.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.purview.account.yml
+++ b/.github/workflows/avm.res.purview.account.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.recovery-services.vault.yml
+++ b/.github/workflows/avm.res.recovery-services.vault.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.relay.namespace.yml
+++ b/.github/workflows/avm.res.relay.namespace.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.resource-graph.query.yml
+++ b/.github/workflows/avm.res.resource-graph.query.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.resources.deployment-script.yml
+++ b/.github/workflows/avm.res.resources.deployment-script.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.resources.resource-group.yml
+++ b/.github/workflows/avm.res.resources.resource-group.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.search.search-service.yml
+++ b/.github/workflows/avm.res.search.search-service.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.security-insights.data-connector.yml
+++ b/.github/workflows/avm.res.security-insights.data-connector.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.security-insights.setting.yml
+++ b/.github/workflows/avm.res.security-insights.setting.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.service-bus.namespace.yml
+++ b/.github/workflows/avm.res.service-bus.namespace.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.service-fabric.cluster.yml
+++ b/.github/workflows/avm.res.service-fabric.cluster.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.service-networking.traffic-controller.yml
+++ b/.github/workflows/avm.res.service-networking.traffic-controller.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.signal-r-service.signal-r.yml
+++ b/.github/workflows/avm.res.signal-r-service.signal-r.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.signal-r-service.web-pub-sub.yml
+++ b/.github/workflows/avm.res.signal-r-service.web-pub-sub.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.sql.instance-pool.yml
+++ b/.github/workflows/avm.res.sql.instance-pool.yml
@@ -50,6 +50,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.sql.managed-instance.yml
+++ b/.github/workflows/avm.res.sql.managed-instance.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.sql.server.yml
+++ b/.github/workflows/avm.res.sql.server.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.storage.storage-account.yml
+++ b/.github/workflows/avm.res.storage.storage-account.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.synapse.private-link-hub.yml
+++ b/.github/workflows/avm.res.synapse.private-link-hub.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.synapse.workspace.yml
+++ b/.github/workflows/avm.res.synapse.workspace.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.virtual-machine-images.image-template.yml
+++ b/.github/workflows/avm.res.virtual-machine-images.image-template.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.web.connection.yml
+++ b/.github/workflows/avm.res.web.connection.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.web.hosting-environment.yml
+++ b/.github/workflows/avm.res.web.hosting-environment.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.web.serverfarm.yml
+++ b/.github/workflows/avm.res.web.serverfarm.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.web.site.yml
+++ b/.github/workflows/avm.res.web.site.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.res.web.static-site.yml
+++ b/.github/workflows/avm.res.web.static-site.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/avm.utl.types.avm-common-types.yml
+++ b/.github/workflows/avm.utl.types.avm-common-types.yml
@@ -49,6 +49,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.deployment.history.cleanup.yml
+++ b/.github/workflows/platform.deployment.history.cleanup.yml
@@ -31,6 +31,7 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
+    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5

--- a/.github/workflows/platform.deployment.history.cleanup.yml
+++ b/.github/workflows/platform.deployment.history.cleanup.yml
@@ -31,7 +31,6 @@ jobs:
   job_initialize_pipeline:
     runs-on: ubuntu-latest
     name: "Initialize pipeline"
-    if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v5


### PR DESCRIPTION
## Description

The workflow is configured in a way that it will trigger on any changes in Upstream's (i.e., `Azure/bicep-registry-modules`) `main` branch if they may have an impact on the module or its validation. However, while in a fork, the workflow will stop right after initiation thanks to the condition:
```yml
# Only run if not canceled and not in a fork, unless triggered by a workflow_dispatch event
if: ${{ !cancelled() && !(github.repository != 'Azure/bicep-registry-modules' && github.event_name != 'workflow_dispatch') }}
```
This condition ensures that you don't accidently trigger a large amount of module workflows when e.g., merging changes from upstream into your fork. Due to the nature of triggers it's unfortunately not possible to not trigger them outright.


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.compute.gallery](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml/badge.svg?branch=users%2Falsehr%2FpipelineCond&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.gallery.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
