### PR TITLE
feat: Pass 'authentication' through to child originGroups in avm/res/cdn/profile

### DIFF
--- a/avm/res/cdn/profile/CHANGELOG.md
+++ b/avm/res/cdn/profile/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/Changelog.md).
 
+## 0.19.0
+
+### Changes
+
+- Add `authentication` parameter to `originGroupType` and pass through to child originGroups from `avm/res/cdn/profile` (#6630)
+
 ## 0.18.0
 
 ### Changes

--- a/avm/res/cdn/profile/CHANGELOG.md
+++ b/avm/res/cdn/profile/CHANGELOG.md
@@ -8,6 +8,10 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 - Add `authentication` parameter to `originGroupType` and pass through to child originGroups from `avm/res/cdn/profile` (#6630)
 
+### Breaking Changes
+
+- None
+
 ## 0.18.0
 
 ### Changes

--- a/avm/res/cdn/profile/README.md
+++ b/avm/res/cdn/profile/README.md
@@ -925,7 +925,7 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
     originGroups: [
       {
         authentication: {
-          scope: '<scope>'
+          scope: 'https://storage.azure.com/.default'
           type: 'UserAssignedIdentity'
           userAssignedIdentity: {
             id: '<id>'
@@ -960,7 +960,7 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
       }
       {
         authentication: {
-          scope: '<scope>'
+          scope: 'https://storage.azure.com/.default'
           type: 'UserAssignedIdentity'
           userAssignedIdentity: {
             id: '<id>'
@@ -1171,7 +1171,7 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
       "value": [
         {
           "authentication": {
-            "scope": "<scope>",
+            "scope": "https://storage.azure.com/.default",
             "type": "UserAssignedIdentity",
             "userAssignedIdentity": {
               "id": "<id>"
@@ -1206,7 +1206,7 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
         },
         {
           "authentication": {
-            "scope": "<scope>",
+            "scope": "https://storage.azure.com/.default",
             "type": "UserAssignedIdentity",
             "userAssignedIdentity": {
               "id": "<id>"
@@ -1407,7 +1407,7 @@ param managedIdentities = {
 param originGroups = [
   {
     authentication: {
-      scope: '<scope>'
+      scope: 'https://storage.azure.com/.default'
       type: 'UserAssignedIdentity'
       userAssignedIdentity: {
         id: '<id>'
@@ -1442,7 +1442,7 @@ param originGroups = [
   }
   {
     authentication: {
-      scope: '<scope>'
+      scope: 'https://storage.azure.com/.default'
       type: 'UserAssignedIdentity'
       userAssignedIdentity: {
         id: '<id>'

--- a/avm/res/cdn/profile/README.md
+++ b/avm/res/cdn/profile/README.md
@@ -841,7 +841,7 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
               'test1-cdnpmax-custom-domain'
             ]
             enabledState: 'Enabled'
-            forwardingProtocol: 'MatchRequest'
+            forwardingProtocol: 'HttpsOnly'
             httpsRedirect: 'Enabled'
             linkToDefaultDomain: 'Enabled'
             name: 'test-cdnpmax-afd-route-1'
@@ -1075,7 +1075,7 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
                 "test1-cdnpmax-custom-domain"
               ],
               "enabledState": "Enabled",
-              "forwardingProtocol": "MatchRequest",
+              "forwardingProtocol": "HttpsOnly",
               "httpsRedirect": "Enabled",
               "linkToDefaultDomain": "Enabled",
               "name": "test-cdnpmax-afd-route-1",
@@ -1323,7 +1323,7 @@ param afdEndpoints = [
           'test1-cdnpmax-custom-domain'
         ]
         enabledState: 'Enabled'
-        forwardingProtocol: 'MatchRequest'
+        forwardingProtocol: 'HttpsOnly'
         httpsRedirect: 'Enabled'
         linkToDefaultDomain: 'Enabled'
         name: 'test-cdnpmax-afd-route-1'

--- a/avm/res/cdn/profile/README.md
+++ b/avm/res/cdn/profile/README.md
@@ -2546,6 +2546,7 @@ Array of origin group objects. Required if the afdEndpoints is specified.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`authentication`](#parameter-origingroupsauthentication) | object | Settings for Origin Authentication. |
 | [`healthProbeSettings`](#parameter-origingroupshealthprobesettings) | object | Health probe settings to the origin that is used to determine the health of the origin. |
 | [`sessionAffinityState`](#parameter-origingroupssessionaffinitystate) | string | Whether to allow session affinity on this host. |
 | [`trafficRestorationTimeToHealedOrNewEndpointsInMinutes`](#parameter-origingroupstrafficrestorationtimetohealedornewendpointsinminutes) | int | Time in minutes to shift the traffic to the endpoint gradually when an unhealthy endpoint comes healthy or a new endpoint is added. Default is 10 mins. |
@@ -2667,6 +2668,13 @@ Weight of the origin in given origin group for load balancing. Must be between 1
 
 - Required: No
 - Type: int
+
+### Parameter: `originGroups.authentication`
+
+Settings for Origin Authentication.
+
+- Required: No
+- Type: object
 
 ### Parameter: `originGroups.healthProbeSettings`
 

--- a/avm/res/cdn/profile/README.md
+++ b/avm/res/cdn/profile/README.md
@@ -924,6 +924,13 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
     }
     originGroups: [
       {
+        authentication: {
+          scope: '<scope>'
+          type: 'UserAssignedIdentity'
+          userAssignedIdentity: {
+            id: '<id>'
+          }
+        }
         healthProbeSettings: {
           probeIntervalInSeconds: 120
           probePath: '/health'
@@ -952,6 +959,13 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
         trafficRestorationTimeToHealedOrNewEndpointsInMinutes: 15
       }
       {
+        authentication: {
+          scope: '<scope>'
+          type: 'UserAssignedIdentity'
+          userAssignedIdentity: {
+            id: '<id>'
+          }
+        }
         loadBalancingSettings: {
           additionalLatencyInMilliseconds: 100
           sampleSize: 6
@@ -1156,6 +1170,13 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
     "originGroups": {
       "value": [
         {
+          "authentication": {
+            "scope": "<scope>",
+            "type": "UserAssignedIdentity",
+            "userAssignedIdentity": {
+              "id": "<id>"
+            }
+          },
           "healthProbeSettings": {
             "probeIntervalInSeconds": 120,
             "probePath": "/health",
@@ -1184,6 +1205,13 @@ module profile 'br/public:avm/res/cdn/profile:<version>' = {
           "trafficRestorationTimeToHealedOrNewEndpointsInMinutes": 15
         },
         {
+          "authentication": {
+            "scope": "<scope>",
+            "type": "UserAssignedIdentity",
+            "userAssignedIdentity": {
+              "id": "<id>"
+            }
+          },
           "loadBalancingSettings": {
             "additionalLatencyInMilliseconds": 100,
             "sampleSize": 6,
@@ -1378,6 +1406,13 @@ param managedIdentities = {
 }
 param originGroups = [
   {
+    authentication: {
+      scope: '<scope>'
+      type: 'UserAssignedIdentity'
+      userAssignedIdentity: {
+        id: '<id>'
+      }
+    }
     healthProbeSettings: {
       probeIntervalInSeconds: 120
       probePath: '/health'
@@ -1406,6 +1441,13 @@ param originGroups = [
     trafficRestorationTimeToHealedOrNewEndpointsInMinutes: 15
   }
   {
+    authentication: {
+      scope: '<scope>'
+      type: 'UserAssignedIdentity'
+      userAssignedIdentity: {
+        id: '<id>'
+      }
+    }
     loadBalancingSettings: {
       additionalLatencyInMilliseconds: 100
       sampleSize: 6

--- a/avm/res/cdn/profile/main.bicep
+++ b/avm/res/cdn/profile/main.bicep
@@ -269,6 +269,7 @@ module profile_originGroups 'origin-group/main.bicep' = [
       enableTelemetry: enableReferencedModulesTelemetry
       name: origingroup.name
       profileName: profile.name
+      authentication: origingroup.authentication
       loadBalancingSettings: origingroup.loadBalancingSettings
       healthProbeSettings: origingroup.?healthProbeSettings
       sessionAffinityState: origingroup.?sessionAffinityState
@@ -395,11 +396,14 @@ type originGroupType = {
   @description('Required. The name of the origin group.')
   name: string
 
+  @description('Optional. Settings for Origin Authentication.')
+  authentication: resourceInput<'Microsoft.Cdn/profiles/originGroups@2025-06-01'>.properties.authentication?
+
   @description('Optional. Health probe settings to the origin that is used to determine the health of the origin.')
-  healthProbeSettings: resourceInput<'Microsoft.Cdn/profiles/originGroups@2025-04-15'>.properties.healthProbeSettings?
+  healthProbeSettings: resourceInput<'Microsoft.Cdn/profiles/originGroups@2025-06-01'>.properties.healthProbeSettings?
 
   @description('Required. Load balancing settings for a backend pool.')
-  loadBalancingSettings: resourceInput<'Microsoft.Cdn/profiles/originGroups@2025-04-15'>.properties.loadBalancingSettings
+  loadBalancingSettings: resourceInput<'Microsoft.Cdn/profiles/originGroups@2025-06-01'>.properties.loadBalancingSettings
 
   @description('Optional. Whether to allow session affinity on this host.')
   sessionAffinityState: 'Enabled' | 'Disabled' | null

--- a/avm/res/cdn/profile/main.bicep
+++ b/avm/res/cdn/profile/main.bicep
@@ -269,7 +269,7 @@ module profile_originGroups 'origin-group/main.bicep' = [
       enableTelemetry: enableReferencedModulesTelemetry
       name: origingroup.name
       profileName: profile.name
-      authentication: origingroup.authentication
+      authentication: origingroup.?authentication
       loadBalancingSettings: origingroup.loadBalancingSettings
       healthProbeSettings: origingroup.?healthProbeSettings
       sessionAffinityState: origingroup.?sessionAffinityState

--- a/avm/res/cdn/profile/main.json
+++ b/avm/res/cdn/profile/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "1525318251351651301"
+      "templateHash": "18153206592238696264"
     },
     "name": "CDN Profiles",
     "description": "This module deploys a CDN Profile."
@@ -50,11 +50,21 @@
             "description": "Required. The name of the origin group."
           }
         },
+        "authentication": {
+          "type": "object",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Cdn/profiles/originGroups@2025-06-01#properties/properties/properties/authentication"
+            },
+            "description": "Optional. Settings for Origin Authentication."
+          },
+          "nullable": true
+        },
         "healthProbeSettings": {
           "type": "object",
           "metadata": {
             "__bicep_resource_derived_type!": {
-              "source": "Microsoft.Cdn/profiles/originGroups@2025-04-15#properties/properties/properties/healthProbeSettings"
+              "source": "Microsoft.Cdn/profiles/originGroups@2025-06-01#properties/properties/properties/healthProbeSettings"
             },
             "description": "Optional. Health probe settings to the origin that is used to determine the health of the origin."
           },
@@ -64,7 +74,7 @@
           "type": "object",
           "metadata": {
             "__bicep_resource_derived_type!": {
-              "source": "Microsoft.Cdn/profiles/originGroups@2025-04-15#properties/properties/properties/loadBalancingSettings"
+              "source": "Microsoft.Cdn/profiles/originGroups@2025-06-01#properties/properties/properties/loadBalancingSettings"
             },
             "description": "Required. Load balancing settings for a backend pool."
           }
@@ -2081,6 +2091,9 @@
           },
           "profileName": {
             "value": "[parameters('name')]"
+          },
+          "authentication": {
+            "value": "[coalesce(parameters('originGroups'), createArray())[copyIndex()].authentication]"
           },
           "loadBalancingSettings": {
             "value": "[coalesce(parameters('originGroups'), createArray())[copyIndex()].loadBalancingSettings]"

--- a/avm/res/cdn/profile/main.json
+++ b/avm/res/cdn/profile/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "18153206592238696264"
+      "templateHash": "5957282577108175179"
     },
     "name": "CDN Profiles",
     "description": "This module deploys a CDN Profile."
@@ -2093,7 +2093,7 @@
             "value": "[parameters('name')]"
           },
           "authentication": {
-            "value": "[coalesce(parameters('originGroups'), createArray())[copyIndex()].authentication]"
+            "value": "[tryGet(coalesce(parameters('originGroups'), createArray())[copyIndex()], 'authentication')]"
           },
           "loadBalancingSettings": {
             "value": "[coalesce(parameters('originGroups'), createArray())[copyIndex()].loadBalancingSettings]"

--- a/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
+++ b/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
@@ -133,6 +133,13 @@ module testDeployment '../../../main.bicep' = [
       originGroups: [
         {
           name: '${namePrefix}-test-${serviceShort}-origin-group-1'
+          authentication: {
+            scope: 'api://${guid('${namePrefix}-test-${serviceShort}-origin-group-1-auth-scope')}/.default'
+            type: 'UserAssignedIdentity'
+            userAssignedIdentity: {
+              id: nestedDependencies.outputs.managedIdentityResourceId
+            }
+          }
           loadBalancingSettings: {
             additionalLatencyInMilliseconds: 50
             sampleSize: 4
@@ -161,6 +168,13 @@ module testDeployment '../../../main.bicep' = [
         }
         {
           name: '${namePrefix}-test-${serviceShort}-origin-group-2'
+          authentication: {
+            scope: 'api://${guid('${namePrefix}-test-${serviceShort}-origin-group-2-auth-scope')}/.default'
+            type: 'UserAssignedIdentity'
+            userAssignedIdentity: {
+              id: nestedDependencies.outputs.managedIdentityResourceId
+            }
+          }
           loadBalancingSettings: {
             additionalLatencyInMilliseconds: 100
             sampleSize: 6

--- a/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
+++ b/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
@@ -249,7 +249,7 @@ module testDeployment '../../../main.bicep' = [
                 '${namePrefix}-test1-${serviceShort}-custom-domain'
               ]
               enabledState: 'Enabled'
-              forwardingProtocol: 'MatchRequest'
+              forwardingProtocol: 'HttpsOnly'
               httpsRedirect: 'Enabled'
               linkToDefaultDomain: 'Enabled'
               patternsToMatch: ['/api/*', '/health']

--- a/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
+++ b/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
@@ -133,13 +133,6 @@ module testDeployment '../../../main.bicep' = [
       originGroups: [
         {
           name: '${namePrefix}-test-${serviceShort}-origin-group-1'
-          authentication: {
-            scope: 'api://${guid('${namePrefix}-test-${serviceShort}-origin-group-1-auth-scope')}/.default'
-            type: 'UserAssignedIdentity'
-            userAssignedIdentity: {
-              id: nestedDependencies.outputs.managedIdentityResourceId
-            }
-          }
           loadBalancingSettings: {
             additionalLatencyInMilliseconds: 50
             sampleSize: 4
@@ -168,13 +161,6 @@ module testDeployment '../../../main.bicep' = [
         }
         {
           name: '${namePrefix}-test-${serviceShort}-origin-group-2'
-          authentication: {
-            scope: 'api://${guid('${namePrefix}-test-${serviceShort}-origin-group-2-auth-scope')}/.default'
-            type: 'UserAssignedIdentity'
-            userAssignedIdentity: {
-              id: nestedDependencies.outputs.managedIdentityResourceId
-            }
-          }
           loadBalancingSettings: {
             additionalLatencyInMilliseconds: 100
             sampleSize: 6

--- a/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
+++ b/avm/res/cdn/profile/tests/e2e/max/main.test.bicep
@@ -133,6 +133,13 @@ module testDeployment '../../../main.bicep' = [
       originGroups: [
         {
           name: '${namePrefix}-test-${serviceShort}-origin-group-1'
+          authentication: {
+            scope: 'https://storage.azure.com/.default'
+            type: 'UserAssignedIdentity'
+            userAssignedIdentity: {
+              id: nestedDependencies.outputs.managedIdentityResourceId
+            }
+          }
           loadBalancingSettings: {
             additionalLatencyInMilliseconds: 50
             sampleSize: 4
@@ -161,6 +168,13 @@ module testDeployment '../../../main.bicep' = [
         }
         {
           name: '${namePrefix}-test-${serviceShort}-origin-group-2'
+          authentication: {
+            scope: 'https://storage.azure.com/.default'
+            type: 'UserAssignedIdentity'
+            userAssignedIdentity: {
+              id: nestedDependencies.outputs.managedIdentityResourceId
+            }
+          }
           loadBalancingSettings: {
             additionalLatencyInMilliseconds: 100
             sampleSize: 6

--- a/avm/res/cdn/profile/version.json
+++ b/avm/res/cdn/profile/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.18"
+    "version": "0.19"
 }


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #123
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.cdn.profile](https://github.com/matthetherington/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml/badge.svg?branch=cdn-profile-authentication-passthrough)](https://github.com/matthetherington/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
