### PR TITLE
fix: DiskEncryptionSet - Render `keySource` optional if vault & disk encryption set don't share the same subscription

### DIFF
--- a/avm/res/compute/disk-encryption-set/CHANGELOG.md
+++ b/avm/res/compute/disk-encryption-set/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/disk-encryption-set/CHANGELOG.md).
 
+## 0.6.1
+
+### Changes
+
+- Small bugfix that ensures the module works if the DiskEncryptionSet and the Key Vault it uses are in different subscriptions. If the case, the `sourceVault` property is not passed into the deployment.
+
+### Breaking Changes
+
+- None
+
 ## 0.6.0
 
 ### Changes

--- a/avm/res/compute/disk-encryption-set/main.bicep
+++ b/avm/res/compute/disk-encryption-set/main.bicep
@@ -162,9 +162,14 @@ resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2025-01-02' = {
   identity: identity
   properties: {
     activeKey: {
-      sourceVault: {
-        id: customerManagedKey!.keyVaultResourceId
-      }
+      // Can only be used if vault & disk encryption set are in the same subscription
+      ...(split(customerManagedKey!.keyVaultResourceId, '/')[2] == subscription().id
+        ? {
+            sourceVault: {
+              id: customerManagedKey!.keyVaultResourceId
+            }
+          }
+        : {})
       keyUrl: !empty(customerManagedKey!.?keyVersion)
         ? (!isHSMManagedCMK
             ? '${cMKKeyVault::cMKKey!.properties.keyUri}/${customerManagedKey!.keyVersion!}'

--- a/avm/res/compute/disk-encryption-set/main.json
+++ b/avm/res/compute/disk-encryption-set/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.38.33.27573",
-      "templateHash": "5278210177325630355"
+      "version": "0.40.2.10011",
+      "templateHash": "13014371579579914637"
     },
     "name": "Disk Encryption Sets",
     "description": "This module deploys a Disk Encryption Set. The module will attempt to set permissions on the provided Key Vault for any used user-assigned identity."
@@ -359,12 +359,7 @@
       "tags": "[parameters('tags')]",
       "identity": "[variables('identity')]",
       "properties": {
-        "activeKey": {
-          "sourceVault": {
-            "id": "[parameters('customerManagedKey').keyVaultResourceId]"
-          },
-          "keyUrl": "[if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), if(not(variables('isHSMManagedCMK')), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, parameters('customerManagedKey').keyVersion), format('https://{0}.managedhsm.azure.net/keys/{1}/{2}', last(split(parameters('customerManagedKey').keyVaultResourceId, '/')), parameters('customerManagedKey').keyName, parameters('customerManagedKey').keyVersion)), if(not(variables('isHSMManagedCMK')), reference('cMKKeyVault::cMKKey').keyUriWithVersion, fail('Managed HSM CMK encryption requires specifying the ''keyVersion''.')))]"
-        },
+        "activeKey": "[shallowMerge(createArray(if(equals(split(parameters('customerManagedKey').keyVaultResourceId, '/')[2], subscription().id), createObject('sourceVault', createObject('id', parameters('customerManagedKey').keyVaultResourceId)), createObject()), createObject('keyUrl', if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), if(not(variables('isHSMManagedCMK')), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, parameters('customerManagedKey').keyVersion), format('https://{0}.managedhsm.azure.net/keys/{1}/{2}', last(split(parameters('customerManagedKey').keyVaultResourceId, '/')), parameters('customerManagedKey').keyName, parameters('customerManagedKey').keyVersion)), if(not(variables('isHSMManagedCMK')), reference('cMKKeyVault::cMKKey').keyUriWithVersion, fail('Managed HSM CMK encryption requires specifying the ''keyVersion''.'))))))]",
         "encryptionType": "[parameters('encryptionType')]",
         "federatedClientId": "[parameters('federatedClientId')]",
         "rotationToLatestKeyVersionEnabled": "[tryGet(parameters('customerManagedKey'), 'autoRotationEnabled')]"
@@ -381,7 +376,7 @@
       },
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
-      "scope": "[format('Microsoft.Compute/diskEncryptionSets/{0}', parameters('name'))]",
+      "scope": "[resourceId('Microsoft.Compute/diskEncryptionSets', parameters('name'))]",
       "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Compute/diskEncryptionSets', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
       "properties": {
         "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -400,7 +395,7 @@
       "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
       "type": "Microsoft.Authorization/locks",
       "apiVersion": "2020-05-01",
-      "scope": "[format('Microsoft.Compute/diskEncryptionSets/{0}', parameters('name'))]",
+      "scope": "[resourceId('Microsoft.Compute/diskEncryptionSets', parameters('name'))]",
       "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
       "properties": {
         "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
@@ -449,8 +444,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.38.33.27573",
-              "templateHash": "14495588861633815705"
+              "version": "0.40.2.10011",
+              "templateHash": "5726881581696810744"
             }
           },
           "parameters": {
@@ -492,7 +487,7 @@
               "condition": "[equals(parameters('rbacAuthorizationEnabled'), true())]",
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.KeyVault/vaults/{0}/keys/{1}', last(split(parameters('keyVaultResourceId'), '/')), parameters('keyName'))]",
+              "scope": "[resourceId('Microsoft.KeyVault/vaults/keys', last(split(parameters('keyVaultResourceId'), '/')), parameters('keyName'))]",
               "name": "[guid(format('msi-{0}-{1}-{2}-Key-Reader-RoleAssignment', resourceId('Microsoft.KeyVault/vaults/keys', last(split(parameters('keyVaultResourceId'), '/')), parameters('keyName')), parameters('location'), parameters('userAssignedIdentityResourceId')))]",
               "properties": {
                 "principalId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('userAssignedIdentityResourceId'), '/')[2], split(parameters('userAssignedIdentityResourceId'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(parameters('userAssignedIdentityResourceId'), '/'))), '2024-11-30').principalId]",
@@ -537,8 +532,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.38.33.27573",
-                      "templateHash": "14666649903122909079"
+                      "version": "0.40.2.10011",
+                      "templateHash": "4021648740442052121"
                     },
                     "name": "Key Vault Access Policies",
                     "description": "This module deploys a Key Vault Access Policy."


### PR DESCRIPTION
## Description

This is a change required to ensure the module works if the Key Vault used by the DiskEncryptionSet is located in a different subscription. Quote from the docs:

<img width="1378" height="301" alt="image" src="https://github.com/user-attachments/assets/fea3ea1e-443c-4f9b-9306-67d6aebf9c5e" />


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.compute.disk-encryption-set](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk-encryption-set.yml/badge.svg?branch=users%2Falsehr%2FdesSourceVault&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk-encryption-set.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
