### PR TITLE
fix: `res/network/ip-group` - Update API versions, and update `ipAddresses` parameter from optional to required

### DIFF
--- a/avm/res/network/ip-group/CHANGELOG.md
+++ b/avm/res/network/ip-group/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/ip-group/CHANGELOG.md).
 
+## 0.3.2
+
+### Changes
+
+- Updated `Microsoft.Network/ipGroups` API version from `2024-05-01` to `2025-05-01`
+- Updated `avm-common-types` imports to `0.7.0`
+
+### Breaking Changes
+
+- None
+
 ## 0.3.1
 
 ### Changes

--- a/avm/res/network/ip-group/CHANGELOG.md
+++ b/avm/res/network/ip-group/CHANGELOG.md
@@ -2,16 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/ip-group/CHANGELOG.md).
 
-## 0.3.2
+## 0.4.0
 
 ### Changes
 
 - Updated `Microsoft.Network/ipGroups` API version from `2024-05-01` to `2025-05-01`
 - Updated `avm-common-types` imports to `0.7.0`
+- Updated `defaults` test to include at least one IP address
 
 ### Breaking Changes
 
-- None
+- `ipAddresses` parameter changed from optional (default `[]`) to **required** with `@minLength(1)` due to `IPGroupsIPAddressCountZero` error on certain Azure regions.
 
 ## 0.3.1
 

--- a/avm/res/network/ip-group/README.md
+++ b/avm/res/network/ip-group/README.md
@@ -25,7 +25,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | :-- | :-- | :-- |
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
-| `Microsoft.Network/ipGroups` | 2024-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_ipgroups.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/ipGroups)</li></ul> |
+| `Microsoft.Network/ipGroups` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_ipgroups.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2025-05-01/ipGroups)</li></ul> |
 
 ## Usage examples
 
