### PR TITLE
fix: ptn/azd/apim-api - pin `defaults` test location due to quota restrictions

### DIFF
--- a/avm/ptn/azd/apim-api/tests/e2e/defaults/main.test.bicep
+++ b/avm/ptn/azd/apim-api/tests/e2e/defaults/main.test.bicep
@@ -10,14 +10,15 @@ metadata description = 'This instance deploys the module with the minimum set of
 @maxLength(90)
 param resourceGroupName string = 'dep-${namePrefix}-apim-api-${serviceShort}-rg'
 
-@description('Optional. The location to deploy resources to.')
-param resourceLocation string = deployment().location
-
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'aapmin'
 
 @description('Optional. A token to inject into the name of each resource.')
 param namePrefix string = '#_namePrefix_#'
+
+// Hardcoding due to quota limitations
+#disable-next-line no-hardcoded-location
+var enforcedLocation = 'westus2'
 
 // ============ //
 // Dependencies //
@@ -27,12 +28,12 @@ param namePrefix string = '#_namePrefix_#'
 // =================
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: resourceGroupName
-  location: resourceLocation
+  location: enforcedLocation
 }
 
 module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
+  name: '${uniqueString(deployment().name, enforcedLocation)}-nestedDependencies'
   params: {
     appServicePlanName: 'dep-${namePrefix}-sp-${serviceShort}'
     appServiceName: 'dep-${namePrefix}-aps-${serviceShort}'
@@ -49,9 +50,9 @@ module nestedDependencies 'dependencies.bicep' = {
 
 module testDeployment '../../../main.bicep' = {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}'
+  name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}'
   params: {
-    location: resourceLocation
+    location: enforcedLocation
     name: nestedDependencies.outputs.apimName
     apiDisplayName: '${namePrefix}-apd-${serviceShort}'
     apiPath: '${namePrefix}-apipath-${serviceShort}'


### PR DESCRIPTION
## Description

Fixes #6672

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
<img width="1898" height="58" alt="image" src="https://github.com/user-attachments/assets/789591fb-d888-46be-ad79-cb9194d730e1" />


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
