### PR TITLE
fix: AKS - Key Vault naming in max test + trigger of publishing

### DIFF
--- a/avm/res/container-service/managed-cluster/README.md
+++ b/avm/res/container-service/managed-cluster/README.md
@@ -3249,7 +3249,7 @@ param tags = {
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`upgradeSettings`](#parameter-upgradesettings) | object | Settings for upgrading the cluster with override options. |
 | [`webApplicationRoutingEnabled`](#parameter-webapplicationroutingenabled) | bool | Specifies whether the webApplicationRoutingEnabled add-on is enabled or not. |
-| [`windowsProfile`](#parameter-windowsprofile) | object | The Windows profile for Windows VMs in the Managed Cluster. |
+| [`windowsProfile`](#parameter-windowsprofile) | object | The profile for Windows VMs in the Managed Cluster. |
 | [`workloadAutoScalerProfile`](#parameter-workloadautoscalerprofile) | object | Workload Auto-scaler profile for the managed cluster. |
 
 ### Parameter: `name`
@@ -5207,7 +5207,7 @@ Specifies whether the webApplicationRoutingEnabled add-on is enabled or not.
 
 ### Parameter: `windowsProfile`
 
-The Windows profile for Windows VMs in the Managed Cluster.
+The profile for Windows VMs in the Managed Cluster.
 
 - Required: No
 - Type: object

--- a/avm/res/container-service/managed-cluster/main.bicep
+++ b/avm/res/container-service/managed-cluster/main.bicep
@@ -274,7 +274,7 @@ param fqdnSubdomain string?
 @description('Optional. Settings for upgrading the cluster with override options.')
 param upgradeSettings resourceInput<'Microsoft.ContainerService/managedClusters@2025-09-01'>.properties.upgradeSettings?
 
-@description('Optional. The Windows profile for Windows VMs in the Managed Cluster.')
+@description('Optional. The profile for Windows VMs in the Managed Cluster.')
 param windowsProfile resourceInput<'Microsoft.ContainerService/managedClusters@2025-09-01'>.properties.windowsProfile?
 
 // =========== //

--- a/avm/res/container-service/managed-cluster/main.json
+++ b/avm/res/container-service/managed-cluster/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.40.2.10011",
-      "templateHash": "17624608039137841174"
+      "templateHash": "15481335468407716579"
     },
     "name": "Azure Kubernetes Service (AKS) Managed Clusters",
     "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster."
@@ -1605,7 +1605,7 @@
         "__bicep_resource_derived_type!": {
           "source": "Microsoft.ContainerService/managedClusters@2025-09-01#properties/properties/properties/windowsProfile"
         },
-        "description": "Optional. The Windows profile for Windows VMs in the Managed Cluster."
+        "description": "Optional. The profile for Windows VMs in the Managed Cluster."
       },
       "nullable": true
     }

--- a/avm/res/container-service/managed-cluster/tests/e2e/max/main.test.bicep
+++ b/avm/res/container-service/managed-cluster/tests/e2e/max/main.test.bicep
@@ -14,6 +14,9 @@ param resourceGroupName string = 'dep-${namePrefix}-containerservice.managedclus
 @description('Optional. The location to deploy resources to.')
 param resourceLocation string = deployment().location
 
+@description('Generated. Used as a basis for unique resource names.')
+param baseTime string = utcNow('u')
+
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'csmax'
 
@@ -35,7 +38,8 @@ module nestedDependencies 'dependencies.bicep' = {
     publicIPName: 'dep-${namePrefix}-pip-${serviceShort}'
     publicIPAKSName: 'dep-${namePrefix}-pip-aks-${serviceShort}'
     diskEncryptionSetName: 'dep-${namePrefix}-des-${serviceShort}'
-    keyVaultName: 'dep-${namePrefix}-kv-${serviceShort}'
+    // Adding base time to make the name unique as purge protection is enabled (but may not be longer than 24 characters total)
+    keyVaultName: 'dep-${namePrefix}-kv-${serviceShort}-${substring(uniqueString(baseTime), 0, 3)}'
     sshDeploymentScriptName: 'dep-${namePrefix}-ds-${serviceShort}'
     sshKeyName: 'dep-${namePrefix}-ssh-${serviceShort}'
   }


### PR DESCRIPTION
## Description

- Fixed Key Vault naming in max test to ensure uniqueness by adding a time-based unique suffix
  - Prevents conflicts when running tests multiple times with purge protection enabled
- Minor fixes to the AKS Managed Cluster module to trigger the Publishing.
  - Updated `windowsProfile` parameter description


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.container-service.managed-cluster](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-service.managed-cluster.yml/badge.svg?branch=users%2Fkrbar%2FaksKeyVaultFix)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.container-service.managed-cluster.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
