### PR TITLE
feat: `avm/res/network/private-endpoint` - update API versions + `ipVersionType` parameter

### DIFF
--- a/avm/res/network/private-endpoint/CHANGELOG.md
+++ b/avm/res/network/private-endpoint/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/private-endpoint/CHANGELOG.md).
 
+## 0.12.0
+
+### Changes
+
+- Updated API versions for all resources to the latest available
+- Updated 'avm-common-types version' to `0.7.0`
+- Added new parameter `ipVersionType` to support both IPv4 and IPv6 private endpoints
+
+### Breaking Changes
+
+- None
+
 ## 0.11.1
 
 ### Changes

--- a/avm/res/network/private-endpoint/README.md
+++ b/avm/res/network/private-endpoint/README.md
@@ -25,8 +25,8 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | :-- | :-- | :-- |
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
-| `Microsoft.Network/privateEndpoints` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_privateendpoints.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/privateEndpoints)</li></ul> |
-| `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_privateendpoints_privatednszonegroups.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/privateEndpoints/privateDnsZoneGroups)</li></ul> |
+| `Microsoft.Network/privateEndpoints` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_privateendpoints.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2025-05-01/privateEndpoints)</li></ul> |
+| `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_privateendpoints_privatednszonegroups.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2025-05-01/privateEndpoints/privateDnsZoneGroups)</li></ul> |
 
 ## Usage examples
 
@@ -181,6 +181,7 @@ module privateEndpoint 'br/public:avm/res/network/private-endpoint:<version>' = 
         }
       }
     ]
+    ipVersionType: 'IPv4'
     location: '<location>'
     lock: {
       kind: 'CanNotDelete'
@@ -285,6 +286,9 @@ module privateEndpoint 'br/public:avm/res/network/private-endpoint:<version>' = 
         }
       ]
     },
+    "ipVersionType": {
+      "value": "IPv4"
+    },
     "location": {
       "value": "<location>"
     },
@@ -387,6 +391,7 @@ param ipConfigurations = [
     }
   }
 ]
