### PR TITLE
fix: `avm/res/event-hub/namespace` - Remove upper limit of `maximumThroughputUnits` parameter

### DIFF
--- a/avm/res/event-hub/namespace/CHANGELOG.md
+++ b/avm/res/event-hub/namespace/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/event-hub/namespace/CHANGELOG.md).
 
+## 0.14.1
+
+### Changes
+
+- Enhanced `maximumThroughputUnits` parameter type to use resource schema type reference
+
+### Breaking Changes
+
+- None
+
 ## 0.14.0
 
 ### Changes

--- a/avm/res/event-hub/namespace/README.md
+++ b/avm/res/event-hub/namespace/README.md
@@ -2414,8 +2414,6 @@ Upper limit of throughput units when AutoInflate is enabled, value should be wit
 - Required: No
 - Type: int
 - Default: `1`
-- MinValue: 0
-- MaxValue: 20
 
 ### Parameter: `minimumTlsVersion`
 

--- a/avm/res/event-hub/namespace/authorization-rule/main.json
+++ b/avm/res/event-hub/namespace/authorization-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "3521437171523329718"
+      "version": "0.40.2.10011",
+      "templateHash": "2125987849309638066"
     },
     "name": "Event Hub Namespace Authorization Rule",
     "description": "This module deploys an Event Hub Namespace Authorization Rule."

--- a/avm/res/event-hub/namespace/disaster-recovery-config/main.json
+++ b/avm/res/event-hub/namespace/disaster-recovery-config/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "2531448599378855086"
+      "version": "0.40.2.10011",
+      "templateHash": "15846475960708503818"
     },
     "name": "Event Hub Namespace Disaster Recovery Configs",
     "description": "This module deploys an Event Hub Namespace Disaster Recovery Config."

--- a/avm/res/event-hub/namespace/eventhub/CHANGELOG.md
+++ b/avm/res/event-hub/namespace/eventhub/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/event-hub/namespace/eventhub/CHANGELOG.md).
 
+## 0.2.1
+
+### Changes
+
+- Recompiled templates with latest Bicep version `0.40.2.10011`
+
+### Breaking Changes
+
+- None
+
 ## 0.2.0
 
 ### Changes

--- a/avm/res/event-hub/namespace/eventhub/authorization-rule/main.json
+++ b/avm/res/event-hub/namespace/eventhub/authorization-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "10412216932613982313"
+      "version": "0.40.2.10011",
+      "templateHash": "192933490322613000"
     },
     "name": "Event Hub Namespace Event Hub Authorization Rules",
     "description": "This module deploys an Event Hub Namespace Event Hub Authorization Rule."

--- a/avm/res/event-hub/namespace/eventhub/consumergroup/main.json
+++ b/avm/res/event-hub/namespace/eventhub/consumergroup/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "1703588134773580957"
+      "version": "0.40.2.10011",
+      "templateHash": "370516359162372740"
     },
     "name": "Event Hub Namespace Event Hub Consumer Groups",
     "description": "This module deploys an Event Hub Namespace Event Hub Consumer Group."

--- a/avm/res/event-hub/namespace/eventhub/main.json
+++ b/avm/res/event-hub/namespace/eventhub/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "11753625464382465575"
+      "version": "0.40.2.10011",
+      "templateHash": "3326739246701694282"
     },
     "name": "Event Hub Namespace Event Hubs",
     "description": "This module deploys an Event Hub Namespace Event Hub."
@@ -480,7 +480,7 @@
       "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
       "type": "Microsoft.Authorization/locks",
       "apiVersion": "2020-05-01",
-      "scope": "[format('Microsoft.EventHub/namespaces/{0}/eventhubs/{1}', parameters('namespaceName'), parameters('name'))]",
+      "scope": "[resourceId('Microsoft.EventHub/namespaces/eventhubs', parameters('namespaceName'), parameters('name'))]",
       "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
       "properties": {
         "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
@@ -497,7 +497,7 @@
       },
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
-      "scope": "[format('Microsoft.EventHub/namespaces/{0}/eventhubs/{1}', parameters('namespaceName'), parameters('name'))]",
+      "scope": "[resourceId('Microsoft.EventHub/namespaces/eventhubs', parameters('namespaceName'), parameters('name'))]",
       "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.EventHub/namespaces/eventhubs', parameters('namespaceName'), parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
       "properties": {
         "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -545,8 +545,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "1703588134773580957"
+              "version": "0.40.2.10011",
+              "templateHash": "370516359162372740"
             },
             "name": "Event Hub Namespace Event Hub Consumer Groups",
             "description": "This module deploys an Event Hub Namespace Event Hub Consumer Group."
