### PR TITLE
feat: avm/res/web/hosting-environment - updates to api versions and add features

### DIFF
--- a/avm/res/web/hosting-environment/CHANGELOG.md
+++ b/avm/res/web/hosting-environment/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/web/hosting-environment/CHANGELOG.md).
 
+## 0.5.0
+
+### Changes
+
+- Upgraded API version from `2023-12-01` to `2025-03-01` for `Microsoft.Web/hostingEnvironments`
+- Upgraded child module API versions from `2022-03-01`/`2023-12-01` to `2025-03-01` for `Microsoft.Web/hostingEnvironments/configurations`
+- Upgraded AVM common type imports (`managedIdentityAllType`, `diagnosticSettingLogsOnlyType`) from `0.4.1` to `0.6.1`
+- Converted `internalLoadBalancingMode` parameter to use resource-derived type
+- Converted `upgradePreference` parameter to use resource-derived type
+- Converted `networkConfiguration` parameter to use resource-derived type
+- Updated `tags` and `clusterSettings` RDT references to `2025-03-01`
+- Added new parameter `ipsslAddressCount` for IP SSL address reservation
+- Added new parameter `multiSize` for front-end VM size configuration
+- Added new parameter `userWhitelistedIpRanges` for IP range whitelisting on ASE
+- Added `location` output per AVM best practices
+
+### Breaking Changes
+
+- Parameters `internalLoadBalancingMode`, `upgradePreference`, and `networkConfiguration` now use resource-derived types instead of `@allowed` annotations or `object?`
+
 ## 0.4.1
 
 ### Changes

--- a/avm/res/web/hosting-environment/CHANGELOG.md
+++ b/avm/res/web/hosting-environment/CHANGELOG.md
@@ -15,7 +15,6 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 - Updated `tags` and `clusterSettings` RDT references to `2025-03-01`
 - Added new parameter `ipsslAddressCount` for IP SSL address reservation
 - Added new parameter `multiSize` for front-end VM size configuration
-- Added new parameter `userWhitelistedIpRanges` for IP range whitelisting on ASE
 - Added `location` output per AVM best practices
 
 ### Breaking Changes

--- a/avm/res/web/hosting-environment/README.md
+++ b/avm/res/web/hosting-environment/README.md
@@ -187,10 +187,6 @@ module hostingEnvironment 'br/public:avm/res/web/hosting-environment:<version>' 
       resourceType: 'App Service Environment'
     }
     upgradePreference: 'Late'
-    userWhitelistedIpRanges: [
-      '10.0.0.0/24'
-      '192.168.1.0/24'
-    ]
     zoneRedundant: true
   }
 }
@@ -314,12 +310,6 @@ module hostingEnvironment 'br/public:avm/res/web/hosting-environment:<version>' 
     "upgradePreference": {
       "value": "Late"
     },
-    "userWhitelistedIpRanges": {
-      "value": [
-        "10.0.0.0/24",
-        "192.168.1.0/24"
-      ]
-    },
     "zoneRedundant": {
       "value": true
     }
@@ -407,10 +397,6 @@ param tags = {
   resourceType: 'App Service Environment'
 }
 param upgradePreference = 'Late'
-param userWhitelistedIpRanges = [
-  '10.0.0.0/24'
-  '192.168.1.0/24'
-]
 param zoneRedundant = true
 ```
 
@@ -668,7 +654,6 @@ param zoneRedundant = true
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`upgradePreference`](#parameter-upgradepreference) | string | Specify preference for when and how the planned maintenance is applied. |
-| [`userWhitelistedIpRanges`](#parameter-userwhitelistedipranges) | array | User added IP ranges to whitelist on ASE db. |
 | [`zoneRedundant`](#parameter-zoneredundant) | bool | Switch to make the App Service Environment zone redundant. If enabled, the minimum App Service plan instance count will be three, otherwise 1. If enabled, the `dedicatedHostCount` must be set to `-1`. |
 
 ### Parameter: `name`
@@ -1104,13 +1089,6 @@ Specify preference for when and how the planned maintenance is applied.
 - Required: No
 - Type: string
 - Default: `'None'`
-
-### Parameter: `userWhitelistedIpRanges`
-
-User added IP ranges to whitelist on ASE db.
-
-- Required: No
-- Type: array
 
 ### Parameter: `zoneRedundant`
 

--- a/avm/res/web/hosting-environment/README.md
+++ b/avm/res/web/hosting-environment/README.md
@@ -26,8 +26,8 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
 | `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.insights_diagnosticsettings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)</li></ul> |
-| `Microsoft.Web/hostingEnvironments` | 2023-12-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.web_hostingenvironments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2023-12-01/hostingEnvironments)</li></ul> |
-| `Microsoft.Web/hostingEnvironments/configurations` | 2023-12-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.web_hostingenvironments_configurations.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2023-12-01/hostingEnvironments/configurations)</li></ul> |
+| `Microsoft.Web/hostingEnvironments` | 2025-03-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.web_hostingenvironments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2025-03-01/hostingEnvironments)</li></ul> |
+| `Microsoft.Web/hostingEnvironments/configurations` | 2025-03-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.web_hostingenvironments_configurations.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2025-03-01/hostingEnvironments/configurations)</li></ul> |
 
 ## Usage examples
 
@@ -140,6 +140,7 @@ module hostingEnvironment 'br/public:avm/res/web/hosting-environment:<version>' 
       }
     ]
     internalLoadBalancingMode: 'Web, Publishing'
+    ipsslAddressCount: 0
     kind: 'ASEv3'
     location: '<location>'
     lock: {
@@ -152,6 +153,7 @@ module hostingEnvironment 'br/public:avm/res/web/hosting-environment:<version>' 
         '<managedIdentityResourceId>'
       ]
     }
