### PR TITLE
fix: Add suffix limit

### DIFF
--- a/avm/ptn/alz/empty/CHANGELOG.md
+++ b/avm/ptn/alz/empty/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/alz/empty/CHANGELOG.md).
 
+## 0.3.6
+
+### Changes
+
+- Fixes issues in ALZ Bicep Accelerator templates where the `deployment().name` was being used in the `main.bicep` of the `avm/ptn/alz/empty` module, which caused deployment failures when the management group name was long and exceeded the 64 character limit for deployment names. The deployment names have been updated to use a base name with a reserved suffix for uniqueness instead of relying on `deployment().name`.
+
+### Breaking Changes
+
+- None
+
 ## 0.3.5
 
 ### Changes

--- a/avm/ptn/alz/empty/main.bicep
+++ b/avm/ptn/alz/empty/main.bicep
@@ -142,6 +142,8 @@ var formattedRoleAssignments = [
 // Reserve 4 chars for "-<idx>" (supports up to 999 iterations) for wait deployment names to avoid truncating the index (which must remain unique)
 var deploymentNameIndexSuffixReserve = 4
 var deploymentNameBaseMax = 64 - deploymentNameIndexSuffixReserve
+var deploymentNamePerItemSuffixReserve = 14
+var deploymentNamePerItemBaseMax = 64 - deploymentNamePerItemSuffixReserve
 
 var deploymentNames = {
   mg: take('${uniqueString(managementGroupName, location)}-alz-mg-${managementGroupName}', 64)
@@ -150,8 +152,14 @@ var deploymentNames = {
     '${uniqueString(managementGroupName, location)}-alz-sub-place-wait-${managementGroupName}',
     deploymentNameBaseMax
   )
-  mgRoleAssignments: take('${uniqueString(managementGroupName, location)}-alz-mg-rbac-asi-${managementGroupName}', 64)
-  mgRoleDefinitions: take('${uniqueString(managementGroupName, location)}-alz-mg-rbac-def-${managementGroupName}', 64)
+  mgRoleAssignments: take(
+    '${uniqueString(managementGroupName, location)}-alz-mg-rbac-asi-${managementGroupName}',
+    deploymentNamePerItemBaseMax
+  )
+  mgRoleDefinitions: take(
+    '${uniqueString(managementGroupName, location)}-alz-mg-rbac-def-${managementGroupName}',
+    deploymentNamePerItemBaseMax
+  )
   mgRoleDefinitionsWait: take(
     '${uniqueString(managementGroupName, location)}-alz-rbac-def-wait-${managementGroupName}',
     deploymentNameBaseMax
@@ -173,7 +181,10 @@ var deploymentNames = {
     '${uniqueString(managementGroupName, location)}-alz-mg-pol-init-${managementGroupName}',
     64
   )
-  mgPolicyAssignments: take('${uniqueString(managementGroupName, location)}-alz-mg-pol-asi-${managementGroupName}', 64)
+  mgPolicyAssignments: take(
+    '${uniqueString(managementGroupName, location)}-alz-mg-pol-asi-${managementGroupName}',
+    deploymentNamePerItemBaseMax
+  )
   mgPolicyAssignmentsWait: take(
     '${uniqueString(managementGroupName, location)}-alz-pol-asi-wait${managementGroupName}',
     deploymentNameBaseMax

--- a/avm/ptn/alz/empty/main.json
+++ b/avm/ptn/alz/empty/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.39.26.7824",
-      "templateHash": "13603940120013600120"
+      "version": "0.40.2.10011",
+      "templateHash": "3433490848730592807"
     },
     "name": "avm/ptn/alz/empty",
     "description": "Azure Landing Zones - Bicep - Empty\n\nPlease review the [Usage examples](https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/alz/empty#Usage-examples) section in the module's README, but please ensure for the `max` example you review the entire [directory](https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/alz/empty/tests/e2e/max) to see the supplementary files that are required for the example.\n\nAlso please ensure you review the [Notes section of the module's README](https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/alz/empty#Notes) for important information about the module as well as features that exist outside of parameter inputs."
@@ -682,19 +682,21 @@
     },
     "deploymentNameIndexSuffixReserve": 4,
     "deploymentNameBaseMax": "[sub(64, variables('deploymentNameIndexSuffixReserve'))]",
+    "deploymentNamePerItemSuffixReserve": 14,
+    "deploymentNamePerItemBaseMax": "[sub(64, variables('deploymentNamePerItemSuffixReserve'))]",
     "deploymentNames": {
       "mg": "[take(format('{0}-alz-mg-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), 64)]",
       "mgSubPlacement": "[take(format('{0}-alz-sub-place-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), 64)]",
       "mgSubPlacementWait": "[take(format('{0}-alz-sub-place-wait-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), variables('deploymentNameBaseMax'))]",
-      "mgRoleAssignments": "[take(format('{0}-alz-mg-rbac-asi-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), 64)]",
-      "mgRoleDefinitions": "[take(format('{0}-alz-mg-rbac-def-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), 64)]",
+      "mgRoleAssignments": "[take(format('{0}-alz-mg-rbac-asi-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), variables('deploymentNamePerItemBaseMax'))]",
+      "mgRoleDefinitions": "[take(format('{0}-alz-mg-rbac-def-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), variables('deploymentNamePerItemBaseMax'))]",
       "mgRoleDefinitionsWait": "[take(format('{0}-alz-rbac-def-wait-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), variables('deploymentNameBaseMax'))]",
       "mgRoleAssignmentsWait": "[take(format('{0}-alz-rbac-asi-wait-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), variables('deploymentNameBaseMax'))]",
       "mgCustomPolicyDefinitionsWait": "[take(format('{0}-alz-pol-def-wait-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), variables('deploymentNameBaseMax'))]",
       "mgCustomPolicySetDefinitionsWait": "[take(format('{0}-alz-pol-init-wait-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), variables('deploymentNameBaseMax'))]",
       "mgPolicyDefinitions": "[take(format('{0}-alz-mg-pol-def-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), 64)]",
       "mgPolicySetDefinitions": "[take(format('{0}-alz-mg-pol-init-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), 64)]",
-      "mgPolicyAssignments": "[take(format('{0}-alz-mg-pol-asi-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), 64)]",
+      "mgPolicyAssignments": "[take(format('{0}-alz-mg-pol-asi-{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), variables('deploymentNamePerItemBaseMax'))]",
       "mgPolicyAssignmentsWait": "[take(format('{0}-alz-pol-asi-wait{1}', uniqueString(parameters('managementGroupName'), parameters('location')), parameters('managementGroupName')), variables('deploymentNameBaseMax'))]"
     },
     "filteredManagementGroupPolicyAssignments": "[filter(coalesce(parameters('managementGroupPolicyAssignments'), createArray()), lambda('polAsi', not(contains(parameters('managementGroupExcludedPolicyAssignments'), lambdaVariables('polAsi').name))))]"
@@ -891,8 +893,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "12451131946120120504"
+              "version": "0.40.2.10011",
+              "templateHash": "7514169282799870055"
             },
             "name": "avm/ptn/alz/empty/wait",
             "description": "Azure Landing Zones - Bicep - Empty - Wait Module\n\nThis module is used to create sequential empty/blank ARM deployments to introduce an artificial wait between deployments in the pattern module. When the `wait()` and `retry()` functions become available in GA in Bicep, this approach will be deprecated and we will migrate to using those functions instead.\n"
@@ -928,8 +930,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "12451131946120120504"
+              "version": "0.40.2.10011",
+              "templateHash": "7514169282799870055"
             },
             "name": "avm/ptn/alz/empty/wait",
             "description": "Azure Landing Zones - Bicep - Empty - Wait Module\n\nThis module is used to create sequential empty/blank ARM deployments to introduce an artificial wait between deployments in the pattern module. When the `wait()` and `retry()` functions become available in GA in Bicep, this approach will be deprecated and we will migrate to using those functions instead.\n"
