### PR TITLE
feat: CommonTypes - New CMK type for CosmosDB

### DIFF
--- a/avm/utl/types/avm-common-types/CHANGELOG.md
+++ b/avm/utl/types/avm-common-types/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utl/types/avm-common-types/CHANGELOG.md).
 
+## 0.6.2
+
+### Changes
+
+- Added an additional type for customer-managed keys that only allow specifying the key vault & key to be used.
+
+### Breaking Changes
+
+- None
+
 ## 0.6.1
 
 ### Changes
@@ -69,7 +79,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 - Common-Types: Fixed incorrect parameter description: The FQDN parameter is optional, yet the description said it was required.
 - Diverse: Fixed metadata descriptions
 - Fixed static test validating parameter descriptions
-- It checked for a line that looke like ('Required. even though the value of the $description variable at the time only has the description's value, that is Required.
+  - It checked for a line that looks like "'Required.", even though the value of the $description variable at the time only has the description's value, that is Required.
 - Added test that tests the reverse, that is, that a parameter's description starts with Required. in its title if it is required
 
 ### Breaking Changes

--- a/avm/utl/types/avm-common-types/CHANGELOG.md
+++ b/avm/utl/types/avm-common-types/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/utl/types/avm-common-types/CHANGELOG.md).
 
-## 0.6.2
+## 0.7.0
 
 ### Changes
 

--- a/avm/utl/types/avm-common-types/README.md
+++ b/avm/utl/types/avm-common-types/README.md
@@ -64,6 +64,7 @@ Note: In your module you would import only the types you need.
 
 import {
   customerManagedKeyType
+  customerManagedKeyAndVaultOnlyType
   customerManagedKeyWithAutoRotateType
   diagnosticSettingFullType
   diagnosticSettingLogsOnlyType
@@ -322,6 +323,12 @@ param customerManagedKeyWithAutoRotate customerManagedKeyWithAutoRotateType = {
   userAssignedIdentityResourceId: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myIdentity'
 }
 output customerManagedKeyWithAutoRotateOutput customerManagedKeyWithAutoRotateType = customerManagedKeyWithAutoRotate
+
+param customerManagedKeyAndVaultOnly customerManagedKeyAndVaultOnlyType = {
+  keyName: 'myKey'
+  keyVaultResourceId: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.KeyVault/vaults/myVault'
+}
+output customerManagedKeyAndVaultOnly customerManagedKeyAndVaultOnlyType = customerManagedKeyAndVaultOnly
 
 // ================== //
 //   Secrets Export   //

--- a/avm/utl/types/avm-common-types/main.bicep
+++ b/avm/utl/types/avm-common-types/main.bicep
@@ -380,6 +380,16 @@ type customerManagedKeyType = {
 }
 
 @export()
+@description('An AVM-aligned type for a customer-managed key. To be used if only the key vault & key may be specified..')
+type customerManagedKeyAndVaultOnlyType = {
+  @description('Required. The resource ID of a key vault to reference a customer managed key for encryption from.')
+  keyVaultResourceId: string
+
+  @description('Required. The name of the customer managed key to use for encryption.')
+  keyName: string
+}
+
+@export()
 @description('An AVM-aligned type for a customer-managed key. To be used if the resource type supports auto-rotation of the customer-managed key.')
 type customerManagedKeyWithAutoRotateType = {
   @description('Required. The resource ID of a key vault to reference a customer managed key for encryption from.')

--- a/avm/utl/types/avm-common-types/main.bicep
+++ b/avm/utl/types/avm-common-types/main.bicep
@@ -380,7 +380,7 @@ type customerManagedKeyType = {
 }
 
 @export()
-@description('An AVM-aligned type for a customer-managed key. To be used if only the key vault & key may be specified..')
+@description('An AVM-aligned type for a customer-managed key. To be used if only the key vault & key may be specified.')
 type customerManagedKeyAndVaultOnlyType = {
   @description('Required. The resource ID of a key vault to reference a customer managed key for encryption from.')
   keyVaultResourceId: string

--- a/avm/utl/types/avm-common-types/main.json
+++ b/avm/utl/types/avm-common-types/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.40.2.10011",
-      "templateHash": "17982478377912932546"
+      "templateHash": "15180421612793324069"
     },
     "name": "Default interface types for AVM modules",
     "description": "This module provides you with all common variants for AVM interfaces to be used in AVM modules.\n\nDetails for how to implement these interfaces can be found in the AVM documentation [here](https://azure.github.io/Azure-Verified-Modules/specs/bcp/res/interfaces/).\n"
@@ -915,7 +915,7 @@
       },
       "metadata": {
         "__bicep_export!": true,
-        "description": "An AVM-aligned type for a customer-managed key. To be used if only the key vault & key may be specified.."
+        "description": "An AVM-aligned type for a customer-managed key. To be used if only the key vault & key may be specified."
       }
     },
     "customerManagedKeyWithAutoRotateType": {

--- a/avm/utl/types/avm-common-types/main.json
+++ b/avm/utl/types/avm-common-types/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "4786376631151649274"
+      "version": "0.40.2.10011",
+      "templateHash": "17982478377912932546"
     },
     "name": "Default interface types for AVM modules",
     "description": "This module provides you with all common variants for AVM interfaces to be used in AVM modules.\n\nDetails for how to implement these interfaces can be found in the AVM documentation [here](https://azure.github.io/Azure-Verified-Modules/specs/bcp/res/interfaces/).\n"
