### PR TITLE
feat: Publish `avm/res/cdn/profile/origin-group/origin` as independent child module

### DIFF
--- a/avm/res/cdn/profile/CHANGELOG.md
+++ b/avm/res/cdn/profile/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/Changelog.md).
 
+## 0.19.1
+
+### Changes
+
+- Publishing child module `avm/res/cdn/profile/origin-group/origin`
+
+### Breaking Changes
+
+- None
+
 ## 0.19.0
 
 ### Changes

--- a/avm/res/cdn/profile/main.json
+++ b/avm/res/cdn/profile/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "5957282577108175179"
+      "templateHash": "18332972276882672820"
     },
     "name": "CDN Profiles",
     "description": "This module deploys a CDN Profile."
@@ -2119,7 +2119,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.41.2.15936",
-              "templateHash": "11354323423619918567"
+              "templateHash": "5061933363497485536"
             },
             "name": "CDN Profiles Origin Group",
             "description": "This module deploys a CDN Profile Origin Group."
@@ -2361,6 +2361,9 @@
               }
             }
           },
+          "variables": {
+            "enableReferencedModulesTelemetry": false
+          },
           "resources": {
             "avmTelemetry": {
               "condition": "[parameters('enableTelemetry')]",
@@ -2447,6 +2450,9 @@
                   },
                   "sharedPrivateLinkResource": {
                     "value": "[tryGet(parameters('origins')[copyIndex()], 'sharedPrivateLinkResource')]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
                   }
                 },
                 "template": {
@@ -2457,7 +2463,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.41.2.15936",
-                      "templateHash": "9365226509800420471"
+                      "templateHash": "5162864735965281576"
                     },
                     "name": "CDN Profiles Origin",
                     "description": "This module deploys a CDN Profile Origin."
@@ -2549,6 +2555,13 @@
                       "metadata": {
                         "description": "Optional. Weight of the origin in given origin group for load balancing. Must be between 1 and 1000."
                       }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
                     }
                   },
                   "resources": {
@@ -2557,6 +2570,26 @@
                       "type": "Microsoft.Cdn/profiles/originGroups",
                       "apiVersion": "2025-04-15",
                       "name": "[format('{0}/{1}', parameters('profileName'), parameters('originGroupName'))]"
+                    },
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.cdn-profile-origingroup-origin.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
                     },
                     "profile": {
                       "existing": true,

--- a/avm/res/cdn/profile/origin-group/CHANGELOG.md
+++ b/avm/res/cdn/profile/origin-group/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/origin-group/Changelog.md).
 
+## 0.1.2
+
+### Changes
+
+- Publishing child module `avm/res/cdn/profile/origin-group/origin`
+
+### Breaking Changes
+
+- None
+
 ## 0.1.1
 
 ### Changes

--- a/avm/res/cdn/profile/origin-group/main.bicep
+++ b/avm/res/cdn/profile/origin-group/main.bicep
@@ -51,6 +51,8 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
+var enableReferencedModulesTelemetry = false
+
 resource profile 'Microsoft.Cdn/profiles@2025-06-01' existing = {
   name: profileName
 }
@@ -85,6 +87,7 @@ module originGroup_origins 'origin/main.bicep' = [
       priority: origin.?priority
       weight: origin.?weight
       sharedPrivateLinkResource: origin.?sharedPrivateLinkResource
+      enableTelemetry: enableReferencedModulesTelemetry
     }
   }
 ]

--- a/avm/res/cdn/profile/origin-group/main.json
+++ b/avm/res/cdn/profile/origin-group/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "11354323423619918567"
+      "templateHash": "5061933363497485536"
     },
     "name": "CDN Profiles Origin Group",
     "description": "This module deploys a CDN Profile Origin Group."
@@ -248,6 +248,9 @@
       }
     }
   },
+  "variables": {
+    "enableReferencedModulesTelemetry": false
+  },
   "resources": {
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
@@ -334,6 +337,9 @@
           },
           "sharedPrivateLinkResource": {
             "value": "[tryGet(parameters('origins')[copyIndex()], 'sharedPrivateLinkResource')]"
+          },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
           }
         },
         "template": {
@@ -344,7 +350,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.41.2.15936",
-              "templateHash": "9365226509800420471"
+              "templateHash": "5162864735965281576"
             },
             "name": "CDN Profiles Origin",
             "description": "This module deploys a CDN Profile Origin."