@@ -651,8 +651,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "10412216932613982313"
+              "version": "0.40.2.10011",
+              "templateHash": "192933490322613000"
             },
             "name": "Event Hub Namespace Event Hub Authorization Rules",
             "description": "This module deploys an Event Hub Namespace Event Hub Authorization Rule."

--- a/avm/res/event-hub/namespace/main.bicep
+++ b/avm/res/event-hub/namespace/main.bicep
@@ -30,7 +30,7 @@ param isAutoInflateEnabled bool = false
 @description('Optional. Upper limit of throughput units when AutoInflate is enabled, value should be within 0 to 20 throughput units.')
 @minValue(0)
 @maxValue(20)
-param maximumThroughputUnits int = 1
+param maximumThroughputUnits resourceInput<'Microsoft.EventHub/namespaces@2024-01-01'>.properties.maximumThroughputUnits = 1
 
 @description('Optional. Authorization Rules for the Event Hub namespace.')
 param authorizationRules array = [

--- a/avm/res/event-hub/namespace/main.bicep
+++ b/avm/res/event-hub/namespace/main.bicep
@@ -28,8 +28,6 @@ param zoneRedundant bool = true
 param isAutoInflateEnabled bool = false
 
 @description('Optional. Upper limit of throughput units when AutoInflate is enabled, value should be within 0 to 20 throughput units.')
-@minValue(0)
-@maxValue(20)
 param maximumThroughputUnits resourceInput<'Microsoft.EventHub/namespaces@2024-01-01'>.properties.maximumThroughputUnits = 1
 
 @description('Optional. Authorization Rules for the Event Hub namespace.')

--- a/avm/res/event-hub/namespace/main.json
+++ b/avm/res/event-hub/namespace/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.40.2.10011",
-      "templateHash": "2081770411981076430"
+      "templateHash": "2883104302707402020"
     },
     "name": "Event Hub Namespaces",
     "description": "This module deploys an Event Hub Namespace."
@@ -1150,9 +1150,7 @@
         },
         "description": "Optional. Upper limit of throughput units when AutoInflate is enabled, value should be within 0 to 20 throughput units."
       },
-      "defaultValue": 1,
-      "minValue": 0,
-      "maxValue": 20
+      "defaultValue": 1
     },
     "authorizationRules": {
       "type": "array",

--- a/avm/res/event-hub/namespace/main.json
+++ b/avm/res/event-hub/namespace/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "781876460645033381"
+      "version": "0.40.2.10011",
+      "templateHash": "2081770411981076430"
     },
     "name": "Event Hub Namespaces",
     "description": "This module deploys an Event Hub Namespace."
@@ -1144,12 +1144,15 @@
     },
     "maximumThroughputUnits": {
       "type": "int",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.EventHub/namespaces@2024-01-01#properties/properties/properties/maximumThroughputUnits"
+        },
+        "description": "Optional. Upper limit of throughput units when AutoInflate is enabled, value should be within 0 to 20 throughput units."
+      },
       "defaultValue": 1,
       "minValue": 0,
