### PR TITLE
feat: MaintenanceConfiguration - Introduced several resource-derived types

### DIFF
--- a/avm/res/maintenance/maintenance-configuration/CHANGELOG.md
+++ b/avm/res/maintenance/maintenance-configuration/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/maintenance/maintenance-configuration/CHANGELOG.md).
 
+## 0.4.0
+
+### Changes
+
+- Replaced custom type for parameter `maintenanceScope` with resource-derived type to enable all available values (e.g., 'Resource')
+- Updated LockType to 'avm-common-types version' `0.7.0`, enabling custom notes for locks.
+
+### Breaking Changes
+
+- Changed type of parameter `visibility` to resource-derived type and changed the default from `''` to nullable.
+
 ## 0.3.2
 
 ### Changes

--- a/avm/res/maintenance/maintenance-configuration/README.md
+++ b/avm/res/maintenance/maintenance-configuration/README.md
@@ -53,10 +53,7 @@ You can find the full example and the setup of its dependencies in the deploymen
 ```bicep
 module maintenanceConfiguration 'br/public:avm/res/maintenance/maintenance-configuration:<version>' = {
   params: {
-    // Required parameters
     name: 'mmcmin001'
-    // Non-required parameters
-    location: '<location>'
   }
 }
 ```
@@ -73,13 +70,8 @@ module maintenanceConfiguration 'br/public:avm/res/maintenance/maintenance-confi
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    // Required parameters
     "name": {
       "value": "mmcmin001"
-    },
-    // Non-required parameters
-    "location": {
-      "value": "<location>"
     }
   }
 }
@@ -95,10 +87,7 @@ module maintenanceConfiguration 'br/public:avm/res/maintenance/maintenance-confi
 ```bicep-params
 using 'br/public:avm/res/maintenance/maintenance-configuration:<version>'
 
-// Required parameters
 param name = 'mmcmin001'
-// Non-required parameters
-param location = '<location>'
 ```
 
 </details>
@@ -394,7 +383,6 @@ module maintenanceConfiguration 'br/public:avm/res/maintenance/maintenance-confi
         kbNumbersToInclude: '<kbNumbersToInclude>'
       }
     }
-    location: '<location>'
     maintenanceScope: 'InGuestPatch'
     maintenanceWindow: {
       duration: '03:00'
@@ -453,9 +441,6 @@ module maintenanceConfiguration 'br/public:avm/res/maintenance/maintenance-confi
           "kbNumbersToInclude": "<kbNumbersToInclude>"
         }
       }
-    },
-    "location": {
-      "value": "<location>"
     },
     "maintenanceScope": {
       "value": "InGuestPatch"
@@ -518,7 +503,6 @@ param installPatches = {
     kbNumbersToInclude: '<kbNumbersToInclude>'
   }
 }
