### PR TITLE
fix(app-service-lza): correct web app kind parameter to respect OS configuration

### DIFF
--- a/avm/ptn/app-service-lza/hosting-environment/modules/app-service/app-service.module.bicep
+++ b/avm/ptn/app-service-lza/hosting-environment/modules/app-service/app-service.module.bicep
@@ -187,7 +187,7 @@ module plan 'br/public:avm/res/web/serverfarm:0.2.4' = {
 module webApp 'br/public:avm/res/web/site:0.9.0' = {
   name: '${uniqueString(deployment().name, location)}-webapp'
   params: {
-    kind: !empty(kind) ? 'app,linux' : 'app'
+    kind: kind
     name: webAppName
     location: location
     enableTelemetry: enableTelemetry


### PR DESCRIPTION
## Description

The `kind` parameter value passed to the web app module is being replaced with a hardcoded `'app,linux'` value when any kind is specified. This breaks Windows App Service deployments because the staging slot gets created as Linux while the production site is Windows.

Found during deployment testing - the conditional on line 190 in `app-service.module.bicep`:

kind: !empty(kind) ? 'app,linux' : 'app'

This always evaluates to `'app,linux'` when a kind parameter is passed (e.g., `'app'` for Windows), regardless of what the actual value is. Changed to pass through the parameter value directly:

kind: kind

Error message encountered:

The slot 'kind' property 'app,linux' must match the Production site 'kind' property 'app'.

## Pipeline Reference

| Pipeline |
| -------- |


## Type of Change

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version