@@ -436,6 +442,13 @@
               "metadata": {
                 "description": "Optional. Weight of the origin in given origin group for load balancing. Must be between 1 and 1000."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "resources": {
@@ -444,6 +457,26 @@
               "type": "Microsoft.Cdn/profiles/originGroups",
               "apiVersion": "2025-04-15",
               "name": "[format('{0}/{1}', parameters('profileName'), parameters('originGroupName'))]"
+            },
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.cdn-profile-origingroup-origin.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
             },
             "profile": {
               "existing": true,

--- a/avm/res/cdn/profile/origin-group/origin/CHANGELOG.md
+++ b/avm/res/cdn/profile/origin-group/origin/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/origin-group/origin/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/cdn/profile/origin-group/origin/README.md
+++ b/avm/res/cdn/profile/origin-group/origin/README.md
@@ -2,11 +2,20 @@
 
 This module deploys a CDN Profile Origin.
 
+You can reference the module as follows:
+```bicep
+module profile 'br/public:avm/res/cdn/profile/origin-group/origin:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -30,6 +39,7 @@ This module deploys a CDN Profile Origin.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`enabledState`](#parameter-enabledstate) | string | Whether to enable health probes to be made against backends defined under backendPools. Health probes can only be disabled if there is a single enabled backend in single enabled backend pool. |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`enforceCertificateNameCheck`](#parameter-enforcecertificatenamecheck) | bool | Whether to enable certificate name check at origin level. |
 | [`httpPort`](#parameter-httpport) | int | The value of the HTTP port. Must be between 1 and 65535. |
 | [`httpsPort`](#parameter-httpsport) | int | The value of the HTTPS port. Must be between 1 and 65535. |
@@ -80,6 +90,14 @@ Whether to enable health probes to be made against backends defined under backen
     'Enabled'
   ]
   ```
+
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
 
 ### Parameter: `enforceCertificateNameCheck`
 
@@ -142,3 +160,7 @@ Weight of the origin in given origin group for load balancing. Must be between 1
 | `name` | string | The name of the origin. |
 | `resourceGroupName` | string | The name of the resource group the origin was created in. |
 | `resourceId` | string | The resource id of the origin. |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/cdn/profile/origin-group/origin/main.bicep
+++ b/avm/res/cdn/profile/origin-group/origin/main.bicep
@@ -41,6 +41,28 @@ param sharedPrivateLinkResource resourceInput<'Microsoft.Cdn/profiles/originGrou
 @description('Optional. Weight of the origin in given origin group for load balancing. Must be between 1 and 1000.')
 param weight int = 1000
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.cdn-profile-origingroup-origin.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
+
 resource profile 'Microsoft.Cdn/profiles@2025-04-15' existing = {
   name: profileName
 

--- a/avm/res/cdn/profile/origin-group/origin/main.json
+++ b/avm/res/cdn/profile/origin-group/origin/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "9365226509800420471"
+      "templateHash": "5162864735965281576"
     },
     "name": "CDN Profiles Origin",
     "description": "This module deploys a CDN Profile Origin."
@@ -98,6 +98,13 @@
       "metadata": {
         "description": "Optional. Weight of the origin in given origin group for load balancing. Must be between 1 and 1000."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "resources": {
@@ -106,6 +113,26 @@
       "type": "Microsoft.Cdn/profiles/originGroups",
       "apiVersion": "2025-04-15",
       "name": "[format('{0}/{1}', parameters('profileName'), parameters('originGroupName'))]"
+    },
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.cdn-profile-origingroup-origin.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
     },
     "profile": {
       "existing": true,

--- a/avm/res/cdn/profile/origin-group/origin/version.json
+++ b/avm/res/cdn/profile/origin-group/origin/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.1"
+}

--- a/utilities/pipelines/staticValidation/compliance/helper/child-module-publish-allowed-list.json
+++ b/utilities/pipelines/staticValidation/compliance/helper/child-module-publish-allowed-list.json
@@ -25,6 +25,7 @@
     "avm/res/cdn/profile/afd-endpoint/route",
     "avm/res/cdn/profile/custom-domain",
     "avm/res/cdn/profile/origin-group",
+    "avm/res/cdn/profile/origin-group/origin",
     "avm/res/cdn/profile/rule-set",
     "avm/res/cdn/profile/security-policy",
     "avm/res/consumption/budget/mg-scope",


### PR DESCRIPTION
## Description

Publishes the `avm/res/cdn/profile/origin-group/origin` child module for standalone use in the AVM public registry.



## Pipeline Status

[![avm.res.cdn.profile](https://github.com/gbeaud/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml/badge.svg?event=workflow_dispatch)](https://github.com/gbeaud/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml)

## Changes

### `avm/res/cdn/profile/origin-group/origin/main.bicep`
- Added `enableTelemetry` parameter (default `true`)
- Added `avmTelemetry` deployment resource with telemetry ID prefix `46d3xbcp.res.cdn-profile-origingroup-origin`

### `avm/res/cdn/profile/origin-group/main.bicep`
- Added `enableReferencedModulesTelemetry = false` variable
- Passes `enableTelemetry: enableReferencedModulesTelemetry` to child origin module deployment

### `avm/res/cdn/profile/origin-group/origin/version.json`
- Created with version `0.1`

### `avm/res/cdn/profile/origin-group/origin/CHANGELOG.md`
- Created with initial `0.1.0` entry

### `utilities/pipelines/staticValidation/compliance/helper/child-module-publish-allowed-list.json`
- Added `avm/res/cdn/profile/origin-group/origin` (alphabetical order)

### Changelog Updates
- `avm/res/cdn/profile/origin-group/CHANGELOG.md` → `0.1.2`
- `avm/res/cdn/profile/CHANGELOG.md` → `0.19.1`

## Type of Change

- [ ] Bug fix
- [x] New feature (child module publishing)
- [ ] Breaking change
- [ ] Documentation update