@@ -966,8 +968,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "4069473875242794338"
+              "version": "0.40.2.10011",
+              "templateHash": "8541419847960126878"
             },
             "name": "avm/ptn/alz/empty/policy-definitions",
             "description": "Azure Landing Zones - Bicep - Empty - Policy Definitions Module"
@@ -1061,8 +1063,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "12451131946120120504"
+              "version": "0.40.2.10011",
+              "templateHash": "7514169282799870055"
             },
             "name": "avm/ptn/alz/empty/wait",
             "description": "Azure Landing Zones - Bicep - Empty - Wait Module\n\nThis module is used to create sequential empty/blank ARM deployments to introduce an artificial wait between deployments in the pattern module. When the `wait()` and `retry()` functions become available in GA in Bicep, this approach will be deprecated and we will migrate to using those functions instead.\n"
@@ -1098,8 +1100,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "3449711888096468278"
+              "version": "0.40.2.10011",
+              "templateHash": "11877796675125293330"
             },
             "name": "avm/ptn/alz/empty/policy-set-definitions",
             "description": "Azure Landing Zones - Bicep - Empty - Policy Set Definitions Module"
@@ -1205,8 +1207,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "12451131946120120504"
+              "version": "0.40.2.10011",
+              "templateHash": "7514169282799870055"
             },
             "name": "avm/ptn/alz/empty/wait",
             "description": "Azure Landing Zones - Bicep - Empty - Wait Module\n\nThis module is used to create sequential empty/blank ARM deployments to introduce an artificial wait between deployments in the pattern module. When the `wait()` and `retry()` functions become available in GA in Bicep, this approach will be deprecated and we will migrate to using those functions instead.\n"
