### PR TITLE
feat: CI - Enable the injection of custom tags on test resources

### DIFF
--- a/.github/workflows/avm.res.key-vault.vault.yml
+++ b/.github/workflows/avm.res.key-vault.vault.yml
@@ -84,8 +84,7 @@ jobs:
     uses: ./.github/workflows/avm.template.module.yml
     with:
       workflowInput: "${{ needs.job_initialize_pipeline.outputs.workflowInput }}"
-      # moduleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.moduleTestFilePaths }}"
-      moduleTestFilePaths: '[{"path":"tests/e2e/waf-aligned/main.test.bicep","name":"waf-aligned","e2eIgnore":false}]'
+      moduleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.moduleTestFilePaths }}"
       psRuleModuleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.psRuleModuleTestFilePaths }}"
       modulePath: "${{ needs.job_initialize_pipeline.outputs.modulePath}}"
     secrets: inherit

--- a/.github/workflows/avm.res.key-vault.vault.yml
+++ b/.github/workflows/avm.res.key-vault.vault.yml
@@ -84,7 +84,8 @@ jobs:
     uses: ./.github/workflows/avm.template.module.yml
     with:
       workflowInput: "${{ needs.job_initialize_pipeline.outputs.workflowInput }}"
-      moduleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.moduleTestFilePaths }}"
+      # moduleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.moduleTestFilePaths }}"
+      moduleTestFilePaths: '[{"path":"tests/e2e/waf-aligned/main.test.bicep","name":"waf-aligned","e2eIgnore":false}]'
       psRuleModuleTestFilePaths: "${{ needs.job_initialize_pipeline.outputs.psRuleModuleTestFilePaths }}"
       modulePath: "${{ needs.job_initialize_pipeline.outputs.modulePath}}"
     secrets: inherit

--- a/avm/res/key-vault/vault/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/key-vault/vault/tests/e2e/waf-aligned/main.test.bicep
@@ -21,6 +21,7 @@ param serviceShort string = 'kvvwaf'
 param namePrefix string = '#_namePrefix_#'
 
 @description('Optional. A JSON string of key-value pairs for tags to be applied to resources in the environment. E.g., \'{ "customTag1": "value1", "customTag2": "value2" }\'.')
+@secure()
 param envTags string?
 
 // ============ //

--- a/avm/res/key-vault/vault/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/key-vault/vault/tests/e2e/waf-aligned/main.test.bicep
@@ -20,6 +20,9 @@ param serviceShort string = 'kvvwaf'
 @description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
 param namePrefix string = '#_namePrefix_#'
 
+@description('Optional. A JSON string of key-value pairs for tags to be applied to resources in the environment. E.g., \'{ "customTag1": "value1", "customTag2": "value2" }\'.')
+param envTags string?
+
 // ============ //
 // Dependencies //
 // ============ //
@@ -52,6 +55,7 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
     eventHubNamespaceEventHubName: 'dep-${namePrefix}-evh-${serviceShort}01'
     eventHubNamespaceName: 'dep-${namePrefix}-evhns-${serviceShort}01'
     location: resourceLocation
+    tags: json(envTags ?? '{}')
   }
 }
 
@@ -141,11 +145,14 @@ module testDeployment '../../../main.bicep' = [
         }
       ]
       softDeleteRetentionInDays: 7
-      tags: {
-        'hidden-title': 'This is visible in the resource name'
-        Environment: 'Non-Prod'
-        Role: 'DeploymentValidation'
-      }
+      tags: union(
+        {
+          'hidden-title': 'This is visible in the resource name'
+          Environment: 'Non-Prod'
+          Role: 'DeploymentValidation'
+        },
+        json(envTags ?? '{}')
+      )
     }
   }
 ]

--- a/utilities/e2e-template-assets/templates/diagnostic.dependencies.bicep
+++ b/utilities/e2e-template-assets/templates/diagnostic.dependencies.bicep
@@ -18,6 +18,9 @@ param eventHubNamespaceEventHubName string
 @description('Optional. The location to deploy resources to.')
 param location string = resourceGroup().location
 
+@description('Optional. A JSON string of key-value pairs for tags to be applied to resources in the environment. E.g., \'{ "customTag1": "value1", "customTag2": "value2" }\'.')
+param tags object?
+
 // ============ //
 // Dependencies //
 // ============ //
@@ -26,6 +29,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: storageAccountName
   location: location
   kind: 'StorageV2'
+  tags: tags
   sku: {
     name: 'Standard_LRS'
   }
@@ -37,11 +41,13 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2025-06-01' = {
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   name: logAnalyticsWorkspaceName
   location: location
+  tags: tags
 }
 
 resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = {
   name: eventHubNamespaceName
   location: location
+  tags: tags
 
   resource eventHub 'eventhubs@2024-01-01' = {
     name: eventHubNamespaceEventHubName

--- a/utilities/e2e-template-assets/templates/diagnostic.dependencies.bicep
+++ b/utilities/e2e-template-assets/templates/diagnostic.dependencies.bicep
@@ -19,7 +19,10 @@ param eventHubNamespaceEventHubName string
 param location string = resourceGroup().location
 
 @description('Optional. A JSON string of key-value pairs for tags to be applied to resources in the environment. E.g., \'{ "customTag1": "value1", "customTag2": "value2" }\'.')
-param tags object?
+param tags {
+  @description('Optional.The key-value pair to be applied as a tag to the resources.')
+  *: string
+}?
 
 // ============ //
 // Dependencies //

--- a/utilities/e2e-template-assets/templates/waitForDeployment.bicep
+++ b/utilities/e2e-template-assets/templates/waitForDeployment.bicep
@@ -46,9 +46,16 @@ param maxRetries int = 60
 @description('Optional. The interval between checks for resource deployment status, in seconds.')
 param waitIntervalInSeconds int = 30
 
+@description('Optional. A JSON string of key-value pairs for tags to be applied to resources in the environment. E.g., \'{ "customTag1": "value1", "customTag2": "value2" }\'.')
+param tags {
+  @description('Optional.The key-value pair to be applied as a tag to the resources.')
+  *: string
+}?
+
 resource msi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
+  tags: tags
 }
 
 // Required role assignment to allow the deployment script to read resource status
@@ -67,6 +74,7 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 resource waitForDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: deploymentScriptName
   location: location
+  tags: tags
   kind: 'AzurePowerShell'
   identity: {
     type: 'UserAssigned'


### PR DESCRIPTION
## Description

This PR shows how on could inject tags to their resources from the CI, that is, a key vault secret as per the already established environment-specific value injection logic.

Of this PR, the only change that will remain is the update of the shared dependency templates.

Closes #6505

Result in Azure Portal:

Diagnostic dependency LAW resource
<img width="1294" height="422" alt="image" src="https://github.com/user-attachments/assets/4cb8b9d2-41db-43df-8443-0a2cdff50b17" />

Main module resource
<img width="1411" height="533" alt="image" src="https://github.com/user-attachments/assets/92a6be95-a139-4790-8222-2661f3c9015e" />

Key Vault secret
<img width="1362" height="338" alt="image" src="https://github.com/user-attachments/assets/d91f475c-1b59-46bc-80bc-7d71b8759751" />
<img width="720" height="52" alt="image" src="https://github.com/user-attachments/assets/388651f2-0342-43c4-9f66-22794d009cc2" />


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.key-vault.vault](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml/badge.svg?branch=users%2Falsehr%2FdependencyTags&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
