### PR TITLE
feat: Add `SecuredByPerimeter` support for Cosmos DB `publicNetworkAccess`

### DIFF
--- a/avm/res/document-db/database-account/CHANGELOG.md
+++ b/avm/res/document-db/database-account/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/document-db/database-account/CHANGELOG.md).
 
+## 0.20.0
+
+### Changes
+
+- Added support to specify `SecuredByPerimeter` for `publicNetworkAccess` in `networkRestrictions`
+
+### Breaking Changes
+
+- None
+
 ## 0.19.0
 
 ### Changes

--- a/avm/res/document-db/database-account/README.md
+++ b/avm/res/document-db/database-account/README.md
@@ -62,12 +62,13 @@ The following section provides usage examples for the module, which were used to
 - [Deploying with Managed identities](#example-8-deploying-with-managed-identities)
 - [Mongo Database](#example-9-mongo-database)
 - [Deploying multiple regions](#example-10-deploying-multiple-regions)
-- [Plain](#example-11-plain)
-- [Public network restricted access with ACL](#example-12-public-network-restricted-access-with-acl)
-- [SQL Database](#example-13-sql-database)
-- [Deploying with a sql role definition and assignment](#example-14-deploying-with-a-sql-role-definition-and-assignment)
-- [API for Table](#example-15-api-for-table)
-- [WAF-aligned](#example-16-waf-aligned)
+- [Using network perimeter](#example-11-using-network-perimeter)
+- [Plain](#example-12-plain)
+- [Public network restricted access with ACL](#example-13-public-network-restricted-access-with-acl)
+- [SQL Database](#example-14-sql-database)
+- [Deploying with a sql role definition and assignment](#example-15-deploying-with-a-sql-role-definition-and-assignment)
+- [API for Table](#example-16-api-for-table)
+- [WAF-aligned](#example-17-waf-aligned)
 
 ### Example 1: _Using analytical storage_
 
@@ -2173,7 +2174,78 @@ param sqlDatabases = [
 </details>
 <p>
 
-### Example 11: _Plain_
+### Example 11: _Using network perimeter_
+
+This instance deploys the module with network perimeter.
+
+You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/perimeter]
+
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module databaseAccount 'br/public:avm/res/document-db/database-account:<version>' = {
+  params: {
+    // Required parameters
+    name: 'dddansp001'
+    // Non-required parameters
+    networkRestrictions: {
+      publicNetworkAccess: 'SecuredByPerimeter'
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON parameters file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "name": {
+      "value": "dddansp001"
+    },
+    // Non-required parameters
+    "networkRestrictions": {
+      "value": {
+        "publicNetworkAccess": "SecuredByPerimeter"
+      }
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via Bicep parameters file</summary>
+
+```bicep-params
+using 'br/public:avm/res/document-db/database-account:<version>'
+
+// Required parameters
+param name = 'dddansp001'
+// Non-required parameters
+param networkRestrictions = {
+  publicNetworkAccess: 'SecuredByPerimeter'
+}
+```
+
+</details>
+<p>
+
+### Example 12: _Plain_
 
 This instance deploys the module without a Database.
 
@@ -2299,7 +2371,7 @@ param zoneRedundant = false
 </details>
 <p>
 
-### Example 12: _Public network restricted access with ACL_
+### Example 13: _Public network restricted access with ACL_
 
 This instance deploys the module with public network access enabled but restricted to IPs, CIDRS or subnets.
 
@@ -2422,7 +2494,7 @@ param zoneRedundant = false
 </details>
 <p>
 
-### Example 13: _SQL Database_
+### Example 14: _SQL Database_
 
 This instance deploys the module with a SQL Database.
 
@@ -3244,7 +3316,7 @@ param zoneRedundant = false
 </details>
 <p>
 
-### Example 14: _Deploying with a sql role definition and assignment_
+### Example 15: _Deploying with a sql role definition and assignment_
 
 This instance deploys the module with sql role definition and assignment
 
@@ -3513,7 +3585,7 @@ param zoneRedundant = false
 </details>
 <p>
 
-### Example 15: _API for Table_
+### Example 16: _API for Table_
 
 This instance deploys the module for an Azure Cosmos DB for Table account with two example tables.
 
@@ -3621,7 +3693,7 @@ param zoneRedundant = false
 </details>
 <p>
 
-### Example 16: _WAF-aligned_
+### Example 17: _WAF-aligned_
 
 This instance deploys the module in alignment with the best-practices of the Azure Well-Architected Framework.
 
@@ -5170,6 +5242,7 @@ Whether requests from the public network are allowed. Default to "Disabled".
   [
     'Disabled'
     'Enabled'
+    'SecuredByPerimeter'
   ]
   ```
 

--- a/avm/res/document-db/database-account/main.bicep
+++ b/avm/res/document-db/database-account/main.bicep
@@ -821,7 +821,7 @@ type networkRestrictionType = {
   networkAclBypass: ('AzureServices' | 'None')?
 
   @description('Optional. Whether requests from the public network are allowed. Default to "Disabled".')
-  publicNetworkAccess: ('Enabled' | 'Disabled')?
+  publicNetworkAccess: ('Enabled' | 'Disabled' | 'SecuredByPerimeter')?
 
   @description('Optional. List of virtual network access control list (ACL) rules configured for the account.')
   virtualNetworkRules: {

--- a/avm/res/document-db/database-account/main.json
+++ b/avm/res/document-db/database-account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "14932604021019437779"
+      "templateHash": "54293194858178697"
     },
     "name": "Azure Cosmos DB account",
     "description": "This module deploys an Azure Cosmos DB account. The API used for the account is determined by the child resources that are deployed."
@@ -219,7 +219,8 @@
           "type": "string",
           "allowedValues": [
             "Disabled",
-            "Enabled"
+            "Enabled",
+            "SecuredByPerimeter"
           ],
           "nullable": true,
           "metadata": {

--- a/avm/res/document-db/database-account/tests/e2e/perimeter/main.test.bicep
+++ b/avm/res/document-db/database-account/tests/e2e/perimeter/main.test.bicep
@@ -1,0 +1,48 @@
+targetScope = 'subscription'
+
+metadata name = 'Using network perimeter'
+metadata description = 'This instance deploys the module with network perimeter.'
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Optional. The name of the resource group to deploy for testing purposes.')
+@maxLength(90)
+param resourceGroupName string = 'dep-${namePrefix}-documentdb.databaseaccounts-${serviceShort}-rg'
+
+@description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
+param serviceShort string = 'dddansp'
+
+@description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
+param namePrefix string = '#_namePrefix_#'
+
+// The default pipeline is selecting random regions which don't have capacity for Azure Cosmos DB or support all Azure Cosmos DB features when creating new accounts.
+#disable-next-line no-hardcoded-location
+var enforcedLocation = 'eastus2'
+
+// ============== //
+// General resources
+// ============== //
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
+  name: resourceGroupName
+  location: enforcedLocation
+}
+
+// ============== //
+// Test Execution //
+// ============== //
+
+@batchSize(1)
+module testDeployment '../../../main.bicep' = [
+  for iteration in ['init', 'idem']: {
+    scope: resourceGroup
+    name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-${iteration}'
+    params: {
+      name: '${namePrefix}${serviceShort}001'
+      networkRestrictions: {
+        publicNetworkAccess: 'SecuredByPerimeter'
+      }
+    }
+  }
+]

--- a/avm/res/document-db/database-account/tests/e2e/perimeter/main.test.bicep
+++ b/avm/res/document-db/database-account/tests/e2e/perimeter/main.test.bicep
@@ -18,8 +18,9 @@ param serviceShort string = 'dddansp'
 param namePrefix string = '#_namePrefix_#'
 
 // The default pipeline is selecting random regions which don't have capacity for Azure Cosmos DB or support all Azure Cosmos DB features when creating new accounts.
+// Using a single zone region for NSP e2e tests.
 #disable-next-line no-hardcoded-location
-var enforcedLocation = 'eastus2'
+var enforcedLocation = 'eastasia'
 
 // ============== //
 // General resources

--- a/avm/res/document-db/database-account/version.json
+++ b/avm/res/document-db/database-account/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.19"
+  "version": "0.20"
 }


### PR DESCRIPTION
## Description

Added support to specify `SecuredByPerimeter` for `publicNetworkAccess` in the `networkRestrictions` parameter of `avm/res/document-db/database-account`.

This enables Azure Cosmos DB accounts to be secured using Network Security Perimeter, which provides a more granular network access control compared to traditional public network access settings.

## Pipeline Reference

<!-- Run the applicable pipeline(s) and paste the status badge(s) below -->

| Pipeline |
| -------- |
| [![avm.res.document-db.database-account](https://github.com/poornachandugade/bicep-registry-modules/actions/workflows/avm.res.document-db.database-account.yml/badge.svg)](https://github.com/poornachandugade/bicep-registry-modules/actions/workflows/avm.res.document-db.database-account.yml)|

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

## Changes

- Added `SecuredByPerimeter` to the `publicNetworkAccess` allowed values in `networkRestrictionType` user-defined type in `main.bicep`
- Added `perimeter` e2e test scenario with idempotency iterations
- Regenerated `main.json` and `README.md` via `Set-AVMModule`
- Bumped version from `0.19` to `0.20` in `version.json`
- Updated `CHANGELOG.md` with `0.20.0` entry