-param location = '<location>'
 param maintenanceScope = 'InGuestPatch'
 param maintenanceWindow = {
   duration: '03:00'
@@ -653,17 +637,6 @@ Gets or sets maintenanceScope of the configuration.
 - Required: No
 - Type: string
 - Default: `'Host'`
-- Allowed:
-  ```Bicep
-  [
-    'Extension'
-    'Host'
-    'InGuestPatch'
-    'OSImage'
-    'SQLDB'
-    'SQLManagedInstance'
-  ]
-  ```
 
 ### Parameter: `maintenanceWindow`
 
@@ -798,15 +771,6 @@ Gets or sets the visibility of the configuration. The default value is 'Custom'.
 
 - Required: No
 - Type: string
-- Default: `''`
-- Allowed:
-  ```Bicep
-  [
-    ''
-    'Custom'
-    'Public'
-  ]
-  ```
 
 ## Outputs
 
@@ -823,8 +787,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.5.1` | Remote reference |
-| `br/public:avm/utl/types/avm-common-types:0.6.0` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.7.0` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/maintenance/maintenance-configuration/main.bicep
+++ b/avm/res/maintenance/maintenance-configuration/main.bicep
@@ -17,20 +17,12 @@ param extensionProperties resourceInput<'Microsoft.Maintenance/maintenanceConfig
 @description('Optional. Location for all Resources.')
 param location string = resourceGroup().location
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. The lock settings of the service.')
 param lock lockType?
 
 @description('Optional. Gets or sets maintenanceScope of the configuration.')
-@allowed([
-  'Host'
-  'OSImage'
-  'Extension'
-  'InGuestPatch'
-  'SQLDB'
-  'SQLManagedInstance'
-])
-param maintenanceScope string = 'Host'
+param maintenanceScope resourceInput<'Microsoft.Maintenance/maintenanceConfigurations@2023-04-01'>.properties.maintenanceScope = 'Host'
 
 @description('Optional. Definition of a MaintenanceWindow.')
 param maintenanceWindow resourceInput<'Microsoft.Maintenance/maintenanceConfigurations@2023-04-01'>.properties.maintenanceWindow = {}
@@ -38,7 +30,7 @@ param maintenanceWindow resourceInput<'Microsoft.Maintenance/maintenanceConfigur
 @description('Optional. Gets or sets namespace of the resource.')
 param namespace string = ''
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
@@ -46,12 +38,7 @@ param roleAssignments roleAssignmentType[]?
 param tags resourceInput<'Microsoft.Maintenance/maintenanceConfigurations@2023-04-01'>.tags?
 
 @description('Optional. Gets or sets the visibility of the configuration. The default value is \'Custom\'.')
-@allowed([
-  ''
-  'Custom'
-  'Public'
-])
-param visibility string = ''
+param visibility resourceInput<'Microsoft.Maintenance/maintenanceConfigurations@2023-04-01'>.properties.visibility?
 
 @description('Optional. Configuration settings for VM guest patching with Azure Update Manager.')
 param installPatches resourceInput<'Microsoft.Maintenance/maintenanceConfigurations@2023-04-01'>.properties.installPatches = {}
@@ -90,7 +77,7 @@ var formattedRoleAssignments = [
 ]
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.maintenance-maintenanceconfiguration.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'

--- a/avm/res/maintenance/maintenance-configuration/main.json
+++ b/avm/res/maintenance/maintenance-configuration/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "6678560934955585185"
+      "templateHash": "2036075341673928595"
     },
     "name": "Maintenance Configurations",
     "description": "This module deploys a Maintenance Configuration."
@@ -45,7 +45,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a lock.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     },
@@ -120,7 +120,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     }
@@ -165,18 +165,13 @@
     },
     "maintenanceScope": {
       "type": "string",
-      "defaultValue": "Host",
-      "allowedValues": [
-        "Host",
-        "OSImage",
-        "Extension",
-        "InGuestPatch",
-        "SQLDB",
-        "SQLManagedInstance"
-      ],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Maintenance/maintenanceConfigurations@2023-04-01#properties/properties/properties/maintenanceScope"
+        },
         "description": "Optional. Gets or sets maintenanceScope of the configuration."
-      }
+      },
+      "defaultValue": "Host"
     },
     "maintenanceWindow": {
       "type": "object",
@@ -217,15 +212,13 @@
     },
     "visibility": {
       "type": "string",
-      "defaultValue": "",
-      "allowedValues": [
-        "",
-        "Custom",
-        "Public"
-      ],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Maintenance/maintenanceConfigurations@2023-04-01#properties/properties/properties/visibility"
+        },
         "description": "Optional. Gets or sets the visibility of the configuration. The default value is 'Custom'."
-      }
+      },
+      "nullable": true
     },
     "installPatches": {
       "type": "object",
@@ -259,7 +252,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.maintenance-maintenanceconfiguration.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",

--- a/avm/res/maintenance/maintenance-configuration/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/maintenance/maintenance-configuration/tests/e2e/defaults/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -42,7 +42,6 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
     }
   }
 ]

--- a/avm/res/maintenance/maintenance-configuration/tests/e2e/max/dependencies.bicep
+++ b/avm/res/maintenance/maintenance-configuration/tests/e2e/max/dependencies.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }

--- a/avm/res/maintenance/maintenance-configuration/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/maintenance/maintenance-configuration/tests/e2e/waf-aligned/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -42,7 +42,6 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
       extensionProperties: {
         InGuestPatchMode: 'User'
       }

--- a/avm/res/maintenance/maintenance-configuration/version.json
+++ b/avm/res/maintenance/maintenance-configuration/version.json
@@ -1,4 +1,4 @@
 {
-    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.3"
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.4"
 }


### PR DESCRIPTION
## Description

### Changes

- Replaced custom type for parameter `maintenanceScope` with resource-derived type to enable all available values (e.g., 'Resource')
- Updated LockType to 'avm-common-types version' `0.7.0`, enabling custom notes for locks.

### Breaking Changes

- Changed type of parameter `visibility` to resource-derived type and changed the default from `''` to nullable.

Fixes #6573

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.maintenance.maintenance-configuration](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.maintenance-configuration.yml/badge.svg?branch=users%2Falsehr%2F6573_maintenanceScope&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.maintenance-configuration.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