@@ -895,6 +895,27 @@
       "metadata": {
         "__bicep_export!": true,
         "description": "An AVM-aligned type for a customer-managed key. To be used if the resource type does not support auto-rotation of the customer-managed key."
+      }
+    },
+    "customerManagedKeyAndVaultOnlyType": {
+      "type": "object",
+      "properties": {
+        "keyVaultResourceId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
+          }
+        },
+        "keyName": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the customer managed key to use for encryption."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "An AVM-aligned type for a customer-managed key. To be used if only the key vault & key may be specified.."
       }
     },
     "customerManagedKeyWithAutoRotateType": {

--- a/avm/utl/types/avm-common-types/tests/e2e/import/main.test.bicep
+++ b/avm/utl/types/avm-common-types/tests/e2e/import/main.test.bicep
@@ -13,6 +13,7 @@ Note: In your module you would import only the types you need.
 
 import {
   customerManagedKeyType
+  customerManagedKeyAndVaultOnlyType
   customerManagedKeyWithAutoRotateType
   diagnosticSettingFullType
   diagnosticSettingLogsOnlyType
@@ -271,6 +272,12 @@ param customerManagedKeyWithAutoRotate customerManagedKeyWithAutoRotateType = {
   userAssignedIdentityResourceId: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myIdentity'
 }
 output customerManagedKeyWithAutoRotateOutput customerManagedKeyWithAutoRotateType = customerManagedKeyWithAutoRotate
+
+param customerManagedKeyAndVaultOnly customerManagedKeyAndVaultOnlyType = {
+  keyName: 'myKey'
+  keyVaultResourceId: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.KeyVault/vaults/myVault'
+}
+output customerManagedKeyAndVaultOnly customerManagedKeyAndVaultOnlyType = customerManagedKeyAndVaultOnly
 
 // ================== //
 //   Secrets Export   //

--- a/avm/utl/types/avm-common-types/version.json
+++ b/avm/utl/types/avm-common-types/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.6"
+  "version": "0.7"
 }


### PR DESCRIPTION
## Description

Added an additional type for customer-managed keys that only allow specifying the key vault & key to be used.
Required for CosmosDB

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.utl.types.avm-common-types](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml/badge.svg?branch=users%2Falsehr%2FcmkNoVersionVar&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.utl.types.avm-common-types.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