@@ -2872,8 +2874,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "12451131946120120504"
+              "version": "0.40.2.10011",
+              "templateHash": "7514169282799870055"
             },
             "name": "avm/ptn/alz/empty/wait",
             "description": "Azure Landing Zones - Bicep - Empty - Wait Module\n\nThis module is used to create sequential empty/blank ARM deployments to introduce an artificial wait between deployments in the pattern module. When the `wait()` and `retry()` functions become available in GA in Bicep, this approach will be deprecated and we will migrate to using those functions instead.\n"
@@ -3111,8 +3113,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "12451131946120120504"
+              "version": "0.40.2.10011",
+              "templateHash": "7514169282799870055"
             },
             "name": "avm/ptn/alz/empty/wait",
             "description": "Azure Landing Zones - Bicep - Empty - Wait Module\n\nThis module is used to create sequential empty/blank ARM deployments to introduce an artificial wait between deployments in the pattern module. When the `wait()` and `retry()` functions become available in GA in Bicep, this approach will be deprecated and we will migrate to using those functions instead.\n"


### PR DESCRIPTION
## Description

This pull request addresses deployment failures in the ALZ Bicep Accelerator templates caused by exceeding the 64-character limit for deployment names when using `deployment().name`. The deployment name generation logic has been updated to ensure names remain within the allowed length, improving reliability for long management group names. Additionally, the Bicep module and generated ARM templates have been updated to reflect these changes.

Deployment name logic improvements:

* Updated deployment name generation in `main.bicep` to reserve a suffix for uniqueness and ensure names for role assignments and policy assignments remain within the 64-character limit, using a new `deploymentNamePerItemBaseMax` variable. (`avm/ptn/alz/empty/main.bicep`) [[1]](diffhunk://#diff-ed20b3161cc23b9d05a96b7fb83431773f7377283331b0bcdc20650095daeb53R145-R146) [[2]](diffhunk://#diff-ed20b3161cc23b9d05a96b7fb83431773f7377283331b0bcdc20650095daeb53L153-R162) [[3]](diffhunk://#diff-ed20b3161cc23b9d05a96b7fb83431773f7377283331b0bcdc20650095daeb53L176-R187)
* Reflected these changes in the generated ARM template variables for deployment name limits and assignment names in `main.json`. (`avm/ptn/alz/empty/main.json`)

Documentation and metadata updates:

* Added a changelog entry for version 0.3.6, explaining the deployment name fix and clarifying that there are no breaking changes. (`avm/ptn/alz/empty/CHANGELOG.md`)
* Updated Bicep generator metadata and template hashes in `main.json` to match the new module version and deployment logic. (`avm/ptn/alz/empty/main.json`) [[1]](diffhunk://#diff-9f2c380431acd579e99103b8edb18303d7666560db2bb02a37cf6a4a79fccc14L8-R9) [[2]](diffhunk://#diff-9f2c380431acd579e99103b8edb18303d7666560db2bb02a37cf6a4a79fccc14L894-R897) [[3]](diffhunk://#diff-9f2c380431acd579e99103b8edb18303d7666560db2bb02a37cf6a4a79fccc14L931-R934) [[4]](diffhunk://#diff-9f2c380431acd579e99103b8edb18303d7666560db2bb02a37cf6a4a79fccc14L969-R972) [[5]](diffhunk://#diff-9f2c380431acd579e99103b8edb18303d7666560db2bb02a37cf6a4a79fccc14L1064-R1067) [[6]](diffhunk://#diff-9f2c380431acd579e99103b8edb18303d7666560db2bb02a37cf6a4a79fccc14L1101-R1104) [[7]](diffhunk://#diff-9f2c380431acd579e99103b8edb18303d7666560db2bb02a37cf6a4a79fccc14L1208-R1211) [[8]](diffhunk://#diff-9f2c380431acd579e99103b8edb18303d7666560db2bb02a37cf6a4a79fccc14L2875-R2878) [[9]](diffhunk://#diff-9f2c380431acd579e99103b8edb18303d7666560db2bb02a37cf6a4a79fccc14L3114-R3117)

Closes https://github.com/Azure/Azure-Landing-Zones/issues/4013

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.ptn.alz.empty](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.ptn.alz.empty.yml/badge.svg?branch=fix-deploymentnames)](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.ptn.alz.empty.yml)


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