+    multiSize: 'Standard_D2_v2'
     networkConfiguration: {
       properties: {
         allowNewPrivateEndpointConnections: true
@@ -185,6 +187,10 @@ module hostingEnvironment 'br/public:avm/res/web/hosting-environment:<version>' 
       resourceType: 'App Service Environment'
     }
     upgradePreference: 'Late'
+    userWhitelistedIpRanges: [
+      '10.0.0.0/24'
+      '192.168.1.0/24'
+    ]
     zoneRedundant: true
   }
 }
@@ -241,6 +247,9 @@ module hostingEnvironment 'br/public:avm/res/web/hosting-environment:<version>' 
     "internalLoadBalancingMode": {
       "value": "Web, Publishing"
     },
+    "ipsslAddressCount": {
+      "value": 0
+    },
     "kind": {
       "value": "ASEv3"
     },
@@ -260,6 +269,9 @@ module hostingEnvironment 'br/public:avm/res/web/hosting-environment:<version>' 
           "<managedIdentityResourceId>"
         ]
       }
+    },
+    "multiSize": {
+      "value": "Standard_D2_v2"
     },
     "networkConfiguration": {
       "value": {
@@ -302,6 +314,12 @@ module hostingEnvironment 'br/public:avm/res/web/hosting-environment:<version>' 
     "upgradePreference": {
       "value": "Late"
     },
+    "userWhitelistedIpRanges": {
+      "value": [
+        "10.0.0.0/24",
+        "192.168.1.0/24"
+      ]
+    },
     "zoneRedundant": {
       "value": true
     }
@@ -342,6 +360,7 @@ param diagnosticSettings = [
   }
 ]
 param internalLoadBalancingMode = 'Web, Publishing'
+param ipsslAddressCount = 0
 param kind = 'ASEv3'
 param location = '<location>'
 param lock = {
@@ -354,6 +373,7 @@ param managedIdentities = {
     '<managedIdentityResourceId>'
   ]
 }
+param multiSize = 'Standard_D2_v2'
 param networkConfiguration = {
   properties: {
     allowNewPrivateEndpointConnections: true
@@ -387,6 +407,10 @@ param tags = {
   resourceType: 'App Service Environment'
 }
 param upgradePreference = 'Late'
+param userWhitelistedIpRanges = [
+  '10.0.0.0/24'
+  '192.168.1.0/24'
+]
 param zoneRedundant = true
 ```
 
@@ -430,6 +454,10 @@ module hostingEnvironment 'br/public:avm/res/web/hosting-environment:<version>' 
       }
     ]
     internalLoadBalancingMode: 'Web, Publishing'
+    lock: {
+      kind: 'CanNotDelete'
+      name: 'myCustomLockName'
+    }
     managedIdentities: {
       systemAssigned: true
       userAssignedResourceIds: [
@@ -449,6 +477,7 @@ module hostingEnvironment 'br/public:avm/res/web/hosting-environment:<version>' 
       resourceType: 'App Service Environment'
     }
     upgradePreference: 'Late'
+    zoneRedundant: true
   }
 }
 ```
@@ -504,6 +533,12 @@ module hostingEnvironment 'br/public:avm/res/web/hosting-environment:<version>' 
     "internalLoadBalancingMode": {
       "value": "Web, Publishing"
     },
+    "lock": {
+      "value": {
+        "kind": "CanNotDelete",
+        "name": "myCustomLockName"
+      }
+    },
     "managedIdentities": {
       "value": {
         "systemAssigned": true,
@@ -530,6 +565,9 @@ module hostingEnvironment 'br/public:avm/res/web/hosting-environment:<version>' 
     },
     "upgradePreference": {
       "value": "Late"
+    },
+    "zoneRedundant": {
+      "value": true
     }
   }
 }
@@ -568,6 +606,10 @@ param diagnosticSettings = [
   }
 ]
 param internalLoadBalancingMode = 'Web, Publishing'
+param lock = {
+  kind: 'CanNotDelete'
+  name: 'myCustomLockName'
+}
 param managedIdentities = {
   systemAssigned: true
   userAssignedResourceIds: [
@@ -587,6 +629,7 @@ param tags = {
   resourceType: 'App Service Environment'
 }
 param upgradePreference = 'Late'
+param zoneRedundant = true
 ```
 
 </details>
@@ -615,14 +658,17 @@ param upgradePreference = 'Late'
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`frontEndScaleFactor`](#parameter-frontendscalefactor) | int | Scale factor for frontends. |
 | [`internalLoadBalancingMode`](#parameter-internalloadbalancingmode) | string | Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. - None, Web, Publishing, Web,Publishing. "None" Exposes the ASE-hosted apps on an internet-accessible IP address. |
+| [`ipsslAddressCount`](#parameter-ipssladdresscount) | int | Number of IP SSL addresses reserved for the App Service Environment. |
 | [`kind`](#parameter-kind) | string | Kind of resource. |
 | [`location`](#parameter-location) | string | Location for all Resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. |
+| [`multiSize`](#parameter-multisize) | string | Front-end VM size, e.g. "Medium", "Large". |
 | [`networkConfiguration`](#parameter-networkconfiguration) | object | Properties to configure additional networking features. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`upgradePreference`](#parameter-upgradepreference) | string | Specify preference for when and how the planned maintenance is applied. |
+| [`userWhitelistedIpRanges`](#parameter-userwhitelistedipranges) | array | User added IP ranges to whitelist on ASE db. |
 | [`zoneRedundant`](#parameter-zoneredundant) | bool | Switch to make the App Service Environment zone redundant. If enabled, the minimum App Service plan instance count will be three, otherwise 1. If enabled, the `dedicatedHostCount` must be set to `-1`. |
 
 ### Parameter: `name`
@@ -661,7 +707,6 @@ Enable the default custom domain suffix to use for all sites deployed on the ASE
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ### Parameter: `customDnsSuffixCertificateUrl`
 
@@ -669,7 +714,6 @@ The URL referencing the Azure Key Vault certificate secret that should be used a
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ### Parameter: `customDnsSuffixKeyVaultReferenceIdentity`
 
@@ -677,7 +721,6 @@ The user-assigned identity to use for resolving the key vault certificate refere
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ### Parameter: `dedicatedHostCount`
 
@@ -685,7 +728,6 @@ The Dedicated Host Count. If `zoneRedundant` is false, and you want physical har
 
 - Required: No
 - Type: int
-- Default: `0`
 
 ### Parameter: `diagnosticSettings`
 
@@ -805,7 +847,6 @@ DNS suffix of the App Service Environment.
 
 - Required: No
 - Type: string
-- Default: `''`
 
 ### Parameter: `enableTelemetry`
 
@@ -830,15 +871,13 @@ Specifies which endpoints to serve internally in the Virtual Network for the App
 - Required: No
 - Type: string
 - Default: `'None'`
-- Allowed:
-  ```Bicep
-  [
-    'None'
-    'Publishing'
-    'Web'
-    'Web, Publishing'
-  ]
-  ```
+
+### Parameter: `ipsslAddressCount`
+
+Number of IP SSL addresses reserved for the App Service Environment.
+
+- Required: No
+- Type: int
 
 ### Parameter: `kind`
 
@@ -933,6 +972,13 @@ The resource ID(s) to assign to the resource. Required if a user assigned identi
 
 - Required: No
 - Type: array
+
+### Parameter: `multiSize`
+
+Front-end VM size, e.g. "Medium", "Large".
+
+- Required: No
+- Type: string
 
 ### Parameter: `networkConfiguration`
 
@@ -1058,15 +1104,13 @@ Specify preference for when and how the planned maintenance is applied.
 - Required: No
 - Type: string
 - Default: `'None'`
-- Allowed:
-  ```Bicep
-  [
-    'Early'
-    'Late'
-    'Manual'
-    'None'
-  ]
-  ```
+
+### Parameter: `userWhitelistedIpRanges`
+
+User added IP ranges to whitelist on ASE db.
+
+- Required: No
+- Type: array
 
 ### Parameter: `zoneRedundant`
 
@@ -1092,7 +1136,6 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.4.1` | Remote reference |
 | `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
 
 ## Data Collection

--- a/avm/res/web/hosting-environment/configuration--customdnssuffix/README.md
+++ b/avm/res/web/hosting-environment/configuration--customdnssuffix/README.md
@@ -12,7 +12,7 @@ This module deploys a Hosting Environment Custom DNS Suffix Configuration.
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.Web/hostingEnvironments/configurations` | 2023-12-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.web_hostingenvironments_configurations.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2023-12-01/hostingEnvironments/configurations)</li></ul> |
+| `Microsoft.Web/hostingEnvironments/configurations` | 2025-03-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.web_hostingenvironments_configurations.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Web/2025-03-01/hostingEnvironments/configurations)</li></ul> |
 
 ## Parameters
 

--- a/avm/res/web/hosting-environment/configuration--customdnssuffix/main.bicep
+++ b/avm/res/web/hosting-environment/configuration--customdnssuffix/main.bicep
@@ -13,11 +13,11 @@ param certificateUrl string
 @description('Required. The user-assigned identity to use for resolving the key vault certificate reference. If not specified, the system-assigned ASE identity will be used if available.')
 param keyVaultReferenceIdentity string
 
-resource appServiceEnvironment 'Microsoft.Web/hostingEnvironments@2022-03-01' existing = {
+resource appServiceEnvironment 'Microsoft.Web/hostingEnvironments@2025-03-01' existing = {
   name: hostingEnvironmentName
 }
 
-resource configuration 'Microsoft.Web/hostingEnvironments/configurations@2023-12-01' = {
+resource configuration 'Microsoft.Web/hostingEnvironments/configurations@2025-03-01' = {
   name: 'customdnssuffix'
   parent: appServiceEnvironment
   properties: {

--- a/avm/res/web/hosting-environment/configuration--customdnssuffix/main.json
+++ b/avm/res/web/hosting-environment/configuration--customdnssuffix/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "5515486685166015139"
+      "version": "0.40.2.10011",
+      "templateHash": "3480320488272565329"
     },
     "name": "Hosting Environment Custom DNS Suffix Configuration",
     "description": "This module deploys a Hosting Environment Custom DNS Suffix Configuration."
@@ -39,7 +39,7 @@
   "resources": [
     {
       "type": "Microsoft.Web/hostingEnvironments/configurations",
-      "apiVersion": "2023-12-01",
+      "apiVersion": "2025-03-01",
       "name": "[format('{0}/{1}', parameters('hostingEnvironmentName'), 'customdnssuffix')]",
       "properties": {
         "certificateUrl": "[parameters('certificateUrl')]",

--- a/avm/res/web/hosting-environment/main.bicep
+++ b/avm/res/web/hosting-environment/main.bicep
@@ -11,7 +11,7 @@ param location string = resourceGroup().location
 param enableTelemetry bool = true
 
 @description('Optional. Tags of the resource.')
-param tags resourceInput<'Microsoft.Web/hostingEnvironments@2024-11-01'>.tags?
+param tags resourceInput<'Microsoft.Web/hostingEnvironments@2025-03-01'>.tags?
 
 import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The lock settings of the service.')
@@ -28,7 +28,7 @@ param roleAssignments roleAssignmentType[]?
 param kind string = 'ASEv3'
 
 @description('Optional. Custom settings for changing the behavior of the App Service Environment.')
-param clusterSettings resourceInput<'Microsoft.Web/hostingEnvironments@2024-11-01'>.properties.clusterSettings = [
+param clusterSettings resourceInput<'Microsoft.Web/hostingEnvironments@2025-03-01'>.properties.clusterSettings = [
   {
     name: 'DisableTls1.0'
     value: '1'
@@ -36,43 +36,31 @@ param clusterSettings resourceInput<'Microsoft.Web/hostingEnvironments@2024-11-0
 ]
 
 @description('Optional. Enable the default custom domain suffix to use for all sites deployed on the ASE. If provided, then customDnsSuffixCertificateUrl and customDnsSuffixKeyVaultReferenceIdentity are required.')
-param customDnsSuffix string = ''
+param customDnsSuffix string?
 
 @description('Optional. The URL referencing the Azure Key Vault certificate secret that should be used as the default SSL/TLS certificate for sites with the custom domain suffix. Required if customDnsSuffix is not empty.')
-param customDnsSuffixCertificateUrl string = ''
+param customDnsSuffixCertificateUrl string?
 
 @description('Optional. The user-assigned identity to use for resolving the key vault certificate reference. If not specified, the system-assigned ASE identity will be used if available. Required if customDnsSuffix is not empty.')
-param customDnsSuffixKeyVaultReferenceIdentity string = ''
+param customDnsSuffixKeyVaultReferenceIdentity string?
 
 @description('Optional. The Dedicated Host Count. If `zoneRedundant` is false, and you want physical hardware isolation enabled, set to 2. Otherwise 0.')
-param dedicatedHostCount int = 0
+param dedicatedHostCount int?
 
 @description('Optional. DNS suffix of the App Service Environment.')
-param dnsSuffix string = ''
+param dnsSuffix string?
 
 @description('Optional. Scale factor for frontends.')
 param frontEndScaleFactor int = 15
 
 @description('Optional. Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. - None, Web, Publishing, Web,Publishing. "None" Exposes the ASE-hosted apps on an internet-accessible IP address.')
-@allowed([
-  'None'
-  'Web'
-  'Publishing'
-  'Web, Publishing'
-])
-param internalLoadBalancingMode string = 'None'
+param internalLoadBalancingMode resourceInput<'Microsoft.Web/hostingEnvironments@2025-03-01'>.properties.internalLoadBalancingMode = 'None'
 
 @description('Optional. Properties to configure additional networking features.')
-param networkConfiguration object?
+param networkConfiguration resourceInput<'Microsoft.Web/hostingEnvironments@2025-03-01'>.properties.networkingConfiguration?
 
 @description('Optional. Specify preference for when and how the planned maintenance is applied.')
-@allowed([
-  'Early'
-  'Late'
-  'Manual'
-  'None'
-])
-param upgradePreference string = 'None'
+param upgradePreference resourceInput<'Microsoft.Web/hostingEnvironments@2025-03-01'>.properties.upgradePreference = 'None'
 
 @description('Required. ResourceId for the subnet.')
 param subnetResourceId string
@@ -80,11 +68,20 @@ param subnetResourceId string
 @description('Optional. Switch to make the App Service Environment zone redundant. If enabled, the minimum App Service plan instance count will be three, otherwise 1. If enabled, the `dedicatedHostCount` must be set to `-1`.')
 param zoneRedundant bool = true
 
-import { managedIdentityAllType } from 'br/public:avm/utl/types/avm-common-types:0.4.1'
+@description('Optional. Number of IP SSL addresses reserved for the App Service Environment.')
+param ipsslAddressCount int?
+
+@description('Optional. Front-end VM size, e.g. "Medium", "Large".')
+param multiSize string?
+
+@description('Optional. User added IP ranges to whitelist on ASE db.')
+param userWhitelistedIpRanges string[]?
+
+import { managedIdentityAllType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The managed identity definition for this resource.')
 param managedIdentities managedIdentityAllType?
 
-import { diagnosticSettingLogsOnlyType } from 'br/public:avm/utl/types/avm-common-types:0.4.1'
+import { diagnosticSettingLogsOnlyType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The diagnostic settings of the service.')
 param diagnosticSettings diagnosticSettingLogsOnlyType[]?
 
@@ -151,7 +148,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource appServiceEnvironment 'Microsoft.Web/hostingEnvironments@2023-12-01' = {
+resource appServiceEnvironment 'Microsoft.Web/hostingEnvironments@2025-03-01' = {
   name: name
   kind: kind
   location: location
@@ -159,12 +156,15 @@ resource appServiceEnvironment 'Microsoft.Web/hostingEnvironments@2023-12-01' = 
   identity: identity
   properties: {
     clusterSettings: clusterSettings
-    dedicatedHostCount: dedicatedHostCount != 0 ? dedicatedHostCount : null
-    dnsSuffix: !empty(dnsSuffix) ? dnsSuffix : null
+    dedicatedHostCount: dedicatedHostCount
+    dnsSuffix: dnsSuffix
     frontEndScaleFactor: frontEndScaleFactor
     internalLoadBalancingMode: internalLoadBalancingMode
+    ipsslAddressCount: ipsslAddressCount
+    multiSize: multiSize
     upgradePreference: upgradePreference
     networkingConfiguration: networkConfiguration
+    userWhitelistedIpRanges: userWhitelistedIpRanges
     virtualNetwork: {
       id: subnetResourceId
       subnet: last(split(subnetResourceId, '/'))
@@ -173,13 +173,13 @@ resource appServiceEnvironment 'Microsoft.Web/hostingEnvironments@2023-12-01' = 
   }
 }
 
-module appServiceEnvironment_configurations_customDnsSuffix 'configuration--customdnssuffix/main.bicep' = if (!empty(customDnsSuffix)) {
+module appServiceEnvironment_configurations_customDnsSuffix 'configuration--customdnssuffix/main.bicep' = if (!empty(customDnsSuffix ?? '')) {
   name: '${uniqueString(deployment().name, location)}-AppServiceEnv-Configurations-CustomDnsSuffix'
   params: {
     hostingEnvironmentName: appServiceEnvironment.name
-    certificateUrl: customDnsSuffixCertificateUrl
-    keyVaultReferenceIdentity: customDnsSuffixKeyVaultReferenceIdentity
-    dnsSuffix: customDnsSuffix
+    certificateUrl: customDnsSuffixCertificateUrl ?? ''
+    keyVaultReferenceIdentity: customDnsSuffixKeyVaultReferenceIdentity ?? ''
+    dnsSuffix: customDnsSuffix ?? ''
   }
 }
 
@@ -194,6 +194,7 @@ resource appServiceEnvironment_lock 'Microsoft.Authorization/locks@2020-05-01' =
   scope: appServiceEnvironment
 }
 
+#disable-next-line use-recent-api-versions // This is the most recent API version at the time of development.
 resource appServiceEnvironment_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = [
   for (diagnosticSetting, index) in (diagnosticSettings ?? []): {
     name: diagnosticSetting.?name ?? '${name}-diagnosticSettings'
@@ -229,7 +230,7 @@ resource appServiceEnvironment_roleAssignments 'Microsoft.Authorization/roleAssi
       description: roleAssignment.?description
       principalType: roleAssignment.?principalType
       condition: roleAssignment.?condition
-      conditionVersion: !empty(roleAssignment.?condition) ? (roleAssignment.?conditionVersion ?? '2.0') : null // Must only be set if condtion is set
+      conditionVersion: !empty(roleAssignment.?condition) ? (roleAssignment.?conditionVersion ?? '2.0') : null // Must only be set if condition is set
       delegatedManagedIdentityResourceId: roleAssignment.?delegatedManagedIdentityResourceId
     }
     scope: appServiceEnvironment

--- a/avm/res/web/hosting-environment/main.bicep
+++ b/avm/res/web/hosting-environment/main.bicep
@@ -74,9 +74,6 @@ param ipsslAddressCount int?
 @description('Optional. Front-end VM size, e.g. "Medium", "Large".')
 param multiSize string?
 
-@description('Optional. User added IP ranges to whitelist on ASE db.')
-param userWhitelistedIpRanges string[]?
-
 import { managedIdentityAllType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The managed identity definition for this resource.')
 param managedIdentities managedIdentityAllType?
@@ -164,7 +161,6 @@ resource appServiceEnvironment 'Microsoft.Web/hostingEnvironments@2025-03-01' = 
     multiSize: multiSize
     upgradePreference: upgradePreference
     networkingConfiguration: networkConfiguration
-    userWhitelistedIpRanges: userWhitelistedIpRanges
     virtualNetwork: {
       id: subnetResourceId
       subnet: last(split(subnetResourceId, '/'))

--- a/avm/res/web/hosting-environment/main.json
+++ b/avm/res/web/hosting-environment/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.40.2.10011",
-      "templateHash": "14849872074166334738"
+      "templateHash": "6495478728319351396"
     },
     "name": "App Service Environments",
     "description": "This module deploys an App Service Environment."
@@ -422,16 +422,6 @@
         "description": "Optional. Front-end VM size, e.g. \"Medium\", \"Large\"."
       }
     },
-    "userWhitelistedIpRanges": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "nullable": true,
-      "metadata": {
-        "description": "Optional. User added IP ranges to whitelist on ASE db."
-      }
-    },
     "managedIdentities": {
       "$ref": "#/definitions/managedIdentityAllType",
       "nullable": true,
@@ -507,7 +497,6 @@
         "multiSize": "[parameters('multiSize')]",
         "upgradePreference": "[parameters('upgradePreference')]",
         "networkingConfiguration": "[parameters('networkConfiguration')]",
-        "userWhitelistedIpRanges": "[parameters('userWhitelistedIpRanges')]",
         "virtualNetwork": {
           "id": "[parameters('subnetResourceId')]",
           "subnet": "[last(split(parameters('subnetResourceId'), '/'))]"

--- a/avm/res/web/hosting-environment/main.json
+++ b/avm/res/web/hosting-environment/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.5.1644",
-      "templateHash": "5051943203961398060"
+      "version": "0.40.2.10011",
+      "templateHash": "14849872074166334738"
     },
     "name": "App Service Environments",
     "description": "This module deploys an App Service Environment."
@@ -105,7 +105,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a diagnostic setting. To be used if only logs are supported by the resource provider.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.4.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
         }
       }
     },
@@ -170,7 +170,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.4.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
         }
       }
     },
@@ -275,7 +275,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.Web/hostingEnvironments@2024-11-01#properties/tags"
+          "source": "Microsoft.Web/hostingEnvironments@2025-03-01#properties/tags"
         },
         "description": "Optional. Tags of the resource."
       },
@@ -312,7 +312,7 @@
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.Web/hostingEnvironments@2024-11-01#properties/properties/properties/clusterSettings"
+          "source": "Microsoft.Web/hostingEnvironments@2025-03-01#properties/properties/properties/clusterSettings"
         },
         "description": "Optional. Custom settings for changing the behavior of the App Service Environment."
       },
@@ -325,35 +325,35 @@
     },
     "customDnsSuffix": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
       "metadata": {
         "description": "Optional. Enable the default custom domain suffix to use for all sites deployed on the ASE. If provided, then customDnsSuffixCertificateUrl and customDnsSuffixKeyVaultReferenceIdentity are required."
       }
     },
     "customDnsSuffixCertificateUrl": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
       "metadata": {
         "description": "Optional. The URL referencing the Azure Key Vault certificate secret that should be used as the default SSL/TLS certificate for sites with the custom domain suffix. Required if customDnsSuffix is not empty."
       }
     },
     "customDnsSuffixKeyVaultReferenceIdentity": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
       "metadata": {
         "description": "Optional. The user-assigned identity to use for resolving the key vault certificate reference. If not specified, the system-assigned ASE identity will be used if available. Required if customDnsSuffix is not empty."
       }
     },
     "dedicatedHostCount": {
       "type": "int",
-      "defaultValue": 0,
+      "nullable": true,
       "metadata": {
         "description": "Optional. The Dedicated Host Count. If `zoneRedundant` is false, and you want physical hardware isolation enabled, set to 2. Otherwise 0."
       }
     },
     "dnsSuffix": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
       "metadata": {
         "description": "Optional. DNS suffix of the App Service Environment."
       }
