### PR TITLE
fix: CI - Add timout to cert creation

### DIFF
--- a/utilities/e2e-template-assets/scripts/Set-CertificateInKeyVault.ps1
+++ b/utilities/e2e-template-assets/scripts/Set-CertificateInKeyVault.ps1
@@ -45,20 +45,36 @@ if (-not $certificate) {
     $null = Add-AzKeyVaultCertificate -VaultName $KeyVaultName -Name $CertName -CertificatePolicy $certPolicy
     Write-Verbose ('Initiated creation of certificate [{0}] in key vault [{1}]' -f $CertName, $KeyVaultName) -Verbose
 
-    while (-not (Get-AzKeyVaultCertificateOperation -VaultName $KeyVaultName -Name $CertName).Status -eq 'completed') {
-        Write-Verbose 'Waiting 10 seconds for certificate creation' -Verbose
-        Start-Sleep 10
+    $maxRetries = 10
+    $retryCount = 0
+    $WaitIntervalInSeconds = 10
+    while (-not (Get-AzKeyVaultCertificateOperation -VaultName $KeyVaultName -Name $CertName -Verbose).Status -eq 'completed' -and $retryCount -lt $maxRetries) {
+        Write-Verbose ('    [⏱️] Waiting {0} seconds for certificate creation to finish. [{1}/{2}]' -f $WaitIntervalInSeconds, $retryCount, $MaxRetries) -Verbose
+        Start-Sleep $WaitIntervalInSeconds
+        $retryCount++
+    }
+    if ($retryCount -eq $maxRetries) {
+        throw "Certificate creation operation did not complete after [$maxRetries] attempts. Please review."
     }
 
     Write-Verbose 'Certificate created' -Verbose
 }
 
 $secretId = $certificate.SecretId
-while ([String]::IsNullOrEmpty($secretId)) {
-    Write-Verbose 'Waiting 10 seconds until certificate can be fetched' -Verbose
-    Start-Sleep 10
+
+$maxRetries = 10
+$retryCount = 0
+$WaitIntervalInSeconds = 10
+while ([String]::IsNullOrEmpty($secretId) -and $retryCount -lt $maxRetries) {
+    Write-Verbose ('    [⏱️] Waiting {0} seconds until certificate can be fetched. [{1}/{2}]' -f $WaitIntervalInSeconds, $retryCount, $MaxRetries) -Verbose
+
+    Start-Sleep $WaitIntervalInSeconds
     $certificate = Get-AzKeyVaultCertificate -VaultName $KeyVaultName -Name $CertName -ErrorAction 'Stop'
     $secretId = $certificate.SecretId
+    $retryCount++
+}
+if ($retryCount -eq $maxRetries -and [String]::IsNullOrEmpty($secretId)) {
+    throw "Failed to fetch certificate secret reference after [$maxRetries] attempts. Please review."
 }
 
 # Write into Deployment Script output stream


### PR DESCRIPTION
## Description

To avoid pipelines from running into a timeout after 6h because of a certificate not being correclty created, this PR adds a maxRetries mechanism to the script.

Result in deployment script:
<img width="707" height="112" alt="image" src="https://github.com/user-attachments/assets/3733c9ee-43e8-4877-b048-f6482a26fd09" />

Example timout: [ref](https://github.com/Azure/bicep-registry-modules/actions/runs/22797559888/attempts/1)

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.web.hosting-environment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.hosting-environment.yml/badge.svg?branch=users%2Falsehr%2FcertTimeout&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.web.hosting-environment.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
