### PR TITLE
fix: Fix identity variable conditional in CDN profile module

### DIFF
--- a/avm/res/cdn/profile/CHANGELOG.md
+++ b/avm/res/cdn/profile/CHANGELOG.md
@@ -6,7 +6,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Changes
 
-- Fixed `identity` variable to check `managedIdentities.?userAssignedResourceIds` instead of `formattedRoleAssignments` when determining identity type. This bug was introduced in v0.17.0 and could cause incorrect identity type assignment when role assignments and user-assigned identities were not both present. (#6538)
+- Fixed `identity` variable to check `formattedUserAssignedIdentities` instead of `formattedRoleAssignments` when determining identity type. This bug was introduced in v0.17.0 and led to unintended logical behavior. (#6538)
 
 ### Breaking Changes
 

--- a/avm/res/cdn/profile/CHANGELOG.md
+++ b/avm/res/cdn/profile/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/CHANGELOG.md).
 
+## 0.17.2
+
+### Changes
+
+- Fixed `identity` variable to check `managedIdentities.?userAssignedResourceIds` instead of `formattedRoleAssignments` when determining identity type. This bug was introduced in v0.17.0 and could cause incorrect identity type assignment when role assignments and user-assigned identities were not both present. (#6538)
+
+### Breaking Changes
+
+- None
+
 ## 0.17.1
 
 ### Changes

--- a/avm/res/cdn/profile/main.bicep
+++ b/avm/res/cdn/profile/main.bicep
@@ -117,8 +117,8 @@ var formattedUserAssignedIdentities = reduce(
 var identity = !empty(managedIdentities)
   ? {
       type: (managedIdentities.?systemAssigned ?? false)
-        ? (!empty(managedIdentities.?userAssignedResourceIds ?? {}) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned')
-        : (!empty(managedIdentities.?userAssignedResourceIds ?? {}) ? 'UserAssigned' : 'None')
+        ? (!empty(formattedUserAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned')
+        : (!empty(formattedUserAssignedIdentities) ? 'UserAssigned' : 'None')
       userAssignedIdentities: !empty(formattedUserAssignedIdentities) ? formattedUserAssignedIdentities : null
     }
   : null

--- a/avm/res/cdn/profile/main.bicep
+++ b/avm/res/cdn/profile/main.bicep
@@ -117,8 +117,8 @@ var formattedUserAssignedIdentities = reduce(
 var identity = !empty(managedIdentities)
   ? {
       type: (managedIdentities.?systemAssigned ?? false)
-        ? (!empty(formattedRoleAssignments) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned')
-        : (!empty(formattedRoleAssignments) ? 'UserAssigned' : 'None')
+        ? (!empty(managedIdentities.?userAssignedResourceIds ?? {}) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned')
+        : (!empty(managedIdentities.?userAssignedResourceIds ?? {}) ? 'UserAssigned' : 'None')
       userAssignedIdentities: !empty(formattedUserAssignedIdentities) ? formattedUserAssignedIdentities : null
     }
   : null

--- a/avm/res/cdn/profile/main.json
+++ b/avm/res/cdn/profile/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.40.2.10011",
-      "templateHash": "6725447162183835764"
+      "templateHash": "3241063816673671058"
     },
     "name": "CDN Profiles",
     "description": "This module deploys a CDN Profile."
@@ -1145,7 +1145,7 @@
       "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
     },
     "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
-    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned,UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]"
+    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(variables('formattedUserAssignedIdentities'))), 'SystemAssigned,UserAssigned', 'SystemAssigned'), if(not(empty(variables('formattedUserAssignedIdentities'))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]"
   },
   "resources": {
     "avmTelemetry": {

--- a/avm/res/cdn/profile/main.json
+++ b/avm/res/cdn/profile/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.40.2.10011",
-      "templateHash": "3471979177769024312"
+      "templateHash": "6725447162183835764"
     },
     "name": "CDN Profiles",
     "description": "This module deploys a CDN Profile."
@@ -1145,7 +1145,7 @@
       "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
     },
     "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
-    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(variables('formattedRoleAssignments'))), 'SystemAssigned,UserAssigned', 'SystemAssigned'), if(not(empty(variables('formattedRoleAssignments'))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]"
+    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned,UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]"
   },
   "resources": {
     "avmTelemetry": {


### PR DESCRIPTION
## Description

Fixes the `identity` variable in `avm/res/cdn/profile/main.bicep` to check `managedIdentities.?userAssignedResourceIds` instead of `formattedRoleAssignments` when determining the identity type. This bug was introduced in v0.17.0 and could cause incorrect identity type assignment when role assignments and user-assigned identities were not both present.

Fixes #6538

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.cdn.profile](https://github.com/gbeaud/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml/badge.svg?branch=Fix-Identity&event=workflow_dispatch)](https://github.com/gbeaud/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml) |

## Type of Change

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version