@@ -589,7 +589,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.7.0` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/network/ip-group/README.md
+++ b/avm/res/network/ip-group/README.md
@@ -54,6 +54,9 @@ You can find the full example and the setup of its dependencies in the deploymen
 module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
   params: {
     // Required parameters
+    ipAddresses: [
+      '10.0.0.1'
+    ]
     name: 'nigmin001'
     // Non-required parameters
     location: '<location>'
@@ -74,6 +77,11 @@ module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "ipAddresses": {
+      "value": [
+        "10.0.0.1"
+      ]
+    },
     "name": {
       "value": "nigmin001"
     },
@@ -96,6 +104,9 @@ module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
 using 'br/public:avm/res/network/ip-group:<version>'
 
 // Required parameters
+param ipAddresses = [
+  '10.0.0.1'
+]
 param name = 'nigmin001'
 // Non-required parameters
 param location = '<location>'
@@ -119,12 +130,12 @@ You can find the full example and the setup of its dependencies in the deploymen
 module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
   params: {
     // Required parameters
-    name: 'nigmax001'
-    // Non-required parameters
     ipAddresses: [
       '10.0.0.1'
       '10.0.0.2'
     ]
+    name: 'nigmax001'
+    // Non-required parameters
     location: '<location>'
     lock: {
       kind: 'CanNotDelete'
@@ -171,16 +182,16 @@ module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "name": {
-      "value": "nigmax001"
-    },
-    // Non-required parameters
     "ipAddresses": {
       "value": [
         "10.0.0.1",
         "10.0.0.2"
       ]
     },
+    "name": {
+      "value": "nigmax001"
+    },
+    // Non-required parameters
     "location": {
       "value": "<location>"
     },
@@ -233,12 +244,12 @@ module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
 using 'br/public:avm/res/network/ip-group:<version>'
 
 // Required parameters
-param name = 'nigmax001'
-// Non-required parameters
 param ipAddresses = [
   '10.0.0.1'
   '10.0.0.2'
 ]
+param name = 'nigmax001'
+// Non-required parameters
 param location = '<location>'
 param lock = {
   kind: 'CanNotDelete'
@@ -288,12 +299,12 @@ You can find the full example and the setup of its dependencies in the deploymen
 module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
   params: {
     // Required parameters
-    name: 'nigwaf001'
-    // Non-required parameters
     ipAddresses: [
       '10.0.0.1'
       '10.0.0.2'
     ]
+    name: 'nigwaf001'
+    // Non-required parameters
     location: '<location>'
     tags: {
       Environment: 'Non-Prod'
@@ -317,16 +328,16 @@ module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "name": {
-      "value": "nigwaf001"
-    },
-    // Non-required parameters
     "ipAddresses": {
       "value": [
         "10.0.0.1",
         "10.0.0.2"
       ]
     },
+    "name": {
+      "value": "nigwaf001"
+    },
+    // Non-required parameters
     "location": {
       "value": "<location>"
     },
@@ -352,12 +363,12 @@ module ipGroup 'br/public:avm/res/network/ip-group:<version>' = {
 using 'br/public:avm/res/network/ip-group:<version>'
 
 // Required parameters
-param name = 'nigwaf001'
-// Non-required parameters
 param ipAddresses = [
   '10.0.0.1'
   '10.0.0.2'
 ]
+param name = 'nigwaf001'
+// Non-required parameters
 param location = '<location>'
 param tags = {
   Environment: 'Non-Prod'
@@ -375,6 +386,7 @@ param tags = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`ipAddresses`](#parameter-ipaddresses) | array | IpAddresses/IpAddressPrefixes in the IP Group resource. |
 | [`name`](#parameter-name) | string | The name of the IP Group. |
 
 **Optional parameters**
@@ -382,11 +394,17 @@ param tags = {
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
-| [`ipAddresses`](#parameter-ipaddresses) | array | IpAddresses/IpAddressPrefixes in the IP Group resource. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Resource tags. |
+
+### Parameter: `ipAddresses`
+
+IpAddresses/IpAddressPrefixes in the IP Group resource.
+
+- Required: Yes
+- Type: array
 
 ### Parameter: `name`
 
@@ -402,14 +420,6 @@ Enable/Disable usage telemetry for module.
 - Required: No
 - Type: bool
 - Default: `True`
-
-### Parameter: `ipAddresses`
-
-IpAddresses/IpAddressPrefixes in the IP Group resource.
-
-- Required: No
-- Type: array
-- Default: `[]`
 
 ### Parameter: `location`
 

--- a/avm/res/network/ip-group/main.bicep
+++ b/avm/res/network/ip-group/main.bicep
@@ -11,16 +11,16 @@ param location string = resourceGroup().location
 @description('Optional. IpAddresses/IpAddressPrefixes in the IP Group resource.')
 param ipAddresses array = []
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. The lock settings of the service.')
 param lock lockType?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
 @description('Optional. Resource tags.')
-param tags resourceInput<'Microsoft.Network/ipGroups@2024-05-01'>.tags?
+param tags resourceInput<'Microsoft.Network/ipGroups@2025-05-01'>.tags?
 
 @description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
@@ -73,7 +73,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource ipGroup 'Microsoft.Network/ipGroups@2024-05-01' = {
+resource ipGroup 'Microsoft.Network/ipGroups@2025-05-01' = {
   name: name
   location: location
   tags: tags

--- a/avm/res/network/ip-group/main.bicep
+++ b/avm/res/network/ip-group/main.bicep
@@ -8,8 +8,9 @@ param name string
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
-@description('Optional. IpAddresses/IpAddressPrefixes in the IP Group resource.')
-param ipAddresses array = []
+@description('Required. IpAddresses/IpAddressPrefixes in the IP Group resource.')
+@minLength(1)
+param ipAddresses array
 
 import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. The lock settings of the service.')

--- a/avm/res/network/ip-group/main.json
+++ b/avm/res/network/ip-group/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "1497260450759933903"
+      "templateHash": "16480005139666301043"
     },
     "name": "IP Groups",
     "description": "This module deploys an IP Group."
@@ -142,9 +142,9 @@
     },
     "ipAddresses": {
       "type": "array",
-      "defaultValue": [],
+      "minLength": 1,
       "metadata": {
-        "description": "Optional. IpAddresses/IpAddressPrefixes in the IP Group resource."
+        "description": "Required. IpAddresses/IpAddressPrefixes in the IP Group resource."
       }
     },
     "lock": {

--- a/avm/res/network/ip-group/main.json
+++ b/avm/res/network/ip-group/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "6043717305389214263"
+      "templateHash": "1497260450759933903"
     },
     "name": "IP Groups",
     "description": "This module deploys an IP Group."
@@ -45,7 +45,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a lock.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     },
@@ -120,7 +120,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     }
@@ -168,7 +168,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.Network/ipGroups@2024-05-01#properties/tags"
+          "source": "Microsoft.Network/ipGroups@2025-05-01#properties/tags"
         },
         "description": "Optional. Resource tags."
       },
@@ -222,7 +222,7 @@
     },
     "ipGroup": {
       "type": "Microsoft.Network/ipGroups",
-      "apiVersion": "2024-05-01",
+      "apiVersion": "2025-05-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -294,7 +294,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('ipGroup', '2024-05-01', 'full').location]"
+      "value": "[reference('ipGroup', '2025-05-01', 'full').location]"
     }
   }
 }

--- a/avm/res/network/ip-group/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/network/ip-group/tests/e2e/defaults/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-07-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/network/ip-group/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/network/ip-group/tests/e2e/defaults/main.test.bicep
@@ -41,5 +41,8 @@ module testDeployment '../../../main.bicep' = {
   params: {
     name: '${namePrefix}${serviceShort}001'
     location: resourceLocation
+    ipAddresses: [
+      '10.0.0.1'
+    ]
   }
 }

--- a/avm/res/network/ip-group/tests/e2e/max/dependencies.bicep
+++ b/avm/res/network/ip-group/tests/e2e/max/dependencies.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }

--- a/avm/res/network/ip-group/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/ip-group/tests/e2e/max/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-07-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/network/ip-group/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/ip-group/tests/e2e/waf-aligned/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-07-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/network/ip-group/version.json
+++ b/avm/res/network/ip-group/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.3"
+  "version": "0.4"
 }


### PR DESCRIPTION
## Description

Updates the ip-group module to align with latest AVM patterns.

**Changes:**
- Bumped `Microsoft.Network/ipGroups` API version from `2024-05-01` to `2025-05-01`
- Updated `avm-common-types` imports to `0.7.0`
- Changed `ipAddresses` parameter from optional (default `[]`) to **required** with `@minLength(1)`
- Updated `defaults` test to include at least one IP address

**Breaking change rationale:**

During CI validation, the `defaults` test (which deploys an IP Group with no IP addresses) failed with error code `IPGroupsIPAddressCountZero`. To confirm this wasn't environment-specific, we tested deploying an empty IP Group across 17 Azure regions:

| Region | Result | | Region | Result |
|---|---|---|---|---|
| eastus | :x: Rejected | | westus2 | :white_check_mark: Accepted |
| centralus | :x: Rejected | | westus3 | :white_check_mark: Accepted |
| northeurope | :x: Rejected | | westeurope | :white_check_mark: Accepted |
| uksouth | :x: Rejected | | canadacentral | :white_check_mark: Accepted |
| brazilsouth | :x: Rejected | | germanywestcentral | :white_check_mark: Accepted |
| koreacentral | :x: Rejected | | swedencentral | :white_check_mark: Accepted |
| centralindia | :x: Rejected | | australiaeast | :white_check_mark: Accepted |
| | | | southeastasia | :white_check_mark: Accepted |
| | | | japaneast | :white_check_mark: Accepted |
| | | | southafricanorth | :white_check_mark: Accepted |

7 of 17 regions (41%) already reject empty IP Groups. Since this enforcement is expanding, `ipAddresses` is now required with `@minLength(1)` to prevent deployment failures.

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.network.ip-group](https://github.com/ahmadabdalla/bicep-registry-modules/actions/workflows/avm.res.network.ip-group.yml/badge.svg?branch=users%2Fahmad%2Fupdate_IP_Group)](https://github.com/ahmadabdalla/bicep-registry-modules/actions/workflows/avm.res.network.ip-group.yml) |


## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in version.json:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in version.json.
  - [ ] Breaking changes and I have bumped the MAJOR version in version.json.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version