+param ipVersionType = 'IPv4'
 param location = '<location>'
 param lock = {
   kind: 'CanNotDelete'
@@ -781,6 +786,7 @@ param tags = {
 | [`customNetworkInterfaceName`](#parameter-customnetworkinterfacename) | string | The custom name of the network interface attached to the private endpoint. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`ipConfigurations`](#parameter-ipconfigurations) | array | A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints. |
+| [`ipVersionType`](#parameter-ipversiontype) | string | Specifies the IP version type for the private IPs of the private endpoint. If not defined, this defaults to IPv4. |
 | [`location`](#parameter-location) | string | Location for all Resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`privateDnsZoneGroup`](#parameter-privatednszonegroup) | object | The private DNS zone group to configure for the private endpoint. |
@@ -850,6 +856,13 @@ A list of IP configurations of the private endpoint. This will be used to map to
 
 - Required: No
 - Type: array
+
+### Parameter: `ipVersionType`
+
+Specifies the IP version type for the private IPs of the private endpoint. If not defined, this defaults to IPv4.
+
+- Required: No
+- Type: string
 
 ### Parameter: `location`
 
@@ -1095,7 +1108,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.7.0` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/network/private-endpoint/README.md
+++ b/avm/res/network/private-endpoint/README.md
@@ -863,6 +863,7 @@ Specifies the IP version type for the private IPs of the private endpoint. If no
 
 - Required: No
 - Type: string
+- Default: `'IPv4'`
 
 ### Parameter: `location`
 

--- a/avm/res/network/private-endpoint/main.bicep
+++ b/avm/res/network/private-endpoint/main.bicep
@@ -14,7 +14,10 @@ param applicationSecurityGroupResourceIds string[]?
 param customNetworkInterfaceName string?
 
 @description('Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints.')
-param ipConfigurations resourceInput<'Microsoft.Network/privateEndpoints@2024-01-01'>.properties.ipConfigurations?
+param ipConfigurations resourceInput<'Microsoft.Network/privateEndpoints@2025-05-01'>.properties.ipConfigurations?
+
+@description('Optional. Specifies the IP version type for the private IPs of the private endpoint. If not defined, this defaults to IPv4.')
+param ipVersionType resourceInput<'Microsoft.Network/privateEndpoints@2025-05-01'>.properties.ipVersionType?
 
 @description('Optional. The private DNS zone group to configure for the private endpoint.')
 param privateDnsZoneGroup privateDnsZoneGroupType?
@@ -31,16 +34,16 @@ import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6
 param roleAssignments roleAssignmentType[]?
 
 @description('Optional. Tags to be applied on all resources/resource groups in this deployment.')
-param tags resourceInput<'Microsoft.Network/privateEndpoints@2024-01-01'>.tags?
+param tags resourceInput<'Microsoft.Network/privateEndpoints@2025-05-01'>.tags?
 
 @description('Optional. Custom DNS configurations.')
-param customDnsConfigs resourceInput<'Microsoft.Network/privateEndpoints@2024-01-01'>.properties.customDnsConfigs?
+param customDnsConfigs resourceInput<'Microsoft.Network/privateEndpoints@2025-05-01'>.properties.customDnsConfigs?
 
 @description('Conditional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource. Required if `privateLinkServiceConnections` is empty.')
-param manualPrivateLinkServiceConnections resourceInput<'Microsoft.Network/privateEndpoints@2024-01-01'>.properties.manualPrivateLinkServiceConnections?
+param manualPrivateLinkServiceConnections resourceInput<'Microsoft.Network/privateEndpoints@2025-05-01'>.properties.manualPrivateLinkServiceConnections?
 
 @description('Conditional. A grouping of information about the connection to the remote resource. Required if `manualPrivateLinkServiceConnections` is empty.')
-param privateLinkServiceConnections resourceInput<'Microsoft.Network/privateEndpoints@2024-01-01'>.properties.privateLinkServiceConnections?
+param privateLinkServiceConnections resourceInput<'Microsoft.Network/privateEndpoints@2025-05-01'>.properties.privateLinkServiceConnections?
 
 @description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
@@ -109,7 +112,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableT
   }
 }
 
-resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-10-01' = {
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2025-05-01' = {
   name: name
   location: location
   tags: tags
@@ -127,6 +130,7 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-10-01' = {
     subnet: {
       id: subnetResourceId
     }
+    ipVersionType: ipVersionType
   }
 }
 
@@ -179,7 +183,7 @@ output name string = privateEndpoint.name
 output location string = privateEndpoint.location
 
 @description('The custom DNS configurations of the private endpoint.')
-output customDnsConfigs resourceOutput<'Microsoft.Network/privateEndpoints@2024-01-01'>.properties.customDnsConfigs = privateEndpoint.properties.customDnsConfigs
+output customDnsConfigs resourceOutput<'Microsoft.Network/privateEndpoints@2025-05-01'>.properties.customDnsConfigs = privateEndpoint.properties.customDnsConfigs
 
 @description('The resource IDs of the network interfaces associated with the private endpoint.')
 output networkInterfaceResourceIds string[] = map(privateEndpoint.properties.networkInterfaces, nic => nic.id)

--- a/avm/res/network/private-endpoint/main.bicep
+++ b/avm/res/network/private-endpoint/main.bicep
@@ -17,7 +17,7 @@ param customNetworkInterfaceName string?
 param ipConfigurations resourceInput<'Microsoft.Network/privateEndpoints@2025-05-01'>.properties.ipConfigurations?
 
 @description('Optional. Specifies the IP version type for the private IPs of the private endpoint. If not defined, this defaults to IPv4.')
-param ipVersionType resourceInput<'Microsoft.Network/privateEndpoints@2025-05-01'>.properties.ipVersionType?
+param ipVersionType resourceInput<'Microsoft.Network/privateEndpoints@2025-05-01'>.properties.ipVersionType = 'IPv4'
 
 @description('Optional. The private DNS zone group to configure for the private endpoint.')
 param privateDnsZoneGroup privateDnsZoneGroupType?

--- a/avm/res/network/private-endpoint/main.bicep
+++ b/avm/res/network/private-endpoint/main.bicep
@@ -25,11 +25,11 @@ param privateDnsZoneGroup privateDnsZoneGroupType?
 @description('Optional. Location for all Resources.')
 param location string = resourceGroup().location
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. The lock settings of the service.')
 param lock lockType?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 

--- a/avm/res/network/private-endpoint/main.json
+++ b/avm/res/network/private-endpoint/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "1689225882409492834"
+      "templateHash": "18260738850189792400"
     },
     "name": "Private Endpoints",
     "description": "This module deploys a Private Endpoint."
@@ -70,7 +70,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a lock.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     },
@@ -169,7 +169,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     }
@@ -208,9 +208,19 @@
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.Network/privateEndpoints@2024-01-01#properties/properties/properties/ipConfigurations"
+          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/ipConfigurations"
         },
         "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
+      },
+      "nullable": true
+    },
+    "ipVersionType": {
+      "type": "string",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/ipVersionType"
+        },
+        "description": "Optional. Specifies the IP version type for the private IPs of the private endpoint. If not defined, this defaults to IPv4."
       },
       "nullable": true
     },
@@ -249,7 +259,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.Network/privateEndpoints@2024-01-01#properties/tags"
+          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/tags"
         },
         "description": "Optional. Tags to be applied on all resources/resource groups in this deployment."
       },
@@ -259,7 +269,7 @@
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.Network/privateEndpoints@2024-01-01#properties/properties/properties/customDnsConfigs"
+          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/customDnsConfigs"
         },
         "description": "Optional. Custom DNS configurations."
       },
@@ -269,7 +279,7 @@
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.Network/privateEndpoints@2024-01-01#properties/properties/properties/manualPrivateLinkServiceConnections"
+          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/manualPrivateLinkServiceConnections"
         },
         "description": "Conditional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource. Required if `privateLinkServiceConnections` is empty."
       },
@@ -279,7 +289,7 @@
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.Network/privateEndpoints@2024-01-01#properties/properties/properties/privateLinkServiceConnections"
+          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/privateLinkServiceConnections"
         },
         "description": "Conditional. A grouping of information about the connection to the remote resource. Required if `manualPrivateLinkServiceConnections` is empty."
       },
@@ -337,7 +347,7 @@
     },
     "privateEndpoint": {
       "type": "Microsoft.Network/privateEndpoints",
-      "apiVersion": "2024-10-01",
+      "apiVersion": "2025-05-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -358,7 +368,8 @@
         "privateLinkServiceConnections": "[coalesce(parameters('privateLinkServiceConnections'), createArray())]",
         "subnet": {
           "id": "[parameters('subnetResourceId')]"
-        }
+        },
+        "ipVersionType": "[parameters('ipVersionType')]"
       }
     },
     "privateEndpoint_lock": {
@@ -426,7 +437,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.41.2.15936",
-              "templateHash": "16749814813950384638"
+              "templateHash": "9935179114830442414"
             },
             "name": "Private Endpoint Private DNS Zone Groups",
             "description": "This module deploys a Private Endpoint Private DNS Zone Group."
@@ -485,12 +496,12 @@
             "privateEndpoint": {
               "existing": true,
               "type": "Microsoft.Network/privateEndpoints",
-              "apiVersion": "2024-10-01",
+              "apiVersion": "2025-05-01",
               "name": "[parameters('privateEndpointName')]"
             },
             "privateDnsZoneGroup": {
               "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
-              "apiVersion": "2024-10-01",
+              "apiVersion": "2025-05-01",
               "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
               "properties": {
                 "copy": [
@@ -565,13 +576,13 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('privateEndpoint', '2024-10-01', 'full').location]"
+      "value": "[reference('privateEndpoint', '2025-05-01', 'full').location]"
     },
     "customDnsConfigs": {
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.Network/privateEndpoints@2024-01-01#properties/properties/properties/customDnsConfigs",
+          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/customDnsConfigs",
           "output": true
         },
         "description": "The custom DNS configurations of the private endpoint."

--- a/avm/res/network/private-endpoint/main.json
+++ b/avm/res/network/private-endpoint/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "18260738850189792400"
+      "templateHash": "102135285937683920"
     },
     "name": "Private Endpoints",
     "description": "This module deploys a Private Endpoint."
@@ -222,7 +222,7 @@
         },
         "description": "Optional. Specifies the IP version type for the private IPs of the private endpoint. If not defined, this defaults to IPv4."
       },
-      "nullable": true
+      "defaultValue": "IPv4"
     },
     "privateDnsZoneGroup": {
       "$ref": "#/definitions/privateDnsZoneGroupType",

--- a/avm/res/network/private-endpoint/private-dns-zone-group/README.md
+++ b/avm/res/network/private-endpoint/private-dns-zone-group/README.md
@@ -12,7 +12,7 @@ This module deploys a Private Endpoint Private DNS Zone Group.
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_privateendpoints_privatednszonegroups.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/privateEndpoints/privateDnsZoneGroups)</li></ul> |
+| `Microsoft.Network/privateEndpoints/privateDnsZoneGroups` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_privateendpoints_privatednszonegroups.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2025-05-01/privateEndpoints/privateDnsZoneGroups)</li></ul> |
 
 ## Parameters
 

--- a/avm/res/network/private-endpoint/private-dns-zone-group/main.bicep
+++ b/avm/res/network/private-endpoint/private-dns-zone-group/main.bicep
@@ -12,11 +12,11 @@ param privateDnsZoneConfigs privateDnsZoneGroupConfigType[]
 @description('Optional. The name of the private DNS zone group.')
 param name string = 'default'
 
-resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-10-01' existing = {
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2025-05-01' existing = {
   name: privateEndpointName
 }
 
-resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-10-01' = {
+resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2025-05-01' = {
   name: name
   parent: privateEndpoint
   properties: {

--- a/avm/res/network/private-endpoint/private-dns-zone-group/main.json
+++ b/avm/res/network/private-endpoint/private-dns-zone-group/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "16749814813950384638"
+      "templateHash": "9935179114830442414"
     },
     "name": "Private Endpoint Private DNS Zone Groups",
     "description": "This module deploys a Private Endpoint Private DNS Zone Group."
@@ -65,12 +65,12 @@
     "privateEndpoint": {
       "existing": true,
       "type": "Microsoft.Network/privateEndpoints",
-      "apiVersion": "2024-10-01",
+      "apiVersion": "2025-05-01",
       "name": "[parameters('privateEndpointName')]"
     },
     "privateDnsZoneGroup": {
       "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
-      "apiVersion": "2024-10-01",
+      "apiVersion": "2025-05-01",
       "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
       "properties": {
         "copy": [

--- a/avm/res/network/private-endpoint/tests/e2e/defaults/dependencies.bicep
+++ b/avm/res/network/private-endpoint/tests/e2e/defaults/dependencies.bicep
@@ -9,7 +9,7 @@ param keyVaultName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -29,7 +29,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   }
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' = {
   name: keyVaultName
   location: location
   properties: {

--- a/avm/res/network/private-endpoint/tests/e2e/max/dependencies.bicep
+++ b/avm/res/network/private-endpoint/tests/e2e/max/dependencies.bicep
@@ -15,7 +15,7 @@ param applicationSecurityGroupName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -35,7 +35,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   }
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' = {
   name: keyVaultName
   location: location
   properties: {
@@ -53,7 +53,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
   }
 }
 
-resource applicationSecurityGroup 'Microsoft.Network/applicationSecurityGroups@2024-05-01' = {
+resource applicationSecurityGroup 'Microsoft.Network/applicationSecurityGroups@2025-05-01' = {
   name: applicationSecurityGroupName
   location: location
 }

--- a/avm/res/network/private-endpoint/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/private-endpoint/tests/e2e/max/main.test.bicep
@@ -100,6 +100,7 @@ module testDeployment '../../../main.bicep' = [
           }
         }
       ]
+      ipVersionType: 'IPv4'
       customDnsConfigs: [
         {
           fqdn: 'abc.keyvault.com'

--- a/avm/res/network/private-endpoint/tests/e2e/private-link/dependencies.bicep
+++ b/avm/res/network/private-endpoint/tests/e2e/private-link/dependencies.bicep
@@ -15,7 +15,7 @@ var backendPoolName = 'backEndPool'
 var loadBalancerFrontEndIpConfigurationName = 'myFrontEnd'
 var healthProbeName = 'healthProbe'
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -42,7 +42,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   }
 }
 
-resource loadbalancer 'Microsoft.Network/loadBalancers@2024-05-01' = {
+resource loadbalancer 'Microsoft.Network/loadBalancers@2025-05-01' = {
   name: loadbalancerName
   location: location
   sku: {
@@ -121,7 +121,7 @@ resource loadbalancer 'Microsoft.Network/loadBalancers@2024-05-01' = {
   }
 }
 
-resource privateLinkService 'Microsoft.Network/privateLinkServices@2024-05-01' = {
+resource privateLinkService 'Microsoft.Network/privateLinkServices@2025-05-01' = {
   name: privateLinkServiceName
   location: location
   properties: {

--- a/avm/res/network/private-endpoint/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/network/private-endpoint/tests/e2e/waf-aligned/dependencies.bicep
@@ -15,7 +15,7 @@ param applicationSecurityGroupName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-10-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -35,7 +35,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-10-01' = {
   }
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' = {
   name: keyVaultName
   location: location
   properties: {
@@ -53,7 +53,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
   }
 }
 
-resource applicationSecurityGroup 'Microsoft.Network/applicationSecurityGroups@2024-05-01' = {
+resource applicationSecurityGroup 'Microsoft.Network/applicationSecurityGroups@2025-05-01' = {
   name: applicationSecurityGroupName
   location: location
 }

--- a/avm/res/network/private-endpoint/version.json
+++ b/avm/res/network/private-endpoint/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.11"
+  "version": "0.12"
 }


### PR DESCRIPTION
## Description

Updates private-endpoint to use the latest Azure API versions and adds support for the new `ipVersionType` property. 

This update resolves static validation warnings that are generated in all AVM modules which reference the private endpoint module, indicating that the `Microsoft.Network/privateEndpoints` API version is outdated.

Closes #6550

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.network.private-endpoint](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-endpoint.yml/badge.svg?branch=users%2Fkrbar%2FpeUpdate)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.private-endpoint.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