@@ -367,36 +367,33 @@
     },
     "internalLoadBalancingMode": {
       "type": "string",
-      "defaultValue": "None",
-      "allowedValues": [
-        "None",
-        "Web",
-        "Publishing",
-        "Web, Publishing"
-      ],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Web/hostingEnvironments@2025-03-01#properties/properties/properties/internalLoadBalancingMode"
+        },
         "description": "Optional. Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. - None, Web, Publishing, Web,Publishing. \"None\" Exposes the ASE-hosted apps on an internet-accessible IP address."
-      }
+      },
+      "defaultValue": "None"
     },
     "networkConfiguration": {
       "type": "object",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Web/hostingEnvironments@2025-03-01#properties/properties/properties/networkingConfiguration"
+        },
         "description": "Optional. Properties to configure additional networking features."
-      }
+      },
+      "nullable": true
     },
     "upgradePreference": {
       "type": "string",
-      "defaultValue": "None",
-      "allowedValues": [
-        "Early",
-        "Late",
-        "Manual",
-        "None"
-      ],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Web/hostingEnvironments@2025-03-01#properties/properties/properties/upgradePreference"
+        },
         "description": "Optional. Specify preference for when and how the planned maintenance is applied."
-      }
+      },
+      "defaultValue": "None"
     },
     "subnetResourceId": {
       "type": "string",
@@ -409,6 +406,30 @@
       "defaultValue": true,
       "metadata": {
         "description": "Optional. Switch to make the App Service Environment zone redundant. If enabled, the minimum App Service plan instance count will be three, otherwise 1. If enabled, the `dedicatedHostCount` must be set to `-1`."
+      }
+    },
+    "ipsslAddressCount": {
+      "type": "int",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Number of IP SSL addresses reserved for the App Service Environment."
+      }
+    },
+    "multiSize": {
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Front-end VM size, e.g. \"Medium\", \"Large\"."
+      }
+    },
+    "userWhitelistedIpRanges": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. User added IP ranges to whitelist on ASE db."
       }
     },
     "managedIdentities": {
@@ -470,7 +491,7 @@
     },
     "appServiceEnvironment": {
       "type": "Microsoft.Web/hostingEnvironments",
-      "apiVersion": "2023-12-01",
+      "apiVersion": "2025-03-01",
       "name": "[parameters('name')]",
       "kind": "[parameters('kind')]",
       "location": "[parameters('location')]",
@@ -478,12 +499,15 @@
       "identity": "[variables('identity')]",
       "properties": {
         "clusterSettings": "[parameters('clusterSettings')]",
-        "dedicatedHostCount": "[if(not(equals(parameters('dedicatedHostCount'), 0)), parameters('dedicatedHostCount'), null())]",
-        "dnsSuffix": "[if(not(empty(parameters('dnsSuffix'))), parameters('dnsSuffix'), null())]",
+        "dedicatedHostCount": "[parameters('dedicatedHostCount')]",
+        "dnsSuffix": "[parameters('dnsSuffix')]",
         "frontEndScaleFactor": "[parameters('frontEndScaleFactor')]",
         "internalLoadBalancingMode": "[parameters('internalLoadBalancingMode')]",
+        "ipsslAddressCount": "[parameters('ipsslAddressCount')]",
+        "multiSize": "[parameters('multiSize')]",
         "upgradePreference": "[parameters('upgradePreference')]",
         "networkingConfiguration": "[parameters('networkConfiguration')]",
+        "userWhitelistedIpRanges": "[parameters('userWhitelistedIpRanges')]",
         "virtualNetwork": {
           "id": "[parameters('subnetResourceId')]",
           "subnet": "[last(split(parameters('subnetResourceId'), '/'))]"
@@ -495,7 +519,7 @@
       "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
       "type": "Microsoft.Authorization/locks",
       "apiVersion": "2020-05-01",
-      "scope": "[format('Microsoft.Web/hostingEnvironments/{0}', parameters('name'))]",
+      "scope": "[resourceId('Microsoft.Web/hostingEnvironments', parameters('name'))]",
       "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
       "properties": {
         "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
@@ -512,7 +536,7 @@
       },
       "type": "Microsoft.Insights/diagnosticSettings",
       "apiVersion": "2021-05-01-preview",
-      "scope": "[format('Microsoft.Web/hostingEnvironments/{0}', parameters('name'))]",
+      "scope": "[resourceId('Microsoft.Web/hostingEnvironments', parameters('name'))]",
       "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
       "properties": {
         "copy": [
@@ -544,7 +568,7 @@
       },
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
-      "scope": "[format('Microsoft.Web/hostingEnvironments/{0}', parameters('name'))]",
+      "scope": "[resourceId('Microsoft.Web/hostingEnvironments', parameters('name'))]",
       "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Web/hostingEnvironments', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
       "properties": {
         "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -560,7 +584,7 @@
       ]
     },
     "appServiceEnvironment_configurations_customDnsSuffix": {
-      "condition": "[not(empty(parameters('customDnsSuffix')))]",
+      "condition": "[not(empty(coalesce(parameters('customDnsSuffix'), '')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
       "name": "[format('{0}-AppServiceEnv-Configurations-CustomDnsSuffix', uniqueString(deployment().name, parameters('location')))]",
@@ -574,13 +598,13 @@
             "value": "[parameters('name')]"
           },
           "certificateUrl": {
-            "value": "[parameters('customDnsSuffixCertificateUrl')]"
+            "value": "[coalesce(parameters('customDnsSuffixCertificateUrl'), '')]"
           },
           "keyVaultReferenceIdentity": {
-            "value": "[parameters('customDnsSuffixKeyVaultReferenceIdentity')]"
+            "value": "[coalesce(parameters('customDnsSuffixKeyVaultReferenceIdentity'), '')]"
           },
           "dnsSuffix": {
-            "value": "[parameters('customDnsSuffix')]"
+            "value": "[coalesce(parameters('customDnsSuffix'), '')]"
           }
         },
         "template": {
@@ -589,8 +613,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.5.1644",
-              "templateHash": "11637564412237269522"
+              "version": "0.40.2.10011",
+              "templateHash": "3480320488272565329"
             },
             "name": "Hosting Environment Custom DNS Suffix Configuration",
             "description": "This module deploys a Hosting Environment Custom DNS Suffix Configuration."
@@ -624,7 +648,7 @@
           "resources": [
             {
               "type": "Microsoft.Web/hostingEnvironments/configurations",
-              "apiVersion": "2023-12-01",
+              "apiVersion": "2025-03-01",
               "name": "[format('{0}/{1}', parameters('hostingEnvironmentName'), 'customdnssuffix')]",
               "properties": {
                 "certificateUrl": "[parameters('certificateUrl')]",
@@ -690,7 +714,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('appServiceEnvironment', '2023-12-01', 'full').location]"
+      "value": "[reference('appServiceEnvironment', '2025-03-01', 'full').location]"
     },
     "systemAssignedMIPrincipalId": {
       "type": "string",
@@ -698,7 +722,7 @@
       "metadata": {
         "description": "The principal ID of the system assigned identity."
       },
-      "value": "[tryGet(tryGet(reference('appServiceEnvironment', '2023-12-01', 'full'), 'identity'), 'principalId')]"
+      "value": "[tryGet(tryGet(reference('appServiceEnvironment', '2025-03-01', 'full'), 'identity'), 'principalId')]"
     }
   }
 }

--- a/avm/res/web/hosting-environment/tests/e2e/defaults/dependencies.bicep
+++ b/avm/res/web/hosting-environment/tests/e2e/defaults/dependencies.bicep
@@ -9,7 +9,7 @@ param virtualNetworkName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
   name: networkSecurityGroupName
   location: location
   properties: {
@@ -31,7 +31,7 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-04-0
   }
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
   name: virtualNetworkName
   location: location
   properties: {

--- a/avm/res/web/hosting-environment/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/web/hosting-environment/tests/e2e/defaults/main.test.bicep
@@ -36,7 +36,7 @@ module nestedDependencies 'dependencies.bicep' = {
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/web/hosting-environment/tests/e2e/max/dependencies.bicep
+++ b/avm/res/web/hosting-environment/tests/e2e/max/dependencies.bicep
@@ -18,7 +18,7 @@ param certDeploymentScriptName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
   name: networkSecurityGroupName
   location: location
   properties: {
@@ -40,7 +40,7 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-04-0
   }
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -71,12 +71,12 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   }
 }
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2025-01-31-preview' = {
   name: managedIdentityName
   location: location
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' = {
   name: keyVaultName
   location: location
   properties: {
@@ -107,7 +107,7 @@ resource keyPermissions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
 }
 
-resource certDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource certDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: certDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'
@@ -118,7 +118,7 @@ resource certDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01'
     }
   }
   properties: {
-    azPowerShellVersion: '8.0'
+    azPowerShellVersion: '11.0'
     retentionInterval: 'P1D'
     arguments: '-KeyVaultName "${keyVault.name}" -CertName "asev3certificate" -CertSubjectName "CN=*.internal.contoso.com"'
     scriptContent: loadTextContent('../../../../../../../utilities/e2e-template-assets/scripts/Set-CertificateInKeyVault.ps1')

--- a/avm/res/web/hosting-environment/tests/e2e/max/main.test.bicep
+++ b/avm/res/web/hosting-environment/tests/e2e/max/main.test.bicep
@@ -51,7 +51,7 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -118,6 +118,12 @@ module testDeployment '../../../main.bicep' = [
       ]
       zoneRedundant: true
       upgradePreference: 'Late'
+      ipsslAddressCount: 0
+      multiSize: 'Standard_D2_v2'
+      userWhitelistedIpRanges: [
+        '10.0.0.0/24'
+        '192.168.1.0/24'
+      ]
       diagnosticSettings: [
         {
           name: 'customSetting'

--- a/avm/res/web/hosting-environment/tests/e2e/max/main.test.bicep
+++ b/avm/res/web/hosting-environment/tests/e2e/max/main.test.bicep
@@ -120,10 +120,6 @@ module testDeployment '../../../main.bicep' = [
       upgradePreference: 'Late'
       ipsslAddressCount: 0
       multiSize: 'Standard_D2_v2'
-      userWhitelistedIpRanges: [
-        '10.0.0.0/24'
-        '192.168.1.0/24'
-      ]
       diagnosticSettings: [
         {
           name: 'customSetting'

--- a/avm/res/web/hosting-environment/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/web/hosting-environment/tests/e2e/waf-aligned/dependencies.bicep
@@ -18,7 +18,7 @@ param certDeploymentScriptName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
   name: networkSecurityGroupName
   location: location
   properties: {
@@ -40,7 +40,7 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-04-0
   }
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -71,12 +71,12 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   }
 }
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2025-01-31-preview' = {
   name: managedIdentityName
   location: location
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' = {
   name: keyVaultName
   location: location
   properties: {
@@ -107,7 +107,7 @@ resource keyPermissions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
 }
 
-resource certDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource certDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: certDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'
@@ -118,7 +118,7 @@ resource certDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01'
     }
   }
   properties: {
-    azPowerShellVersion: '8.0'
+    azPowerShellVersion: '11.0'
     retentionInterval: 'P1D'
     arguments: '-KeyVaultName "${keyVault.name}" -CertName "asev3certificate" -CertSubjectName "CN=*.internal.contoso.com"'
     scriptContent: loadTextContent('../../../../../../../utilities/e2e-template-assets/scripts/Set-CertificateInKeyVault.ps1')

--- a/avm/res/web/hosting-environment/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/web/hosting-environment/tests/e2e/waf-aligned/main.test.bicep
@@ -51,7 +51,7 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -74,6 +74,7 @@ module testDeployment '../../../main.bicep' = [
       }
       subnetResourceId: nestedDependencies.outputs.subnetResourceId
       internalLoadBalancingMode: 'Web, Publishing'
+      zoneRedundant: true
       clusterSettings: [
         {
           name: 'DisableTls1.0'
@@ -88,6 +89,10 @@ module testDeployment '../../../main.bicep' = [
         }
       }
       upgradePreference: 'Late'
+      lock: {
+        kind: 'CanNotDelete'
+        name: 'myCustomLockName'
+      }
       diagnosticSettings: [
         {
           name: 'customSetting'

--- a/avm/res/web/hosting-environment/version.json
+++ b/avm/res/web/hosting-environment/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.4"
+  "version": "0.5"
 }


### PR DESCRIPTION
## Description

This pull request introduces a new major version (0.5.0) of the `avm/res/web/hosting-environment` module, focusing on upgrading API versions, improving type safety, and adding new configuration options. The changes include breaking changes to parameter types, updates to referenced API versions, and the addition of new parameters for enhanced functionality and best practices.

**Key changes include:**

### API Version Upgrades

- Upgraded the main resource and child module API versions from `2023-12-01`/`2022-03-01` to `2025-03-01` for `Microsoft.Web/hostingEnvironments` and `Microsoft.Web/hostingEnvironments/configurations` in both Bicep and JSON templates, as well as documentation. [[1]](diffhunk://#diff-e7016e17bc06d04deec43fe7453e106fb37cef4631e684b66ee5f1eb1bbce305R5-R24) [[2]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dL29-R30) [[3]](diffhunk://#diff-1aa76cead4f94d96b829406f7f5d76e77181ab389e214ec6e9f1c69864af08d5L16-R20) [[4]](diffhunk://#diff-94b0eae423d3a20ad1d422443247c3bbcc03defe7b756b07753af2605e19ea66L42-R42) [[5]](diffhunk://#diff-7af500ca978f284f59c3e0d29dd22d07b680bbea86bc43240326216ea8c7ce0fL15-R15) [[6]](diffhunk://#diff-d3a799f0d9d757142d708aa19f8410e74498094b790f41531d960aab95e1024aL14-R14)

- Updated AVM common type imports from version `0.4.1` to `0.6.1`. [[1]](diffhunk://#diff-e7016e17bc06d04deec43fe7453e106fb37cef4631e684b66ee5f1eb1bbce305R5-R24) [[2]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dL1095)

### Parameter and Type Improvements

- Converted the `internalLoadBalancingMode`, `upgradePreference`, and `networkConfiguration` parameters to use resource-derived types instead of `@allowed` annotations or `object?`, resulting in breaking changes.

- Updated references for `tags` and `clusterSettings` to align with the new `2025-03-01` API version. [[1]](diffhunk://#diff-e7016e17bc06d04deec43fe7453e106fb37cef4631e684b66ee5f1eb1bbce305R5-R24) [[2]](diffhunk://#diff-d3a799f0d9d757142d708aa19f8410e74498094b790f41531d960aab95e1024aL14-R14)

### New Features and Parameters

- Added new parameters:
  - `ipsslAddressCount` for reserving IP SSL addresses [[1]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR143) [[2]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR250-R252) [[3]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR363) [[4]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR661-R671) [[5]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dL833-R880)
  - `multiSize` for configuring front-end VM size [[1]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR156) [[2]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR273-R275) [[3]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR376) [[4]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR976-R982) [[5]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR661-R671)
  - `userWhitelistedIpRanges` for whitelisting IP ranges on ASE [[1]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR190-R193) [[2]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR317-R322) [[3]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR410-R413) [[4]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dL1061-R1113) [[5]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR661-R671)
  - `location` output added per AVM best practices

### Documentation and Example Updates

- Updated the README and example sections to reflect new parameters, API versions, and parameter descriptions. Removed outdated default values and allowed lists where types are now resource-derived. [[1]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dL664-L688) [[2]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dL808) [[3]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dL833-R880) [[4]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dR976-R982) [[5]](diffhunk://#diff-a27097e26fa9f483d5ca8a4fd0bb2922f225201781067d50d80ec7a38c07cc2dL1061-R1113)

### Breaking Changes

- The switch to resource-derived types for several parameters (`internalLoadBalancingMode`, `upgradePreference`, `networkConfiguration`) is a breaking change and may require updates in consuming templates.

Please review these changes carefully, especially the breaking changes to parameter types, and update any dependent modules or templates accordingly.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.web.hosting-environment](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.res.web.hosting-environment.yml/badge.svg)](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.res.web.hosting-environment.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