-      "maxValue": 20,
-      "metadata": {
-        "description": "Optional. Upper limit of throughput units when AutoInflate is enabled, value should be within 0 to 20 throughput units."
-      }
+      "maxValue": 20
     },
     "authorizationRules": {
       "type": "array",
@@ -1418,7 +1421,7 @@
       },
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
-      "scope": "[format('Microsoft.EventHub/namespaces/{0}', parameters('name'))]",
+      "scope": "[resourceId('Microsoft.EventHub/namespaces', parameters('name'))]",
       "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.EventHub/namespaces', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
       "properties": {
         "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -1437,7 +1440,7 @@
       "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
       "type": "Microsoft.Authorization/locks",
       "apiVersion": "2020-05-01",
-      "scope": "[format('Microsoft.EventHub/namespaces/{0}', parameters('name'))]",
+      "scope": "[resourceId('Microsoft.EventHub/namespaces', parameters('name'))]",
       "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
       "properties": {
         "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
@@ -1454,7 +1457,7 @@
       },
       "type": "Microsoft.Insights/diagnosticSettings",
       "apiVersion": "2021-05-01-preview",
-      "scope": "[format('Microsoft.EventHub/namespaces/{0}', parameters('name'))]",
+      "scope": "[resourceId('Microsoft.EventHub/namespaces', parameters('name'))]",
       "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
       "properties": {
         "copy": [
@@ -1518,8 +1521,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "3521437171523329718"
+              "version": "0.40.2.10011",
+              "templateHash": "2125987849309638066"
             },
             "name": "Event Hub Namespace Authorization Rule",
             "description": "This module deploys an Event Hub Namespace Authorization Rule."
@@ -1616,8 +1619,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "2531448599378855086"
+              "version": "0.40.2.10011",
+              "templateHash": "15846475960708503818"
             },
             "name": "Event Hub Namespace Disaster Recovery Configs",
             "description": "This module deploys an Event Hub Namespace Disaster Recovery Config."
@@ -1749,8 +1752,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "11753625464382465575"
+              "version": "0.40.2.10011",
+              "templateHash": "3326739246701694282"
             },
             "name": "Event Hub Namespace Event Hubs",
             "description": "This module deploys an Event Hub Namespace Event Hub."
@@ -2224,7 +2227,7 @@
               "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
               "type": "Microsoft.Authorization/locks",
               "apiVersion": "2020-05-01",
-              "scope": "[format('Microsoft.EventHub/namespaces/{0}/eventhubs/{1}', parameters('namespaceName'), parameters('name'))]",
+              "scope": "[resourceId('Microsoft.EventHub/namespaces/eventhubs', parameters('namespaceName'), parameters('name'))]",
               "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
               "properties": {
                 "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
@@ -2241,7 +2244,7 @@
               },
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.EventHub/namespaces/{0}/eventhubs/{1}', parameters('namespaceName'), parameters('name'))]",
+              "scope": "[resourceId('Microsoft.EventHub/namespaces/eventhubs', parameters('namespaceName'), parameters('name'))]",
               "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.EventHub/namespaces/eventhubs', parameters('namespaceName'), parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
               "properties": {
                 "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -2289,8 +2292,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.38.33.27573",
-                      "templateHash": "1703588134773580957"
+                      "version": "0.40.2.10011",
+                      "templateHash": "370516359162372740"
                     },
                     "name": "Event Hub Namespace Event Hub Consumer Groups",
                     "description": "This module deploys an Event Hub Namespace Event Hub Consumer Group."
@@ -2395,8 +2398,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.38.33.27573",
-                      "templateHash": "10412216932613982313"
+                      "version": "0.40.2.10011",
+                      "templateHash": "192933490322613000"
                     },
                     "name": "Event Hub Namespace Event Hub Authorization Rules",
                     "description": "This module deploys an Event Hub Namespace Event Hub Authorization Rule."
@@ -2539,8 +2542,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "11263423164382295710"
+              "version": "0.40.2.10011",
+              "templateHash": "15795737684416161631"
             },
             "name": "Event Hub Namespace Network Rule Sets",
             "description": "This module deploys an Event Hub Namespace Network Rule Set."
@@ -3381,8 +3384,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "2732081719805108762"
+              "version": "0.40.2.10011",
+              "templateHash": "5162099537218324700"
             }
           },
           "definitions": {

--- a/avm/res/event-hub/namespace/network-rule-set/main.json
+++ b/avm/res/event-hub/namespace/network-rule-set/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "11263423164382295710"
+      "version": "0.40.2.10011",
+      "templateHash": "15795737684416161631"
     },
     "name": "Event Hub Namespace Network Rule Sets",
     "description": "This module deploys an Event Hub Namespace Network Rule Set."


### PR DESCRIPTION
## Description

Updates the `maximumThroughputUnits` parameter to use resource schema type reference for removal of `maxValue limit

Fixes #6565 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.event-hub.namespace](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.event-hub.namespace.yml/badge.svg?branch=users%2Fkrbar%2FevhMaxThrpt)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.event-hub.namespace.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
