### PR TITLE
fix(avm/res/azure-stack-hci/virtual-machine-instance): add @secure() to osProfile parameter

### DIFF
--- a/avm/res/azure-stack-hci/virtual-machine-instance/CHANGELOG.md
+++ b/avm/res/azure-stack-hci/virtual-machine-instance/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/azure-stack-hci/virtual-machine-instance/CHANGELOG.md).
 
+## 0.1.2
+
+### Changes
+
+- Added @secure() decorator to osProfile parameter to prevent adminPassword exposure in ARM deployment history
+
+### Breaking Changes
+
+- None
+
 ## 0.1.1
 
 ### Changes

--- a/avm/res/azure-stack-hci/virtual-machine-instance/README.md
+++ b/avm/res/azure-stack-hci/virtual-machine-instance/README.md
@@ -350,7 +350,7 @@ param location = '<location>'
 | [`hardwareProfile`](#parameter-hardwareprofile) | object | Hardware profile configuration. |
 | [`name`](#parameter-name) | string | Name of the resource to create. |
 | [`networkProfile`](#parameter-networkprofile) | object | Network profile configuration. |
-| [`osProfile`](#parameter-osprofile) | object | OS profile configuration. |
+| [`osProfile`](#parameter-osprofile) | secureObject | OS profile configuration. |
 | [`storageProfile`](#parameter-storageprofile) | object | Storage profile configuration. |
 
 **Optional parameters**
@@ -399,7 +399,7 @@ Network profile configuration.
 OS profile configuration.
 
 - Required: Yes
-- Type: object
+- Type: secureObject
 
 ### Parameter: `storageProfile`
 

--- a/avm/res/azure-stack-hci/virtual-machine-instance/main.bicep
+++ b/avm/res/azure-stack-hci/virtual-machine-instance/main.bicep
@@ -22,6 +22,7 @@ param httpProxyConfig resourceInput<'Microsoft.AzureStackHCI/virtualMachineInsta
 @description('Required. Network profile configuration.')
 param networkProfile resourceInput<'Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview'>.properties.networkProfile
 
+@secure()
 @description('Required. OS profile configuration.')
 param osProfile resourceInput<'Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview'>.properties.osProfile
 

--- a/avm/res/azure-stack-hci/virtual-machine-instance/main.json
+++ b/avm/res/azure-stack-hci/virtual-machine-instance/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "1371405258321986233"
+      "version": "0.40.2.10011",
+      "templateHash": "4963312133934804886"
     },
     "name": "Azure Stack HCI Virtual Machine Instance",
     "description": "This module deploys an Azure Stack HCI virtual machine."
@@ -144,7 +144,7 @@
       }
     },
     "osProfile": {
-      "type": "object",
+      "type": "secureObject",
       "metadata": {
         "__bicep_resource_derived_type!": {
           "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/osProfile"

--- a/avm/res/azure-stack-hci/virtual-machine-instance/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/azure-stack-hci/virtual-machine-instance/tests/e2e/defaults/main.test.bicep
@@ -82,7 +82,6 @@ module nestedDependencies '../../../../../../../utilities/e2e-template-assets/mo
     arbDeploymentSPObjectId: arbDeploymentSPObjectId
     deploymentUserPassword: arbLocalAdminAndDeploymentUserPass
     localAdminPassword: arbLocalAdminAndDeploymentUserPass
-    domainAdminPassword: arbLocalAdminAndDeploymentUserPass
     location: enforcedLocation
   }
 }

--- a/avm/res/azure-stack-hci/virtual-machine-instance/tests/e2e/defaults/main.test.json
+++ b/avm/res/azure-stack-hci/virtual-machine-instance/tests/e2e/defaults/main.test.json
@@ -1,0 +1,4341 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.40.2.10011",
+      "templateHash": "12586573045572217083"
+    },
+    "name": "Using default config",
+    "description": "This instance deploys the module with the minimum set of required parameters."
+  },
+  "parameters": {
+    "resourceGroupName": {
+      "type": "string",
+      "defaultValue": "[format('dep-{0}-azurestackhci.vmi-{1}-rg', parameters('namePrefix'), parameters('serviceShort'))]",
+      "maxLength": 90,
+      "metadata": {
+        "description": "Optional. The name of the resource group to deploy for testing purposes."
+      }
+    },
+    "serviceShort": {
+      "type": "string",
+      "defaultValue": "ashvmimin",
+      "metadata": {
+        "description": "Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints."
+      }
+    },
+    "namePrefix": {
+      "type": "string",
+      "defaultValue": "#_namePrefix_#",
+      "metadata": {
+        "description": "Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI."
+      }
+    },
+    "arbLocalAdminAndDeploymentUserPass": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Required. The password of the LCM deployment user and local administrator accounts."
+      }
+    },
+    "arbDeploymentAppId": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Required. The app ID of the service principal used for the Azure Stack HCI Resource Bridge deployment. If omitted, the deploying user must have permissions to create service principals and role assignments in Entra ID."
+      }
+    },
+    "arbDeploymentSPObjectId": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Required. The service principal ID of the service principal used for the Azure Stack HCI Resource Bridge deployment. If omitted, the deploying user must have permissions to create service principals and role assignments in Entra ID."
+      }
+    },
+    "arbDeploymentServicePrincipalSecret": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Required. The secret of the service principal used for the Azure Stack HCI Resource Bridge deployment. If omitted, the deploying user must have permissions to create service principals and role assignments in Entra ID."
+      }
+    },
+    "hciResourceProviderObjectId": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. The service principal ID of the Azure Stack HCI Resource Provider. If this is not provided, the module attemps to determine this value by querying the Microsoft Graph."
+      }
+    },
+    "localAdminAndDeploymentUserPass": {
+      "type": "string",
+      "defaultValue": "[newGuid()]",
+      "metadata": {
+        "description": "Optional. The password to use for the local and domain accounts in the test."
+      }
+    }
+  },
+  "variables": {
+    "enforcedLocation": "southeastasia"
+  },
+  "resources": {
+    "resourceGroup": {
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2021-04-01",
+      "name": "[parameters('resourceGroupName')]",
+      "location": "[variables('enforcedLocation')]"
+    },
+    "customLocation": {
+      "existing": true,
+      "type": "Microsoft.ExtendedLocation/customLocations",
+      "apiVersion": "2021-08-31-preview",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "name": "[format('{0}{1}-location', parameters('namePrefix'), parameters('serviceShort'))]",
+      "dependsOn": [
+        "azlocal",
+        "resourceGroup"
+      ]
+    },
+    "nestedDependencies": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}-test-nestedDependencies-{1}', uniqueString(deployment().name, variables('enforcedLocation')), parameters('serviceShort'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "clusterName": {
+            "value": "[format('{0}{1}01', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "clusterWitnessStorageAccountName": {
+            "value": "[format('dep{0}wst{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "keyVaultDiagnosticStorageAccountName": {
+            "value": "[format('dep{0}st{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "keyVaultName": {
+            "value": "[format('dep-{0}-kv-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "userAssignedIdentityName": {
+            "value": "[format('dep-{0}-msi-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "maintenanceConfigurationName": {
+            "value": "[format('dep-{0}-mc-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "maintenanceConfigurationAssignmentName": {
+            "value": "[format('dep-{0}-mca-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "HCIHostVirtualMachineScaleSetName": {
+            "value": "[format('dep-{0}-hvmss-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "virtualNetworkName": {
+            "value": "[format('dep-{0}-vnet-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "networkSecurityGroupName": {
+            "value": "[format('dep-{0}-nsg-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "networkInterfaceName": {
+            "value": "[format('dep-{0}-mice-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "virtualMachineName": {
+            "value": "[format('dep-{0}-vm-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "arbDeploymentAppId": {
+            "value": "[parameters('arbDeploymentAppId')]"
+          },
+          "arbDeploymentServicePrincipalSecret": {
+            "value": "[parameters('arbDeploymentServicePrincipalSecret')]"
+          },
+          "arbDeploymentSPObjectId": {
+            "value": "[parameters('arbDeploymentSPObjectId')]"
+          },
+          "deploymentUserPassword": {
+            "value": "[parameters('arbLocalAdminAndDeploymentUserPass')]"
+          },
+          "localAdminPassword": {
+            "value": "[parameters('arbLocalAdminAndDeploymentUserPass')]"
+          },
+          "location": {
+            "value": "[variables('enforcedLocation')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.40.2.10011",
+              "templateHash": "5940711904875428862"
+            }
+          },
+          "parameters": {
+            "deploymentUserPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Optional. The password of the LCM deployment user and local administrator accounts."
+              }
+            },
+            "localAdminPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Required. The password of the LCM deployment user and local administrator accounts."
+              }
+            },
+            "arbDeploymentAppId": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The app ID of the service principal used for the Azure Stack HCI Resource Bridge deployment. If omitted, the deploying user must have permissions to create service principals and role assignments in Entra ID."
+              }
+            },
+            "arbDeploymentSPObjectId": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The service principal ID of the service principal used for the Azure Stack HCI Resource Bridge deployment. If omitted, the deploying user must have permissions to create service principals and role assignments in Entra ID."
+              }
+            },
+            "arbDeploymentServicePrincipalSecret": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The secret of the service principal used for the Azure Stack HCI Resource Bridge deployment. If omitted, the deploying user must have permissions to create service principals and role assignments in Entra ID."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The location to deploy the resources into."
+              }
+            },
+            "clusterWitnessStorageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the storage account to create as a cluster witness."
+              }
+            },
+            "keyVaultDiagnosticStorageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the storage account to be created to collect Key Vault diagnostic logs."
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the Key Vault to create."
+              }
+            },
+            "clusterName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the Azure Stack HCI cluster."
+              }
+            },
+            "userAssignedIdentityName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the VM-managed user identity to create, used for HCI Arc onboarding."
+              }
+            },
+            "maintenanceConfigurationName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the maintenance configuration for the Azure Stack HCI Host VM and proxy server."
+              }
+            },
+            "HCIHostVirtualMachineScaleSetName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the Azure VM scale set for the HCI host."
+              }
+            },
+            "networkSecurityGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the Network Security Group ro create."
+              }
+            },
+            "virtualNetworkName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the virtual network to create. Used to connect the HCI Azure Host VM to an existing VNET in the same region."
+              }
+            },
+            "networkInterfaceName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the Network Interface Card to create."
+              }
+            },
+            "virtualMachineName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the Azure VM to create."
+              }
+            },
+            "maintenanceConfigurationAssignmentName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the Maintenance Configuration Assignment for the proxy server."
+              }
+            },
+            "diskNamePrefix": {
+              "type": "string",
+              "defaultValue": "dep-disk",
+              "metadata": {
+                "description": "Required. The name prefix for disk resources."
+              }
+            },
+            "waitDeploymentScriptPrefixName": {
+              "type": "string",
+              "defaultValue": "dep-wait",
+              "metadata": {
+                "description": "Required. The name prefix for the wait deployment scripts."
+              }
+            }
+          },
+          "variables": {
+            "clusterNodeNames": [
+              "hcinode1",
+              "hcinode2"
+            ],
+            "domainOUPath": "OU=HCI,DC=hci,DC=local"
+          },
+          "resources": {
+            "cluster": {
+              "type": "Microsoft.AzureStackHCI/clusters",
+              "apiVersion": "2024-04-01",
+              "name": "[parameters('clusterName')]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "location": "[parameters('location')]",
+              "properties": {}
+            },
+            "hciHostDeployment": {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-test-hcihostdeploy', uniqueString(deployment().name, parameters('location')))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "domainOUPath": {
+                    "value": "[variables('domainOUPath')]"
+                  },
+                  "hciNodeCount": {
+                    "value": "[length(variables('clusterNodeNames'))]"
+                  },
+                  "hostVMSize": {
+                    "value": "Standard_E32bds_v5"
+                  },
+                  "localAdminPassword": {
+                    "value": "[parameters('localAdminPassword')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "switchlessStorageConfig": {
+                    "value": false
+                  },
+                  "diskNamePrefix": {
+                    "value": "[parameters('diskNamePrefix')]"
+                  },
+                  "HCIHostVirtualMachineScaleSetName": {
+                    "value": "[parameters('HCIHostVirtualMachineScaleSetName')]"
+                  },
+                  "maintenanceConfigurationAssignmentName": {
+                    "value": "[parameters('maintenanceConfigurationAssignmentName')]"
+                  },
+                  "maintenanceConfigurationName": {
+                    "value": "[parameters('maintenanceConfigurationName')]"
+                  },
+                  "networkInterfaceName": {
+                    "value": "[parameters('networkInterfaceName')]"
+                  },
+                  "networkSecurityGroupName": {
+                    "value": "[parameters('networkSecurityGroupName')]"
+                  },
+                  "virtualNetworkName": {
+                    "value": "[parameters('virtualNetworkName')]"
+                  },
+                  "userAssignedIdentityName": {
+                    "value": "[parameters('userAssignedIdentityName')]"
+                  },
+                  "virtualMachineName": {
+                    "value": "[parameters('virtualMachineName')]"
+                  },
+                  "waitDeploymentScriptPrefixName": {
+                    "value": "[parameters('waitDeploymentScriptPrefixName')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.40.2.10011",
+                      "templateHash": "16884311595766837236"
+                    }
+                  },
+                  "parameters": {
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The location for all resource except HCI Arc Nodes and HCI resources"
+                      }
+                    },
+                    "hostVMSize": {
+                      "type": "string",
+                      "defaultValue": "Standard_E32bds_v5",
+                      "metadata": {
+                        "description": "Optional. The Azure VM size for the HCI Host VM, which must support nested virtualization and have sufficient capacity for the HCI node VMs!"
+                      }
+                    },
+                    "hciNodeCount": {
+                      "type": "int",
+                      "defaultValue": 2,
+                      "metadata": {
+                        "description": "Optional. The number of Azure Stack HCI nodes to deploy."
+                      }
+                    },
+                    "switchlessStorageConfig": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Enable configuring switchless storage."
+                      }
+                    },
+                    "hciISODownloadURL": {
+                      "type": "string",
+                      "defaultValue": "https://azurestackreleases.download.prss.microsoft.com/dbazure/AzureStackHCI/OS-Composition/10.2408.0.3061/AZURESTACKHci23H2.25398.469.LCM.10.2408.0.3061.x64.en-us.iso",
+                      "metadata": {
+                        "description": "Optional. The download URL for the Azure Stack HCI ISO."
+                      }
+                    },
+                    "localAdminUsername": {
+                      "type": "string",
+                      "defaultValue": "admin-hci",
+                      "metadata": {
+                        "description": "Optional. The local admin user name."
+                      }
+                    },
+                    "localAdminPassword": {
+                      "type": "securestring",
+                      "metadata": {
+                        "description": "Required. The local admin password."
+                      }
+                    },
+                    "domainOUPath": {
+                      "type": "string",
+                      "defaultValue": "OU=HCI,DC=HCI,DC=local",
+                      "metadata": {
+                        "description": "Optional. The domain OU path."
+                      }
+                    },
+                    "deploymentUsername": {
+                      "type": "string",
+                      "defaultValue": "deployUser",
+                      "metadata": {
+                        "description": "Optional. The deployment username."
+                      }
+                    },
+                    "userAssignedIdentityName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the VM-managed user identity to create, used for HCI Arc onboarding."
+                      }
+                    },
+                    "virtualNetworkName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the VNET for the HCI host Azure VM."
+                      }
+                    },
+                    "networkSecurityGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the NSG to create."
+                      }
+                    },
+                    "maintenanceConfigurationName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the maintenance configuration for the Azure Stack HCI Host VM and proxy server."
+                      }
+                    },
+                    "HCIHostVirtualMachineScaleSetName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the Azure VM scale set for the HCI host."
+                      }
+                    },
+                    "networkInterfaceName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the Network Interface Card to create."
+                      }
+                    },
+                    "diskNamePrefix": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name prefix for the Disks to create."
+                      }
+                    },
+                    "virtualMachineName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the Azure VM to create."
+                      }
+                    },
+                    "maintenanceConfigurationAssignmentName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the Maintenance Configuration Assignment for the proxy server."
+                      }
+                    },
+                    "waitDeploymentScriptPrefixName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name prefix for the 'wait' deployment scripts to create."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "$fxv#0": "Function log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-1.log'\n    )\n\n    If (!(Test-Path -Path C:\\temp)) {\n        New-Item -Path C:\\temp -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage1] - $message\"\n}\n\n$ErrorActionPreference = 'Stop'\n\n# prep host - install hyper-v, AD, DHCP, RRAS\nlog 'Installing required features and roles...'\n$features = @('rsat-hyper-v-tools', 'rsat-clustering', 'rsat-adds', 'rsat-dns-server', 'RSAT-RemoteAccess-Mgmt', 'Routing', 'AD-Domain-Services', 'DHCP')\n$missingFeatures = Get-WindowsFeature -Name $features | Where-Object { $_.Installed -eq $false }\n\nForEach ($missingFeature in $missingFeatures) {\n    log \"Installing $($missingFeature.Name)...\"\n    Add-WindowsFeature -Name $missingFeature.Name -IncludeAllSubFeature -IncludeManagementTools\n\n    If ($?) {\n        log \"Successfully installed $($missingFeature.Name)\"\n    } Else {\n        log \"Failed to install $($missingFeature.Name)\"\n    }\n    If (Test-Path -Path C:\\Windows\\winsxs\\pending.xml) {\n        log 'Reboot required, exiting...'\n    }\n}\n\nlog 'Enabling Hyper-V...'\nEnable-WindowsOptionalFeature -Online -FeatureName 'microsoft-hyper-v-online' -All -NoRestart\n\n# create temp directory\nlog 'Creating temp directory...'\nIf (!(Test-Path -Path C:\\temp)) {\n    New-Item -Path C:\\temp -ItemType Directory\n}\n\n# create reboot status file\nIf (Test-Path -Path 'C:\\temp\\Reboot1Completed.status') {\n    log 'Reboot has already been completed, skipping...'\n} ElseIf (Test-Path -Path 'C:\\temp\\Reboot1Initiated.status') {\n    log 'Reboot has already been initiated, skipping...'\n} Else {\n    log 'Reboot required, creating status file...'\n    Set-Content -Path 'C:\\temp\\Reboot1Required.status' -Value 'Reboot 1 Required'\n}\n",
+                    "$fxv#1": "Function log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-2.log'\n    )\n\n    If (!(Test-Path -Path C:\\temp)) {\n        New-Item -Path C:\\temp -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage2] - $message\"\n}\n\n$ErrorActionPreference = 'Stop'\n\n# check for reboot status file, reboot if needed\nIf (Test-Path -Path 'C:\\temp\\Reboot1Required.status') {\n    log 'Reboot 1 is required'\n\n    Remove-Item 'C:\\temp\\Reboot1Required.status'\n    Set-Content -Path 'C:\\temp\\Reboot1Initiated.status' -Value 'Reboot 1 Initiated'\n\n    # use scheduled task to reboot the machine, ensuring the runCommand exits gracefully\n    $action = New-ScheduledTaskAction -Execute 'shutdown.exe' -Argument '-r -f -t 0'\n    $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(2)\n    $principal = New-ScheduledTaskPrincipal -UserId 'NT AUTHORITY\\SYSTEM' -LogonType ServiceAccount\n    $task = New-ScheduledTask -Action $action -Description 'Reboot 1' -Trigger $trigger -Principal $principal\n    Register-ScheduledTask -TaskName 'Reboot1' -InputObject $task\n} ElseIf (Test-Path -Path 'C:\\temp\\Reboot1Initiated.status') {\n    log 'Reboot 1 has been initiated and now completed'\n\n    Remove-Item 'C:\\temp\\Reboot1Initiated.status'\n    Set-Content -Path 'C:\\temp\\Reboot1Completed.status' -Value 'Reboot 1 Completed'\n\n\n} ElseIf (Test-Path -Path 'C:\\temp\\Reboot1Completed.status') {\n    log 'Reboot 1 has been completed'\n\n}\n",
+                    "$fxv#2": "[CmdletBinding()]\nparam (\n    [Parameter()]\n    [string]\n    $hciVHDXDownloadURL,\n\n    [Parameter()]\n    [string]\n    $hciISODownloadURL,\n\n    [Parameter()]\n    [ValidateRange(1, 16)]\n    [int]\n    $hciNodeCount\n)\nFunction log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-3.log'\n    )\n\n    If (!(Test-Path -Path C:\\temp)) {\n        New-Item -Path C:\\temp -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage3] - $message\"\n}\n\nFunction Test-ADConnection {\n    try {\n        If ((Get-Service -Name 'ADWS' -ErrorAction SilentlyContinue).Status -ne 'Running') { return $false }\n        $env:ADPS_LoadDefaultDrive = 0\n        Import-Module -Name ActiveDirectory -ErrorAction Stop\n        [bool](Get-ADDomainController -Server $env:COMPUTERNAME -ErrorAction SilentlyContinue)\n    } catch {\n        $false\n    }\n}\n\n# THANKS https://github.com/bfrankMS/CreateHypervVms/blob/master/Scenario-AzStackHCI/CreateVhdxFromIso.ps1\nFunction New-VHDXFromISO {\n    # Parameter help description\n    param(\n        [Parameter(ParameterSetName = 'SRC', Mandatory = $true, ValueFromPipeline = $true)]\n        [Alias('ISO')]\n        [string]\n        [ValidateNotNullOrEmpty()]\n        [ValidateScript({ Test-Path $(Resolve-Path $_) })]\n        $IsoPath,\n\n        [Parameter(ParameterSetName = 'SRC')]\n        [Alias('VHD')]\n        [string]\n        [ValidateNotNullOrEmpty()]\n        $VhdxPath,\n\n        [Parameter(ParameterSetName = 'SRC')]\n        [Alias('Size')]\n        [UInt64]\n        [ValidateNotNullOrEmpty()]\n        [ValidateRange(512MB, 64TB)]\n        $SizeBytes = 120GB,\n\n        [Parameter(ParameterSetName = 'SRC')]\n        [Alias('Index')]\n        [UInt64]\n        [ValidateNotNullOrEmpty()]\n        [ValidateRange(1, 10)]\n        $ImageIndex = 1          #defaults to azure stack hci on 2405 image\n    )\n\n    $BCDBoot = 'bcdboot.exe'\n    $VHDFormat = 'VHDX'\n    $TempDirectory = $env:Temp\n\n    function\n    Write-ActionInfo {\n        # Function to make the Write-Host output a bit prettier.\n        [CmdletBinding()]\n        param(\n            [Parameter(Mandatory = $true, ValueFromPipeline = $true)]\n            [string]\n            [ValidateNotNullOrEmpty()]\n            $text\n        )\n        Write-Host \"INFO   : $($text)\" -ForegroundColor White\n    }\n\n    function\n    Start-Executable {\n        <#\n          .SYNOPSIS\n              Runs an external executable file, and validates the error level.\n\n          .PARAMETER Executable\n              The path to the executable to run and monitor.\n\n          .PARAMETER Arguments\n              An array of arguments to pass to the executable when it's executed.\n\n          .PARAMETER SuccessfulErrorCode\n              The error code that means the executable ran successfully.\n              The default value is 0.\n      #>\n\n        [CmdletBinding()]\n        param(\n            [Parameter(Mandatory = $true)]\n            [string]\n            [ValidateNotNullOrEmpty()]\n            $Executable,\n\n            [Parameter(Mandatory = $true)]\n            [string[]]\n            [ValidateNotNullOrEmpty()]\n            $Arguments,\n\n            [Parameter()]\n            [int]\n            [ValidateNotNullOrEmpty()]\n            $SuccessfulErrorCode = 0\n\n        )\n\n        Write-ActionInfo \"Running $Executable $Arguments\"\n        $ret = Start-Process           `\n            -FilePath $Executable      `\n            -ArgumentList $Arguments   `\n            -NoNewWindow               `\n            -Wait                      `\n            -RedirectStandardOutput \"$($TempDirectory)\\$($scriptName)\\$($sessionKey)\\$($Executable)-StandardOutput.txt\" `\n            -RedirectStandardError \"$($TempDirectory)\\$($scriptName)\\$($sessionKey)\\$($Executable)-StandardError.txt\"  `\n            -PassThru\n\n        Write-ActionInfo \"Return code was $($ret.ExitCode).\"\n\n        if ($ret.ExitCode -ne $SuccessfulErrorCode) {\n            throw \"$Executable failed with code $($ret.ExitCode)!\"\n        }\n    }\n\n    Write-ActionInfo 'Creating virtual hard disk...'\n    $newVhd = New-VHD -Path $VhdxPath -SizeBytes $SizeBytes -Dynamic\n\n    Write-ActionInfo \"Mounting $VHDFormat...\"\n    $disk = $newVhd | Mount-VHD -Passthru | Get-Disk\n\n\n    # UEFI : 3 partitions : efi - msr - windows\n    <#https://learn.microsoft.com/de-de/windows/win32/api/winioctl/ns-winioctl-partition_information_gpt\nPARTITION_BASIC_DATA_GUID - ebd0a0a2-b9e5-4433-87c0-68b6b72699c7\nPARTITION_SYSTEM_GUID - c12a7328-f81f-11d2-ba4b-00a0c93ec93b    # EFI\nPARTITION_MSFT_RESERVED_GUID - e3c9e316-0b5c-4db8-817d-f92df00215ae  # MSR\nPARTITION_MSFT_RECOVERY_GUID - de94bba4-06d1-4d40-a16a-bfd50179d6ac   # Recovery partition (Windows) we are not using this\n#>\n\n    try {\n        Write-ActionInfo 'Initializing disk...'\n        Initialize-Disk -Number $disk.Number -PartitionStyle GPT\n\n        Write-ActionInfo 'Creating EFI system partition...'\n        $systemPartition = New-Partition -DiskNumber $disk.Number -Size 200MB -GptType '{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}'\n\n        Write-ActionInfo 'Formatting EFI system volume...'\n        $null = Format-Volume -Partition $systemPartition -FileSystem FAT32 -Force -Confirm:$false\n\n        Write-ActionInfo 'Setting EFI system partition PARTITION_SYSTEM_GUID...'\n        $systemPartition | Set-Partition -GptType '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'\n        $systemPartition | Add-PartitionAccessPath -AssignDriveLetter\n\n        # Create the reserved partition\n        Write-ActionInfo 'Creating MSR partition...'\n        $null = New-Partition -DiskNumber $disk.Number -Size 128MB -GptType '{e3c9e316-0b5c-4db8-817d-f92df00215ae}' -Verbose\n\n        # Create the Windows partition\n        Write-ActionInfo 'Creating windows partition...'\n        $windowsPartition = New-Partition -DiskNumber $disk.Number -UseMaximumSize -GptType '{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}'\n\n        Write-ActionInfo 'Formatting windows volume...'\n        $windowsVolume = Format-Volume -Partition $windowsPartition -FileSystem NTFS -Force -Confirm:$false\n\n        # Assign drive letter to Windows partition.  This is required for bcdboot\n        $windowsPartition | Add-PartitionAccessPath -AssignDriveLetter\n        $windowsDrive = $(Get-Partition -Volume $windowsVolume).AccessPaths[0].substring(0, 2)\n        Write-ActionInfo \"Windows path ($windowsDrive) has been assigned.\"\n\n        # Refresh access paths (we have now formatted the volume)\n        $systemPartition = $systemPartition | Get-Partition\n        $systemDrive = $systemPartition.AccessPaths[0].trimend('\\').replace('\\?', '??')\n        Write-ActionInfo \"System volume location: $systemDrive\"\n\n        # Mount .iso to get the install.wim\n        $beforeMount = (Get-Volume).DriveLetter -split ' '\n        $null = Mount-DiskImage -StorageType ISO -ImagePath $IsoPath\n        $afterMount = (Get-Volume).DriveLetter -split ' '\n        $setuppath = (Compare-Object $beforeMount $afterMount -PassThru )\n        Write-ActionInfo \"Mounted .iso to $($setuppath):\"\n\n        Write-ActionInfo \"Applying image from .iso $(\"$setuppath\"+':\\sources\\install.wim') to $VHDFormat. This could take a while...\"\n\n        Expand-WindowsImage -ApplyPath $windowsDrive -ImagePath \"$setuppath`:\\sources\\install.wim\" -Index $ImageIndex #-LogPath \"$($logFolder)\\DismLogs.log\" | Out-Null\n        Write-ActionInfo 'Image was applied successfully. '\n\n        Write-ActionInfo 'Making image bootable...'\n        $bcdBootArgs = @(\n            \"$($windowsDrive)\\Windows\", # Path to the \\Windows on the VHD\n            \"/s $systemDrive\", # Specifies the volume letter of the drive to create the \\BOOT folder on.\n            '/v'                        # Enabled verbose logging.\n        )\n        $bcdBootArgs += '/f UEFI'   # Specifies the firmware type of the target system partition\n\n        Start-Executable -Executable $BCDBoot -Arguments $bcdBootArgs\n\n        Write-ActionInfo 'Drive is bootable.  Cleaning up...'\n\n        # Remove system partition access path, if necessary\n        $systemPartition | Remove-PartitionAccessPath -AccessPath $systemPartition.AccessPaths[0]\n    } finally {\n        Write-ActionInfo \"Dismounting $VHDFormat...\"\n        try {\n            Dismount-VHD -Path $VhdxPath -ErrorAction Stop\n        } catch {\n            Write-ActionInfo \"WARNING: Dismount-VHD failed: $_. Continuing cleanup...\"\n        }\n\n        #ejecting .iso - releasing drive letter.\n        Write-ActionInfo 'Dismounting .iso...'\n        $dismountRetries = 3\n        for ($r = 1; $r -le $dismountRetries; $r++) {\n            try {\n                Dismount-DiskImage -ImagePath $IsoPath -ErrorAction Stop\n                Write-ActionInfo 'ISO dismounted successfully.'\n                break\n            } catch {\n                Write-ActionInfo \"Dismount-DiskImage attempt $r/$dismountRetries failed: $_\"\n                if ($r -lt $dismountRetries) {\n                    Start-Sleep -Seconds 5\n                } else {\n                    Write-ActionInfo 'WARNING: Could not dismount ISO after retries. The VHDX was created successfully; continuing.'\n                }\n            }\n        }\n    }\n}\n\n$ErrorActionPreference = 'Stop'\n\n# Clean up any leftover ISO mount from a previous failed run\nif (Test-Path 'c:\\isos\\hci_os.iso') {\n    try {\n        $diskImage = Get-DiskImage -ImagePath 'c:\\isos\\hci_os.iso' -ErrorAction SilentlyContinue\n        if ($diskImage -and $diskImage.Attached) {\n            log 'Found leftover mounted ISO from previous run, dismounting...'\n            Dismount-DiskImage -ImagePath 'c:\\isos\\hci_os.iso' -ErrorAction SilentlyContinue\n        }\n    } catch {\n        log \"WARNING: Could not check/dismount leftover ISO: $_\"\n    }\n}\n\n# download HCI VHDX or ISO\nIf (!(Test-Path -Path 'c:\\ISOs')) {\n    log 'Creating c:\\ISOs directory...'\n    mkdir c:\\ISOs\n} Else {\n    log 'ISOs directory already exists, skipping...'\n}\n\nIf ($hciVHDXDownloadURL) {\n    log 'Downloading HCI VHDX...'\n    If (! (Test-Path c:\\ISOs\\hci_os.vhdx)) {\n        [System.Net.WebClient]::new().DownloadFile($hciVHDXDownloadURL, 'c:\\isos\\hci_os.vhdx')\n    } Else {\n        log 'HCI VHDX already exists, skipping download...'\n    }\n} ElseIf ($hciISODownloadURL) {\n    log 'Downloading HCI ISO...'\n    If (! (Test-Path c:\\ISOs\\hci_os.iso)) {\n        [System.Net.WebClient]::new().DownloadFile($hciISODownloadURL, 'c:\\isos\\hci_os.iso')\n    } Else {\n        log 'HCI ISO already exists, skipping download...'\n    }\n\n    # convert ISO to VHDX\n    If (!(Test-Path 'c:\\isos\\hci_os.vhdx')) {\n        log 'Converting ISO to VHDX...'\n        New-VHDXFromISO -IsoPath 'c:\\isos\\hci_os.iso' -VhdxPath 'c:\\isos\\hci_os.vhdx'\n    } Else {\n        log 'HCI VHDX already exists, skipping conversion...'\n\n    }\n} Else {\n    log 'No download URL provided, cannot continue...'\n    Write-Error 'No download URL provided, cannot continue...' -ErrorAction Stop\n}\n\n# create mount point directories on C:\\\nlog 'Creating mount points...'\nFor ($i = 0; $i -lt $hciNodeCount; $i++) {\n    $dirPath = \"c:\\diskmounts\\hcinode$($i + 1)\"\n    If (!(Test-Path -Path $dirPath)) {\n        mkdir $dirPath\n    } Else {\n        log \"Mount point '$dirPath' already exists, skipping...\"\n    }\n}\n\n# format and mount disks\nlog 'Formatting and mounting disks...'\n$count = 0\n$rawDisks = Get-Disk | Where-Object PartitionStyle -EQ 'RAW'\n$rawDisks |\n    Initialize-Disk -PartitionStyle GPT -PassThru |\n    New-Partition -UseMaximumSize -AssignDriveLetter:$false |\n    Format-Volume -FileSystem NTFS |\n    Get-Partition |\n    Where-Object { $_.type -ne 'Reserved' } |\n    ForEach-Object { $count++; mountvol c:\\diskMounts\\HCINode$count $_.accesspaths[0] }\n\nlog 'Copying VHDX to mount points...'\nFor ($i = 0; $i -lt $hciNodeCount; $i++) {\n    If (!(Test-Path -Path \"c:\\diskmounts\\hcinode$($i + 1)\\hci_os.vhdx\")) {\n        Copy-Item -Path c:\\isos\\hci_os.vhdx -Destination \"c:\\diskmounts\\hcinode$($i + 1)\"\n    } Else {\n        log \"HCI VHDX already exists at 'c:\\diskmounts\\hcinode$($i + 1)', skipping...\"\n    }\n}\n\n# install RRAS configure for routing\nlog 'Installing RRAS and configuring for routing...'\nWhile (!(Test-Path -Path 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules\\RemoteAccess\\RemoteAccess.psd1')) {\n    Start-Sleep -Seconds 5\n    log 'Waiting for RRAS module to be available...'\n}\nImport-Module 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules\\RemoteAccess\\RemoteAccess.psd1'\nInstall-RemoteAccess -VpnType RoutingOnly\nSet-Service -Name RemoteAccess -StartupType Automatic -PassThru | Start-Service\n\n# install domain controller\nlog 'Checking whether AD is installed...'\nIf (!(Test-ADConnection)) {\n    log 'AD is not installed, installing...'\n    Import-Module 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules\\ADDSDeployment\\ADDSDeployment.psd1'\n\n    $ADRecoveryPassword = ConvertTo-SecureString -Force -AsPlainText (New-Guid).guid\n    Install-ADDSForest -DomainName hci.local -DomainNetbiosName hci -ForestMode Default -DomainMode Default -InstallDns:$true -SafeModeAdministratorPassword $ADRecoveryPassword -NoRebootOnCompletion:$true -Force:$true\n} Else {\n    log 'AD is already installed, skipping...'\n}\n\nlog 'Adding DNS forwarders...'\nImport-Module 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules\\DnsServer\\DnsServer.psd1'\nAdd-DnsServerForwarder -IPAddress 8.8.8.8\n\n# create reboot status file\nIf (Test-Path -Path 'C:\\temp\\Reboot2Completed.status') {\n    log 'Reboot has already been completed, skipping...'\n} ElseIf (Test-Path -Path 'C:\\temp\\Reboot2Initiated.status') {\n    log 'Reboot has already been initiated, skipping...'\n} Else {\n    log 'Reboot required, creating status file...'\n    Set-Content -Path 'C:\\temp\\Reboot2Required.status' -Value 'Reboot 2 Required'\n}\n",
+                    "$fxv#3": "\nFunction log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-4.log'\n    )\n\n    If (!(Test-Path -Path C:\\temp)) {\n        New-Item -Path C:\\temp -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage4] - $message\"\n}\n\n$ErrorActionPreference = 'Stop'\n\n# check for reboot status file, reboot if needed\nIf (Test-Path -Path 'C:\\temp\\Reboot2Required.status') {\n    log 'Reboot 2 is required'\n\n    Remove-Item 'C:\\temp\\Reboot2Required.status'\n    Set-Content -Path 'C:\\temp\\Reboot2Initiated.status' -Value 'Reboot 2 Initiated'\n\n    # use scheduled task to reboot the machine, ensuring the runCommand exits gracefully\n    $action = New-ScheduledTaskAction -Execute 'shutdown.exe' -Argument '-r -f -t 0'\n    $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(2)\n    $principal = New-ScheduledTaskPrincipal -UserId 'NT AUTHORITY\\SYSTEM' -LogonType ServiceAccount\n    $task = New-ScheduledTask -Action $action -Description 'Reboot 2' -Trigger $trigger -Principal $principal\n    Register-ScheduledTask -TaskName 'Reboot2' -InputObject $task\n\n} ElseIf (Test-Path -Path 'C:\\temp\\Reboot2Initiated.status') {\n    log 'Reboot 2 has been initiated and now completed'\n\n    Remove-Item 'C:\\temp\\Reboot2Initiated.status'\n    Set-Content -Path 'C:\\temp\\Reboot2Completed.status' -Value 'Reboot 2 Completed'\n\n} ElseIf (Test-Path -Path 'C:\\temp\\Reboot2Completed.status') {\n    log 'Reboot 2 has been completed'\n\n}\n",
+                    "$fxv#4": "[CmdletBinding()]\nparam (\n    [Parameter()]\n    [string]\n    $adminUsername,\n\n    [Parameter()]\n    [string]\n    $adminPw,\n\n    [Parameter()]\n    [int]\n    $hciNodeCount,\n\n    [Parameter()]\n    [string]\n    $switchlessStorageConfig = 'switched'\n)\n\nFunction log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-5.log'\n    )\n\n    If (!(Test-Path -Path C:\\temp)) {\n        New-Item -Path C:\\temp -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage5] - $message\"\n}\n\nFunction Test-ADConnection {\n    try {\n        If ((Get-Service -Name 'ADWS' -ErrorAction SilentlyContinue).Status -ne 'Running') { return $false }\n        $env:ADPS_LoadDefaultDrive = 0\n        Import-Module -Name ActiveDirectory -ErrorAction Stop\n        [bool](Get-ADDomainController -Server $env:COMPUTERNAME -ErrorAction SilentlyContinue)\n    } catch {\n        $false\n    }\n}\n\n$ErrorActionPreference = 'Stop'\n\n# create hyperv switches\nlog 'Creating Hyper-V switches...'\n$existingSwitches = Get-VMSwitch\n\nIf ($switchlessStorageConfig -eq 'switched') {\n    log 'Creating Hyper-V switches for switched storage configuration...'\n    If ($existingSwitches.Name -notcontains 'external' ) { New-VMSwitch -Name external -AllowManagementOS:$true -NetAdapterName Ethernet }\n    If ($existingSwitches.Name -notcontains 'hciNodeMgmtInternal' ) { New-VMSwitch -Name hciNodeMgmtInternal -SwitchType Internal -EnableIov $true }\n    If ($existingSwitches.Name -notcontains 'hciNodeStoragePrivate' ) { New-VMSwitch -Name hciNodeStoragePrivate -SwitchType Private -EnableIov $true }\n} ElseIf ($switchlessStorageConfig -eq 'switchless') {\n    If ($hciNodeCount -gt 3) {\n        log -message 'ERROR: Switchless storage configuration is only supported for 3 or fewer HCI nodes. Exiting script...'\n        Write-Error 'ERROR: Switchless storage configuration is only supported for 3 or fewer HCI nodes. Exiting script...'\n        exit 1\n    }\n\n    log 'Creating Hyper-V switches for switchless storage configuration...'\n    If ($existingSwitches.Name -notcontains 'external' ) { New-VMSwitch -Name external -AllowManagementOS:$true -NetAdapterName Ethernet }\n    If ($existingSwitches.Name -notcontains 'hciNodeMgmtInternal' ) { New-VMSwitch -Name hciNodeMgmtInternal -SwitchType Internal -EnableIov $true }\n    If ($existingSwitches.Name -notcontains 'hciNodeStoragePrivateA' ) { New-VMSwitch -Name hciNodeStoragePrivateA -SwitchType Private -EnableIov $true }\n    If ($existingSwitches.Name -notcontains 'hciNodeStoragePrivateB' ) { New-VMSwitch -Name hciNodeStoragePrivateB -SwitchType Private -EnableIov $true }\n    If ($existingSwitches.Name -notcontains 'hciNodeStoragePrivateC' ) { New-VMSwitch -Name hciNodeStoragePrivateC -SwitchType Private -EnableIov $true }\n}\n\n# add IPs for host\nlog 'Adding IPs for host...'\n$existingIPs = Get-NetIPAddress\nIf ($existingIPs.IPAddress -notcontains '172.20.0.1') { New-NetIPAddress -InterfaceAlias 'vEthernet (hciNodeMgmtInternal)' -IPAddress 172.20.0.1 -PrefixLength 24 }\n\n# configure NAT\nlog 'Restarting RemoteAccess service...'\nRestart-Service RemoteAccess\n\nlog 'Configuring NAT...'\n\nnetsh routing ip nat uninstall\nnetsh routing ip nat install\nnetsh routing ip nat set global tcptimeoutmins=1440 udptimeoutmins=1 loglevel=ERROR\nnetsh routing ip nat add interface name=\"vEthernet (external)\" mode=FULL\nIf (!$?) {\n    $message = \"Failed to run netsh command: ''netsh routing ip nat add interface name='vEthernet (external)' mode=FULL''.\"\n    log $message\n    Write-Error $message\n}\nnetsh routing ip nat add interface name=\"vEthernet (hciNodeMgmtInternal)\" mode=PRIVATE\nIf (!$?) {\n    $message = \"Failed to run netsh command: ''netsh routing ip nat add interface name='vEthernet (hciNodeMgmtInternal)' mode=PRIVATE''.\"\n    log $message\n    Write-Error $message\n}\n\n# Verify and retry NAT configuration (JumpStart-inspired reliability pattern)\nlog 'Verifying NAT configuration with retry...'\n$natRetryCount = 0\n$natMaxRetries = 3\nwhile ($natRetryCount -lt $natMaxRetries) {\n    Start-Sleep -Seconds 10\n    $natInterfaces = netsh routing ip nat show interface\n    if ($natInterfaces -match 'external' -and $natInterfaces -match 'hciNodeMgmtInternal') {\n        log \"NAT configuration verified successfully (attempt $($natRetryCount + 1))\"\n        break\n    }\n    $natRetryCount++\n    log \"NAT verification failed (attempt $natRetryCount/$natMaxRetries). Retrying NAT setup...\"\n    Restart-Service RemoteAccess -Force\n    Start-Sleep -Seconds 15\n    netsh routing ip nat uninstall\n    netsh routing ip nat install\n    netsh routing ip nat set global tcptimeoutmins=1440 udptimeoutmins=1 loglevel=ERROR\n    netsh routing ip nat add interface name=\"vEthernet (external)\" mode=FULL\n    netsh routing ip nat add interface name=\"vEthernet (hciNodeMgmtInternal)\" mode=PRIVATE\n}\nif ($natRetryCount -ge $natMaxRetries) {\n    log 'WARNING: NAT configuration could not be fully verified after retries. Proceeding anyway...'\n}\n\n# create DHCP scopes\nlog 'Creating DHCP scopes...'\n$existingScopes = Get-DhcpServerv4Scope\nIf ($existingScopes.name -notcontains 'HCIMgmt') { Add-DhcpServerv4Scope -StartRange 172.20.0.10 -EndRange 172.20.0.250 -Name HCIMgmt -State Active -SubnetMask 255.255.255.0 }\n\n# exclude LCM IP range from DHCP to prevent conflicts during Azure Local cluster deployment\ntry { Add-DhcpServerv4ExclusionRange -ScopeId 172.20.0.0 -StartRange 172.20.0.50 -EndRange 172.20.0.70 } catch { log \"DHCP exclusion range already exists or failed: $_\" }\n\n# test DC connectivity before attempting to authorize DHCP server in AD\nlog 'Testing DC connectivity...'\n$count = 0\nWhile (!(Test-ADConnection) -and $count -lt 120) {\n    Start-Sleep -Seconds 5\n    log 'Waiting for AD Web Services to be available...'\n    $count++\n}\n\n# authorize DHCP servers in AD for DNS updates\nlog 'Authorizing DHCP servers in AD for DNS updates...'\ntry {\n    $existingAuthorizedServers = Get-DhcpServerInDC -ErrorAction Stop\n} catch {\n    log 'Failed to query authorized DHCP servers in AD. Waiting 120 seconds before retrying...'\n    Start-Sleep -Seconds 120\n    $existingAuthorizedServers = Get-DhcpServerInDC\n}\n\nIf ($existingAuthorizedServers.IPAddress -notcontains '172.20.0.1') { Add-DhcpServerInDC -DnsName \"$($env:COMPUTERNAME).hci.local\" -IPAddress 172.20.0.1 }\n\n# set router and dns options for mgmt DHCP scope\nlog 'Setting router and dns options for mgmt DHCP scope...'\nSet-DhcpServerv4OptionValue -ScopeId 172.20.0.0 -DnsDomain hci.local -DnsServer 172.20.0.1 -Router 172.20.0.1\n\n# create HCI node VMs\nlog 'Creating HCI node VMs...'\n$existingVMs = Get-VM\nFor ($i = 1; $i -le $hciNodeCount; $i++) {\n    $hciNodeName = \"hcinode$i\"\n    $hciNodePath = \"C:\\diskMounts\\$hciNodeName\"\n\n    If ($existingVMs.name -notcontains $hciNodeName) { New-VM -Name $hciNodeName -MemoryStartupBytes 32GB -BootDevice VHD -SwitchName hciNodeMgmtInternal -Path C:\\diskMounts\\ -VHDPath \"$hciNodePath\\hci_os.vhdx\" -Generation 2 }\n}\n\n# configure HCI node VMs\nlog 'Configuring HCI node VMs...'\nlog 'Setting VM processor count to 16 and enabling virtualization extensions...'\nGet-VM | Set-VMProcessor -ExposeVirtualizationExtensions $true -Count 8\n\nlog 'Setting VM key protector and enabling TPM...'\nGet-VM | ForEach-Object {\n    If (($_ | Get-VMKeyProtector).Length -eq 4) {\n        log \"Adding key protector for VM '$($_.Name)'\"\n        $_ | Set-VMKeyProtector -NewLocalKeyProtector\n    } Else {\n        log \"Key protector already exists for VM '$($_.Name)'\"\n    }\n\n    If (($_ | Get-VMSecurity).TpmEnabled -eq $false) {\n        log \"Enabling TPM for VM '$($_.Name)'\"\n        $_ | Enable-VMTPM\n    } Else {\n        log \"TPM already enabled for VM '$($_.Name)'\"\n    }\n}\n\n\n# rename first NIC to FABRIC (matches Azure Local ManagementCompute intent)\nlog 'Renaming first network adapter on HCI nodes to FABRIC...'\nif (Get-VMNetworkAdapter -Name 'Network Adapter' -VMName * -ErrorAction SilentlyContinue) { Rename-VMNetworkAdapter -NewName FABRIC -VMName * -Name 'Network Adapter' }\nGet-VM | Get-VMNetworkAdapter -Name 'FABRIC' | Set-VMNetworkAdapter -DeviceNaming On\n\n# add additional NICs to HCI node VMs (FABRIC2 for ManagementCompute, StorageA/StorageB for Storage intent)\nlog 'Adding additional NICs to HCI node VMs...'\nForEach ($existingVM in (Get-VM)) {\n    $existingNICs = Get-VMNetworkAdapter -VM $existingVM\n    # FABRIC2 on management switch - paired with FABRIC for ManagementCompute intent\n    If ($existingNICs.name -notcontains 'FABRIC2') { $existingVM | Add-VMNetworkAdapter -Name FABRIC2 -SwitchName hciNodeMgmtInternal -DeviceNaming On }\n\n    If ($switchlessStorageConfig -eq 'switched') {\n        log \"Adding storage NICs to VM '$($existingVM.name)' for switched storage configuration...\"\n        If ($existingNICs.name -notcontains 'StorageA') { $existingVM | Add-VMNetworkAdapter -Name StorageA -SwitchName hciNodeStoragePrivate -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n        If ($existingNICs.name -notcontains 'StorageB') { $existingVM | Add-VMNetworkAdapter -Name StorageB -SwitchName hciNodeStoragePrivate -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '712' -NativeVlanId 0 }\n    } ElseIf ($switchlessStorageConfig -eq 'switchless') {\n        log \"Adding storage NICs to VM '$($existingVM.name)' for switchless storage configuration...\"\n\n        switch ($existingVM.Name[-1]) {\n            1 {\n                If ($existingNICs.name -notcontains 'StorageA') { $existingVM | Add-VMNetworkAdapter -Name StorageA -SwitchName hciNodeStoragePrivateA -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n                If ($existingNICs.name -notcontains 'StorageB') { $existingVM | Add-VMNetworkAdapter -Name StorageB -SwitchName hciNodeStoragePrivateB -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n            }\n            2 {\n                If ($existingNICs.name -notcontains 'StorageA') { $existingVM | Add-VMNetworkAdapter -Name StorageA -SwitchName hciNodeStoragePrivateA -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n                If ($existingNICs.name -notcontains 'StorageB') { $existingVM | Add-VMNetworkAdapter -Name StorageB -SwitchName hciNodeStoragePrivateC -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n            }\n            3 {\n                If ($existingNICs.name -notcontains 'StorageA') { $existingVM | Add-VMNetworkAdapter -Name StorageA -SwitchName hciNodeStoragePrivateB -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n                If ($existingNICs.name -notcontains 'StorageB') { $existingVM | Add-VMNetworkAdapter -Name StorageB -SwitchName hciNodeStoragePrivateC -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n            }\n            Default {}\n        }\n    }\n}\n\n# add disks to HCI node VMs\nlog 'Adding disks to HCI node VMs...'\nForeach ($vm in (Get-VM)) {\n    (1..4) | ForEach-Object {\n        $diskPath = \"C:\\diskMounts\\$($vm.Name)\\hciNodeDisk$($_).vhdx\"\n        If (!(Test-Path -Path $diskPath)) {\n            log \"Creating disk: $diskPath\"\n            New-VHD -Path $diskPath -SizeBytes 1TB -Dynamic | Out-Null\n        }\n        If ($VM.HardDrives.Path -notcontains $diskPath) {\n            log \"Adding disk: $diskPath to VM: $($vm.Name)\"\n            Add-VMHardDiskDrive -VMName $vm.Name -ControllerType SCSI -ControllerNumber 0 -ControllerLocation $_ -Path $diskPath | Out-Null\n        }\n    }\n}\n\n# enable mac soofing on HCI node VMs\nlog 'Enabling MAC spoofing on HCI node VMs...'\nGet-VM | Get-VMNetworkAdapter | Set-VMNetworkAdapter -MacAddressSpoofing On\n\n# define unattend.xml for HCI node VMs template\n$unattendSource = @'\n<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<unattend xmlns=\"urn:schemas-microsoft-com:unattend\">\n    <settings pass=\"specialize\">\n        <component name=\"Microsoft-Windows-Shell-Setup\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <ComputerName>$hciNodeName</ComputerName>\n            <RegisteredOrganization>Organization</RegisteredOrganization>\n            <RegisteredOwner>Owner</RegisteredOwner>\n            <TimeZone>UTC</TimeZone>\n        </component>\n        <component name=\"Microsoft-Windows-IE-ESC\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <IEHardenAdmin>false</IEHardenAdmin>\n        </component>\n        <component name=\"Microsoft-Windows-ErrorReportingCore\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <DisableWER>1</DisableWER>\n        </component>\n        <component name=\"Microsoft-Windows-TerminalServices-LocalSessionManager\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <fDenyTSConnections>false</fDenyTSConnections>\n        </component>\n        <component name=\"Microsoft-Windows-TCPIP\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <Interfaces>\n                <Interface wcm:action=\"add\">\n                    <Ipv4Settings>\n                        <DhcpEnabled>true</DhcpEnabled>\n                    </Ipv4Settings>\n                </Interface>\n            </Interfaces>\n        </component>\n    </settings>\n    <settings pass=\"oobeSystem\">\n        <component name=\"Microsoft-Windows-Shell-Setup\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <OOBE>\n                <HideEULAPage>true</HideEULAPage>\n                <HideLocalAccountScreen>true</HideLocalAccountScreen>\n                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>\n                <NetworkLocation>Work</NetworkLocation>\n                <ProtectYourPC>1</ProtectYourPC>\n            </OOBE>\n            <FirstLogonCommands>\n                <SynchronousCommand wcm:action=\"add\">\n                    <CommandLine>powershell.exe -command &quot;Get-NetAdapterAdvancedProperty -DisplayName 'Hyper-V Network Adapter Name' | Foreach-Object {`$_ | Get-NetAdapter | Rename-NetAdapter -NewName `$_.DisplayValue}&quot;</CommandLine>\n                    <Order>1</Order>\n                    <RequiresUserInput>false</RequiresUserInput>\n                </SynchronousCommand>\n                <SynchronousCommand wcm:action=\"add\">\n                    <CommandLine>powershell.exe -command &quot;Enable-WindowsOptionalFeature -Online -FeatureName 'microsoft-hyper-v-online' -all -NoRestart&quot;</CommandLine>\n                    <Order>2</Order>\n                    <RequiresUserInput>false</RequiresUserInput>\n                </SynchronousCommand>\n                <SynchronousCommand wcm:action=\"add\">\n                <CommandLine>powershell.exe -command &quot;Remove-Item -Path &apos;C:\\unattend.xml&apos; -Force&quot;</CommandLine>\n                <Order>3</Order>\n                <RequiresUserInput>false</RequiresUserInput>\n            </SynchronousCommand>\n                <SynchronousCommand wcm:action=\"add\">\n                    <CommandLine>shutdown -r -f -t 0</CommandLine>\n                    <Order>4</Order>\n                    <RequiresUserInput>false</RequiresUserInput>\n            </SynchronousCommand>\n            </FirstLogonCommands>\n            <AutoLogon>\n                <Username>Administrator</Username>\n                <Enabled>true</Enabled>\n                <LogonCount>1</LogonCount>\n                <Password>\n                    <Value>$adminPw</Value>\n                    <PlainText>true</PlainText>\n                </Password>\n            </AutoLogon>\n            <UserAccounts>\n                <AdministratorPassword>\n                    <Value>$adminPw</Value>\n                    <PlainText>True</PlainText>\n                </AdministratorPassword>\n                <LocalAccounts>\n                <LocalAccount wcm:action=\"add\">\n                   <Password>\n                      <Value>$adminPw</Value>\n                      <PlainText>true</PlainText>\n                   </Password>\n                   <Description>HCI Admin User</Description>\n                   <DisplayName>$adminUsername</DisplayName>\n                   <Group>Administrators;Power Users</Group>\n                   <Name>$adminUsername</Name>\n                </LocalAccount>\n                </LocalAccounts>\n            </UserAccounts>\n        </component>\n        <component name=\"Microsoft-Windows-International-Core\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <InputLocale>en-us</InputLocale>\n            <SystemLocale>en-us</SystemLocale>\n            <UILanguage>en-us</UILanguage>\n            <UILanguageFallback>en-us</UILanguageFallback>\n            <UserLocale>en-us</UserLocale>\n        </component>\n    </settings>\n</unattend>\n'@\n\n# inject updated sysp answer file into each HCI node disk\nlog 'Injecting updated sysprep answer file into each HCI node disk...'\nFor ($i = 1; $i -le $hciNodeCount; $i++) {\n    $hciNodeName = \"hciNode$i\"\n    $hciProductKey = ''\n\n    Push-Location c:\\diskMounts\\$hciNodeName\n\n    If (!(Test-Path -Path unattend_injected.status) -and (Get-VM -Name $hciNodeName).State -eq 'Off') {\n        log \"Injecting unattend.xml into HCI node disk '$hciNodeName'...\"\n        $mountedVolume = Mount-VHD .\\hci_os.vhdx -Passthru | Get-Disk | Get-Partition | Get-Volume | Where-Object FileSystemType -EQ 'NTFS'\n\n        $clone = $unattendSource.psobject.copy()\n        $clone = $ExecutionContext.InvokeCommand.ExpandString($clone)\n\n        Set-Content -Path \"$($mountedVolume.DriveLetter):\\unattend.xml\" -Value $clone -Force\n\n        Dismount-VHD .\\hci_os.vhdx\n\n        Set-Content 'unattend_injected.status' -Value 'Unattend.xml injected'\n    } Else {\n        log \"Unattend.xml already injected into HCI node disk '$hciNodeName'.\"\n    }\n\n    Pop-Location\n}\n\n# start HCI node VMs\nIf (Get-VM | Where-Object State -EQ 'Off') {\n    log 'Starting HCI node VMs...'\n    try {\n        $errorActionPreference = 'Stop'\n        Get-VM | Start-VM\n    } catch {\n        log \"Failed to start HCI node VMs. $_\"\n        Write-Error \"Failed to start HCI node VMs. $_\"\n    }\n\n    #wait for vms to boot\n    log 'Waiting 300s for VMs to boot and apply sysprep...'\n    Start-Sleep -Seconds 300\n} Else {\n    log 'HCI node VMs are already running.'\n}\n\n# create DHCP reservations for HCI node VMs management interfaces\nlog 'Checking DHCP reservations for HCI node VMs management interfaces...'\n$existingReservations = Get-DhcpServerv4Reservation -ScopeId 172.20.0.0\nFor ($i = 1; $i -le $hciNodeCount; $i++) {\n    $hciNodeName = \"hciNode$i\"\n    $hciNodeIP = \"172.20.0.$(9 + $i)\"\n    If ($existingReservations.Description -notcontains $hciNodeName) {\n        log \"Creating DHCP reservation for HCI node '$hciNodeName' with IP '$hciNodeIP'...\"\n\n        $fabricNIC = Get-VMNetworkAdapter -VMName $hciNodeName -Name FABRIC\n\n        If ($fabricNIC) {\n            $fabricMac = $fabricNIC.MacAddress -split '(.{2})' -ne '' -join '-'\n\n            log \"Creating DHCP reservation for HCI node '$hciNodeName' with IP '$hciNodeIP' for MAC address '$fabricMac'...\"\n            Add-DhcpServerv4Reservation -ScopeId 172.20.0.0 -Name $hciNodeName -IPAddress $hciNodeIP -ClientId $fabricMac -Description $hciNodeName\n        } Else {\n            log \"Failed to create DHCP reservation for HCI node '$hciNodeName'. Could not find NIC named 'FABRIC'.\"\n            Write-Error \"Failed to create DHCP reservation for HCI node '$hciNodeName'. Could not find NIC named 'FABRIC'.\"\n            exit 1\n        }\n    } Else {\n        log \"DHCP reservation for HCI node '$hciNodeName' already exists.\"\n    }\n}\n",
+                    "$fxv#5": "[CmdletBinding()]\nparam (\n    [Parameter()]\n    [String]\n    $resourceGroupName,\n\n    [Parameter()]\n    [String]\n    $subscriptionId,\n\n    [Parameter()]\n    [String]\n    $tenantId,\n\n    [Parameter()]\n    [String]\n    $location,\n\n    [Parameter()]\n    [String]\n    $accountName,\n\n    [Parameter()]\n    [String]\n    $adminUsername,\n\n    [Parameter()]\n    [String]\n    $adminPw,\n\n    [Parameter()]\n    [String]\n    $arcGatewayId,\n\n    [Parameter()]\n    [String]\n    $domainOUPath = 'OU=HCI,DC=HCI,DC=local',\n\n    [Parameter()]\n    [string]\n    $deploymentUsername,\n\n    [Parameter()]\n    [string]\n    $proxyServerEndpoint, #http://[Proxy_Server_Address]:[Proxy_Port],\n\n    [parameter()]\n    [string]\n    $proxyBypassString, #\"localhost;127.0.0.1;*.contoso.com;node1;node2;192.168.1.*;s-cluster\",\n\n    [Parameter()]\n    [string]\n    $userAssignedManagedIdentityClientId\n)\n\nFunction log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-6.log'\n    )\n\n    If (!(Test-Path -Path 'C:\\temp')) {\n        New-Item -Path 'C:\\temp' -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage6] - $message\"\n}\n\n$ErrorActionPreference = 'Stop'\n\n# export or re-import local administrator credential\n# we do this to support re-run of the template. If deployed, the HCI node password will be set to the password provided in the template, but future re-runs will generate a new password.\nIf (!(Test-Path -Path 'C:\\temp\\hciHostDeployAdminCred.xml')) {\n    log \"Exporting local '$($adminUsername)' credential (for re-use if script is re-run)...\"\n    $adminCred = [pscredential]::new($adminUsername, (ConvertTo-SecureString -AsPlainText -Force $adminPw))\n    $adminCred | Export-Clixml -Path 'C:\\temp\\hciHostDeployAdminCred.xml'\n} Else {\n    log \"Re-importing local '$($adminUsername)' credential...\"\n    $adminCredOld = Import-Clixml -Path 'C:\\temp\\hciHostDeployAdminCred.xml'\n\n    $newCredFileName = 'hciHostDeployAdminCred_{0}.xml' -f (Get-Date -Format 'yyyyMMddHHmmss')\n    log \"Renaming the old credential file to '$newCredFileName' prevent overwriting...\"\n    Rename-Item -Path 'C:\\temp\\hciHostDeployAdminCred.xml' -NewName $newCredFileName\n\n    log \"Exporting local '$($adminUsername)' credential (for re-use if script is re-run)...\"\n    $adminCred = [pscredential]::new($adminUsername, (ConvertTo-SecureString -AsPlainText -Force $adminPw))\n    $adminCred | Export-Clixml -Path 'C:\\temp\\hciHostDeployAdminCred.xml'\n}\n\nIf (!(Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) { Register-PSRepository -Default }\nIf (!(Get-PackageProvider -Name Nuget -ListAvailable -ErrorAction SilentlyContinue)) { Install-PackageProvider -Name NuGet -Confirm:$false -Force }\nSet-PSRepository -Name PSGallery -InstallationPolicy Trusted\n\nInstall-Module Az\n\n# get an access token for the VM MSI, which has been granted rights and will be used for the HCI Arc Initialization\nlog \"Logging in to Azure with user-assigned managed identity '$($userAssignedManagedIdentityClientId)'...\"\nLogin-AzAccount -Identity -Subscription $subscriptionId -AccountId $userAssignedManagedIdentityClientId\n\nlog 'Getting access token for Azure Stack HCI Arc initialization...'\n$tokenResult = Get-AzAccessToken -ResourceUrl 'https://management.azure.com'\n# Handle both old (plain string) and new (SecureString) Az.Accounts token formats\nif ($tokenResult.Token -is [System.Security.SecureString]) {\n    $t = [System.Net.NetworkCredential]::new('', $tokenResult.Token).Password\n} else {\n    $t = $tokenResult.Token\n}\n\n# pre-create AD objects\nlog 'Pre-creating AD objects with deployment username '$deploymentUsername'...'\n$deployUserCred = [pscredential]::new($deploymentUsername, (ConvertTo-SecureString -AsPlainText -Force $adminPw))\n\nInstall-Module AsHciADArtifactsPreCreationTool\nNew-HciAdObjectsPreCreation -AzureStackLCMUserCredential $deployUserCred -AsHciOUName $domainOUPath\n\n## set the LCM deployUser password to the adminPw value - this aligns the password with the KeyVault during re-runs\nlog \"Setting deploy user '$deploymentUsername's password...\"\nSet-AdAccountPassword -Identity $deploymentUsername -NewPassword (ConvertTo-SecureString -AsPlainText -Force $adminPw) -Reset -Confirm:$false\n\n# initialize arc on hci nodes\nlog 'Initializing Azure Arc on HCI nodes...'\n\n# wait for VMs to reach 'Running' state\nlog 'Checking that VMs are running...'\n$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()\nwhile ((Get-VM | Where-Object State -NE 'Running') -and $stopwatch.Elapsed.TotalMinutes -lt 15) {\n    log \"Waiting for HCI node VMs to reach 'Running' state. Current state: $((Get-VM) | Select-Object Name,State)...\"\n    Start-Sleep -Seconds 30\n}\n\nIf ($stopwatch.Elapsed.TotalMinutes -ge 15) {\n    log \"HCI node VMs did not reach 'Running' state within 15 minutes. Exiting...\"\n    Write-Error \"HCI node VMs did not reach 'Running' state within 15 minutes. Exiting...\"\n    Exit 1\n}\n\nlog \"Creating PSSessions to HCI nodes [$((Get-VM).Name -join ',')]...\"\ntry {\n    $VMs = Get-VM\n    If ($adminCredOld) {\n        log 'Using old local administrator credential from exported CliXML...'\n        $localAdminCred = $adminCredOld\n    } Else {\n        log 'Using new local administrator credential from parameter input...'\n        $localAdminCred = $adminCred\n    }\n    $sessions = New-PSSession -VMName $VMs.Name -Credential $localAdminCred -ErrorAction Stop\n\n    log \"Created '$(($sessions | Where-Object State -EQ 'Opened').Count)' PSSessions to HCI nodes [$($VMs.Name -join ',')].\"\n} catch {\n    If ($_ -like '*The credential is invalid*') {\n        log 'Failed to create PSSessions with \"The credential is invalid\" error. This is likely due to the password not matching the local administrator password on the HCI nodes. Retrying with the older passwords...'\n\n        $credFiles = Get-ChildItem -Path 'C:\\temp\\*' -Include 'hciHostDeployAdminCred*.xml' -Exclude 'hciHostDeployAdminCred.xml'\n\n        If ($credFiles.count -eq 0) {\n            log 'No old credential files found. Exiting...'\n            Write-Error 'No old credential files found. Exiting...'\n            Exit 1\n        }\n\n        :retryCreds ForEach ($credFile in $credFiles) {\n            log \"Attempting login with credential file '$($credFile.name)'...\"\n            $localAdminCred = Import-Clixml -Path $credFile.FullName\n\n            try {\n                $sessions = New-PSSession -VMName $VMs.Name -Credential $localAdminCred -ErrorAction Stop\n\n                If (($sessions | Where-Object State -EQ 'Opened').count -eq $VMs.Count) {\n                    log \"Created '$(($sessions | Where-Object State -EQ 'Opened').Count)' PSSessions to HCI nodes [$($VMs.Name -join ',')].\"\n                    break retryCreds\n                }\n            } catch {\n                log \"Failed to create PSSessions with credential file '$($credFile.name)'. Error: $_\"\n                continue\n            } finally {\n                If (($sessions | Where-Object State -EQ 'Opened').count -eq $VMs.Count) {\n                    log \"Created '$(($sessions | Where-Object State -EQ 'Opened').Count)' PSSessions to HCI nodes [$($VMs.Name -join ',')].\"\n                    $adminCredOld = $localAdminCred\n                }\n            }\n\n        }\n    } else {\n        log \"Failed to create PSSessions to HCI nodes [$($VMs.Name -join ',')]. $sessions $_ Exiting...\"\n        Write-Error \"Failed to create PSSessions to HCI nodes [$($VMs.Name -join ',')]. $sessions $_ Exiting...\"\n        Exit 1\n    }\n}\n\n# update local admin password to match the adminPw value\nIf ($adminCredOld) {\n    log 'Updating local administrator password to match the adminPw value...'\n    Invoke-Command -VMName (Get-VM).Name -Credential $adminCredOld {\n        $ErrorActionPreference = 'Stop'\n\n        $adminPw = $args[0]\n        $adminUsername = $args[1]\n\n        Write-Host \"$($env:computerName):Setting local administrator password to match the adminPw value...\"\n        $adminCred = [pscredential]::new($adminUsername, (ConvertTo-SecureString -AsPlainText -Force $adminPw))\n        Set-LocalUser -Name $adminUsername -Password $adminCred.Password -Confirm:$false\n    } -ArgumentList $adminPw, $adminUsername\n} Else {\n    log \"Password for '$($adminUsername)' should already match the adminPw value...\"\n}\n\n# disable IPv6 on all HCI nodes\nlog 'Disabling IPv6 on HCI nodes...'\nInvoke-Command -VMName (Get-VM).Name -Credential $adminCred {\n    reg add hklm\\system\\currentcontrolset\\services\\tcpip6\\parameters /v DisabledComponents /t REG_DWORD /d 0xFF /f\n}\n\n# set proxy settings if provided\nif (![string]::IsNullOrEmpty($proxyServerEndpoint) -and ![string]::IsNullOrEmpty($proxyBypassString)) {\n    log 'Both -proxyServerEndpoiint and -proxyBypassString passed, setting proxy settings...'\n    log \"Proxy Server Endpoint: $proxyServerEndpoint\"\n    log \"Proxy Bypass String: $proxyBypassString\"\n\n    If ($proxyBypassString -eq 'GENERATE_PROXY_BYPASS_DYNAMICALLY') {\n        log 'Generating proxy bypass string dynamically...'\n        $proxyBypassString = '127.0.0.1;localhost;172.20.0.*;*.hci.local;hcicluster;172.20.0.2;172.20.0.3;172.20.0.4;172.20.0.5;*.svc'\n        For ($i = 1; $i -le (Get-VM).count; $i++) {\n            $proxyBypassString += \";hcinode$i\"\n            $proxyBypassString += ';172.20.0.{0}' -f (9 + $i)\n        }\n    }\n\n    log 'Configuring proxy settings on HCI nodes...'\n    $proxyConfigLogs = Invoke-Command -VMName (Get-VM).Name -Credential $adminCred {\n        $ErrorActionPreference = 'Stop'\n\n        $proxyServerEndpoint = $args[0]\n        $proxyBypassString = $args[1]\n\n        ## install winInetProxy module\n        If (!(Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction SilentlyContinue)) { Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force }\n        If (!(Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) { Register-PSRepository -Default }\n        Set-PSRepository -Name PSGallery -InstallationPolicy Trusted\n        If (!(Get-InstalledModule -Name WinInetProxy -ErrorAction SilentlyContinue)) { Install-Module WinInetProxy -Force }\n        Set-PSRepository -Name PSGallery -InstallationPolicy Untrusted\n\n        ## set WinInet proxy settings\n        Set-WinInetProxy -ProxyServer $proxyServerEndpoint -ProxyBypass $proxyBypassString -ProxySettingsPerUser 0\n\n        ## set winhttp proxy settings\n        Set-WinhttpProxy -ProxyServer $proxyServerEndpoint -BypassList $proxyBypassString\n\n        ## set proxy environment variables\n        $proxyBypassStringEnv = $proxyBypassString.replace(';', ',').replace('*', '').replace('172.20.0.*', '172.20.0.0/24')\n        $proxyBypassStringEnv += ',.svc'\n\n        [Environment]::SetEnvironmentVariable('HTTPS_PROXY', $proxyServerEndpoint, 'Machine')\n        [Environment]::SetEnvironmentVariable('HTTP_PROXY', $proxyServerEndpoint, 'Machine')\n        [Environment]::SetEnvironmentVariable('NO_PROXY', $proxyBypassStringEnv, 'Machine')\n\n        Write-Output \"[$($env:COMPUTERNAME)] WinInetProxy Settings: $(Get-WinhttpProxy -Advanced)\"\n        Write-Output \"[$($env:COMPUTERNAME)] WinhttpProxy Settings: $(Get-WinhttpProxy -Default)\"\n\n        Write-Output (\"[{0}] Environment Variables {1}: '{2}'\" -f $env:COMPUTERNAME, 'HTTPS_PROXY', [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'Machine'))\n        Write-Output (\"[{0}] Environment Variables {1}: '{2}'\" -f $env:COMPUTERNAME, 'HTTP_PROXY', [Environment]::GetEnvironmentVariable('HTTP_PROXY', 'Machine'))\n        Write-Output (\"[{0}] Environment Variables {1}: '{2}'\" -f $env:COMPUTERNAME, 'NO_PROXY', [Environment]::GetEnvironmentVariable('NO_PROXY', 'Machine'))\n\n    } -ArgumentList $proxyServerEndpoint, $proxyBypassString\n\n    $proxyConfigLogs | ForEach-Object {\n        log $_\n    }\n} Else {\n    log \"Skipping proxy settings because both -proxyServerEndpoint and -proxyBypassString were not passed... (proxyServerEndpoint: '$proxyServerEndpoint', proxyBypassString:'$proxyBypassString')\"\n}\n\n## test node internet connection with retry - required for Azure Arc initialization\n$firstVM = Get-VM | Select-Object -First 1\nlog \"Testing node internet connection on VM '$($firstVM.Name)' with retry...\"\n$testNodeInternetConnection = $false\n$internetRetryCount = 0\n$internetMaxRetries = 6\nwhile (!$testNodeInternetConnection -and $internetRetryCount -lt $internetMaxRetries) {\n    try {\n        $testNodeInternetConnection = Invoke-Command -VMName $firstVM.Name -Credential $adminCred {\n            [bool](Invoke-RestMethod ipinfo.io -UseBasicParsing -TimeoutSec 30)\n        } -ErrorAction SilentlyContinue\n    } catch {\n        log \"Internet test attempt $($internetRetryCount + 1) failed: $_\"\n    }\n    if (!$testNodeInternetConnection) {\n        $internetRetryCount++\n        if ($internetRetryCount -lt $internetMaxRetries) {\n            log \"Node '$($firstVM.Name)' internet check failed (attempt $internetRetryCount/$internetMaxRetries). Restarting RRAS NAT and retrying in 30s...\"\n            Restart-Service RemoteAccess -Force -ErrorAction SilentlyContinue\n            Start-Sleep -Seconds 30\n        }\n    }\n}\n\nIf (!$testNodeInternetConnection) {\n    log \"Node '$($firstVM.name)' does not have internet connection after $internetMaxRetries retries. Check RRAS NAT configuration. Exiting...\"\n    Write-Error \"Node '$($firstVM.name)' does not have internet connection after $internetMaxRetries retries. Check RRAS NAT configuration. Exiting...\"\n    Exit 1\n} Else {\n    log \"Node '$($firstVM.name)' has internet connection. Curl IPInfo: '$($testNodeInternetConnection)'\"\n}\n\n## create jobs for each node to initialize Azure Arc\nlog \"Creating Azure Arc initialization jobs for HCI nodes [$((Get-VM).Name -join ',')]. ArcGatewayId: '$arcGatewayId', ProxyServerEndpoint: '$proxyServerEndpoint'...\"\n$arcInitializationJobs = Invoke-Command -VMName (Get-VM).Name -Credential $adminCred {\n    $ErrorActionPreference = 'Stop'\n\n    $t = $args[0]\n    $subscriptionId = $args[1]\n    $resourceGroupName = $args[2]\n    $tenantId = $args[3]\n    $location = $args[4]\n    $accountName = $args[5]\n    $arcGatewayId = $args[6]\n    $proxyServerEndpoint = $args[7]\n    $proxyBypassString = $args[8]\n\n    $optionalParameters = @{}\n\n    If ($arcGatewayId) {\n        $optionalParameters += @{\n            'arcGatewayId' = $arcGatewayId\n        }\n    }\n    If ($proxyServerEndpoint) {\n        $optionalParameters += @{\n            'proxy'       = $proxyServerEndpoint\n            'proxyBypass' = $proxyBypassString\n        }\n    }\n\n    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null\n    If (!(Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) { Register-PSRepository -Default }\n    Set-PSRepository -Name PSGallery -InstallationPolicy Trusted\n    Install-Module Az.Resources\n    Install-Module -Name AzsHCI.ARCinstaller # -RequiredVersion '0.2.2690.99' # hardcode for 2408 testing\n    Set-PSRepository -Name PSGallery -InstallationPolicy Untrusted\n\n    #wait for bootstrap service to be reachable\n    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()\n    While (!(Test-NetConnection -ComputerName '127.0.0.1' -Port 9098 -InformationLevel Quiet) -and $stopwatch.Elapsed.TotalMinutes -lt 30) {\n        Write-Host 'Waiting for bootstrap service at 127.0.0.1:9098 to be reachable...'\n        Start-Sleep -Seconds 30\n    }\n    If ($stopwatch.Elapsed.TotalMinutes -ge 30) {\n        Write-Error 'Bootstrap service at 127.0.0.1:9098 did not become reachable within 30 minutes. Exiting...' -ErrorAction Stop\n    }\n\n    try {\n        # Invoke-AzStackHciArcInitialization -SubscriptionID $subscriptionId -ResourceGroup $resourceGroupName -TenantID $tenantId -Cloud AzureCloud -AccountID $accountName -ArmAccessToken $t -Region $location -ErrorAction Stop @optionalParameters\n\n        function Install-ModuleIfMissing {\n            param(\n                [Parameter(Mandatory = $true)]\n                [string]$Name,\n                [Parameter(Mandatory = $false)]\n                [string]$Repository = 'PSGallery',\n                [Parameter(Mandatory = $false)]\n                [switch]$Force,\n                [Parameter(Mandatory = $false)]\n                [switch]$AllowClobber\n            )\n            $module = Get-Module -Name $Name -ListAvailable\n            if (!$module) {\n                Install-Module -Name $Name -Repository $Repository -Force:$Force -AllowClobber:$AllowClobber\n            }\n        }\n\n        wget -Uri 'https://aka.ms/AzureConnectedMachineAgent' -OutFile \"$env:TEMP\\AzureConnectedMachineAgent.msi\"\n        msiexec /i \"$env:TEMP\\AzureConnectedMachineAgent.msi\" /l*v \"$env:TEMP\\AzureConnectedMachineAgentInstall.log\" /qn\n\n        Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Confirm:$false\n        Install-ModuleIfMissing -Name Az -Repository PSGallery -Force\n        Install-ModuleIfMissing -Name Az.Accounts -Force -AllowClobber\n        Install-ModuleIfMissing -Name Az.ConnectedMachine -Force -AllowClobber\n        Install-ModuleIfMissing -Name Az.Resources -Force -AllowClobber\n\n        $machineName = [System.Net.Dns]::GetHostName()\n        $correlationID = New-Guid\n\n        $azcmagentPath = \"$env:ProgramW6432\\AzureConnectedMachineAgent\\azcmagent.exe\"\n        & \"$azcmagentPath\" --version\n        & \"$azcmagentPath\" connect --resource-group \"$resourceGroupName\" --resource-name \"$machineName\" --tenant-id \"$tenantId\" --location \"$location\" --subscription-id \"$subscriptionId\" --cloud 'AzureCloud' --correlation-id \"$correlationID\" --access-token \"$t\";\n        if ($LASTEXITCODE -ne 0) {\n            throw 'Arc server connection failed'\n        }\n\n        Write-Output 'PUT edge device resource to install mandatory extensions'\n        $uri = \"https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.HybridCompute/machines/$machineName/providers/Microsoft.AzureStackHCI/edgeDevices/default?api-version=2024-04-01\"\n        $body = @{\n            'kind'       = 'HCI';\n            'properties' = @{};\n        }\n        $headers = @{\n            'Authorization' = \"Bearer $t\";\n        }\n        Invoke-RestMethod -Uri $uri -Method Put -Headers $headers -Body ($body | ConvertTo-Json) -ContentType 'application/json'\n\n        Write-Output 'Waiting for Edge device resource to be ready'\n        Start-Sleep -Seconds 600\n        $waitInterval = 60\n        $maxWaitCount = 15\n        $ready = $false\n        for ($waitCount = 0; $job.JobState -ne 'Transferred' -and $waitCount -lt $maxWaitCount; $waitCount++) {\n            $headers = @{\n                'Authorization' = \"Bearer $t\";\n            }\n            try {\n                $response = Invoke-RestMethod -Uri $uri -Method Get -Headers $headers\n                if ($response.properties.provisioningState -eq 'Succeeded') {\n                    $ready = $true\n                    break\n                }\n            } catch {\n                Write-Output \"Failed to get Edge device resource: $_\"\n            } finally {\n                Write-Output 'Waiting for Edge device resource to be ready'\n                Start-Sleep -Seconds $waitInterval\n            }\n        }\n\n        if (!$ready) {\n            throw 'Edge device resource is not ready after 30 minutes.'\n        }\n    } catch {\n        Write-Error $_ -ErrorAction Stop\n    }\n} -AsJob -ArgumentList $t, $subscriptionId, $resourceGroupName, $tenantId, $location, $accountName, $arcGatewayId, $proxyServerEndpoint, $proxyBypassString\n\nlog 'Waiting up to 30 minutes for Azure Arc initialization to complete on nodes...'\n\n$arcInitializationJobs | Wait-Job -Timeout 1800\n\n# check for failed arc initialization jobs\nlog 'Checking status of Azure Arc initialization jobs...'\n$arcInitializationJobs | ForEach-Object {\n    $job = $_\n    log \"[$($job.ComputerName)] Job output (Receive-Job): '$($job | Receive-Job -Keep -ErrorAction Continue | Out-String)'\"\n    Get-Job -Id $job.Id -IncludeChildJob | Receive-Job -ErrorAction SilentlyContinue | ForEach-Object {\n        If ($_.Exception -or $_.state -eq 'Failed') {\n            log \"Azure Arc initialization failed on node '$($job.Location)' with error: $($_.Exception.Message)\"\n            Exit 1\n        } Else {\n            log \"[$($job.ComputerName)] Job output: '$($_ | ConvertTo-Json -Compress)'\"\n\n        }\n    }\n}\n",
+                    "$fxv#6": "param(\n    [Parameter()]\n    [String]\n    $resourceGroupName,\n\n    [Parameter()]\n    [String]\n    $subscriptionId,\n\n    [Parameter()]\n    [int]\n    $hciNodeCount,\n\n    [Parameter()]\n    [String]\n    $userAssignedManagedIdentityClientId\n\n)\nFunction log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-7.log'\n    )\n\n    If (!(Test-Path -Path C:\\temp)) {\n        New-Item -Path C:\\temp -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage7] - $message\"\n}\n\n$ErrorActionPreference = 'Stop'\n\n$hciNodeNames = @()\nfor ($i = 1; $i -le $hciNodeCount; $i++) {\n    $hciNodeNames += \"hcinode$i\"\n}\n\nSet-PSRepository -Name PSGallery -InstallationPolicy Trusted\nInstall-Module -Name Az.ConnectedMachine -Force -AllowClobber -Scope CurrentUser -Repository PSGallery -ErrorAction SilentlyContinue\nSet-PSRepository -Name PSGallery -InstallationPolicy Untrusted\n\nlog \"Logging in to Azure with user-assigned managed identity '$($userAssignedManagedIdentityClientId)'...\"\nLogin-AzAccount -Identity -Subscription $subscriptionId -AccountId $userAssignedManagedIdentityClientId\n\nlog \"Waiting for HCI Arc Machines to exist in the resource group '$($resourceGroupName)'...\"\n\n$timer = [System.Diagnostics.Stopwatch]::StartNew()\nWhile (($arcMachines = Get-AzConnectedMachine -ResourceGroupName $resourceGroupName | Where-Object { $_.name -in ($hciNodeNames) }).Count -lt $hciNodeNames.Count -and $timer.Elapsed.TotalMinutes -lt 60) {\n    log \"Found '$($arcMachines.Count)' HCI Arc Machines, waiting for '$($hciNodeNames.Count)' machines for up to 1 hour...\"\n    Start-Sleep -Seconds 30\n}\nIf ($timer.Elapsed.TotalMinutes -gt 60) {\n    log 'HCI Arc Machines did not exist within the 1 hour timeout period'\n    Write-Error 'HCI Arc Machines did not exist within the 1 hour timeout period' -ErrorAction Stop\n    Exit 1\n} Else {\n    log \"All HCI Arc Machines exist in the resource group '$($resourceGroupName)'\"\n}\n\nlog 'Waiting up to two hours for HCI Arc Machine extensions to be installed...'\n$timer = [System.Diagnostics.Stopwatch]::StartNew()\n$allExtensionsReady = $false\nwhile (!$allExtensionsReady -and $timer.Elapsed.TotalMinutes -lt 120) {\n    $allExtensionsReadyCheck = $true\n    foreach ($arcMachine in $arcMachines) {\n        $extensions = Get-AzConnectedMachineExtension -ResourceGroupName $resourceGroupName -MachineName $arcMachine.Name\n        if ($extensions.MachineExtensionType -notcontains 'TelemetryAndDiagnostics' -or $extensions.MachineExtensionType -notcontains 'DeviceManagementExtension' -or $extensions.MachineExtensionType -notcontains 'LcmController' -or $extensions.MachineExtensionType -notcontains 'EdgeRemoteSupport') {\n            log \"Waiting for extensions to be installed on HCI Arc Machine '$($arcMachine.Name)'...\"\n\n            # install extensions if not already installed\n            log \"Installing any missing extensions on HCI Arc Machine '$($arcMachine.Name)'...\"\n            $extensionParams = @{\n                ResourceGroupName = $resourceGroupName\n                MachineName       = $arcMachine.Name\n                Location          = $arcMachine.Location\n                ErrorAction       = 'Continue'\n            }\n\n            # Invoke-AzStackHciArcInitialization seemingly misses installing some extensions some of the time - so we'll install them here if missing\n            If ($extensions.MachineExtensionType -notcontains 'TelemetryAndDiagnostics') {\n                log \"Installing TelemetryAndDiagnostics extension on HCI Arc Machine '$($arcMachine.Name)'...\"\n                New-AzConnectedMachineExtension -Name 'AzureEdgeTelemetryAndDiagnostics' -Publisher 'Microsoft.AzureStack.Observability' -ExtensionType 'TelemetryAndDiagnostics' -NoWait @extensionParams\n            }\n            If ($extensions.MachineExtensionType -notcontains 'DeviceManagementExtension') {\n                log \"Installing DeviceManagementExtension extension on HCI Arc Machine '$($arcMachine.Name)'...\"\n                New-AzConnectedMachineExtension -Name 'AzureEdgeDeviceManagement' -Publisher 'Microsoft.Edge' -ExtensionType 'DeviceManagementExtension' -NoWait @extensionParams\n            }\n            If ($extensions.MachineExtensionType -notcontains 'LcmController') {\n                log \"Installing LcmController extension on HCI Arc Machine '$($arcMachine.Name)'...\"\n                New-AzConnectedMachineExtension -Name 'AzureEdgeLifecycleManager' -Publisher 'Microsoft.AzureStack.Orchestration' -ExtensionType 'LcmController' -NoWait @extensionParams\n            }\n            If ($extensions.MachineExtensionType -notcontains 'EdgeRemoteSupport') {\n                log \"Installing EdgeRemoteSupport extension on HCI Arc Machine '$($arcMachine.Name)'...\"\n                New-AzConnectedMachineExtension -Name 'AzureEdgeRemoteSupport' -Publisher 'Microsoft.AzureStack.Observability' -ExtensionType 'EdgeRemoteSupport' -NoWait @extensionParams\n            }\n\n            $allExtensionsReadyCheck = $false\n            continue\n        } elseIf (($extensionState = $extensions | Where-Object MachineExtensionType -EQ 'TelemetryAndDiagnostics').ProvisioningState -ne 'Succeeded') {\n            log \"Waiting for TelemetryAndDiagnostics extension to be installed on HCI Arc Machine '$($arcMachine.Name)'. Current state: '$($extensionState.ProvisioningState)'...\"\n            $allExtensionsReadyCheck = $false\n        } elseIf (($extensionState = $extensions | Where-Object MachineExtensionType -EQ 'DeviceManagementExtension').ProvisioningState -ne 'Succeeded') {\n            log \"Waiting for DeviceManagementExtension extension to be installed on HCI Arc Machine '$($arcMachine.Name)'. Current state: '$($extensionState.ProvisioningState)'...\"\n            $allExtensionsReadyCheck = $false\n        } elseIf (($extensionState = $extensions | Where-Object MachineExtensionType -EQ 'LcmController').ProvisioningState -ne 'Succeeded') {\n            log \"Waiting for LcmController extension to be installed on HCI Arc Machine '$($arcMachine.Name)'. Current state: '$($extensionState.ProvisioningState)'...\"\n            $allExtensionsReadyCheck = $false\n        } elseIf (($extensionState = $extensions | Where-Object MachineExtensionType -EQ 'EdgeRemoteSupport').ProvisioningState -ne 'Succeeded') {\n            log \"Waiting for EdgeRemoteSupport extension to be installed on HCI Arc Machine '$($arcMachine.Name)'. Current state: '$($extensionState.ProvisioningState)'...\"\n            $allExtensionsReadyCheck = $false\n        } else {\n            log \"All extensions are installed and ready on HCI Arc Machine '$($arcMachine.Name)'\"\n        }\n    }\n    $allExtensionsReady = $allExtensionsReadyCheck\n    If (!$allExtensionsReady) {\n        log 'waiting 30 seconds to check extensions again...'\n        Start-Sleep -Seconds 30\n    }\n}\n\nIf (!$allExtensionsReady) {\n    log 'Extensions did not install within the two hour timeout period'\n    Exit 1\n} Else {\n    log 'All extensions are installed and ready on all HCI Arc Machines'\n}\n\n# import local administrator credential (exported in stage 6)\nlog \"Re-importing local '$($adminUsername)' credential...\"\n$adminCred = Import-Clixml -Path 'C:\\temp\\hciHostDeployAdminCred.xml'\n\n# name net adapters - seems to be required on 2405\nlog 'Renaming network adapters on HCI nodes...'\n$vmNicLocalNamingOut = Invoke-Command -VMName (Get-VM).Name -Credential $adminCred {\n    $ErrorActionPreference = 'Stop'\n\n    Get-NetAdapter | ForEach-Object {\n        $adapter = $_\n\n        try {\n            Write-Output \"Getting Hyper-V network adapter name for '$($adapter.Name)' on VM '$($env:COMPUTERNAME)'...\"\n            $newAdapterName = Get-NetAdapterAdvancedProperty -RegistryKeyword HyperVNetworkAdapterName -Name $adapter.Name | Select-Object -ExpandProperty DisplayValue\n        } catch {\n            Write-Output \"Failed to get Hyper-V network adapter name for '$($adapter.Name)' on VM '$($env:COMPUTERNAME)'. Ensure DeviceNaming is turned on for the VM Network Adapter! $_ Exiting...\"\n            Write-Error \"Failed to get Hyper-V network adapter name for '$($adapter.Name)'  on VM '$($env:COMPUTERNAME)'. Ensure DeviceNaming is turned on for the VM Network Adapter! $_ Exiting...\" -ErrorAction Stop\n            Exit 1\n        }\n\n        If ($adapter.InterfaceAlias -ne $newAdapterName) {\n            Write-Output \"Renaming network adapter '$($adapter.InterfaceAlias)' to '$newAdapterName'  on VM '$($env:COMPUTERNAME)'...\"\n            Rename-NetAdapter -Name $adapter.Name -NewName $newAdapterName\n        } Else {\n            Write-Output \"Network adapter '$($adapter.InterfaceAlias)' is already named correctly on VM '$($env:COMPUTERNAME)'...\"\n        }\n    }\n}\nlog \"VM NIC local naming output: $vmNicLocalNamingOut\"\n\n# change dynamically assigned FABRIC IP addresses to static IPs as required by validation\nlog 'Changing dynamically assigned FABRIC IP addresses to static IPs on HCI nodes...'\n$ipChangeOutput = Invoke-Command -VMName (Get-VM).Name -Credential $adminCred {\n    $ErrorActionPreference = 'Stop'\n\n    $dhcpIpConfig = Get-NetIPConfiguration -InterfaceAlias 'FABRIC'\n    $prefixLength = Get-NetIPAddress -InterfaceAlias 'FABRIC' -AddressFamily IPv4 | Select-Object -ExpandProperty PrefixLength\n    $dnsClientConfig = Get-DnsClientServerAddress -InterfaceAlias 'FABRIC' -AddressFamily IPv4 | Select-Object -ExpandProperty ServerAddresses\n\n    try {\n        If (!(Get-NetIPInterface -InterfaceAlias 'FABRIC' -Dhcp Enabled -ErrorAction SilentlyContinue)) {\n            Write-Output \"[$env:computerName]DHCP is already disabled on network interface 'FABRIC'...\"\n        } Else {\n            Write-Output \"[$env:computerName]Disabling DHCP on network interface 'FABRIC'...\"\n            Set-NetIPInterface -InterfaceAlias 'FABRIC' -Dhcp Disabled\n        }\n    } catch {\n        Write-Output \"[$env:computerName]Failed to disable DHCP on network interface 'FABRIC'. Error message: $_. Exiting...\"\n        Write-Error \"[$env:computerName]Failed to disable DHCP on network interface 'FABRIC'. Error message: $_. Exiting...\" -ErrorAction Stop\n        Exit 1\n    }\n\n    try {\n        If (!(Get-NetIPAddress -IPAddress $dhcpIpConfig.IPv4Address.ipAddress -InterfaceAlias 'FABRIC' -ErrorAction SilentlyContinue)) {\n            Write-Output \"[$env:computerName]Setting static IP address on network interface 'FABRIC'...\"\n            New-NetIPAddress -InterfaceAlias 'FABRIC' -IPAddress $dhcpIpConfig.IPv4Address.ipAddress -DefaultGateway $dhcpIpConfig.Ipv4DefaultGateway.NextHop -AddressFamily IPv4 -PrefixLength $prefixLength\n        } Else {\n            Write-Output \"[$env:computerName]Static IP address already set on network interface 'FABRIC'...\"\n        }\n    } catch {\n        Write-Output \"[$env:computerName]Failed to set static IP address on network interface 'FABRIC'. Error message: $_. Exiting...\"\n        Write-Error \"[$env:computerName]Failed to set static IP address on network interface 'FABRIC'. Error message: $_. Exiting...\" -ErrorAction Stop\n        Exit 1\n    }\n\n    try {\n        Write-Output \"[$env:computerName]Setting DNS server addresses on network interface 'FABRIC' to '$dnsClientConfig'...\"\n        Set-DnsClientServerAddress -InterfaceAlias 'FABRIC' -ResetServerAddresses\n        Set-DnsClientServerAddress -InterfaceAlias 'FABRIC' -ServerAddresses $dnsClientConfig\n    } catch {\n        Write-Output \"[$env:computerName]Failed to set DNS server addresses on network interface 'FABRIC'. Error message: $_. Exiting...\"\n        Write-Error \"[$env:computerName]Failed to set DNS server addresses on network interface 'FABRIC'. Error message: $_. Exiting...\" -ErrorAction Stop\n        Exit 1\n    }\n}\nlog \"IP change output: $ipChangeOutput\"\n\n# change dynamically assigned FABRIC2 IP addresses to static IPs as required by validation\nlog 'Changing dynamically assigned FABRIC2 IP addresses to static IPs on HCI nodes...'\n$ipChangeOutput2 = Invoke-Command -VMName (Get-VM).Name -Credential $adminCred {\n    $ErrorActionPreference = 'Stop'\n\n    $dhcpIpConfig2 = Get-NetIPConfiguration -InterfaceAlias 'FABRIC2'\n    $prefixLength2 = Get-NetIPAddress -InterfaceAlias 'FABRIC2' -AddressFamily IPv4 | Select-Object -ExpandProperty PrefixLength\n\n    try {\n        If (!(Get-NetIPInterface -InterfaceAlias 'FABRIC2' -Dhcp Enabled -ErrorAction SilentlyContinue)) {\n            Write-Output \"[$env:computerName]DHCP is already disabled on network interface 'FABRIC2'...\"\n        } Else {\n            Write-Output \"[$env:computerName]Disabling DHCP on network interface 'FABRIC2'...\"\n            Set-NetIPInterface -InterfaceAlias 'FABRIC2' -Dhcp Disabled\n        }\n    } catch {\n        Write-Output \"[$env:computerName]Failed to disable DHCP on network interface 'FABRIC2'. Error message: $_. Exiting...\"\n        Write-Error \"[$env:computerName]Failed to disable DHCP on network interface 'FABRIC2'. Error message: $_. Exiting...\" -ErrorAction Stop\n        Exit 1\n    }\n\n    try {\n        If (!(Get-NetIPAddress -IPAddress $dhcpIpConfig2.IPv4Address.ipAddress -InterfaceAlias 'FABRIC2' -ErrorAction SilentlyContinue)) {\n            Write-Output \"[$env:computerName]Setting static IP address on network interface 'FABRIC2'...\"\n            New-NetIPAddress -InterfaceAlias 'FABRIC2' -IPAddress $dhcpIpConfig2.IPv4Address.ipAddress -AddressFamily IPv4 -PrefixLength $prefixLength2\n        } Else {\n            Write-Output \"[$env:computerName]Static IP address already set on network interface 'FABRIC2'...\"\n        }\n    } catch {\n        Write-Output \"[$env:computerName]Failed to set static IP address on network interface 'FABRIC2'. Error message: $_. Exiting...\"\n        Write-Error \"[$env:computerName]Failed to set static IP address on network interface 'FABRIC2'. Error message: $_. Exiting...\" -ErrorAction Stop\n        Exit 1\n    }\n}\nlog \"IP change output (FABRIC2): $ipChangeOutput2\"\n"
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+                      "apiVersion": "2023-07-31-preview",
+                      "name": "[parameters('userAssignedIdentityName')]",
+                      "location": "[parameters('location')]"
+                    },
+                    {
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "name": "[guid(subscription().subscriptionId, parameters('userAssignedIdentityName'), 'Owner', resourceGroup().id)]",
+                      "properties": {
+                        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName')), '2023-07-31-preview').principalId]",
+                        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                        "principalType": "ServicePrincipal",
+                        "description": "Role assigned used for Azure Stack HCI IaC testing pipeline - remove if identity no longer exists!"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Network/publicIPAddresses",
+                      "apiVersion": "2024-07-01",
+                      "name": "[format('{0}-natgw-pip', parameters('virtualNetworkName'))]",
+                      "location": "[parameters('location')]",
+                      "sku": {
+                        "name": "Standard"
+                      },
+                      "properties": {
+                        "publicIPAllocationMethod": "Static",
+                        "publicIPAddressVersion": "IPv4"
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Network/natGateways",
+                      "apiVersion": "2024-07-01",
+                      "name": "[format('{0}-natgw', parameters('virtualNetworkName'))]",
+                      "location": "[parameters('location')]",
+                      "sku": {
+                        "name": "Standard"
+                      },
+                      "properties": {
+                        "idleTimeoutInMinutes": 10,
+                        "publicIpAddresses": [
+                          {
+                            "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-natgw-pip', parameters('virtualNetworkName')))]"
+                          }
+                        ]
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-natgw-pip', parameters('virtualNetworkName')))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Network/virtualNetworks",
+                      "apiVersion": "2024-07-01",
+                      "name": "[parameters('virtualNetworkName')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "addressSpace": {
+                          "addressPrefixes": [
+                            "10.0.0.0/24"
+                          ]
+                        },
+                        "subnets": [
+                          {
+                            "name": "subnet01",
+                            "properties": {
+                              "addressPrefix": "10.0.0.0/24",
+                              "natGateway": {
+                                "id": "[resourceId('Microsoft.Network/natGateways', format('{0}-natgw', parameters('virtualNetworkName')))]"
+                              },
+                              "serviceEndpoints": [
+                                {
+                                  "service": "Microsoft.Storage",
+                                  "locations": [
+                                    "[parameters('location')]"
+                                  ]
+                                },
+                                {
+                                  "service": "Microsoft.KeyVault",
+                                  "locations": [
+                                    "[parameters('location')]"
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/natGateways', format('{0}-natgw', parameters('virtualNetworkName')))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Maintenance/maintenanceConfigurations",
+                      "apiVersion": "2023-09-01-preview",
+                      "name": "[coalesce(parameters('maintenanceConfigurationName'), '')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "maintenanceScope": "InGuestPatch",
+                        "maintenanceWindow": {
+                          "recurEvery": "Week Sunday",
+                          "startDateTime": "2020-04-30 08:00",
+                          "duration": "02:00",
+                          "timeZone": "UTC"
+                        },
+                        "installPatches": {
+                          "windowsParameters": {
+                            "classificationsToInclude": [
+                              "Critical",
+                              "Security"
+                            ]
+                          },
+                          "rebootSetting": "IfRequired"
+                        },
+                        "extensionProperties": {
+                          "InGuestPatchMode": "User"
+                        }
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Network/networkSecurityGroups",
+                      "apiVersion": "2020-11-01",
+                      "name": "[parameters('networkSecurityGroupName')]",
+                      "location": "[parameters('location')]"
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachineScaleSets",
+                      "apiVersion": "2024-03-01",
+                      "name": "[parameters('HCIHostVirtualMachineScaleSetName')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "orchestrationMode": "Flexible",
+                        "platformFaultDomainCount": 1
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Network/networkInterfaces",
+                      "apiVersion": "2020-11-01",
+                      "name": "[parameters('networkInterfaceName')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "networkSecurityGroup": {
+                          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]"
+                        },
+                        "ipConfigurations": [
+                          {
+                            "name": "ipConfig01",
+                            "properties": {
+                              "subnet": {
+                                "id": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), '2024-07-01').subnets[0].id]"
+                              },
+                              "privateIPAllocationMethod": "Dynamic"
+                            }
+                          }
+                        ]
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]",
+                        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+                      ]
+                    },
+                    {
+                      "copy": {
+                        "name": "disks",
+                        "count": "[length(range(1, parameters('hciNodeCount')))]"
+                      },
+                      "type": "Microsoft.Compute/disks",
+                      "apiVersion": "2023-10-02",
+                      "name": "[format('{0}{1}', parameters('diskNamePrefix'), string(range(1, parameters('hciNodeCount'))[copyIndex()]))]",
+                      "location": "[parameters('location')]",
+                      "sku": {
+                        "name": "Premium_LRS"
+                      },
+                      "properties": {
+                        "diskSizeGB": 2048,
+                        "networkAccessPolicy": "DenyAll",
+                        "creationData": {
+                          "createOption": "Empty"
+                        }
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines",
+                      "apiVersion": "2024-03-01",
+                      "name": "[parameters('virtualMachineName')]",
+                      "location": "[parameters('location')]",
+                      "identity": {
+                        "type": "UserAssigned",
+                        "userAssignedIdentities": {
+                          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName')))]": {}
+                        }
+                      },
+                      "properties": {
+                        "virtualMachineScaleSet": {
+                          "id": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('HCIHostVirtualMachineScaleSetName'))]"
+                        },
+                        "hardwareProfile": {
+                          "vmSize": "[parameters('hostVMSize')]"
+                        },
+                        "priority": "Regular",
+                        "networkProfile": {
+                          "networkInterfaces": [
+                            {
+                              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceName'))]"
+                            }
+                          ]
+                        },
+                        "storageProfile": {
+                          "copy": [
+                            {
+                              "name": "dataDisks",
+                              "count": "[length(range(1, parameters('hciNodeCount')))]",
+                              "input": {
+                                "lun": "[range(1, parameters('hciNodeCount'))[copyIndex('dataDisks')]]",
+                                "createOption": "Attach",
+                                "caching": "ReadOnly",
+                                "managedDisk": {
+                                  "id": "[resourceId('Microsoft.Compute/disks', format('{0}{1}', parameters('diskNamePrefix'), string(range(1, parameters('hciNodeCount'))[sub(range(1, parameters('hciNodeCount'))[copyIndex('dataDisks')], 1)])))]"
+                                },
+                                "deleteOption": "Delete"
+                              }
+                            }
+                          ],
+                          "imageReference": {
+                            "publisher": "MicrosoftWindowsServer",
+                            "offer": "WindowsServer",
+                            "sku": "2022-datacenter-g2",
+                            "version": "latest"
+                          },
+                          "osDisk": {
+                            "createOption": "FromImage",
+                            "diskSizeGB": 1024,
+                            "deleteOption": "Delete",
+                            "managedDisk": {
+                              "storageAccountType": "Premium_LRS"
+                            }
+                          }
+                        },
+                        "osProfile": {
+                          "adminPassword": "[parameters('localAdminPassword')]",
+                          "adminUsername": "[parameters('localAdminUsername')]",
+                          "computerName": "hciHost01",
+                          "windowsConfiguration": {
+                            "provisionVMAgent": true,
+                            "enableAutomaticUpdates": true,
+                            "patchSettings": {
+                              "patchMode": "AutomaticByPlatform",
+                              "automaticByPlatformSettings": {
+                                "bypassPlatformSafetyChecksOnUserSchedule": true
+                              }
+                            }
+                          }
+                        },
+                        "securityProfile": {
+                          "uefiSettings": {
+                            "secureBootEnabled": true,
+                            "vTpmEnabled": true
+                          },
+                          "securityType": "TrustedLaunch"
+                        },
+                        "licenseType": "Windows_Server"
+                      },
+                      "dependsOn": [
+                        "disks",
+                        "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('HCIHostVirtualMachineScaleSetName'))]",
+                        "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceName'))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Maintenance/configurationAssignments",
+                      "apiVersion": "2023-04-01",
+                      "scope": "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]",
+                      "name": "[parameters('maintenanceConfigurationAssignmentName')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "maintenanceConfigurationId": "[resourceId('Microsoft.Maintenance/maintenanceConfigurations', coalesce(parameters('maintenanceConfigurationName'), ''))]"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Maintenance/maintenanceConfigurations', coalesce(parameters('maintenanceConfigurationName'), ''))]",
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand1')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#0')]"
+                        },
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand2')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#1')]"
+                        },
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/runCommands', parameters('virtualMachineName'), 'runCommand1')]",
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Resources/deploymentScripts",
+                      "apiVersion": "2023-08-01",
+                      "name": "[format('{0}-wait1', parameters('waitDeploymentScriptPrefixName'))]",
+                      "location": "[parameters('location')]",
+                      "kind": "AzurePowerShell",
+                      "properties": {
+                        "azPowerShellVersion": "3.0",
+                        "scriptContent": "Start-Sleep -Seconds 90",
+                        "retentionInterval": "PT6H"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/runCommands', parameters('virtualMachineName'), 'runCommand2')]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand3')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#2')]"
+                        },
+                        "parameters": [
+                          {
+                            "name": "hciVHDXDownloadURL",
+                            "value": ""
+                          },
+                          {
+                            "name": "hciISODownloadURL",
+                            "value": "[parameters('hciISODownloadURL')]"
+                          },
+                          {
+                            "name": "hciNodeCount",
+                            "value": "[string(parameters('hciNodeCount'))]"
+                          }
+                        ],
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]",
+                        "[resourceId('Microsoft.Resources/deploymentScripts', format('{0}-wait1', parameters('waitDeploymentScriptPrefixName')))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand4')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#3')]"
+                        },
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/runCommands', parameters('virtualMachineName'), 'runCommand3')]",
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Resources/deploymentScripts",
+                      "apiVersion": "2023-08-01",
+                      "name": "[format('{0}-wait2', parameters('waitDeploymentScriptPrefixName'))]",
+                      "location": "[parameters('location')]",
+                      "kind": "AzurePowerShell",
+                      "properties": {
+                        "azPowerShellVersion": "3.0",
+                        "scriptContent": "Start-Sleep -Seconds 300 #enough time for AD start-up",
+                        "retentionInterval": "PT6H"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/runCommands', parameters('virtualMachineName'), 'runCommand4')]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand5')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#4')]"
+                        },
+                        "parameters": [
+                          {
+                            "name": "adminUsername",
+                            "value": "[parameters('localAdminUsername')]"
+                          },
+                          {
+                            "name": "hciNodeCount",
+                            "value": "[string(parameters('hciNodeCount'))]"
+                          },
+                          {
+                            "name": "switchlessStorageConfig",
+                            "value": "[if(parameters('switchlessStorageConfig'), 'switchless', 'switched')]"
+                          }
+                        ],
+                        "protectedParameters": [
+                          {
+                            "name": "adminPw",
+                            "value": "[parameters('localAdminPassword')]"
+                          }
+                        ],
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]",
+                        "[resourceId('Microsoft.Resources/deploymentScripts', format('{0}-wait2', parameters('waitDeploymentScriptPrefixName')))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand6')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#5')]"
+                        },
+                        "parameters": [
+                          {
+                            "name": "location",
+                            "value": "[parameters('location')]"
+                          },
+                          {
+                            "name": "resourceGroupName",
+                            "value": "[resourceGroup().name]"
+                          },
+                          {
+                            "name": "subscriptionId",
+                            "value": "[subscription().subscriptionId]"
+                          },
+                          {
+                            "name": "tenantId",
+                            "value": "[tenant().tenantId]"
+                          },
+                          {
+                            "name": "accountName",
+                            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName')), '2023-07-31-preview').principalId]"
+                          },
+                          {
+                            "name": "adminUsername",
+                            "value": "[parameters('localAdminUsername')]"
+                          },
+                          {
+                            "name": "arcGatewayId",
+                            "value": ""
+                          },
+                          {
+                            "name": "deploymentUsername",
+                            "value": "[parameters('deploymentUsername')]"
+                          },
+                          {
+                            "name": "domainOUPath",
+                            "value": "[parameters('domainOUPath')]"
+                          },
+                          {
+                            "name": "proxyBypassString",
+                            "value": ""
+                          },
+                          {
+                            "name": "proxyServerEndpoint",
+                            "value": ""
+                          },
+                          {
+                            "name": "userAssignedManagedIdentityClientId",
+                            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName')), '2023-07-31-preview').clientId]"
+                          }
+                        ],
+                        "protectedParameters": [
+                          {
+                            "name": "adminPw",
+                            "value": "[parameters('localAdminPassword')]"
+                          }
+                        ],
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/runCommands', parameters('virtualMachineName'), 'runCommand5')]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName'))]",
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand7')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#6')]"
+                        },
+                        "parameters": [
+                          {
+                            "name": "hciNodeCount",
+                            "value": "[string(parameters('hciNodeCount'))]"
+                          },
+                          {
+                            "name": "resourceGroupName",
+                            "value": "[resourceGroup().name]"
+                          },
+                          {
+                            "name": "subscriptionId",
+                            "value": "[subscription().subscriptionId]"
+                          },
+                          {
+                            "name": "userAssignedManagedIdentityClientId",
+                            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName')), '2023-07-31-preview').clientId]"
+                          }
+                        ],
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/runCommands', parameters('virtualMachineName'), 'runCommand6')]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName'))]",
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-hcihostmi-roleAssignment_subContributor', uniqueString(deployment().name, parameters('location')))]",
+                      "subscriptionId": "[subscription().subscriptionId]",
+                      "location": "[resourceGroup().location]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "principalId": {
+                            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName')), '2023-07-31-preview').principalId]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.40.2.10011",
+                              "templateHash": "3824400371169904663"
+                            }
+                          },
+                          "parameters": {
+                            "principalId": {
+                              "type": "string"
+                            }
+                          },
+                          "resources": [
+                            {
+                              "type": "Microsoft.Authorization/roleAssignments",
+                              "apiVersion": "2020-04-01-preview",
+                              "name": "[guid(parameters('principalId'), subscription().id, 'Contributor')]",
+                              "properties": {
+                                "principalId": "[parameters('principalId')]",
+                                "principalType": "ServicePrincipal",
+                                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName'))]"
+                      ]
+                    }
+                  ],
+                  "outputs": {
+                    "vnetSubnetResourceId": {
+                      "type": "string",
+                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), '2024-07-01').subnets[0].id]"
+                    }
+                  }
+                }
+              }
+            },
+            "hciClusterPreqs": {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-test-hciclusterreqs', uniqueString(deployment().name, parameters('location')))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "arbDeploymentAppId": {
+                    "value": "[parameters('arbDeploymentAppId')]"
+                  },
+                  "arbDeploymentServicePrincipalSecret": {
+                    "value": "[parameters('arbDeploymentServicePrincipalSecret')]"
+                  },
+                  "arbDeploymentSPObjectId": {
+                    "value": "[parameters('arbDeploymentSPObjectId')]"
+                  },
+                  "clusterWitnessStorageAccountName": {
+                    "value": "[parameters('clusterWitnessStorageAccountName')]"
+                  },
+                  "keyVaultDiagnosticStorageAccountName": {
+                    "value": "[parameters('keyVaultDiagnosticStorageAccountName')]"
+                  },
+                  "deploymentUsername": {
+                    "value": "deployUser"
+                  },
+                  "deploymentUserPassword": {
+                    "value": "[parameters('deploymentUserPassword')]"
+                  },
+                  "keyVaultName": {
+                    "value": "[parameters('keyVaultName')]"
+                  },
+                  "localAdminPassword": {
+                    "value": "[parameters('localAdminPassword')]"
+                  },
+                  "localAdminUsername": {
+                    "value": "Administrator"
+                  },
+                  "logsRetentionInDays": {
+                    "value": 30
+                  },
+                  "softDeleteRetentionDays": {
+                    "value": 30
+                  },
+                  "tenantId": {
+                    "value": "[subscription().tenantId]"
+                  },
+                  "vnetSubnetResourceId": {
+                    "value": "[reference('hciHostDeployment').outputs.vnetSubnetResourceId.value]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.40.2.10011",
+                      "templateHash": "17875009895763037288"
+                    }
+                  },
+                  "parameters": {
+                    "location": {
+                      "type": "string"
+                    },
+                    "clusterWitnessStorageAccountName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the storage account to create as a cluster witness."
+                      }
+                    },
+                    "keyVaultDiagnosticStorageAccountName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the storage account to be created to collect Key Vault diagnostic logs."
+                      }
+                    },
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the Azure Key Vault to create."
+                      }
+                    },
+                    "softDeleteRetentionDays": {
+                      "type": "int",
+                      "defaultValue": 30
+                    },
+                    "logsRetentionInDays": {
+                      "type": "int",
+                      "defaultValue": 30,
+                      "minValue": 0,
+                      "maxValue": 365,
+                      "metadata": {
+                        "description": "Optional. The number of days for the retention in days. A value of 0 will retain the events indefinitely."
+                      }
+                    },
+                    "tenantId": {
+                      "type": "string"
+                    },
+                    "deploymentUsername": {
+                      "type": "string",
+                      "defaultValue": "deployUser"
+                    },
+                    "deploymentUserPassword": {
+                      "type": "securestring"
+                    },
+                    "localAdminUsername": {
+                      "type": "string"
+                    },
+                    "localAdminPassword": {
+                      "type": "securestring"
+                    },
+                    "arbDeploymentAppId": {
+                      "type": "securestring",
+                      "nullable": true
+                    },
+                    "arbDeploymentSPObjectId": {
+                      "type": "securestring",
+                      "nullable": true
+                    },
+                    "arbDeploymentServicePrincipalSecret": {
+                      "type": "securestring",
+                      "nullable": true
+                    },
+                    "vnetSubnetResourceId": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "allowIPtoStorageAndKeyVault": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "usingArcGW": {
+                      "type": "bool",
+                      "defaultValue": false
+                    },
+                    "useSharedKeyVault": {
+                      "type": "bool",
+                      "defaultValue": true
+                    }
+                  },
+                  "variables": {
+                    "deploymentUserSecretValue": "[base64(format('{0}:{1}', parameters('deploymentUsername'), parameters('deploymentUserPassword')))]",
+                    "localAdminSecretValue": "[base64(format('{0}:{1}', parameters('localAdminUsername'), parameters('localAdminPassword')))]",
+                    "arbDeploymentServicePrincipalValue": "[if(and(not(empty(coalesce(parameters('arbDeploymentAppId'), ''))), not(empty(coalesce(parameters('arbDeploymentServicePrincipalSecret'), '')))), base64(format('{0}:{1}', parameters('arbDeploymentAppId'), parameters('arbDeploymentServicePrincipalSecret'))), '')]",
+                    "storageAccountType": "Standard_ZRS"
+                  },
+                  "resources": {
+                    "diagnosticStorageAccount::blobService": {
+                      "type": "Microsoft.Storage/storageAccounts/blobServices",
+                      "apiVersion": "2023-01-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultDiagnosticStorageAccountName'), 'default')]",
+                      "properties": {
+                        "deleteRetentionPolicy": {
+                          "enabled": true,
+                          "days": 7
+                        },
+                        "containerDeleteRetentionPolicy": {
+                          "enabled": true,
+                          "days": 7
+                        }
+                      },
+                      "dependsOn": [
+                        "diagnosticStorageAccount"
+                      ]
+                    },
+                    "witnessStorageAccount::blobService": {
+                      "type": "Microsoft.Storage/storageAccounts/blobServices",
+                      "apiVersion": "2023-01-01",
+                      "name": "[format('{0}/{1}', parameters('clusterWitnessStorageAccountName'), 'default')]",
+                      "properties": {
+                        "deleteRetentionPolicy": {
+                          "enabled": true,
+                          "days": 7
+                        },
+                        "containerDeleteRetentionPolicy": {
+                          "enabled": true,
+                          "days": 7
+                        }
+                      },
+                      "dependsOn": [
+                        "witnessStorageAccount"
+                      ]
+                    },
+                    "keyVault::keyVaultName_domainAdminSecret": {
+                      "condition": "[not(parameters('useSharedKeyVault'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), 'AzureStackLCMUserCredential')]",
+                      "properties": {
+                        "contentType": "Secret",
+                        "value": "[variables('deploymentUserSecretValue')]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "dependsOn": [
+                        "keyVault"
+                      ]
+                    },
+                    "keyVault::keyVaultName_localAdminSecret": {
+                      "condition": "[not(parameters('useSharedKeyVault'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), 'LocalAdminCredential')]",
+                      "properties": {
+                        "contentType": "Secret",
+                        "value": "[variables('localAdminSecretValue')]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "dependsOn": [
+                        "keyVault"
+                      ]
+                    },
+                    "keyVault::keyVaultName_arbDeploymentServicePrincipal": {
+                      "condition": "[and(and(not(parameters('useSharedKeyVault')), not(empty(coalesce(parameters('arbDeploymentAppId'), '')))), not(empty(coalesce(parameters('arbDeploymentServicePrincipalSecret'), ''))))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), 'DefaultARBApplication')]",
+                      "properties": {
+                        "contentType": "Secret",
+                        "value": "[variables('arbDeploymentServicePrincipalValue')]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "dependsOn": [
+                        "keyVault"
+                      ]
+                    },
+                    "keyVault::keyVaultName_storageWitness": {
+                      "condition": "[not(parameters('useSharedKeyVault'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), 'WitnessStorageKey')]",
+                      "properties": {
+                        "contentType": "Secret",
+                        "value": "[base64(listKeys('witnessStorageAccount', '2023-01-01').keys[0].value)]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "dependsOn": [
+                        "keyVault",
+                        "witnessStorageAccount"
+                      ]
+                    },
+                    "diagnosticStorageAccount": {
+                      "type": "Microsoft.Storage/storageAccounts",
+                      "apiVersion": "2023-01-01",
+                      "name": "[parameters('keyVaultDiagnosticStorageAccountName')]",
+                      "location": "[parameters('location')]",
+                      "sku": {
+                        "name": "[variables('storageAccountType')]"
+                      },
+                      "kind": "StorageV2",
+                      "properties": {
+                        "supportsHttpsTrafficOnly": true,
+                        "allowBlobPublicAccess": false,
+                        "minimumTlsVersion": "TLS1_2",
+                        "networkAcls": {
+                          "bypass": "AzureServices",
+                          "defaultAction": "Deny",
+                          "ipRules": [],
+                          "virtualNetworkRules": []
+                        }
+                      }
+                    },
+                    "witnessStorageAccount": {
+                      "type": "Microsoft.Storage/storageAccounts",
+                      "apiVersion": "2023-01-01",
+                      "name": "[parameters('clusterWitnessStorageAccountName')]",
+                      "location": "[parameters('location')]",
+                      "sku": {
+                        "name": "[variables('storageAccountType')]"
+                      },
+                      "kind": "StorageV2",
+                      "properties": {
+                        "supportsHttpsTrafficOnly": true,
+                        "allowBlobPublicAccess": false,
+                        "minimumTlsVersion": "TLS1_2",
+                        "networkAcls": {
+                          "bypass": "AzureServices",
+                          "defaultAction": "[if(parameters('usingArcGW'), 'Allow', 'Deny')]",
+                          "ipRules": "[if(not(equals(parameters('allowIPtoStorageAndKeyVault'), null())), createArray(createObject('value', parameters('allowIPtoStorageAndKeyVault'))), createArray())]",
+                          "virtualNetworkRules": "[if(not(equals(parameters('vnetSubnetResourceId'), null())), createArray(createObject('id', parameters('vnetSubnetResourceId'))), createArray())]"
+                        }
+                      }
+                    },
+                    "keyVault": {
+                      "type": "Microsoft.KeyVault/vaults",
+                      "apiVersion": "2023-07-01",
+                      "name": "[parameters('keyVaultName')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "enabledForDeployment": true,
+                        "enabledForTemplateDeployment": true,
+                        "enabledForDiskEncryption": true,
+                        "enableSoftDelete": true,
+                        "softDeleteRetentionInDays": "[parameters('softDeleteRetentionDays')]",
+                        "enableRbacAuthorization": true,
+                        "publicNetworkAccess": "Enabled",
+                        "accessPolicies": [],
+                        "tenantId": "[parameters('tenantId')]",
+                        "sku": {
+                          "name": "standard",
+                          "family": "A"
+                        },
+                        "networkAcls": {
+                          "bypass": "AzureServices",
+                          "defaultAction": "Deny",
+                          "ipRules": "[if(not(equals(parameters('allowIPtoStorageAndKeyVault'), null())), createArray(createObject('value', parameters('allowIPtoStorageAndKeyVault'))), createArray())]",
+                          "virtualNetworkRules": "[if(not(equals(parameters('vnetSubnetResourceId'), null())), createArray(createObject('id', parameters('vnetSubnetResourceId'))), createArray())]"
+                        }
+                      },
+                      "dependsOn": [
+                        "diagnosticStorageAccount"
+                      ]
+                    },
+                    "keyVaultName_Microsoft_Insights_service": {
+                      "type": "microsoft.insights/diagnosticSettings",
+                      "apiVersion": "2016-09-01",
+                      "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
+                      "name": "service",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('keyVaultDiagnosticStorageAccountName'))]",
+                        "logs": [
+                          {
+                            "category": "AuditEvent",
+                            "enabled": true,
+                            "retentionPolicy": {
+                              "enabled": true,
+                              "days": "[parameters('logsRetentionInDays')]"
+                            }
+                          }
+                        ]
+                      },
+                      "dependsOn": [
+                        "diagnosticStorageAccount",
+                        "keyVault"
+                      ]
+                    },
+                    "ARBDeploymentSPNSubscriptionRoleAssignmnent": {
+                      "condition": "[not(empty(coalesce(parameters('arbDeploymentSPObjectId'), '')))]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-test-arbroleassignment', uniqueString(deployment().name, parameters('location')))]",
+                      "subscriptionId": "[subscription().subscriptionId]",
+                      "location": "[resourceGroup().location]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "arbDeploymentSPObjectId": {
+                            "value": "[parameters('arbDeploymentSPObjectId')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.40.2.10011",
+                              "templateHash": "15330173694387796079"
+                            }
+                          },
+                          "parameters": {
+                            "arbDeploymentSPObjectId": {
+                              "type": "securestring"
+                            }
+                          },
+                          "variables": {
+                            "ARBDeploymentRoleID": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7b1f81f9-4196-4058-8aae-762e593270df')]"
+                          },
+                          "resources": [
+                            {
+                              "type": "Microsoft.Authorization/roleAssignments",
+                              "apiVersion": "2022-04-01",
+                              "name": "[guid('ARBServicePrincipalResourceBridgeDeploymentRolePermissions', subscription().id, parameters('arbDeploymentSPObjectId'))]",
+                              "properties": {
+                                "roleDefinitionId": "[variables('ARBDeploymentRoleID')]",
+                                "principalId": "[parameters('arbDeploymentSPObjectId')]",
+                                "principalType": "ServicePrincipal",
+                                "description": "Created by Azure Stack HCI deployment template"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "hciHostDeployment"
+              ]
+            }
+          },
+          "outputs": {
+            "clusterName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the created cluster"
+              },
+              "value": "[parameters('clusterName')]"
+            },
+            "clusterNodeNames": {
+              "type": "array",
+              "metadata": {
+                "description": "The name of the cluster's nodes."
+              },
+              "value": "[variables('clusterNodeNames')]"
+            },
+            "clusterWitnessStorageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the storage account used as the cluster witness."
+              },
+              "value": "[parameters('clusterWitnessStorageAccountName')]"
+            },
+            "domainOUPath": {
+              "type": "string",
+              "metadata": {
+                "description": "The OU path for the domain."
+              },
+              "value": "[variables('domainOUPath')]"
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the created Key Vault."
+              },
+              "value": "[parameters('keyVaultName')]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "resourceGroup"
+      ]
+    },
+    "azlocal": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}-test-clustermodule-{1}', uniqueString(deployment().name, variables('enforcedLocation')), parameters('serviceShort'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[reference('nestedDependencies').outputs.clusterName.value]"
+          },
+          "deploymentUser": {
+            "value": "deployUser"
+          },
+          "deploymentUserPassword": {
+            "value": "[parameters('arbLocalAdminAndDeploymentUserPass')]"
+          },
+          "localAdminUser": {
+            "value": "Administrator"
+          },
+          "localAdminPassword": {
+            "value": "[parameters('arbLocalAdminAndDeploymentUserPass')]"
+          },
+          "servicePrincipalId": {
+            "value": "[parameters('arbDeploymentAppId')]"
+          },
+          "servicePrincipalSecret": {
+            "value": "[parameters('arbDeploymentServicePrincipalSecret')]"
+          },
+          "hciResourceProviderObjectId": {
+            "value": "[parameters('hciResourceProviderObjectId')]"
+          },
+          "deploymentSettings": {
+            "value": {
+              "customLocationName": "[format('{0}{1}-location', parameters('namePrefix'), parameters('serviceShort'))]",
+              "clusterNodeNames": "[reference('nestedDependencies').outputs.clusterNodeNames.value]",
+              "clusterWitnessStorageAccountName": "[reference('nestedDependencies').outputs.clusterWitnessStorageAccountName.value]",
+              "defaultGateway": "192.168.1.1",
+              "deploymentPrefix": "[format('a{0}', take(uniqueString(parameters('namePrefix'), parameters('serviceShort')), 7))]",
+              "dnsServers": [
+                "192.168.1.254"
+              ],
+              "domainFqdn": "jumpstart.local",
+              "domainOUPath": "[reference('nestedDependencies').outputs.domainOUPath.value]",
+              "startingIPAddress": "192.168.1.55",
+              "endingIPAddress": "192.168.1.65",
+              "enableStorageAutoIp": true,
+              "keyVaultName": "[reference('nestedDependencies').outputs.keyVaultName.value]",
+              "networkIntents": [
+                {
+                  "adapter": [
+                    "FABRIC",
+                    "FABRIC2"
+                  ],
+                  "name": "ManagementCompute",
+                  "overrideAdapterProperty": true,
+                  "adapterPropertyOverrides": {
+                    "jumboPacket": "9014",
+                    "networkDirect": "Disabled",
+                    "networkDirectTechnology": "iWARP"
+                  },
+                  "overrideQosPolicy": false,
+                  "qosPolicyOverrides": {
+                    "bandwidthPercentageSMB": "50",
+                    "priorityValue8021ActionCluster": "7",
+                    "priorityValue8021ActionSMB": "3"
+                  },
+                  "overrideVirtualSwitchConfiguration": false,
+                  "virtualSwitchConfigurationOverrides": {
+                    "enableIov": "true",
+                    "loadBalancingAlgorithm": "Dynamic"
+                  },
+                  "trafficType": [
+                    "Management",
+                    "Compute"
+                  ]
+                },
+                {
+                  "adapter": [
+                    "StorageA",
+                    "StorageB"
+                  ],
+                  "name": "Storage",
+                  "overrideAdapterProperty": true,
+                  "adapterPropertyOverrides": {
+                    "jumboPacket": "9014",
+                    "networkDirect": "Disabled",
+                    "networkDirectTechnology": "iWARP"
+                  },
+                  "overrideQosPolicy": true,
+                  "qosPolicyOverrides": {
+                    "bandwidthPercentageSMB": "50",
+                    "priorityValue8021ActionCluster": "7",
+                    "priorityValue8021ActionSMB": "3"
+                  },
+                  "overrideVirtualSwitchConfiguration": false,
+                  "virtualSwitchConfigurationOverrides": {
+                    "enableIov": "true",
+                    "loadBalancingAlgorithm": "Dynamic"
+                  },
+                  "trafficType": [
+                    "Storage"
+                  ]
+                }
+              ],
+              "storageConnectivitySwitchless": false,
+              "storageNetworks": [
+                {
+                  "name": "Storage1Network",
+                  "adapterName": "StorageA",
+                  "vlan": "711"
+                },
+                {
+                  "name": "Storage2Network",
+                  "adapterName": "StorageB",
+                  "vlan": "712"
+                }
+              ],
+              "subnetMask": "255.255.255.0"
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.36.177.2456",
+              "templateHash": "15260394227717230397"
+            },
+            "name": "Azure Stack HCI Cluster",
+            "description": "This module deploys an Azure Stack HCI Cluster on the provided Arc Machines."
+          },
+          "definitions": {
+            "networkIntentType": {
+              "type": "object",
+              "properties": {
+                "adapter": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "Required. The names of the network adapters to include in the intent."
+                  }
+                },
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the network intent."
+                  }
+                },
+                "overrideAdapterProperty": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Specify whether to override the adapter property. Use false by default."
+                  }
+                },
+                "adapterPropertyOverrides": {
+                  "type": "object",
+                  "properties": {
+                    "jumboPacket": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The jumboPacket configuration for the network adapters."
+                      }
+                    },
+                    "networkDirect": {
+                      "type": "string",
+                      "allowedValues": [
+                        "Disabled",
+                        "Enabled"
+                      ],
+                      "metadata": {
+                        "description": "Required. The networkDirect configuration for the network adapters."
+                      }
+                    },
+                    "networkDirectTechnology": {
+                      "type": "string",
+                      "allowedValues": [
+                        "RoCEv2",
+                        "iWARP"
+                      ],
+                      "metadata": {
+                        "description": "Required. The networkDirectTechnology configuration for the network adapters."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. The adapter property overrides for the network intent."
+                  }
+                },
+                "overrideQosPolicy": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Specify whether to override the qosPolicy property. Use false by default."
+                  }
+                },
+                "qosPolicyOverrides": {
+                  "type": "object",
+                  "properties": {
+                    "bandwidthPercentageSMB": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The bandwidthPercentage for the network intent. Recommend 50."
+                      }
+                    },
+                    "priorityValue8021ActionCluster": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Recommend 7."
+                      }
+                    },
+                    "priorityValue8021ActionSMB": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Recommend 3."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. The qosPolicy overrides for the network intent."
+                  }
+                },
+                "overrideVirtualSwitchConfiguration": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Specify whether to override the virtualSwitchConfiguration property. Use false by default."
+                  }
+                },
+                "virtualSwitchConfigurationOverrides": {
+                  "type": "object",
+                  "properties": {
+                    "enableIov": {
+                      "type": "string",
+                      "allowedValues": [
+                        "false",
+                        "true"
+                      ],
+                      "metadata": {
+                        "description": "Required. The enableIov configuration for the network intent."
+                      }
+                    },
+                    "loadBalancingAlgorithm": {
+                      "type": "string",
+                      "allowedValues": [
+                        "Dynamic",
+                        "HyperVPort",
+                        "IPHash"
+                      ],
+                      "metadata": {
+                        "description": "Required. The loadBalancingAlgorithm configuration for the network intent."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. The virtualSwitchConfiguration overrides for the network intent."
+                  }
+                },
+                "trafficType": {
+                  "type": "array",
+                  "allowedValues": [
+                    "Compute",
+                    "Management",
+                    "Storage"
+                  ],
+                  "metadata": {
+                    "description": "Required. The traffic types for the network intent."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "storageAdapterIPInfoType": {
+              "type": "object",
+              "properties": {
+                "physicalNode": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The HCI node name."
+                  }
+                },
+                "ipv4Address": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The IPv4 address for the storage adapter."
+                  }
+                },
+                "subnetMask": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The subnet mask for the storage adapter."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "storageNetworksType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the storage network."
+                  }
+                },
+                "adapterName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the storage adapter."
+                  }
+                },
+                "vlan": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The VLAN for the storage adapter."
+                  }
+                },
+                "storageAdapterIPInfo": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/storageAdapterIPInfoType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The storage adapter IP information for 3-node switchless or manual config deployments."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "securityConfigurationType": {
+              "type": "object",
+              "properties": {
+                "hvciProtection": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable HVCI protection."
+                  }
+                },
+                "drtmProtection": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable DRTM protection."
+                  }
+                },
+                "driftControlEnforced": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable Drift Control enforcement."
+                  }
+                },
+                "credentialGuardEnforced": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable Credential Guard enforcement."
+                  }
+                },
+                "smbSigningEnforced": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable SMB signing enforcement."
+                  }
+                },
+                "smbClusterEncryption": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable SMB cluster encryption."
+                  }
+                },
+                "sideChannelMitigationEnforced": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable Side Channel Mitigation enforcement."
+                  }
+                },
+                "bitlockerBootVolume": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable BitLocker protection for boot volume."
+                  }
+                },
+                "bitlockerDataVolumes": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable BitLocker protection for data volumes."
+                  }
+                },
+                "wdacEnforced": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable WDAC enforcement."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "deploymentSettingsType": {
+              "type": "object",
+              "properties": {
+                "deploymentPrefix": {
+                  "type": "string",
+                  "minLength": 4,
+                  "maxLength": 8,
+                  "metadata": {
+                    "description": "Required. The prefix for the resource for the deployment. This value is used in key vault and storage account names in this template, as well as for the deploymentSettings.properties.deploymentConfiguration.scaleUnits.deploymentData.namingPrefix property which requires regex pattern: ^[a-zA-Z0-9-]{1,8}$."
+                  }
+                },
+                "clusterNodeNames": {
+                  "type": "array",
+                  "metadata": {
+                    "description": "Required. Names of the cluster node Arc Machine resources. These are the name of the Arc Machine resources created when the new HCI nodes were Arc initialized. Example: [hci-node-1, hci-node-2]."
+                  }
+                },
+                "domainFqdn": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The domain name of the Active Directory Domain Services. Example: \"contoso.com\"."
+                  }
+                },
+                "domainOUPath": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The ADDS OU path - ex \"OU=HCI,DC=contoso,DC=com\"."
+                  }
+                },
+                "hvciProtection": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Hypervisor-protected Code Integrity setting."
+                  }
+                },
+                "drtmProtection": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The hardware-dependent Secure Boot setting."
+                  }
+                },
+                "driftControlEnforced": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. When set to true, the security baseline is re-applied regularly."
+                  }
+                },
+                "credentialGuardEnforced": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enables the Credential Guard."
+                  }
+                },
+                "smbSigningEnforced": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. When set to true, the SMB default instance requires sign in for the client and server services."
+                  }
+                },
+                "smbClusterEncryption": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. When set to true, cluster east-west traffic is encrypted."
+                  }
+                },
+                "sideChannelMitigationEnforced": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. When set to true, all the side channel mitigations are enabled."
+                  }
+                },
+                "bitlockerBootVolume": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. When set to true, BitLocker XTS_AES 256-bit encryption is enabled for all data-at-rest on the OS volume of your Azure Stack HCI cluster. This setting is TPM-hardware dependent."
+                  }
+                },
+                "bitlockerDataVolumes": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. When set to true, BitLocker XTS-AES 256-bit encryption is enabled for all data-at-rest on your Azure Stack HCI cluster shared volumes."
+                  }
+                },
+                "wdacEnforced": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Limits the applications and the code that you can run on your Azure Stack HCI cluster."
+                  }
+                },
+                "streamingDataClient": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The metrics data for deploying a HCI cluster."
+                  }
+                },
+                "isEuropeanUnionLocation": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The location data for deploying a HCI cluster."
+                  }
+                },
+                "episodicDataUpload": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The diagnostic data for deploying a HCI cluster."
+                  }
+                },
+                "storageConfigurationMode": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Express",
+                    "InfraOnly",
+                    "KeepStorage"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The storage volume configuration mode. See documentation for details."
+                  }
+                },
+                "subnetMask": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The subnet mask pf the Management Network for the HCI cluster - ex: 255.255.252.0."
+                  }
+                },
+                "defaultGateway": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The default gateway of the Management Network. Example: 192.168.0.1."
+                  }
+                },
+                "startingIPAddress": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The starting IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs."
+                  }
+                },
+                "endingIPAddress": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The ending IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs."
+                  }
+                },
+                "dnsServers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "Required. The DNS servers accessible from the Management Network for the HCI cluster."
+                  }
+                },
+                "networkIntents": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/networkIntentType"
+                  },
+                  "metadata": {
+                    "description": "Required. An array of Network ATC Network Intent objects that define the Compute, Management, and Storage network configuration for the cluster."
+                  }
+                },
+                "storageConnectivitySwitchless": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Specify whether the Storage Network connectivity is switched or switchless."
+                  }
+                },
+                "enableStorageAutoIp": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable storage auto IP assignment. This should be true for most deployments except when deploying a three-node switchless cluster, in which case storage IPs should be configured before deployment and this value set to false."
+                  }
+                },
+                "storageNetworks": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/storageNetworksType"
+                  },
+                  "metadata": {
+                    "description": "Required. An array of JSON objects that define the storage network configuration for the cluster. Each object should contain the adapterName, VLAN properties, and (optionally) IP configurations."
+                  }
+                },
+                "customLocationName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the Custom Location associated with the Arc Resource Bridge for this cluster. This value should reflect the physical location and identifier of the HCI cluster. Example: cl-hci-den-clu01."
+                  }
+                },
+                "clusterWitnessStorageAccountName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the storage account to be used as the witness for the HCI Windows Failover Cluster."
+                  }
+                },
+                "keyVaultName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the key vault to be used for storing secrets for the HCI cluster. This currently needs to be unique per HCI cluster."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "minLength": 4,
+              "maxLength": 40,
+              "metadata": {
+                "description": "Required. The name of the Azure Stack HCI cluster - this will be the name of your cluster in Azure."
+              }
+            },
+            "clusterADName": {
+              "type": "string",
+              "nullable": true,
+              "minLength": 4,
+              "maxLength": 15,
+              "metadata": {
+                "description": "Optional. The name of the Azure Stack HCI cluster - this must be a valid Active Directory computer name."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all resources."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the resource."
+              }
+            },
+            "deploymentOperations": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "defaultValue": [
+                "Validate",
+                "Deploy"
+              ],
+              "allowedValues": [
+                "Deploy",
+                "Validate"
+              ],
+              "metadata": {
+                "description": "Optional. The cluster deployment operations to execute. Defaults to \"[Validate, Deploy]\"."
+              }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
+            },
+            "deploymentSettings": {
+              "$ref": "#/definitions/deploymentSettingsType",
+              "metadata": {
+                "description": "Required. The deployment settings of the cluster."
+              }
+            },
+            "roleAssignments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Array of role assignments to create."
+              }
+            },
+            "useSharedKeyVault": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Specify whether to use the shared key vault for the HCI cluster."
+              }
+            },
+            "deploymentUser": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The name of the deployment user. Required if useSharedKeyVault is true."
+              }
+            },
+            "deploymentUserPassword": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The password of the deployment user. Required if useSharedKeyVault is true."
+              }
+            },
+            "localAdminUser": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The name of the local admin user. Required if useSharedKeyVault is true."
+              }
+            },
+            "localAdminPassword": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The password of the local admin user. Required if useSharedKeyVault is true."
+              }
+            },
+            "servicePrincipalId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The service principal ID for ARB. Required if useSharedKeyVault is true and need ARB service principal id."
+              }
+            },
+            "servicePrincipalSecret": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The service principal secret for ARB. Required if useSharedKeyVault is true and need ARB service principal id."
+              }
+            },
+            "azureStackLCMUserCredentialContentType": {
+              "type": "string",
+              "defaultValue": "Secret",
+              "metadata": {
+                "description": "Optional. Content type of the azure stack lcm user credential."
+              }
+            },
+            "localAdminCredentialContentType": {
+              "type": "string",
+              "defaultValue": "Secret",
+              "metadata": {
+                "description": "Optional. Content type of the local admin credential."
+              }
+            },
+            "witnessStoragekeyContentType": {
+              "type": "string",
+              "defaultValue": "Secret",
+              "metadata": {
+                "description": "Optional. Content type of the witness storage key."
+              }
+            },
+            "defaultARBApplicationContentType": {
+              "type": "string",
+              "defaultValue": "Secret",
+              "metadata": {
+                "description": "Optional. Content type of the default ARB application."
+              }
+            },
+            "azureStackLCMUserCredentialTags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of azure stack LCM user credential."
+              }
+            },
+            "localAdminCredentialTags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the local admin credential."
+              }
+            },
+            "witnessStoragekeyTags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the witness storage key."
+              }
+            },
+            "defaultARBApplicationTags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the default ARB application."
+              }
+            },
+            "keyvaultSubscriptionId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Key vault subscription ID, which is used for for storing secrets for the HCI cluster."
+              }
+            },
+            "keyvaultResourceGroup": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Key vault resource group, which is used for for storing secrets for the HCI cluster."
+              }
+            },
+            "witnessStorageAccountSubscriptionId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Storage account subscription ID, which is used as the witness for the HCI Windows Failover Cluster."
+              }
+            },
+            "witnessStorageAccountResourceGroup": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Storage account resource group, which is used as the witness for the HCI Windows Failover Cluster."
+              }
+            },
+            "hciResourceProviderObjectId": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Required. The service principal object ID of the Azure Stack HCI Resource Provider in this tenant. Can be fetched via `Get-AzADServicePrincipal -ApplicationId 1412d89f-b8a8-4111-b4fd-e82905cbd85d` after the 'Microsoft.AzureStackHCI' provider was registered in the subscription."
+              }
+            },
+            "operationType": {
+              "type": "string",
+              "defaultValue": "ClusterProvisioning",
+              "allowedValues": [
+                "ClusterProvisioning",
+                "ClusterUpgrade"
+              ],
+              "metadata": {
+                "description": "Optional. The intended operation for a cluster."
+              }
+            }
+          },
+          "variables": {
+            "copy": [
+              {
+                "name": "formattedRoleAssignments",
+                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+              },
+              {
+                "name": "arcNodeResourceIds",
+                "count": "[length(parameters('deploymentSettings').clusterNodeNames)]",
+                "input": "[resourceId('Microsoft.HybridCompute/machines', parameters('deploymentSettings').clusterNodeNames[copyIndex('arcNodeResourceIds')])]"
+              }
+            ],
+            "$fxv#0": "@description('Optional. The cluster deployment operations to execute. Defaults to \"[Validate, Deploy]\".')\n@allowed([\n  'Deploy'\n  'Validate'\n])\nparam deploymentOperations string[] = ['Validate', 'Deploy']\n\n@description('Required. The deployment settings of the cluster.')\nparam deploymentSettings deploymentSettingsType\n\n@description('Optional. Specify whether to use the shared key vault for the HCI cluster.')\nparam useSharedKeyVault bool = true\n\n@description('Optional. The intended operation for a cluster.')\n@allowed([\n  'ClusterProvisioning'\n  'ClusterUpgrade'\n])\nparam operationType string = 'ClusterProvisioning'\n\nparam clusterName string\nparam clusterADName string\nparam cloudId string\n\nparam needArbSecret bool\n\n// if deployment operations requested, validation must be performed first so we reverse sort the array\nvar sortedDeploymentOperations = (!empty(deploymentOperations)) ? sort(deploymentOperations, (a, b) => a > b) : []\n\n@batchSize(1)\nmodule deploymentSetting '../deployment-setting/main.bicep' = [\n  for deploymentOperation in sortedDeploymentOperations: if (!empty(deploymentOperation) && !empty(deploymentSettings)) {\n    name: 'deploymentSettings-${deploymentOperation}'\n    params: {\n      cloudId: useSharedKeyVault ? cloudId : null\n      clusterName: clusterName\n      clusterADName: clusterADName\n      operationType: operationType\n      deploymentMode: deploymentOperation\n      clusterNodeNames: deploymentSettings!.clusterNodeNames\n      clusterWitnessStorageAccountName: deploymentSettings!.clusterWitnessStorageAccountName\n      customLocationName: deploymentSettings!.customLocationName\n      defaultGateway: deploymentSettings!.defaultGateway\n      deploymentPrefix: deploymentSettings!.deploymentPrefix\n      dnsServers: deploymentSettings!.dnsServers\n      domainFqdn: deploymentSettings!.domainFqdn\n      domainOUPath: deploymentSettings!.domainOUPath\n      endingIPAddress: deploymentSettings!.endingIPAddress\n      keyVaultName: deploymentSettings!.keyVaultName\n      networkIntents: [\n        for intent in deploymentSettings.networkIntents: {\n          ...intent\n          qosPolicyOverrides: {\n            bandwidthPercentage_SMB: intent.qosPolicyOverrides.bandwidthPercentageSMB\n            priorityValue8021Action_Cluster: intent.qosPolicyOverrides.priorityValue8021ActionCluster\n            priorityValue8021Action_SMB: intent.qosPolicyOverrides.priorityValue8021ActionSMB\n          }\n        }\n      ]\n      startingIPAddress: deploymentSettings!.startingIPAddress\n      storageConnectivitySwitchless: deploymentSettings!.storageConnectivitySwitchless\n      storageNetworks: deploymentSettings!.storageNetworks\n      subnetMask: deploymentSettings!.subnetMask\n      bitlockerBootVolume: deploymentSettings!.?bitlockerBootVolume\n      bitlockerDataVolumes: deploymentSettings!.?bitlockerDataVolumes\n      credentialGuardEnforced: deploymentSettings!.?credentialGuardEnforced\n      driftControlEnforced: deploymentSettings!.?driftControlEnforced\n      drtmProtection: deploymentSettings!.?drtmProtection\n      enableStorageAutoIp: deploymentSettings!.?enableStorageAutoIp\n      episodicDataUpload: deploymentSettings!.?episodicDataUpload\n      hvciProtection: deploymentSettings!.?hvciProtection\n      isEuropeanUnionLocation: deploymentSettings!.?isEuropeanUnionLocation\n      sideChannelMitigationEnforced: deploymentSettings!.?sideChannelMitigationEnforced\n      smbClusterEncryption: deploymentSettings!.?smbClusterEncryption\n      smbSigningEnforced: deploymentSettings!.?smbSigningEnforced\n      storageConfigurationMode: deploymentSettings!.?storageConfigurationMode\n      streamingDataClient: deploymentSettings!.?streamingDataClient\n      wdacEnforced: deploymentSettings!.?wdacEnforced\n      needArbSecret: needArbSecret\n    }\n  }\n]\n\nimport { networkIntentType, storageNetworksType } from 'br/public:avm/res/azure-stack-hci/cluster:0.1.6'\ntype deploymentSettingsType = {\n  @minLength(4)\n  @maxLength(8)\n  @description('Required. The prefix for the resource for the deployment. This value is used in key vault and storage account names in this template, as well as for the deploymentSettings.properties.deploymentConfiguration.scaleUnits.deploymentData.namingPrefix property which requires regex pattern: ^[a-zA-Z0-9-]{1,8}$.')\n  deploymentPrefix: string\n\n  @description('Required. Names of the cluster node Arc Machine resources. These are the name of the Arc Machine resources created when the new HCI nodes were Arc initialized. Example: [hci-node-1, hci-node-2].')\n  clusterNodeNames: array\n\n  @description('Required. The domain name of the Active Directory Domain Services. Example: \"contoso.com\".')\n  domainFqdn: string\n\n  @description('Required. The ADDS OU path - ex \"OU=HCI,DC=contoso,DC=com\".')\n  domainOUPath: string\n\n  @description('Optional. The Hypervisor-protected Code Integrity setting.')\n  hvciProtection: bool?\n\n  @description('Optional. The hardware-dependent Secure Boot setting.')\n  drtmProtection: bool?\n\n  @description('Optional. When set to true, the security baseline is re-applied regularly.')\n  driftControlEnforced: bool?\n\n  @description('Optional. Enables the Credential Guard.')\n  credentialGuardEnforced: bool?\n\n  @description('Optional. When set to true, the SMB default instance requires sign in for the client and server services.')\n  smbSigningEnforced: bool?\n\n  @description('Optional. When set to true, cluster east-west traffic is encrypted.')\n  smbClusterEncryption: bool?\n\n  @description('Optional. When set to true, all the side channel mitigations are enabled.')\n  sideChannelMitigationEnforced: bool?\n\n  @description('Optional. When set to true, BitLocker XTS_AES 256-bit encryption is enabled for all data-at-rest on the OS volume of your Azure Stack HCI cluster. This setting is TPM-hardware dependent.')\n  bitlockerBootVolume: bool?\n\n  @description('Optional. When set to true, BitLocker XTS-AES 256-bit encryption is enabled for all data-at-rest on your Azure Stack HCI cluster shared volumes.')\n  bitlockerDataVolumes: bool?\n\n  @description('Optional. Limits the applications and the code that you can run on your Azure Stack HCI cluster.')\n  wdacEnforced: bool?\n\n  // cluster diagnostics and telemetry configuration\n  @description('Optional. The metrics data for deploying a HCI cluster.')\n  streamingDataClient: bool?\n\n  @description('Optional. The location data for deploying a HCI cluster.')\n  isEuropeanUnionLocation: bool?\n\n  @description('Optional. The diagnostic data for deploying a HCI cluster.')\n  episodicDataUpload: bool?\n\n  // storage configuration\n  @description('Optional. The storage volume configuration mode. See documentation for details.')\n  storageConfigurationMode: ('Express' | 'InfraOnly' | 'KeepStorage')?\n\n  // cluster network configuration details\n  @description('Required. The subnet mask pf the Management Network for the HCI cluster - ex: 255.255.252.0.')\n  subnetMask: string\n\n  @description('Required. The default gateway of the Management Network. Example: 192.168.0.1.')\n  defaultGateway: string\n\n  @description('Required. The starting IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs.')\n  startingIPAddress: string\n\n  @description('Required. The ending IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs.')\n  endingIPAddress: string\n\n  @description('Required. The DNS servers accessible from the Management Network for the HCI cluster.')\n  dnsServers: string[]\n\n  @description('Required. An array of Network ATC Network Intent objects that define the Compute, Management, and Storage network configuration for the cluster.')\n  networkIntents: networkIntentType[]\n\n  @description('Required. Specify whether the Storage Network connectivity is switched or switchless.')\n  storageConnectivitySwitchless: bool\n\n  @description('Optional. Enable storage auto IP assignment. This should be true for most deployments except when deploying a three-node switchless cluster, in which case storage IPs should be configured before deployment and this value set to false.')\n  enableStorageAutoIp: bool?\n\n  @description('Required. An array of JSON objects that define the storage network configuration for the cluster. Each object should contain the adapterName, VLAN properties, and (optionally) IP configurations.')\n  storageNetworks: storageNetworksType[]\n\n  // other cluster configuration parameters\n  @description('Required. The name of the Custom Location associated with the Arc Resource Bridge for this cluster. This value should reflect the physical location and identifier of the HCI cluster. Example: cl-hci-den-clu01.')\n  customLocationName: string\n\n  @description('Required. The name of the storage account to be used as the witness for the HCI Windows Failover Cluster.')\n  clusterWitnessStorageAccountName: string\n\n  @description('Required. The name of the key vault to be used for storing secrets for the HCI cluster. This currently needs to be unique per HCI cluster.')\n  keyVaultName: string\n}\n",
+            "$fxv#1": "metadata name = 'Azure Stack HCI Cluster Deployment Settings'\nmetadata description = 'This module deploys an Azure Stack HCI Cluster Deployment Settings resource.'\n\n@description('Optional. The name of the deployment settings.')\n@allowed([\n  'default'\n])\nparam name string = 'default'\n\n@description('Conditional. The name of the Azure Stack HCI cluster - this will be the name of your cluster in Azure. Required if the template is used in a standalone deployment.')\n@maxLength(40)\n@minLength(4)\nparam clusterName string\n\n@description('Conditional. The name of the Azure Stack HCI cluster - this must be a valid Active Directory computer name. Required if the template is used in a standalone deployment.')\n@maxLength(15)\n@minLength(4)\nparam clusterADName string\n\n@description('Required. First must pass with this parameter set to Validate prior running with it set to Deploy. If either Validation or Deployment phases fail, fix the issue, then resubmit the template with the same deploymentMode to retry.')\n@allowed([\n  'Validate'\n  'Deploy'\n])\nparam deploymentMode string\n\n@minLength(4)\n@maxLength(8)\n@description('Required. The prefix for the resource for the deployment. This value is used in key vault and storage account names in this template, as well as for the deploymentSettings.properties.deploymentConfiguration.scaleUnits.deploymentData.namingPrefix property which requires regex pattern: ^[a-zA-Z0-9-]{1,8}$.')\nparam deploymentPrefix string\n\n@description('Required. Names of the cluster node Arc Machine resources. These are the name of the Arc Machine resources created when the new HCI nodes were Arc initialized. Example: [hci-node-1, hci-node-2].')\nparam clusterNodeNames array\n\n@description('Required. The domain name of the Active Directory Domain Services. Example: \"contoso.com\".')\nparam domainFqdn string\n\n@description('Required. The ADDS OU path - ex \"OU=HCI,DC=contoso,DC=com\".')\nparam domainOUPath string\n\n@description('Optional. The Hypervisor-protected Code Integrity setting.')\nparam hvciProtection bool = true\n\n@description('Optional. The hardware-dependent Secure Boot setting.')\nparam drtmProtection bool = true\n\n@description('Optional. When set to true, the security baseline is re-applied regularly.')\nparam driftControlEnforced bool = false\n\n@description('Optional. Enables the Credential Guard.')\nparam credentialGuardEnforced bool = false\n\n@description('Optional. When set to true, the SMB default instance requires sign in for the client and server services.')\nparam smbSigningEnforced bool = false\n\n@description('Optional. When set to true, cluster east-west traffic is encrypted.')\nparam smbClusterEncryption bool = false\n\n@description('Optional. When set to true, all the side channel mitigations are enabled.')\nparam sideChannelMitigationEnforced bool = false\n\n@description('Optional. When set to true, BitLocker XTS_AES 256-bit encryption is enabled for all data-at-rest on the OS volume of your Azure Stack HCI cluster. This setting is TPM-hardware dependent.')\nparam bitlockerBootVolume bool = false\n\n@description('Optional. When set to true, BitLocker XTS-AES 256-bit encryption is enabled for all data-at-rest on your Azure Stack HCI cluster shared volumes.')\nparam bitlockerDataVolumes bool = false\n\n@description('Optional. Limits the applications and the code that you can run on your Azure Stack HCI cluster.')\nparam wdacEnforced bool = true\n\n// cluster diagnostics and telemetry configuration\n@description('Optional. The metrics data for deploying a HCI cluster.')\nparam streamingDataClient bool = true\n\n@description('Optional. The location data for deploying a HCI cluster.')\nparam isEuropeanUnionLocation bool = false\n\n@description('Optional. The diagnostic data for deploying a HCI cluster.')\nparam episodicDataUpload bool = true\n\n// storage configuration\n@description('Optional. The storage volume configuration mode. See documentation for details.')\n@allowed([\n  'Express'\n  'InfraOnly'\n  'KeepStorage'\n])\nparam storageConfigurationMode string = 'Express'\n\n@description('Required. If true, the service principal secret for ARB is required. If false, the secrets wiil not be required.')\nparam needArbSecret bool\n\n// cluster network configuration details\n@description('Required. The subnet mask pf the Management Network for the HCI cluster - ex: 255.255.252.0.')\nparam subnetMask string\n\n@description('Required. The default gateway of the Management Network. Example: 192.168.0.1.')\nparam defaultGateway string\n\n@description('Required. The starting IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs.')\nparam startingIPAddress string\n\n@description('Required. The ending IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs.')\nparam endingIPAddress string\n\n@description('Required. The DNS servers accessible from the Management Network for the HCI cluster.')\nparam dnsServers string[]\n\n@description('Required. An array of Network ATC Network Intent objects that define the Compute, Management, and Storage network configuration for the cluster.')\nparam networkIntents array\n\n@description('Required. Specify whether the Storage Network connectivity is switched or switchless.')\nparam storageConnectivitySwitchless bool\n\n@description('Optional. Enable storage auto IP assignment. This should be true for most deployments except when deploying a three-node switchless cluster, in which case storage IPs should be configured before deployment and this value set to false.')\nparam enableStorageAutoIp bool = true\n\n@description('Required. An array of JSON objects that define the storage network configuration for the cluster. Each object should contain the adapterName, VLAN properties, and (optionally) IP configurations.')\nparam storageNetworks array\n\n// other cluster configuration parameters\n@description('Required. The name of the Custom Location associated with the Arc Resource Bridge for this cluster. This value should reflect the physical location and identifier of the HCI cluster. Example: cl-hci-den-clu01.')\nparam customLocationName string\n\n@description('Required. The name of the storage account to be used as the witness for the HCI Windows Failover Cluster.')\nparam clusterWitnessStorageAccountName string\n\n@description('Required. The name of the key vault to be used for storing secrets for the HCI cluster.')\nparam keyVaultName string\n\n@description('Optional. If using a shared key vault or non-legacy secret naming, pass the properties.cloudId guid from the pre-created HCI cluster resource.')\nparam cloudId string?\n\n@description('Optional. The intended operation for a cluster.')\n@allowed([\n  'ClusterProvisioning'\n  'ClusterUpgrade'\n])\nparam operationType string = 'ClusterProvisioning'\n\nvar arcNodeResourceIds = [\n  for (nodeName, index) in clusterNodeNames: resourceId('Microsoft.HybridCompute/machines', nodeName)\n]\n\nvar storageNetworksArray = [\n  for (storageAdapter, index) in storageNetworks: {\n    name: storageAdapter.name\n    networkAdapterName: storageAdapter.adapterName\n    vlanId: storageAdapter.vlan\n    storageAdapterIPInfo: storageAdapter.?storageAdapterIPInfo\n  }\n]\n\nresource cluster 'Microsoft.AzureStackHCI/clusters@2024-04-01' existing = {\n  name: clusterName\n}\n\nvar baseSecretNames = [\n  'LocalAdminCredential'\n  'AzureStackLCMUserCredential'\n  'WitnessStorageKey'\n]\n\nvar allSecretNames = needArbSecret ? concat(baseSecretNames, ['DefaultARBApplication']) : baseSecretNames\n\nresource deploymentSettings 'Microsoft.AzureStackHCI/clusters/deploymentSettings@2024-04-01' = {\n  name: name\n  parent: cluster\n  properties: {\n    arcNodeResourceIds: arcNodeResourceIds\n    deploymentMode: deploymentMode\n    deploymentConfiguration: {\n      version: operationType == 'ClusterUpgrade' ? '10.1.0.0' : '10.0.0.0'\n      scaleUnits: [\n        {\n          deploymentData: {\n            securitySettings: operationType == 'ClusterUpgrade'\n              ? null\n              : {\n                  hvciProtection: hvciProtection\n                  drtmProtection: drtmProtection\n                  driftControlEnforced: driftControlEnforced\n                  credentialGuardEnforced: credentialGuardEnforced\n                  smbSigningEnforced: smbSigningEnforced\n                  smbClusterEncryption: smbClusterEncryption\n                  sideChannelMitigationEnforced: sideChannelMitigationEnforced\n                  bitlockerBootVolume: bitlockerBootVolume\n                  bitlockerDataVolumes: bitlockerDataVolumes\n                  wdacEnforced: wdacEnforced\n                }\n            observability: {\n              streamingDataClient: streamingDataClient\n              euLocation: isEuropeanUnionLocation\n              episodicDataUpload: episodicDataUpload\n            }\n            cluster: {\n              name: clusterADName\n              witnessType: 'Cloud'\n              witnessPath: ''\n              cloudAccountName: clusterWitnessStorageAccountName\n              azureServiceEndpoint: environment().suffixes.storage\n            }\n            storage: {\n              configurationMode: storageConfigurationMode\n            }\n            namingPrefix: deploymentPrefix\n            domainFqdn: domainFqdn\n            infrastructureNetwork: [\n              {\n                subnetMask: subnetMask\n                gateway: defaultGateway\n                ipPools: [\n                  {\n                    startingAddress: startingIPAddress\n                    endingAddress: endingIPAddress\n                  }\n                ]\n                dnsServers: dnsServers\n              }\n            ]\n            physicalNodes: [\n              for hciNode in arcNodeResourceIds: {\n                name: reference(hciNode, '2022-12-27', 'Full').properties.displayName\n                // Getting the IP from the first NIC of the node with a default gateway. Only the first management pNIC should have a gateway defined.\n                // This reference call requires that the 'DeviceManagementExtension' extension be fully initialized on each node, which creates the\n                // edgeDevices sub-resource queried below, containing the IP configuration. View the edgedevice to troubleshoot by appending\n                // `/providers/microsoft.azurestackhci/edgedevices/default` to the end the HCI Arc Machine resource id and using `az resource show --id <id>`\n                ipv4Address: (filter(\n                  reference('${hciNode}/providers/microsoft.azurestackhci/edgeDevices/default', '2024-01-01', 'Full').properties.deviceConfiguration.nicDetails,\n                  nic => nic.?defaultGateway != null\n                ))[0].ip4Address\n              }\n            ]\n            hostNetwork: operationType == 'ClusterUpgrade'\n              ? null\n              : {\n                  intents: networkIntents\n                  storageConnectivitySwitchless: storageConnectivitySwitchless\n                  storageNetworks: storageNetworksArray\n                  enableStorageAutoIp: enableStorageAutoIp\n                }\n            adouPath: domainOUPath\n            secretsLocation: 'https://${keyVaultName}${environment().suffixes.keyvaultDns}'\n            optionalServices: {\n              customLocation: customLocationName\n            }\n            secrets: [\n              for secretName in allSecretNames: {\n                secretName: empty(cloudId) ? secretName : '${clusterName}-${secretName}-${cloudId}'\n                eceSecretName: secretName\n                secretLocation: empty(cloudId)\n                  ? 'https://${keyVaultName}${environment().suffixes.keyvaultDns}/secrets/${secretName}'\n                  : 'https://${keyVaultName}${environment().suffixes.keyvaultDns}/secrets/${clusterName}-${secretName}-${cloudId}'\n              }\n            ]\n          }\n        }\n      ]\n    }\n  }\n}\n\n@description('The name of the cluster deployment settings.')\noutput name string = deploymentSettings.name\n\n@description('The ID of the cluster deployment settings.')\noutput resourceId string = deploymentSettings.id\n\n@description('The resource group of the cluster deployment settings.')\noutput resourceGroupName string = resourceGroup().name\n",
+            "$fxv#2": "#!/bin/bash\n\nset -e  # Exit on any error\n\necho \"Starting HCI deployment script...\"\n\n# Check required environment variables\nif [ -z \"$RESOURCE_GROUP_NAME\" ] || [ -z \"$SUBSCRIPTION_ID\" ] || [ -z \"$CLUSTER_NAME\" ] || [ -z \"$CLUSTER_AD_NAME\" ] || [ -z \"$CLOUD_ID\" ] || [ -z \"$USE_SHARED_KEYVAULT\" ] || [ -z \"$DEPLOYMENT_SETTINGS\" ] || [ -z \"$DEPLOYMENT_SETTING_BICEP_BASE64\" ] || [ -z \"$DEPLOYMENT_SETTING_MAIN_BICEP_BASE64\" ] || [ -z \"$NEED_ARB_SECRET\" ] || [ -z \"$OPERATION_TYPE\" ]; then\n    echo \"Error: Required environment variables are missing\"\n    exit 1\nfi\n\n# Set subscription context\necho \"Setting subscription context to: $SUBSCRIPTION_ID\"\naz account set --subscription \"$SUBSCRIPTION_ID\"\n\n# Create directory structure and decode base64 files\necho \"Creating required directory structure and bicep files...\"\n\n# Create nested directory\nmkdir -p nested\n# Create deployment-setting directory\nmkdir -p deployment-setting\n\n# Decode and create deployment-setting.bicep file\necho \"Creating deployment-setting.bicep file from base64 encoded content...\"\necho \"$DEPLOYMENT_SETTING_BICEP_BASE64\" | base64 -d > nested/deployment-setting.bicep\n\n# Decode and create deployment-setting/main.bicep file\necho \"Creating deployment-setting/main.bicep file from base64 encoded content...\"\necho \"$DEPLOYMENT_SETTING_MAIN_BICEP_BASE64\" | base64 -d > deployment-setting/main.bicep\n\n# Verify the files were created successfully\nif [ ! -f \"nested/deployment-setting.bicep\" ] || [ ! -s \"nested/deployment-setting.bicep\" ]; then\n    echo \"Error: Failed to create nested/deployment-setting.bicep file or file is empty\"\n    exit 1\nfi\n\nif [ ! -f \"deployment-setting/main.bicep\" ] || [ ! -s \"deployment-setting/main.bicep\" ]; then\n    echo \"Error: Failed to create deployment-setting/main.bicep file or file is empty\"\n    exit 1\nfi\n\necho \"✅ All bicep files created successfully\"\necho \"nested/deployment-setting.bicep size: $(wc -c < nested/deployment-setting.bicep) bytes\"\necho \"deployment-setting/main.bicep size: $(wc -c < deployment-setting/main.bicep) bytes\"\n\n# List current directory structure for debugging\necho \"Current directory structure:\"\nfind . -name \"*.bicep\" -type f\n\n# Parse deployment operations into JSON array format\nIFS=',' read -ra OPERATIONS <<< \"$DEPLOYMENT_OPERATIONS\"\necho \"Deployment operations: ${OPERATIONS[@]}\"\n\n# Convert operations array to JSON format\nOPERATIONS_JSON=\"[\"\nfor i in \"${!OPERATIONS[@]}\"; do\n    if [ $i -gt 0 ]; then\n        OPERATIONS_JSON+=\",\"\n    fi\n    OPERATIONS_JSON+=\"\\\"${OPERATIONS[$i]}\\\"\"\ndone\nOPERATIONS_JSON+=\"]\"\n\necho \"Deployment operations JSON: $OPERATIONS_JSON\"\n\n# Convert boolean values to proper JSON format\nUSE_SHARED_KEYVAULT_JSON=$(echo \"$USE_SHARED_KEYVAULT\" | tr '[:upper:]' '[:lower:]')\nif [ \"$USE_SHARED_KEYVAULT_JSON\" = \"true\" ] || [ \"$USE_SHARED_KEYVAULT_JSON\" = \"1\" ]; then\n    USE_SHARED_KEYVAULT_JSON=\"true\"\nelse\n    USE_SHARED_KEYVAULT_JSON=\"false\"\nfi\n\necho \"Use shared key vault: $USE_SHARED_KEYVAULT_JSON\"\n\nNEED_ARB_SECRET_JSON=$(echo \"$NEED_ARB_SECRET\" | tr '[:upper:]' '[:lower:]')\nif [ \"$NEED_ARB_SECRET_JSON\" = \"true\" ] || [ \"$NEED_ARB_SECRET_JSON\" = \"1\" ]; then\n    NEED_ARB_SECRET_JSON=\"true\"\nelse\n    NEED_ARB_SECRET_JSON=\"false\"\nfi\n\necho \"Use shared key vault: $NEED_ARB_SECRET_JSON\"\n\n# Debug: Check the content of DEPLOYMENT_SETTINGS\necho \"Debug: DEPLOYMENT_SETTINGS type check...\"\necho \"First 100 chars of DEPLOYMENT_SETTINGS: ${DEPLOYMENT_SETTINGS:0:100}\"\n\n# Validate if DEPLOYMENT_SETTINGS is valid JSON\nif ! echo \"$DEPLOYMENT_SETTINGS\" | jq empty 2>/dev/null; then\n    echo \"Error: DEPLOYMENT_SETTINGS is not valid JSON\"\n    echo \"Content: $DEPLOYMENT_SETTINGS\"\n    exit 1\nfi\n\n# Create parameter file for deployment\nPARAM_FILE=\"deployment-params.json\"\n\n# Create a proper parameter file with JSON object\necho \"Creating parameter file...\"\ncat > \"$PARAM_FILE\" << EOF\n{\n  \"\\$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#\",\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"deploymentOperations\": {\n      \"value\": $OPERATIONS_JSON\n    },\n    \"deploymentSettings\": {\n      \"value\": $DEPLOYMENT_SETTINGS\n    },\n    \"useSharedKeyVault\": {\n      \"value\": $USE_SHARED_KEYVAULT_JSON\n    },\n    \"clusterName\": {\n      \"value\": \"$CLUSTER_NAME\"\n    },\n    \"clusterADName\": {\n      \"value\": \"$CLUSTER_AD_NAME\"\n    },\n    \"operationType\": {\n      \"value\": \"$OPERATION_TYPE\"\n    },\n    \"cloudId\": {\n      \"value\": \"$CLOUD_ID\"\n    },\n    \"needArbSecret\": {\n      \"value\": $NEED_ARB_SECRET_JSON\n    }\n  }\n}\nEOF\n\n# Validate the parameter file\necho \"Validating parameter file...\"\nif ! jq empty \"$PARAM_FILE\" 2>/dev/null; then\n    echo \"Error: Generated parameter file is not valid JSON\"\n    cat \"$PARAM_FILE\"\n    exit 1\nfi\n\necho \"✅ Parameter file created and validated successfully\"\n\n# Print parameter file content for debugging\necho \"============================================\"\necho \"Parameter file content:\"\necho \"============================================\"\ncat \"$PARAM_FILE\" | jq '.'\necho \"============================================\"\n\n# Check if deployment-settings resource exists\necho \"Checking if deployment-settings resource already exists...\"\n\n# Construct the resource ID for deployment-settings\nDEPLOYMENT_SETTINGS_RESOURCE_ID=\"/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP_NAME/providers/Microsoft.AzureStackHCI/clusters/$CLUSTER_NAME/deploymentSettings/default\"\n\necho \"Checking resource: $DEPLOYMENT_SETTINGS_RESOURCE_ID\"\n\n# Check if the deployment-settings resource exists\n# Redirect both stdout and stderr to suppress all output, only check exit code\nif az resource show --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" >/dev/null 2>&1; then\n    echo \"✅ Deployment-settings resource already exists. Checking status...\"\n\n    # Get the provisioning state and deployment mode\n    PROVISIONING_STATE=$(az resource show --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" --query \"properties.provisioningState\" --output tsv 2>/dev/null)\n    DEPLOYMENT_MODE=$(az resource show --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" --query \"properties.deploymentMode\" --output tsv 2>/dev/null)\n\n    echo \"Resource ID: $DEPLOYMENT_SETTINGS_RESOURCE_ID\"\n    echo \"Provisioning State: $PROVISIONING_STATE\"\n    echo \"Deployment Mode: $DEPLOYMENT_MODE\"\n\n    # First check deployment mode\n    if [ \"$DEPLOYMENT_MODE\" = \"Validate\" ]; then\n        echo \"🗑️  Deployment mode is 'Validate'. Removing the validation resource...\"\n\n        # Delete the resource\n        if az resource delete --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" --verbose; then\n            echo \"✅ Validation resource deleted successfully.\"\n            echo \"📝 Proceeding with deployment...\"\n        else\n            echo \"❌ Failed to delete the validation resource. Please check permissions and try again.\"\n            exit 1\n        fi\n    elif [ \"$DEPLOYMENT_MODE\" = \"Deploy\" ]; then\n        # Check if deployment is successful\n        if [ \"$PROVISIONING_STATE\" = \"Succeeded\" ]; then\n            echo \"✅ Deployment resource is in successful state. Skipping deployment.\"\n\n            # Show existing resource details\n            echo \"Existing deployment-settings details:\"\n            az resource show --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" --query \"{name: name, provisioningState: properties.provisioningState, deploymentMode: properties.deploymentMode}\" --output table 2>/dev/null || echo \"Could not retrieve resource details\"\n\n            exit 0\n        else\n            echo \"❌ Deployment resource exists but is not in successful state!\"\n            echo \"Expected: Succeeded, Actual: $PROVISIONING_STATE\"\n\n            # Show resource details for debugging\n            echo \"Resource details:\"\n            az resource show --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" --query \"{name: name, provisioningState: properties.provisioningState, deploymentMode: properties.deploymentMode}\" --output table 2>/dev/null || echo \"Could not retrieve resource details\"\n\n            exit 1\n        fi\n    else\n        echo \"⚠️  Unknown deployment mode: $DEPLOYMENT_MODE\"\n        echo \"Expected 'Validate' or 'Deploy'\"\n\n        # Show resource details for debugging\n        echo \"Resource details:\"\n        az resource show --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" --query \"{name: name, provisioningState: properties.provisioningState, deploymentMode: properties.deploymentMode}\" --output table 2>/dev/null || echo \"Could not retrieve resource details\"\n\n        exit 1\n    fi\nelse\n    echo \"📝 Deployment-settings resource does not exist. Proceeding with deployment...\"\nfi\n\n# Execute Bicep deployment\nDEPLOYMENT_NAME=\"hci-deployment-$(date +%s)\"\n\necho \"Starting deployment: $DEPLOYMENT_NAME\"\necho \"Using template: nested/deployment-setting.bicep\"\necho \"Using parameter file: $PARAM_FILE\"\n\n# Check if nested/deployment-setting.bicep file was created successfully\nif [ ! -f \"nested/deployment-setting.bicep\" ]; then\n    echo \"Error: nested/deployment-setting.bicep file was not created successfully\"\n    echo \"Current directory contents:\"\n    ls -la\n    exit 1\nfi\n\necho \"✅ nested/deployment-setting.bicep file found and ready for deployment\"\n\n# Execute deployment with parameter file\naz deployment group create \\\n    --resource-group \"$RESOURCE_GROUP_NAME\" \\\n    --name \"$DEPLOYMENT_NAME\" \\\n    --template-file \"nested/deployment-setting.bicep\" \\\n    --parameters \"@$PARAM_FILE\" \\\n    --verbose\n\nDEPLOYMENT_STATUS=$?\n\nif [ $DEPLOYMENT_STATUS -eq 0 ]; then\n    echo \"✅ Deployment completed successfully\"\n\n    # Get deployment outputs\n    echo \"Deployment outputs:\"\n    az deployment group show \\\n        --resource-group \"$RESOURCE_GROUP_NAME\" \\\n        --name \"$DEPLOYMENT_NAME\" \\\n        --query \"properties.outputs\" \\\n        --output table\nelse\n    echo \"❌ Deployment failed with status: $DEPLOYMENT_STATUS\"\n\n    # Get deployment error details\n    echo \"Deployment error details:\"\n    az deployment group show \\\n        --resource-group \"$RESOURCE_GROUP_NAME\" \\\n        --name \"$DEPLOYMENT_NAME\" \\\n        --query \"properties.error\" \\\n        --output json\n\n    # Also show the deployment operations for more details\n    echo \"Deployment operations:\"\n    az deployment operation group list \\\n        --resource-group \"$RESOURCE_GROUP_NAME\" \\\n        --name \"$DEPLOYMENT_NAME\" \\\n        --query \"[?properties.provisioningState=='Failed'].{operation: operationId, code: properties.statusCode, message: properties.statusMessage}\" \\\n        --output table\n\n    exit $DEPLOYMENT_STATUS\nfi\n\n# Clean up temporary files\nrm -f \"$PARAM_FILE\"\nrm -f \"nested/deployment-setting.bicep\"\nrm -rf \"deployment-setting\"\n\necho \"Completed deployment\"\n\necho \"🎉 HCI deployment completed successfully!\"\n\n# Set output for Bicep usage\ncat > $AZ_SCRIPTS_OUTPUT_PATH << EOF\n{\n  \"status\": \"success\",\n  \"message\": \"Deployment completed successfully\",\n  \"operations\": $OPERATIONS_JSON\n}\nEOF\n",
+            "builtInRoleNames": {
+              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+              "Azure Stack HCI Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'bda0d508-adf1-4af0-9c28-88919fc3ae06')]",
+              "Windows Admin Center Administrator Login": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a6333a3e-0164-44c3-b281-7a577aff287f')]"
+            },
+            "azureConnectedMachineResourceManagerRoleID": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f5819b54-e033-4d82-ac66-4fec3cbf3f4c')]",
+            "readerRoleID": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+            "azureStackHCIDeviceManagementRole": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '865ae368-6a45-4bd1-8fbf-0d5151f56fc1')]",
+            "sortedDeploymentOperations": "[if(not(empty(parameters('deploymentOperations'))), sort(parameters('deploymentOperations'), lambda('a', 'b', greater(lambdaVariables('a'), lambdaVariables('b')))), createArray())]",
+            "managementNetworks": "[filter(parameters('deploymentSettings').networkIntents, lambda('n', contains(lambdaVariables('n').trafficType, 'Management')))]",
+            "managementIntentName": "[if(greater(length(variables('managementNetworks')), 0), variables('managementNetworks')[0].name, '')]"
+          },
+          "resources": {
+            "spConnectedMachineResourceManagerRolePermissions": {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(subscription().subscriptionId, parameters('hciResourceProviderObjectId'), 'ConnectedMachineResourceManagerRolePermissions', resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('azureConnectedMachineResourceManagerRoleID')]",
+                "principalId": "[parameters('hciResourceProviderObjectId')]",
+                "principalType": "ServicePrincipal",
+                "description": "Created by Azure Stack HCI deployment template"
+              }
+            },
+            "nodeAzureConnectedMachineResourceManagerRolePermissions": {
+              "copy": {
+                "name": "nodeAzureConnectedMachineResourceManagerRolePermissions",
+                "count": "[length(variables('arcNodeResourceIds'))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(subscription().subscriptionId, parameters('hciResourceProviderObjectId'), 'azureConnectedMachineResourceManager', variables('arcNodeResourceIds')[copyIndex()], resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('azureConnectedMachineResourceManagerRoleID')]",
+                "principalId": "[reference(variables('arcNodeResourceIds')[copyIndex()], '2023-10-03-preview', 'Full').identity.principalId]",
+                "principalType": "ServicePrincipal",
+                "description": "Created by Azure Stack HCI deployment template"
+              }
+            },
+            "nodeazureStackHCIDeviceManagementRole": {
+              "copy": {
+                "name": "nodeazureStackHCIDeviceManagementRole",
+                "count": "[length(variables('arcNodeResourceIds'))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(subscription().subscriptionId, parameters('hciResourceProviderObjectId'), 'azureStackHCIDeviceManagementRole', variables('arcNodeResourceIds')[copyIndex()], resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('azureStackHCIDeviceManagementRole')]",
+                "principalId": "[reference(variables('arcNodeResourceIds')[copyIndex()], '2023-10-03-preview', 'Full').identity.principalId]",
+                "principalType": "ServicePrincipal",
+                "description": "Created by Azure Stack HCI deployment template"
+              }
+            },
+            "nodereaderRoleIDPermissions": {
+              "copy": {
+                "name": "nodereaderRoleIDPermissions",
+                "count": "[length(variables('arcNodeResourceIds'))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(subscription().subscriptionId, parameters('hciResourceProviderObjectId'), 'reader', variables('arcNodeResourceIds')[copyIndex()], resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('readerRoleID')]",
+                "principalId": "[reference(variables('arcNodeResourceIds')[copyIndex()], '2023-10-03-preview', 'Full').identity.principalId]",
+                "principalType": "ServicePrincipal",
+                "description": "Created by Azure Stack HCI deployment template"
+              }
+            },
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2023-07-01",
+              "name": "[take(format('46d3xbcp.res.azurestackhci-cluster.{0}.{1}', replace('0.1.12', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4)), 64)]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
+            "arcMachines": {
+              "copy": {
+                "name": "arcMachines",
+                "count": "[length(parameters('deploymentSettings').clusterNodeNames)]"
+              },
+              "existing": true,
+              "type": "Microsoft.HybridCompute/machines",
+              "apiVersion": "2024-07-10",
+              "name": "[parameters('deploymentSettings').clusterNodeNames[copyIndex()]]"
+            },
+            "edgeDevices": {
+              "copy": {
+                "name": "edgeDevices",
+                "count": "[length(parameters('deploymentSettings').clusterNodeNames)]"
+              },
+              "type": "Microsoft.AzureStackHCI/edgeDevices",
+              "apiVersion": "2024-02-15-preview",
+              "scope": "[format('Microsoft.HybridCompute/machines/{0}', parameters('deploymentSettings').clusterNodeNames[copyIndex()])]",
+              "name": "default",
+              "kind": "HCI",
+              "properties": {
+                "deviceConfiguration": {
+                  "deviceMetadata": "",
+                  "nicDetails": []
+                }
+              }
+            },
+            "cluster": {
+              "type": "Microsoft.AzureStackHCI/clusters",
+              "apiVersion": "2024-04-01",
+              "name": "[parameters('name')]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "location": "[parameters('location')]",
+              "properties": {},
+              "tags": "[parameters('tags')]",
+              "dependsOn": [
+                "edgeDevices"
+              ]
+            },
+            "managedIdentity": {
+              "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+              "apiVersion": "2023-01-31",
+              "name": "[format('temp-{0}', parameters('name'))]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]"
+            },
+            "roleAssignmentContributor": {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('temp-{0}', parameters('name'))), variables('builtInRoleNames').Contributor, resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('builtInRoleNames').Contributor]",
+                "principalId": "[reference('managedIdentity').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "managedIdentity"
+              ]
+            },
+            "roleAssignmentReader": {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('temp-{0}', parameters('name'))), variables('builtInRoleNames').Reader, resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('builtInRoleNames').Reader]",
+                "principalId": "[reference('managedIdentity').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "managedIdentity"
+              ]
+            },
+            "roleAssignmentRBACAdmin": {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('temp-{0}', parameters('name'))), variables('builtInRoleNames')['Role Based Access Control Administrator'], resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('builtInRoleNames')['Role Based Access Control Administrator']]",
+                "principalId": "[reference('managedIdentity').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "managedIdentity"
+              ]
+            },
+            "deploymentScript": {
+              "type": "Microsoft.Resources/deploymentScripts",
+              "apiVersion": "2023-08-01",
+              "name": "[format('hci-deployment-script-{0}', uniqueString(resourceGroup().id))]",
+              "location": "[resourceGroup().location]",
+              "kind": "AzureCLI",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                  "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('temp-{0}', parameters('name'))))]": {}
+                }
+              },
+              "properties": {
+                "azCliVersion": "2.50.0",
+                "timeout": "PT5H",
+                "retentionInterval": "P1D",
+                "cleanupPreference": "OnSuccess",
+                "environmentVariables": [
+                  {
+                    "name": "RESOURCE_GROUP_NAME",
+                    "value": "[resourceGroup().name]"
+                  },
+                  {
+                    "name": "SUBSCRIPTION_ID",
+                    "value": "[subscription().subscriptionId]"
+                  },
+                  {
+                    "name": "CLUSTER_NAME",
+                    "value": "[parameters('name')]"
+                  },
+                  {
+                    "name": "CLUSTER_AD_NAME",
+                    "value": "[coalesce(parameters('clusterADName'), parameters('name'))]"
+                  },
+                  {
+                    "name": "CLOUD_ID",
+                    "value": "[reference('cluster').cloudId]"
+                  },
+                  {
+                    "name": "USE_SHARED_KEYVAULT",
+                    "value": "[string(parameters('useSharedKeyVault'))]"
+                  },
+                  {
+                    "name": "DEPLOYMENT_OPERATIONS",
+                    "value": "[join(variables('sortedDeploymentOperations'), ',')]"
+                  },
+                  {
+                    "name": "OPERATION_TYPE",
+                    "value": "[parameters('operationType')]"
+                  },
+                  {
+                    "name": "DEPLOYMENT_SETTINGS",
+                    "value": "[string(parameters('deploymentSettings'))]"
+                  },
+                  {
+                    "name": "DEPLOYMENT_SETTING_BICEP_BASE64",
+                    "value": "[base64(variables('$fxv#0'))]"
+                  },
+                  {
+                    "name": "DEPLOYMENT_SETTING_MAIN_BICEP_BASE64",
+                    "value": "[base64(variables('$fxv#1'))]"
+                  },
+                  {
+                    "name": "NEED_ARB_SECRET",
+                    "value": "[if(or(empty(parameters('servicePrincipalId')), empty(parameters('servicePrincipalSecret'))), string(false()), string(true()))]"
+                  }
+                ],
+                "scriptContent": "[variables('$fxv#2')]"
+              },
+              "dependsOn": [
+                "cluster",
+                "edgeDevices",
+                "managedIdentity",
+                "nodeAzureConnectedMachineResourceManagerRolePermissions",
+                "nodeazureStackHCIDeviceManagementRole",
+                "nodereaderRoleIDPermissions",
+                "roleAssignmentContributor",
+                "roleAssignmentRBACAdmin",
+                "roleAssignmentReader",
+                "secrets",
+                "spConnectedMachineResourceManagerRolePermissions"
+              ]
+            },
+            "cluster_roleAssignments": {
+              "copy": {
+                "name": "cluster_roleAssignments",
+                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[format('Microsoft.AzureStackHCI/clusters/{0}', parameters('name'))]",
+              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.AzureStackHCI/clusters', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+              "properties": {
+                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+              },
+              "dependsOn": [
+                "cluster"
+              ]
+            },
+            "secrets": {
+              "condition": "[parameters('useSharedKeyVault')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-secrets', uniqueString(deployment().name, parameters('location')))]",
+              "subscriptionId": "[coalesce(parameters('keyvaultSubscriptionId'), subscription().subscriptionId)]",
+              "resourceGroup": "[coalesce(parameters('keyvaultResourceGroup'), resourceGroup().name)]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "clusterName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "cloudId": {
+                    "value": "[reference('cluster').cloudId]"
+                  },
+                  "keyVaultName": {
+                    "value": "[parameters('deploymentSettings').keyVaultName]"
+                  },
+                  "storageAccountName": {
+                    "value": "[parameters('deploymentSettings').clusterWitnessStorageAccountName]"
+                  },
+                  "deploymentUser": {
+                    "value": "[parameters('deploymentUser')]"
+                  },
+                  "deploymentUserPassword": {
+                    "value": "[parameters('deploymentUserPassword')]"
+                  },
+                  "localAdminUser": {
+                    "value": "[parameters('localAdminUser')]"
+                  },
+                  "localAdminPassword": {
+                    "value": "[parameters('localAdminPassword')]"
+                  },
+                  "servicePrincipalId": {
+                    "value": "[parameters('servicePrincipalId')]"
+                  },
+                  "servicePrincipalSecret": {
+                    "value": "[parameters('servicePrincipalSecret')]"
+                  },
+                  "azureStackLCMUserCredentialContentType": {
+                    "value": "[parameters('azureStackLCMUserCredentialContentType')]"
+                  },
+                  "localAdminCredentialContentType": {
+                    "value": "[parameters('localAdminCredentialContentType')]"
+                  },
+                  "witnessStoragekeyContentType": {
+                    "value": "[parameters('witnessStoragekeyContentType')]"
+                  },
+                  "defaultARBApplicationContentType": {
+                    "value": "[parameters('defaultARBApplicationContentType')]"
+                  },
+                  "azureStackLCMUserCredentialTags": {
+                    "value": "[parameters('azureStackLCMUserCredentialTags')]"
+                  },
+                  "localAdminCredentialTags": {
+                    "value": "[parameters('localAdminCredentialTags')]"
+                  },
+                  "witnessStoragekeyTags": {
+                    "value": "[parameters('witnessStoragekeyTags')]"
+                  },
+                  "defaultARBApplicationTags": {
+                    "value": "[parameters('defaultARBApplicationTags')]"
+                  },
+                  "witnessStorageAccountResourceGroup": {
+                    "value": "[coalesce(parameters('witnessStorageAccountResourceGroup'), resourceGroup().name)]"
+                  },
+                  "witnessStorageAccountSubscriptionId": {
+                    "value": "[coalesce(parameters('witnessStorageAccountSubscriptionId'), subscription().subscriptionId)]"
+                  },
+                  "hciResourceProviderObjectId": {
+                    "value": "[parameters('hciResourceProviderObjectId')]"
+                  },
+                  "arcNodeResourceIds": {
+                    "value": "[variables('arcNodeResourceIds')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.36.177.2456",
+                      "templateHash": "10008583855790273441"
+                    }
+                  },
+                  "parameters": {
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the key vault."
+                      }
+                    },
+                    "storageAccountName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the strorage account."
+                      }
+                    },
+                    "clusterName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the cluster."
+                      }
+                    },
+                    "cloudId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The cloud ID."
+                      }
+                    },
+                    "deploymentUser": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the deployment user."
+                      }
+                    },
+                    "deploymentUserPassword": {
+                      "type": "securestring",
+                      "metadata": {
+                        "description": "Required. The password of the deployment user."
+                      }
+                    },
+                    "localAdminUser": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the local admin user."
+                      }
+                    },
+                    "localAdminPassword": {
+                      "type": "securestring",
+                      "metadata": {
+                        "description": "Required. The password of the local admin user."
+                      }
+                    },
+                    "servicePrincipalId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Conditional. The service principal ID for ARB."
+                      }
+                    },
+                    "servicePrincipalSecret": {
+                      "type": "securestring",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Conditional. The service principal secret for ARB."
+                      }
+                    },
+                    "azureStackLCMUserCredentialContentType": {
+                      "type": "string",
+                      "defaultValue": "Secret",
+                      "metadata": {
+                        "description": "Optional. Content type of the azure stack lcm user credential."
+                      }
+                    },
+                    "localAdminCredentialContentType": {
+                      "type": "string",
+                      "defaultValue": "Secret",
+                      "metadata": {
+                        "description": "Optional. Content type of the local admin credential."
+                      }
+                    },
+                    "witnessStoragekeyContentType": {
+                      "type": "string",
+                      "defaultValue": "Secret",
+                      "metadata": {
+                        "description": "Optional. Content type of the witness storage key."
+                      }
+                    },
+                    "defaultARBApplicationContentType": {
+                      "type": "string",
+                      "defaultValue": "Secret",
+                      "metadata": {
+                        "description": "Optional. Content type of the default ARB application."
+                      }
+                    },
+                    "azureStackLCMUserCredentialTags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of azure stack LCM user credential."
+                      }
+                    },
+                    "localAdminCredentialTags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of the local admin credential."
+                      }
+                    },
+                    "witnessStoragekeyTags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of the witness storage key."
+                      }
+                    },
+                    "defaultARBApplicationTags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of the default ARB application."
+                      }
+                    },
+                    "witnessStorageAccountSubscriptionId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Optional. Storage account subscription ID, which is used as the witness for the HCI Windows Failover Cluster."
+                      }
+                    },
+                    "witnessStorageAccountResourceGroup": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Optional. Storage account resource group, which is used as the witness for the HCI Windows Failover Cluster.."
+                      }
+                    },
+                    "hciResourceProviderObjectId": {
+                      "type": "securestring",
+                      "metadata": {
+                        "description": "Required. The service principal object ID of the Azure Stack HCI Resource Provider in this tenant. Can be fetched via `Get-AzADServicePrincipal -ApplicationId 1412d89f-b8a8-4111-b4fd-e82905cbd85d` after the 'Microsoft.AzureStackHCI' provider was registered in the subscription."
+                      }
+                    },
+                    "arcNodeResourceIds": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "Required. Resource ids of the cluster node Arc Machine resources. These are the id of the Arc Machine resources created when the new HCI nodes were Arc initialized."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "keyVaultSecretUserRoleID": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]"
+                  },
+                  "resources": {
+                    "witnessStorageAccount": {
+                      "existing": true,
+                      "type": "Microsoft.Storage/storageAccounts",
+                      "apiVersion": "2023-01-01",
+                      "subscriptionId": "[parameters('witnessStorageAccountSubscriptionId')]",
+                      "resourceGroup": "[parameters('witnessStorageAccountResourceGroup')]",
+                      "name": "[parameters('storageAccountName')]"
+                    },
+                    "keyVault": {
+                      "existing": true,
+                      "type": "Microsoft.KeyVault/vaults",
+                      "apiVersion": "2022-07-01",
+                      "name": "[parameters('keyVaultName')]"
+                    },
+                    "KeyVaultSecretsUserPermissions": {
+                      "copy": {
+                        "name": "KeyVaultSecretsUserPermissions",
+                        "count": "[length(parameters('arcNodeResourceIds'))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.KeyVault/vaults/{0}', parameters('keyVaultName'))]",
+                      "name": "[guid(subscription().subscriptionId, parameters('hciResourceProviderObjectId'), 'keyVaultSecretUser', parameters('arcNodeResourceIds')[copyIndex()], resourceGroup().id)]",
+                      "properties": {
+                        "roleDefinitionId": "[variables('keyVaultSecretUserRoleID')]",
+                        "principalId": "[reference(parameters('arcNodeResourceIds')[copyIndex()], '2023-10-03-preview', 'Full').identity.principalId]",
+                        "principalType": "ServicePrincipal",
+                        "description": "Created by Azure Stack HCI deployment template"
+                      }
+                    },
+                    "azureStackLCMUserCredential": {
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), format('{0}-AzureStackLCMUserCredential-{1}', parameters('clusterName'), parameters('cloudId')))]",
+                      "properties": {
+                        "contentType": "[parameters('azureStackLCMUserCredentialContentType')]",
+                        "value": "[base64(format('{0}:{1}', parameters('deploymentUser'), parameters('deploymentUserPassword')))]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "tags": "[parameters('azureStackLCMUserCredentialTags')]"
+                    },
+                    "localAdminCredential": {
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), format('{0}-LocalAdminCredential-{1}', parameters('clusterName'), parameters('cloudId')))]",
+                      "properties": {
+                        "contentType": "[parameters('localAdminCredentialContentType')]",
+                        "value": "[base64(format('{0}:{1}', parameters('localAdminUser'), parameters('localAdminPassword')))]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "tags": "[parameters('localAdminCredentialTags')]"
+                    },
+                    "witnessStorageKey": {
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), format('{0}-WitnessStorageKey-{1}', parameters('clusterName'), parameters('cloudId')))]",
+                      "properties": {
+                        "contentType": "[parameters('witnessStoragekeyContentType')]",
+                        "value": "[base64(listKeys('witnessStorageAccount', '2023-01-01').keys[0].value)]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "tags": "[parameters('witnessStoragekeyTags')]"
+                    },
+                    "defaultARBApplication": {
+                      "condition": "[and(not(empty(parameters('servicePrincipalId'))), not(empty(parameters('servicePrincipalSecret'))))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), format('{0}-DefaultARBApplication-{1}', parameters('clusterName'), parameters('cloudId')))]",
+                      "properties": {
+                        "contentType": "[parameters('defaultARBApplicationContentType')]",
+                        "value": "[base64(format('{0}:{1}', parameters('servicePrincipalId'), parameters('servicePrincipalSecret')))]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "tags": "[parameters('defaultARBApplicationTags')]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "cluster"
+              ]
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the cluster."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The ID of the cluster."
+              },
+              "value": "[resourceId('Microsoft.AzureStackHCI/clusters', parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the cluster."
+              },
+              "value": "[resourceGroup().name]"
+            },
+            "systemAssignedMIPrincipalId": {
+              "type": "string",
+              "metadata": {
+                "description": "The managed identity of the cluster."
+              },
+              "value": "[reference('cluster', '2024-04-01', 'full').identity.principalId]"
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "The location of the cluster."
+              },
+              "value": "[reference('cluster', '2024-04-01', 'full').location]"
+            },
+            "vSwitchName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the vSwitch."
+              },
+              "value": "[format('ConvergedSwitch({0})', variables('managementIntentName'))]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "nestedDependencies",
+        "resourceGroup"
+      ]
+    },
+    "hciImage": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}-test-mgi-{1}', uniqueString(deployment().name, variables('enforcedLocation')), parameters('serviceShort'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[format('{0}{1}marketplaceimage', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "customLocationResourceId": {
+            "value": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.ExtendedLocation/customLocations', format('{0}{1}-location', parameters('namePrefix'), parameters('serviceShort')))]"
+          },
+          "identifier": {
+            "value": {
+              "offer": "WindowsServer",
+              "publisher": "MicrosoftWindowsServer",
+              "sku": "2022-datacenter-azure-edition"
+            }
+          },
+          "osType": {
+            "value": "Windows"
+          },
+          "version": {
+            "value": {
+              "name": "20348.2461.240510"
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.36.1.42791",
+              "templateHash": "14152740400046034707"
+            },
+            "name": "Azure Stack HCI Marketplace Gallery Image",
+            "description": "This module deploys an Azure Stack HCI Marketplace Gallery Image."
+          },
+          "definitions": {
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the resource to create."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all Resources."
+              }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
+            },
+            "customLocationResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The custom location ID."
+              }
+            },
+            "osType": {
+              "type": "string",
+              "allowedValues": [
+                "Windows",
+                "Linux"
+              ],
+              "metadata": {
+                "description": "Required. Operating system type that the gallery image uses."
+              }
+            },
+            "identifier": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/marketplaceGalleryImages@2025-04-01-preview#properties/properties/properties/identifier"
+                },
+                "description": "Required. The gallery image identifier configuration containing publisher, offer, and SKU."
+              }
+            },
+            "hyperVGeneration": {
+              "type": "string",
+              "defaultValue": "V2",
+              "allowedValues": [
+                "V1",
+                "V2"
+              ],
+              "metadata": {
+                "description": "Optional. The hypervisor generation of the Virtual Machine."
+              }
+            },
+            "cloudInitDataSource": {
+              "type": "string",
+              "nullable": true,
+              "allowedValues": [
+                "NoCloud",
+                "Azure"
+              ],
+              "metadata": {
+                "description": "Optional. Datasource for the gallery image when provisioning with cloud-init."
+              }
+            },
+            "containerResourceId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Storage Container resourceId of the storage container to be used for marketplace gallery image."
+              }
+            },
+            "version": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/marketplaceGalleryImages@2025-04-01-preview#properties/properties/properties/version"
+                },
+                "description": "Required. Gallery image version configuration."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/marketplaceGalleryImages@2025-04-01-preview#properties/tags"
+                },
+                "description": "Optional. Tags for the marketplace gallery image."
+              },
+              "nullable": true
+            },
+            "roleAssignments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Array of role assignments to create."
+              }
+            }
+          },
+          "variables": {
+            "copy": [
+              {
+                "name": "formattedRoleAssignments",
+                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+              }
+            ],
+            "builtInRoleNames": {
+              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+            }
+          },
+          "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2024-03-01",
+              "name": "[take(format('46d3xbcp.res.azurestackhci-markplgalleryimg.{0}.{1}', replace('0.1.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4)), 64)]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
+            "marketplaceGalleryImage": {
+              "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+              "apiVersion": "2025-04-01-preview",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "extendedLocation": {
+                "name": "[parameters('customLocationResourceId')]",
+                "type": "CustomLocation"
+              },
+              "properties": {
+                "cloudInitDataSource": "[parameters('cloudInitDataSource')]",
+                "containerId": "[parameters('containerResourceId')]",
+                "hyperVGeneration": "[parameters('hyperVGeneration')]",
+                "identifier": {
+                  "offer": "[parameters('identifier').offer]",
+                  "publisher": "[parameters('identifier').publisher]",
+                  "sku": "[parameters('identifier').sku]"
+                },
+                "osType": "[parameters('osType')]",
+                "version": "[parameters('version')]"
+              }
+            },
+            "marketplaceGalleryImage_roleAssignments": {
+              "copy": {
+                "name": "marketplaceGalleryImage_roleAssignments",
+                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[format('Microsoft.AzureStackHCI/marketplaceGalleryImages/{0}', parameters('name'))]",
+              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.AzureStackHCI/marketplaceGalleryImages', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+              "properties": {
+                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+              },
+              "dependsOn": [
+                "marketplaceGalleryImage"
+              ]
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the marketplace gallery image."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the marketplace gallery image."
+              },
+              "value": "[resourceId('Microsoft.AzureStackHCI/marketplaceGalleryImages', parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the marketplace gallery image."
+              },
+              "value": "[resourceGroup().name]"
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "The location of the marketplace gallery image."
+              },
+              "value": "[reference('marketplaceGalleryImage', '2025-04-01-preview', 'full').location]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "azlocal",
+        "resourceGroup"
+      ]
+    },
+    "testDeployment": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}-vm-{1}', uniqueString(deployment().name, variables('enforcedLocation')), parameters('serviceShort'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[format('{0}-hc-{1}', uniqueString(deployment().name, variables('enforcedLocation')), parameters('serviceShort'))]"
+          },
+          "customLocationResourceId": {
+            "value": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.ExtendedLocation/customLocations', format('{0}{1}-location', parameters('namePrefix'), parameters('serviceShort')))]"
+          },
+          "hardwareProfile": {
+            "value": {
+              "memoryMB": 4096,
+              "processors": 2
+            }
+          },
+          "networkProfile": {
+            "value": {}
+          },
+          "osProfile": {
+            "value": {
+              "computerName": "[format('{0}{1}vm', parameters('namePrefix'), parameters('serviceShort'))]",
+              "linuxConfiguration": {},
+              "windowsConfiguration": {
+                "provisionVMAgent": true,
+                "provisionVMConfigAgent": true
+              },
+              "adminUsername": "Administrator",
+              "adminPassword": "[parameters('localAdminAndDeploymentUserPass')]"
+            }
+          },
+          "storageProfile": {
+            "value": {
+              "imageReference": {
+                "id": "[reference('hciImage').outputs.resourceId.value]"
+              },
+              "osDisk": {
+                "osType": "Windows"
+              }
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.40.2.10011",
+              "templateHash": "10681649339677827998"
+            },
+            "name": "Azure Stack HCI Virtual Machine Instance",
+            "description": "This module deploys an Azure Stack HCI virtual machine."
+          },
+          "definitions": {
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the resource to create."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all Resources."
+              }
+            },
+            "customLocationResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Resource ID of the associated custom location."
+              }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
+            },
+            "hardwareProfile": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/hardwareProfile"
+                },
+                "description": "Required. Hardware profile configuration."
+              }
+            },
+            "httpProxyConfig": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/httpProxyConfig"
+                },
+                "description": "Optional. HTTP proxy configuration."
+              },
+              "defaultValue": {}
+            },
+            "networkProfile": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/networkProfile"
+                },
+                "description": "Required. Network profile configuration."
+              }
+            },
+            "osProfile": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/osProfile"
+                },
+                "description": "Required. OS profile configuration."
+              }
+            },
+            "securityProfile": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/securityProfile"
+                },
+                "description": "Optional. Security profile configuration."
+              },
+              "defaultValue": {
+                "uefiSettings": {
+                  "secureBootEnabled": true
+                }
+              }
+            },
+            "storageProfile": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/storageProfile"
+                },
+                "description": "Required. Storage profile configuration."
+              }
+            },
+            "roleAssignments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Array of role assignments to create."
+              }
+            },
+            "adminPassword": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The password of arc vm. If it is provided, it will be used for the admin account in osProfile."
+              }
+            },
+            "httpProxy": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The HTTP proxy server endpoint to use. If it is provided, it will be used in HttpProxyConfiguration."
+              }
+            },
+            "httpsProxy": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The HTTPS proxy server endpoint to use. If it is provided, it will be used in HttpProxyConfiguration."
+              }
+            }
+          },
+          "variables": {
+            "copy": [
+              {
+                "name": "formattedRoleAssignments",
+                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+              }
+            ],
+            "builtInRoleNames": {
+              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+            },
+            "enableReferencedModulesTelemetry": false
+          },
+          "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2024-03-01",
+              "name": "[format('46d3xbcp.res.azurestackhci-virtualmachineinstance.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
+            "existingMachine": {
+              "existing": true,
+              "type": "Microsoft.HybridCompute/machines",
+              "apiVersion": "2023-10-03-preview",
+              "name": "[parameters('name')]",
+              "dependsOn": [
+                "hybridCompute"
+              ]
+            },
+            "virtualMachineInstance": {
+              "type": "Microsoft.AzureStackHCI/virtualMachineInstances",
+              "apiVersion": "2024-01-01",
+              "scope": "[resourceId('Microsoft.HybridCompute/machines', parameters('name'))]",
+              "name": "default",
+              "extendedLocation": {
+                "type": "CustomLocation",
+                "name": "[parameters('customLocationResourceId')]"
+              },
+              "properties": {
+                "hardwareProfile": {
+                  "memoryMB": "[parameters('hardwareProfile').memoryMB]",
+                  "processors": "[parameters('hardwareProfile').processors]",
+                  "vmSize": "[if(empty(tryGet(parameters('hardwareProfile'), 'vmSize')), 'Custom', tryGet(parameters('hardwareProfile'), 'vmSize'))]",
+                  "dynamicMemoryConfig": "[tryGet(parameters('hardwareProfile'), 'dynamicMemoryConfig')]"
+                },
+                "httpProxyConfig": "[if(empty(parameters('httpProxyConfig')), null(), union(parameters('httpProxyConfig'), createObject('httpProxy', parameters('httpProxy'), 'httpsProxy', parameters('httpsProxy'))))]",
+                "networkProfile": "[parameters('networkProfile')]",
+                "osProfile": "[union(parameters('osProfile'), createObject('adminPassword', parameters('adminPassword')))]",
+                "securityProfile": "[if(empty(parameters('securityProfile')), null(), parameters('securityProfile'))]",
+                "storageProfile": "[parameters('storageProfile')]"
+              },
+              "dependsOn": [
+                "hybridCompute"
+              ]
+            },
+            "virtualMachine_roleAssignments": {
+              "copy": {
+                "name": "virtualMachine_roleAssignments",
+                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[extensionResourceId(resourceId('Microsoft.HybridCompute/machines', parameters('name')), 'Microsoft.AzureStackHCI/virtualMachineInstances', 'default')]",
+              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(extensionResourceId(resourceId('Microsoft.HybridCompute/machines', parameters('name')), 'Microsoft.AzureStackHCI/virtualMachineInstances', 'default'), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+              "properties": {
+                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+              },
+              "dependsOn": [
+                "virtualMachineInstance"
+              ]
+            },
+            "hybridCompute": {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-deployment', parameters('name'))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[parameters('name')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "kind": {
+                    "value": "HCI"
+                  },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.33.13.18514",
+                      "templateHash": "2332904181907667266"
+                    },
+                    "name": "Hybrid Compute Machines",
+                    "description": "This module deploys an Arc Machine for use with Arc Resource Bridge for Azure Stack HCI or VMware. In these scenarios, this resource module will be used in combination with another resource module to create the require Virtual Machine Instance extension resource on this Arc Machine resource. This module should not be used for other Arc-enabled server scenarios, where the Arc Machine resource is created automatically by the onboarding process."
+                  },
+                  "definitions": {
+                    "lockType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the name of lock."
+                          }
+                        },
+                        "kind": {
+                          "type": "string",
+                          "allowedValues": [
+                            "CanNotDelete",
+                            "None",
+                            "ReadOnly"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the type of lock."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a lock.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.4.1"
+                        }
+                      }
+                    },
+                    "roleAssignmentType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.4.1"
+                        }
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the Arc machine to be created. You should use a unique prefix to reduce name collisions in Active Directory."
+                      }
+                    },
+                    "kind": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Kind of Arc machine to be created. Possible values are: HCI, SCVMM, VMware."
+                      }
+                    },
+                    "privateLinkScopeResourceId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Conditional. The resource ID of an Arc Private Link Scope which which to associate this machine. Required if you are using Private Link for Arc and your Arc Machine will resolve a Private Endpoint for connectivity to Azure."
+                      }
+                    },
+                    "parentClusterResourceId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Parent cluster resource ID (Azure Stack HCI)."
+                      }
+                    },
+                    "vmId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The GUID of the on-premises virtual machine from your hypervisor."
+                      }
+                    },
+                    "clientPublicKey": {
+                      "type": "securestring",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The Public Key that the client provides to be used during initial resource onboarding."
+                      }
+                    },
+                    "patchMode": {
+                      "type": "string",
+                      "nullable": true,
+                      "allowedValues": [
+                        "AutomaticByPlatform",
+                        "AutomaticByOS",
+                        "Manual",
+                        "ImageDefault"
+                      ],
+                      "metadata": {
+                        "description": "Optional. VM guest patching orchestration mode. 'AutomaticByOS' & 'Manual' are for Windows only, 'ImageDefault' for Linux only."
+                      }
+                    },
+                    "patchAssessmentMode": {
+                      "type": "string",
+                      "defaultValue": "ImageDefault",
+                      "allowedValues": [
+                        "AutomaticByPlatform",
+                        "ImageDefault"
+                      ],
+                      "metadata": {
+                        "description": "Optional. VM guest patching assessment mode. Set it to 'AutomaticByPlatform' to enable automatically check for updates every 24 hours."
+                      }
+                    },
+                    "guestConfiguration": {
+                      "type": "object",
+                      "defaultValue": {},
+                      "metadata": {
+                        "description": "Optional. The guest configuration for the Arc machine. Needs the Guest Configuration extension to be enabled."
+                      }
+                    },
+                    "osType": {
+                      "type": "string",
+                      "nullable": true,
+                      "allowedValues": [
+                        "Windows",
+                        "Linux"
+                      ],
+                      "metadata": {
+                        "description": "Conditional. Required if you are providing OS-type specified configurations, such as patch settings. The chosen OS type, either Windows or Linux."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]",
+                      "metadata": {
+                        "description": "Optional. Location for all resources."
+                      }
+                    },
+                    "lock": {
+                      "$ref": "#/definitions/lockType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The lock settings of the service."
+                      }
+                    },
+                    "roleAssignments": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of role assignments to create."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of the resource."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "copy": [
+                      {
+                        "name": "formattedRoleAssignments",
+                        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                        "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                      }
+                    ],
+                    "linuxConfiguration": {
+                      "patchSettings": "[if(or(equals(parameters('patchMode'), 'AutomaticByPlatform'), equals(parameters('patchMode'), 'ImageDefault')), createObject('patchMode', parameters('patchMode'), 'assessmentMode', parameters('patchAssessmentMode')), null())]"
+                    },
+                    "windowsConfiguration": {
+                      "patchSettings": "[if(or(or(equals(parameters('patchMode'), 'AutomaticByPlatform'), equals(parameters('patchMode'), 'AutomaticByOS')), equals(parameters('patchMode'), 'Manual')), createObject('patchMode', parameters('patchMode'), 'assessmentMode', parameters('patchAssessmentMode')), null())]"
+                    },
+                    "builtInRoleNames": {
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+                      "Arc machine Administrator Login": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '1c0163c0-47e6-4577-8991-ea5c82e286e4')]",
+                      "Arc machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9980e02c-c2be-4d73-94e8-173b1dc7cf3c')]",
+                      "Arc machine User Login": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'fb879df8-f326-4884-b1cf-06f3ad86be52')]",
+                      "Windows Admin Center Administrator Login": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a6333a3e-0164-44c3-b281-7a577aff287f')]"
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('46d3xbcp.res.hybridcompute-machine.{0}.{1}', replace('0.4.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "machine": {
+                      "type": "Microsoft.HybridCompute/machines",
+                      "apiVersion": "2024-07-10",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "identity": {
+                        "type": "SystemAssigned"
+                      },
+                      "tags": "[parameters('tags')]",
+                      "kind": "[parameters('kind')]",
+                      "properties": {
+                        "osProfile": {
+                          "windowsConfiguration": "[if(equals(parameters('osType'), 'Windows'), variables('windowsConfiguration'), null())]",
+                          "linuxConfiguration": "[if(equals(parameters('osType'), 'Linux'), variables('linuxConfiguration'), null())]"
+                        },
+                        "parentClusterResourceId": "[parameters('parentClusterResourceId')]",
+                        "vmId": "[parameters('vmId')]",
+                        "clientPublicKey": "[parameters('clientPublicKey')]",
+                        "privateLinkScopeResourceId": "[if(not(empty(parameters('privateLinkScopeResourceId'))), parameters('privateLinkScopeResourceId'), null())]"
+                      }
+                    },
+                    "AzureWindowsBaseline": {
+                      "condition": "[not(empty(parameters('guestConfiguration')))]",
+                      "type": "Microsoft.GuestConfiguration/guestConfigurationAssignments",
+                      "apiVersion": "2020-06-25",
+                      "scope": "[format('Microsoft.HybridCompute/machines/{0}', parameters('name'))]",
+                      "name": "[format('gca-{0}', parameters('name'))]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "guestConfiguration": "[parameters('guestConfiguration')]"
+                      },
+                      "dependsOn": [
+                        "machine"
+                      ]
+                    },
+                    "machine_lock": {
+                      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                      "type": "Microsoft.Authorization/locks",
+                      "apiVersion": "2020-05-01",
+                      "scope": "[format('Microsoft.HybridCompute/machines/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                      "properties": {
+                        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                        "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+                      },
+                      "dependsOn": [
+                        "machine"
+                      ]
+                    },
+                    "machine_roleAssignments": {
+                      "copy": {
+                        "name": "machine_roleAssignments",
+                        "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.HybridCompute/machines/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.HybridCompute/machines', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                      "properties": {
+                        "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                        "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                        "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                        "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                        "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                        "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                      },
+                      "dependsOn": [
+                        "machine"
+                      ]
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the machine."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the machine."
+                      },
+                      "value": "[resourceId('Microsoft.HybridCompute/machines', parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the resource group the VM was created in."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "systemAssignedMIPrincipalId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "The principal ID of the system assigned identity."
+                      },
+                      "value": "[tryGet(tryGet(reference('machine', '2024-07-10', 'full'), 'identity'), 'principalId')]"
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The location the resource was deployed into."
+                      },
+                      "value": "[reference('machine', '2024-07-10', 'full').location]"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the virtual machine instance."
+              },
+              "value": "default"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the virtual machine instance."
+              },
+              "value": "[extensionResourceId(resourceId('Microsoft.HybridCompute/machines', parameters('name')), 'Microsoft.AzureStackHCI/virtualMachineInstances', 'default')]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the virtual machine instance."
+              },
+              "value": "[resourceGroup().name]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "azlocal",
+        "hciImage",
+        "resourceGroup"
+      ]
+    }
+  }
+}

--- a/avm/res/azure-stack-hci/virtual-machine-instance/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/azure-stack-hci/virtual-machine-instance/tests/e2e/waf-aligned/main.test.bicep
@@ -69,7 +69,6 @@ module nestedDependencies '../../../../../../../utilities/e2e-template-assets/mo
     arbDeploymentSPObjectId: arbDeploymentSPObjectId
     deploymentUserPassword: arbLocalAdminAndDeploymentUserPass
     localAdminPassword: arbLocalAdminAndDeploymentUserPass
-    domainAdminPassword: arbLocalAdminAndDeploymentUserPass
     location: enforcedLocation
   }
 }

--- a/avm/res/azure-stack-hci/virtual-machine-instance/tests/e2e/waf-aligned/main.test.json
+++ b/avm/res/azure-stack-hci/virtual-machine-instance/tests/e2e/waf-aligned/main.test.json
@@ -1,0 +1,4354 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.40.2.10011",
+      "templateHash": "15146524859804964428"
+    },
+    "name": "WAF-aligned",
+    "description": "This instance deploys the module in alignment with the best-practices of the Azure Well-Architected Framework."
+  },
+  "parameters": {
+    "resourceGroupName": {
+      "type": "string",
+      "defaultValue": "[format('dep-{0}-azurestackhci.vmi-{1}-rg', parameters('namePrefix'), parameters('serviceShort'))]",
+      "maxLength": 90,
+      "metadata": {
+        "description": "Optional. The name of the resource group to deploy for testing purposes."
+      }
+    },
+    "serviceShort": {
+      "type": "string",
+      "defaultValue": "ashvmiwaf",
+      "metadata": {
+        "description": "Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints."
+      }
+    },
+    "namePrefix": {
+      "type": "string",
+      "defaultValue": "#_namePrefix_#",
+      "metadata": {
+        "description": "Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI."
+      }
+    },
+    "arbLocalAdminAndDeploymentUserPass": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Required. The password of the LCM deployment user and local administrator accounts."
+      }
+    },
+    "arbDeploymentAppId": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Required. The app ID of the service principal used for the Azure Stack HCI Resource Bridge deployment."
+      }
+    },
+    "arbDeploymentSPObjectId": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Required. The service principal ID of the service principal used for the Azure Stack HCI Resource Bridge deployment."
+      }
+    },
+    "arbDeploymentServicePrincipalSecret": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Required. The secret of the service principal used for the Azure Stack HCI Resource Bridge deployment."
+      }
+    },
+    "hciResourceProviderObjectId": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Required. The service principal object ID of the Azure Stack HCI Resource Provider in this tenant. Can be fetched via `Get-AzADServicePrincipal -ApplicationId 1412d89f-b8a8-4111-b4fd-e82905cbd85d` after the 'Microsoft.AzureStackHCI' provider was registered in the subscription."
+      }
+    },
+    "localAdminAndDeploymentUserPass": {
+      "type": "string",
+      "defaultValue": "[newGuid()]",
+      "metadata": {
+        "description": "Optional. The password to use for the local and domain accounts in the test."
+      }
+    }
+  },
+  "variables": {
+    "enforcedLocation": "southeastasia"
+  },
+  "resources": {
+    "resourceGroup": {
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2021-04-01",
+      "name": "[parameters('resourceGroupName')]",
+      "location": "[variables('enforcedLocation')]"
+    },
+    "customLocation": {
+      "existing": true,
+      "type": "Microsoft.ExtendedLocation/customLocations",
+      "apiVersion": "2021-08-31-preview",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "name": "[format('{0}{1}-location', parameters('namePrefix'), parameters('serviceShort'))]",
+      "dependsOn": [
+        "azlocal",
+        "resourceGroup"
+      ]
+    },
+    "nestedDependencies": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}-test-nestedDependencies-{1}', uniqueString(deployment().name, variables('enforcedLocation')), parameters('serviceShort'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "clusterName": {
+            "value": "[format('{0}{1}01', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "clusterWitnessStorageAccountName": {
+            "value": "[format('dep{0}wst{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "keyVaultDiagnosticStorageAccountName": {
+            "value": "[format('dep{0}st{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "keyVaultName": {
+            "value": "[format('dep-{0}-kv-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "userAssignedIdentityName": {
+            "value": "[format('dep-{0}-msi-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "maintenanceConfigurationName": {
+            "value": "[format('dep-{0}-mc-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "maintenanceConfigurationAssignmentName": {
+            "value": "[format('dep-{0}-mca-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "HCIHostVirtualMachineScaleSetName": {
+            "value": "[format('dep-{0}-hvmss-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "virtualNetworkName": {
+            "value": "[format('dep-{0}-vnet-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "networkSecurityGroupName": {
+            "value": "[format('dep-{0}-nsg-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "networkInterfaceName": {
+            "value": "[format('dep-{0}-mice-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "virtualMachineName": {
+            "value": "[format('dep-{0}-vm-{1}', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "arbDeploymentAppId": {
+            "value": "[parameters('arbDeploymentAppId')]"
+          },
+          "arbDeploymentServicePrincipalSecret": {
+            "value": "[parameters('arbDeploymentServicePrincipalSecret')]"
+          },
+          "arbDeploymentSPObjectId": {
+            "value": "[parameters('arbDeploymentSPObjectId')]"
+          },
+          "deploymentUserPassword": {
+            "value": "[parameters('arbLocalAdminAndDeploymentUserPass')]"
+          },
+          "localAdminPassword": {
+            "value": "[parameters('arbLocalAdminAndDeploymentUserPass')]"
+          },
+          "location": {
+            "value": "[variables('enforcedLocation')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.40.2.10011",
+              "templateHash": "5940711904875428862"
+            }
+          },
+          "parameters": {
+            "deploymentUserPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Optional. The password of the LCM deployment user and local administrator accounts."
+              }
+            },
+            "localAdminPassword": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Required. The password of the LCM deployment user and local administrator accounts."
+              }
+            },
+            "arbDeploymentAppId": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The app ID of the service principal used for the Azure Stack HCI Resource Bridge deployment. If omitted, the deploying user must have permissions to create service principals and role assignments in Entra ID."
+              }
+            },
+            "arbDeploymentSPObjectId": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The service principal ID of the service principal used for the Azure Stack HCI Resource Bridge deployment. If omitted, the deploying user must have permissions to create service principals and role assignments in Entra ID."
+              }
+            },
+            "arbDeploymentServicePrincipalSecret": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The secret of the service principal used for the Azure Stack HCI Resource Bridge deployment. If omitted, the deploying user must have permissions to create service principals and role assignments in Entra ID."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The location to deploy the resources into."
+              }
+            },
+            "clusterWitnessStorageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the storage account to create as a cluster witness."
+              }
+            },
+            "keyVaultDiagnosticStorageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the storage account to be created to collect Key Vault diagnostic logs."
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the Key Vault to create."
+              }
+            },
+            "clusterName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the Azure Stack HCI cluster."
+              }
+            },
+            "userAssignedIdentityName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the VM-managed user identity to create, used for HCI Arc onboarding."
+              }
+            },
+            "maintenanceConfigurationName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the maintenance configuration for the Azure Stack HCI Host VM and proxy server."
+              }
+            },
+            "HCIHostVirtualMachineScaleSetName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the Azure VM scale set for the HCI host."
+              }
+            },
+            "networkSecurityGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the Network Security Group ro create."
+              }
+            },
+            "virtualNetworkName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the virtual network to create. Used to connect the HCI Azure Host VM to an existing VNET in the same region."
+              }
+            },
+            "networkInterfaceName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the Network Interface Card to create."
+              }
+            },
+            "virtualMachineName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the Azure VM to create."
+              }
+            },
+            "maintenanceConfigurationAssignmentName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the Maintenance Configuration Assignment for the proxy server."
+              }
+            },
+            "diskNamePrefix": {
+              "type": "string",
+              "defaultValue": "dep-disk",
+              "metadata": {
+                "description": "Required. The name prefix for disk resources."
+              }
+            },
+            "waitDeploymentScriptPrefixName": {
+              "type": "string",
+              "defaultValue": "dep-wait",
+              "metadata": {
+                "description": "Required. The name prefix for the wait deployment scripts."
+              }
+            }
+          },
+          "variables": {
+            "clusterNodeNames": [
+              "hcinode1",
+              "hcinode2"
+            ],
+            "domainOUPath": "OU=HCI,DC=hci,DC=local"
+          },
+          "resources": {
+            "cluster": {
+              "type": "Microsoft.AzureStackHCI/clusters",
+              "apiVersion": "2024-04-01",
+              "name": "[parameters('clusterName')]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "location": "[parameters('location')]",
+              "properties": {}
+            },
+            "hciHostDeployment": {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-test-hcihostdeploy', uniqueString(deployment().name, parameters('location')))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "domainOUPath": {
+                    "value": "[variables('domainOUPath')]"
+                  },
+                  "hciNodeCount": {
+                    "value": "[length(variables('clusterNodeNames'))]"
+                  },
+                  "hostVMSize": {
+                    "value": "Standard_E32bds_v5"
+                  },
+                  "localAdminPassword": {
+                    "value": "[parameters('localAdminPassword')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "switchlessStorageConfig": {
+                    "value": false
+                  },
+                  "diskNamePrefix": {
+                    "value": "[parameters('diskNamePrefix')]"
+                  },
+                  "HCIHostVirtualMachineScaleSetName": {
+                    "value": "[parameters('HCIHostVirtualMachineScaleSetName')]"
+                  },
+                  "maintenanceConfigurationAssignmentName": {
+                    "value": "[parameters('maintenanceConfigurationAssignmentName')]"
+                  },
+                  "maintenanceConfigurationName": {
+                    "value": "[parameters('maintenanceConfigurationName')]"
+                  },
+                  "networkInterfaceName": {
+                    "value": "[parameters('networkInterfaceName')]"
+                  },
+                  "networkSecurityGroupName": {
+                    "value": "[parameters('networkSecurityGroupName')]"
+                  },
+                  "virtualNetworkName": {
+                    "value": "[parameters('virtualNetworkName')]"
+                  },
+                  "userAssignedIdentityName": {
+                    "value": "[parameters('userAssignedIdentityName')]"
+                  },
+                  "virtualMachineName": {
+                    "value": "[parameters('virtualMachineName')]"
+                  },
+                  "waitDeploymentScriptPrefixName": {
+                    "value": "[parameters('waitDeploymentScriptPrefixName')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.40.2.10011",
+                      "templateHash": "16884311595766837236"
+                    }
+                  },
+                  "parameters": {
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The location for all resource except HCI Arc Nodes and HCI resources"
+                      }
+                    },
+                    "hostVMSize": {
+                      "type": "string",
+                      "defaultValue": "Standard_E32bds_v5",
+                      "metadata": {
+                        "description": "Optional. The Azure VM size for the HCI Host VM, which must support nested virtualization and have sufficient capacity for the HCI node VMs!"
+                      }
+                    },
+                    "hciNodeCount": {
+                      "type": "int",
+                      "defaultValue": 2,
+                      "metadata": {
+                        "description": "Optional. The number of Azure Stack HCI nodes to deploy."
+                      }
+                    },
+                    "switchlessStorageConfig": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Enable configuring switchless storage."
+                      }
+                    },
+                    "hciISODownloadURL": {
+                      "type": "string",
+                      "defaultValue": "https://azurestackreleases.download.prss.microsoft.com/dbazure/AzureStackHCI/OS-Composition/10.2408.0.3061/AZURESTACKHci23H2.25398.469.LCM.10.2408.0.3061.x64.en-us.iso",
+                      "metadata": {
+                        "description": "Optional. The download URL for the Azure Stack HCI ISO."
+                      }
+                    },
+                    "localAdminUsername": {
+                      "type": "string",
+                      "defaultValue": "admin-hci",
+                      "metadata": {
+                        "description": "Optional. The local admin user name."
+                      }
+                    },
+                    "localAdminPassword": {
+                      "type": "securestring",
+                      "metadata": {
+                        "description": "Required. The local admin password."
+                      }
+                    },
+                    "domainOUPath": {
+                      "type": "string",
+                      "defaultValue": "OU=HCI,DC=HCI,DC=local",
+                      "metadata": {
+                        "description": "Optional. The domain OU path."
+                      }
+                    },
+                    "deploymentUsername": {
+                      "type": "string",
+                      "defaultValue": "deployUser",
+                      "metadata": {
+                        "description": "Optional. The deployment username."
+                      }
+                    },
+                    "userAssignedIdentityName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the VM-managed user identity to create, used for HCI Arc onboarding."
+                      }
+                    },
+                    "virtualNetworkName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the VNET for the HCI host Azure VM."
+                      }
+                    },
+                    "networkSecurityGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the NSG to create."
+                      }
+                    },
+                    "maintenanceConfigurationName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the maintenance configuration for the Azure Stack HCI Host VM and proxy server."
+                      }
+                    },
+                    "HCIHostVirtualMachineScaleSetName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the Azure VM scale set for the HCI host."
+                      }
+                    },
+                    "networkInterfaceName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the Network Interface Card to create."
+                      }
+                    },
+                    "diskNamePrefix": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name prefix for the Disks to create."
+                      }
+                    },
+                    "virtualMachineName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the Azure VM to create."
+                      }
+                    },
+                    "maintenanceConfigurationAssignmentName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the Maintenance Configuration Assignment for the proxy server."
+                      }
+                    },
+                    "waitDeploymentScriptPrefixName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name prefix for the 'wait' deployment scripts to create."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "$fxv#0": "Function log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-1.log'\n    )\n\n    If (!(Test-Path -Path C:\\temp)) {\n        New-Item -Path C:\\temp -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage1] - $message\"\n}\n\n$ErrorActionPreference = 'Stop'\n\n# prep host - install hyper-v, AD, DHCP, RRAS\nlog 'Installing required features and roles...'\n$features = @('rsat-hyper-v-tools', 'rsat-clustering', 'rsat-adds', 'rsat-dns-server', 'RSAT-RemoteAccess-Mgmt', 'Routing', 'AD-Domain-Services', 'DHCP')\n$missingFeatures = Get-WindowsFeature -Name $features | Where-Object { $_.Installed -eq $false }\n\nForEach ($missingFeature in $missingFeatures) {\n    log \"Installing $($missingFeature.Name)...\"\n    Add-WindowsFeature -Name $missingFeature.Name -IncludeAllSubFeature -IncludeManagementTools\n\n    If ($?) {\n        log \"Successfully installed $($missingFeature.Name)\"\n    } Else {\n        log \"Failed to install $($missingFeature.Name)\"\n    }\n    If (Test-Path -Path C:\\Windows\\winsxs\\pending.xml) {\n        log 'Reboot required, exiting...'\n    }\n}\n\nlog 'Enabling Hyper-V...'\nEnable-WindowsOptionalFeature -Online -FeatureName 'microsoft-hyper-v-online' -All -NoRestart\n\n# create temp directory\nlog 'Creating temp directory...'\nIf (!(Test-Path -Path C:\\temp)) {\n    New-Item -Path C:\\temp -ItemType Directory\n}\n\n# create reboot status file\nIf (Test-Path -Path 'C:\\temp\\Reboot1Completed.status') {\n    log 'Reboot has already been completed, skipping...'\n} ElseIf (Test-Path -Path 'C:\\temp\\Reboot1Initiated.status') {\n    log 'Reboot has already been initiated, skipping...'\n} Else {\n    log 'Reboot required, creating status file...'\n    Set-Content -Path 'C:\\temp\\Reboot1Required.status' -Value 'Reboot 1 Required'\n}\n",
+                    "$fxv#1": "Function log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-2.log'\n    )\n\n    If (!(Test-Path -Path C:\\temp)) {\n        New-Item -Path C:\\temp -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage2] - $message\"\n}\n\n$ErrorActionPreference = 'Stop'\n\n# check for reboot status file, reboot if needed\nIf (Test-Path -Path 'C:\\temp\\Reboot1Required.status') {\n    log 'Reboot 1 is required'\n\n    Remove-Item 'C:\\temp\\Reboot1Required.status'\n    Set-Content -Path 'C:\\temp\\Reboot1Initiated.status' -Value 'Reboot 1 Initiated'\n\n    # use scheduled task to reboot the machine, ensuring the runCommand exits gracefully\n    $action = New-ScheduledTaskAction -Execute 'shutdown.exe' -Argument '-r -f -t 0'\n    $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(2)\n    $principal = New-ScheduledTaskPrincipal -UserId 'NT AUTHORITY\\SYSTEM' -LogonType ServiceAccount\n    $task = New-ScheduledTask -Action $action -Description 'Reboot 1' -Trigger $trigger -Principal $principal\n    Register-ScheduledTask -TaskName 'Reboot1' -InputObject $task\n} ElseIf (Test-Path -Path 'C:\\temp\\Reboot1Initiated.status') {\n    log 'Reboot 1 has been initiated and now completed'\n\n    Remove-Item 'C:\\temp\\Reboot1Initiated.status'\n    Set-Content -Path 'C:\\temp\\Reboot1Completed.status' -Value 'Reboot 1 Completed'\n\n\n} ElseIf (Test-Path -Path 'C:\\temp\\Reboot1Completed.status') {\n    log 'Reboot 1 has been completed'\n\n}\n",
+                    "$fxv#2": "[CmdletBinding()]\nparam (\n    [Parameter()]\n    [string]\n    $hciVHDXDownloadURL,\n\n    [Parameter()]\n    [string]\n    $hciISODownloadURL,\n\n    [Parameter()]\n    [ValidateRange(1, 16)]\n    [int]\n    $hciNodeCount\n)\nFunction log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-3.log'\n    )\n\n    If (!(Test-Path -Path C:\\temp)) {\n        New-Item -Path C:\\temp -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage3] - $message\"\n}\n\nFunction Test-ADConnection {\n    try {\n        If ((Get-Service -Name 'ADWS' -ErrorAction SilentlyContinue).Status -ne 'Running') { return $false }\n        $env:ADPS_LoadDefaultDrive = 0\n        Import-Module -Name ActiveDirectory -ErrorAction Stop\n        [bool](Get-ADDomainController -Server $env:COMPUTERNAME -ErrorAction SilentlyContinue)\n    } catch {\n        $false\n    }\n}\n\n# THANKS https://github.com/bfrankMS/CreateHypervVms/blob/master/Scenario-AzStackHCI/CreateVhdxFromIso.ps1\nFunction New-VHDXFromISO {\n    # Parameter help description\n    param(\n        [Parameter(ParameterSetName = 'SRC', Mandatory = $true, ValueFromPipeline = $true)]\n        [Alias('ISO')]\n        [string]\n        [ValidateNotNullOrEmpty()]\n        [ValidateScript({ Test-Path $(Resolve-Path $_) })]\n        $IsoPath,\n\n        [Parameter(ParameterSetName = 'SRC')]\n        [Alias('VHD')]\n        [string]\n        [ValidateNotNullOrEmpty()]\n        $VhdxPath,\n\n        [Parameter(ParameterSetName = 'SRC')]\n        [Alias('Size')]\n        [UInt64]\n        [ValidateNotNullOrEmpty()]\n        [ValidateRange(512MB, 64TB)]\n        $SizeBytes = 120GB,\n\n        [Parameter(ParameterSetName = 'SRC')]\n        [Alias('Index')]\n        [UInt64]\n        [ValidateNotNullOrEmpty()]\n        [ValidateRange(1, 10)]\n        $ImageIndex = 1          #defaults to azure stack hci on 2405 image\n    )\n\n    $BCDBoot = 'bcdboot.exe'\n    $VHDFormat = 'VHDX'\n    $TempDirectory = $env:Temp\n\n    function\n    Write-ActionInfo {\n        # Function to make the Write-Host output a bit prettier.\n        [CmdletBinding()]\n        param(\n            [Parameter(Mandatory = $true, ValueFromPipeline = $true)]\n            [string]\n            [ValidateNotNullOrEmpty()]\n            $text\n        )\n        Write-Host \"INFO   : $($text)\" -ForegroundColor White\n    }\n\n    function\n    Start-Executable {\n        <#\n          .SYNOPSIS\n              Runs an external executable file, and validates the error level.\n\n          .PARAMETER Executable\n              The path to the executable to run and monitor.\n\n          .PARAMETER Arguments\n              An array of arguments to pass to the executable when it's executed.\n\n          .PARAMETER SuccessfulErrorCode\n              The error code that means the executable ran successfully.\n              The default value is 0.\n      #>\n\n        [CmdletBinding()]\n        param(\n            [Parameter(Mandatory = $true)]\n            [string]\n            [ValidateNotNullOrEmpty()]\n            $Executable,\n\n            [Parameter(Mandatory = $true)]\n            [string[]]\n            [ValidateNotNullOrEmpty()]\n            $Arguments,\n\n            [Parameter()]\n            [int]\n            [ValidateNotNullOrEmpty()]\n            $SuccessfulErrorCode = 0\n\n        )\n\n        Write-ActionInfo \"Running $Executable $Arguments\"\n        $ret = Start-Process           `\n            -FilePath $Executable      `\n            -ArgumentList $Arguments   `\n            -NoNewWindow               `\n            -Wait                      `\n            -RedirectStandardOutput \"$($TempDirectory)\\$($scriptName)\\$($sessionKey)\\$($Executable)-StandardOutput.txt\" `\n            -RedirectStandardError \"$($TempDirectory)\\$($scriptName)\\$($sessionKey)\\$($Executable)-StandardError.txt\"  `\n            -PassThru\n\n        Write-ActionInfo \"Return code was $($ret.ExitCode).\"\n\n        if ($ret.ExitCode -ne $SuccessfulErrorCode) {\n            throw \"$Executable failed with code $($ret.ExitCode)!\"\n        }\n    }\n\n    Write-ActionInfo 'Creating virtual hard disk...'\n    $newVhd = New-VHD -Path $VhdxPath -SizeBytes $SizeBytes -Dynamic\n\n    Write-ActionInfo \"Mounting $VHDFormat...\"\n    $disk = $newVhd | Mount-VHD -Passthru | Get-Disk\n\n\n    # UEFI : 3 partitions : efi - msr - windows\n    <#https://learn.microsoft.com/de-de/windows/win32/api/winioctl/ns-winioctl-partition_information_gpt\nPARTITION_BASIC_DATA_GUID - ebd0a0a2-b9e5-4433-87c0-68b6b72699c7\nPARTITION_SYSTEM_GUID - c12a7328-f81f-11d2-ba4b-00a0c93ec93b    # EFI\nPARTITION_MSFT_RESERVED_GUID - e3c9e316-0b5c-4db8-817d-f92df00215ae  # MSR\nPARTITION_MSFT_RECOVERY_GUID - de94bba4-06d1-4d40-a16a-bfd50179d6ac   # Recovery partition (Windows) we are not using this\n#>\n\n    try {\n        Write-ActionInfo 'Initializing disk...'\n        Initialize-Disk -Number $disk.Number -PartitionStyle GPT\n\n        Write-ActionInfo 'Creating EFI system partition...'\n        $systemPartition = New-Partition -DiskNumber $disk.Number -Size 200MB -GptType '{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}'\n\n        Write-ActionInfo 'Formatting EFI system volume...'\n        $null = Format-Volume -Partition $systemPartition -FileSystem FAT32 -Force -Confirm:$false\n\n        Write-ActionInfo 'Setting EFI system partition PARTITION_SYSTEM_GUID...'\n        $systemPartition | Set-Partition -GptType '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'\n        $systemPartition | Add-PartitionAccessPath -AssignDriveLetter\n\n        # Create the reserved partition\n        Write-ActionInfo 'Creating MSR partition...'\n        $null = New-Partition -DiskNumber $disk.Number -Size 128MB -GptType '{e3c9e316-0b5c-4db8-817d-f92df00215ae}' -Verbose\n\n        # Create the Windows partition\n        Write-ActionInfo 'Creating windows partition...'\n        $windowsPartition = New-Partition -DiskNumber $disk.Number -UseMaximumSize -GptType '{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}'\n\n        Write-ActionInfo 'Formatting windows volume...'\n        $windowsVolume = Format-Volume -Partition $windowsPartition -FileSystem NTFS -Force -Confirm:$false\n\n        # Assign drive letter to Windows partition.  This is required for bcdboot\n        $windowsPartition | Add-PartitionAccessPath -AssignDriveLetter\n        $windowsDrive = $(Get-Partition -Volume $windowsVolume).AccessPaths[0].substring(0, 2)\n        Write-ActionInfo \"Windows path ($windowsDrive) has been assigned.\"\n\n        # Refresh access paths (we have now formatted the volume)\n        $systemPartition = $systemPartition | Get-Partition\n        $systemDrive = $systemPartition.AccessPaths[0].trimend('\\').replace('\\?', '??')\n        Write-ActionInfo \"System volume location: $systemDrive\"\n\n        # Mount .iso to get the install.wim\n        $beforeMount = (Get-Volume).DriveLetter -split ' '\n        $null = Mount-DiskImage -StorageType ISO -ImagePath $IsoPath\n        $afterMount = (Get-Volume).DriveLetter -split ' '\n        $setuppath = (Compare-Object $beforeMount $afterMount -PassThru )\n        Write-ActionInfo \"Mounted .iso to $($setuppath):\"\n\n        Write-ActionInfo \"Applying image from .iso $(\"$setuppath\"+':\\sources\\install.wim') to $VHDFormat. This could take a while...\"\n\n        Expand-WindowsImage -ApplyPath $windowsDrive -ImagePath \"$setuppath`:\\sources\\install.wim\" -Index $ImageIndex #-LogPath \"$($logFolder)\\DismLogs.log\" | Out-Null\n        Write-ActionInfo 'Image was applied successfully. '\n\n        Write-ActionInfo 'Making image bootable...'\n        $bcdBootArgs = @(\n            \"$($windowsDrive)\\Windows\", # Path to the \\Windows on the VHD\n            \"/s $systemDrive\", # Specifies the volume letter of the drive to create the \\BOOT folder on.\n            '/v'                        # Enabled verbose logging.\n        )\n        $bcdBootArgs += '/f UEFI'   # Specifies the firmware type of the target system partition\n\n        Start-Executable -Executable $BCDBoot -Arguments $bcdBootArgs\n\n        Write-ActionInfo 'Drive is bootable.  Cleaning up...'\n\n        # Remove system partition access path, if necessary\n        $systemPartition | Remove-PartitionAccessPath -AccessPath $systemPartition.AccessPaths[0]\n    } finally {\n        Write-ActionInfo \"Dismounting $VHDFormat...\"\n        try {\n            Dismount-VHD -Path $VhdxPath -ErrorAction Stop\n        } catch {\n            Write-ActionInfo \"WARNING: Dismount-VHD failed: $_. Continuing cleanup...\"\n        }\n\n        #ejecting .iso - releasing drive letter.\n        Write-ActionInfo 'Dismounting .iso...'\n        $dismountRetries = 3\n        for ($r = 1; $r -le $dismountRetries; $r++) {\n            try {\n                Dismount-DiskImage -ImagePath $IsoPath -ErrorAction Stop\n                Write-ActionInfo 'ISO dismounted successfully.'\n                break\n            } catch {\n                Write-ActionInfo \"Dismount-DiskImage attempt $r/$dismountRetries failed: $_\"\n                if ($r -lt $dismountRetries) {\n                    Start-Sleep -Seconds 5\n                } else {\n                    Write-ActionInfo 'WARNING: Could not dismount ISO after retries. The VHDX was created successfully; continuing.'\n                }\n            }\n        }\n    }\n}\n\n$ErrorActionPreference = 'Stop'\n\n# Clean up any leftover ISO mount from a previous failed run\nif (Test-Path 'c:\\isos\\hci_os.iso') {\n    try {\n        $diskImage = Get-DiskImage -ImagePath 'c:\\isos\\hci_os.iso' -ErrorAction SilentlyContinue\n        if ($diskImage -and $diskImage.Attached) {\n            log 'Found leftover mounted ISO from previous run, dismounting...'\n            Dismount-DiskImage -ImagePath 'c:\\isos\\hci_os.iso' -ErrorAction SilentlyContinue\n        }\n    } catch {\n        log \"WARNING: Could not check/dismount leftover ISO: $_\"\n    }\n}\n\n# download HCI VHDX or ISO\nIf (!(Test-Path -Path 'c:\\ISOs')) {\n    log 'Creating c:\\ISOs directory...'\n    mkdir c:\\ISOs\n} Else {\n    log 'ISOs directory already exists, skipping...'\n}\n\nIf ($hciVHDXDownloadURL) {\n    log 'Downloading HCI VHDX...'\n    If (! (Test-Path c:\\ISOs\\hci_os.vhdx)) {\n        [System.Net.WebClient]::new().DownloadFile($hciVHDXDownloadURL, 'c:\\isos\\hci_os.vhdx')\n    } Else {\n        log 'HCI VHDX already exists, skipping download...'\n    }\n} ElseIf ($hciISODownloadURL) {\n    log 'Downloading HCI ISO...'\n    If (! (Test-Path c:\\ISOs\\hci_os.iso)) {\n        [System.Net.WebClient]::new().DownloadFile($hciISODownloadURL, 'c:\\isos\\hci_os.iso')\n    } Else {\n        log 'HCI ISO already exists, skipping download...'\n    }\n\n    # convert ISO to VHDX\n    If (!(Test-Path 'c:\\isos\\hci_os.vhdx')) {\n        log 'Converting ISO to VHDX...'\n        New-VHDXFromISO -IsoPath 'c:\\isos\\hci_os.iso' -VhdxPath 'c:\\isos\\hci_os.vhdx'\n    } Else {\n        log 'HCI VHDX already exists, skipping conversion...'\n\n    }\n} Else {\n    log 'No download URL provided, cannot continue...'\n    Write-Error 'No download URL provided, cannot continue...' -ErrorAction Stop\n}\n\n# create mount point directories on C:\\\nlog 'Creating mount points...'\nFor ($i = 0; $i -lt $hciNodeCount; $i++) {\n    $dirPath = \"c:\\diskmounts\\hcinode$($i + 1)\"\n    If (!(Test-Path -Path $dirPath)) {\n        mkdir $dirPath\n    } Else {\n        log \"Mount point '$dirPath' already exists, skipping...\"\n    }\n}\n\n# format and mount disks\nlog 'Formatting and mounting disks...'\n$count = 0\n$rawDisks = Get-Disk | Where-Object PartitionStyle -EQ 'RAW'\n$rawDisks |\n    Initialize-Disk -PartitionStyle GPT -PassThru |\n    New-Partition -UseMaximumSize -AssignDriveLetter:$false |\n    Format-Volume -FileSystem NTFS |\n    Get-Partition |\n    Where-Object { $_.type -ne 'Reserved' } |\n    ForEach-Object { $count++; mountvol c:\\diskMounts\\HCINode$count $_.accesspaths[0] }\n\nlog 'Copying VHDX to mount points...'\nFor ($i = 0; $i -lt $hciNodeCount; $i++) {\n    If (!(Test-Path -Path \"c:\\diskmounts\\hcinode$($i + 1)\\hci_os.vhdx\")) {\n        Copy-Item -Path c:\\isos\\hci_os.vhdx -Destination \"c:\\diskmounts\\hcinode$($i + 1)\"\n    } Else {\n        log \"HCI VHDX already exists at 'c:\\diskmounts\\hcinode$($i + 1)', skipping...\"\n    }\n}\n\n# install RRAS configure for routing\nlog 'Installing RRAS and configuring for routing...'\nWhile (!(Test-Path -Path 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules\\RemoteAccess\\RemoteAccess.psd1')) {\n    Start-Sleep -Seconds 5\n    log 'Waiting for RRAS module to be available...'\n}\nImport-Module 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules\\RemoteAccess\\RemoteAccess.psd1'\nInstall-RemoteAccess -VpnType RoutingOnly\nSet-Service -Name RemoteAccess -StartupType Automatic -PassThru | Start-Service\n\n# install domain controller\nlog 'Checking whether AD is installed...'\nIf (!(Test-ADConnection)) {\n    log 'AD is not installed, installing...'\n    Import-Module 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules\\ADDSDeployment\\ADDSDeployment.psd1'\n\n    $ADRecoveryPassword = ConvertTo-SecureString -Force -AsPlainText (New-Guid).guid\n    Install-ADDSForest -DomainName hci.local -DomainNetbiosName hci -ForestMode Default -DomainMode Default -InstallDns:$true -SafeModeAdministratorPassword $ADRecoveryPassword -NoRebootOnCompletion:$true -Force:$true\n} Else {\n    log 'AD is already installed, skipping...'\n}\n\nlog 'Adding DNS forwarders...'\nImport-Module 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules\\DnsServer\\DnsServer.psd1'\nAdd-DnsServerForwarder -IPAddress 8.8.8.8\n\n# create reboot status file\nIf (Test-Path -Path 'C:\\temp\\Reboot2Completed.status') {\n    log 'Reboot has already been completed, skipping...'\n} ElseIf (Test-Path -Path 'C:\\temp\\Reboot2Initiated.status') {\n    log 'Reboot has already been initiated, skipping...'\n} Else {\n    log 'Reboot required, creating status file...'\n    Set-Content -Path 'C:\\temp\\Reboot2Required.status' -Value 'Reboot 2 Required'\n}\n",
+                    "$fxv#3": "\nFunction log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-4.log'\n    )\n\n    If (!(Test-Path -Path C:\\temp)) {\n        New-Item -Path C:\\temp -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage4] - $message\"\n}\n\n$ErrorActionPreference = 'Stop'\n\n# check for reboot status file, reboot if needed\nIf (Test-Path -Path 'C:\\temp\\Reboot2Required.status') {\n    log 'Reboot 2 is required'\n\n    Remove-Item 'C:\\temp\\Reboot2Required.status'\n    Set-Content -Path 'C:\\temp\\Reboot2Initiated.status' -Value 'Reboot 2 Initiated'\n\n    # use scheduled task to reboot the machine, ensuring the runCommand exits gracefully\n    $action = New-ScheduledTaskAction -Execute 'shutdown.exe' -Argument '-r -f -t 0'\n    $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(2)\n    $principal = New-ScheduledTaskPrincipal -UserId 'NT AUTHORITY\\SYSTEM' -LogonType ServiceAccount\n    $task = New-ScheduledTask -Action $action -Description 'Reboot 2' -Trigger $trigger -Principal $principal\n    Register-ScheduledTask -TaskName 'Reboot2' -InputObject $task\n\n} ElseIf (Test-Path -Path 'C:\\temp\\Reboot2Initiated.status') {\n    log 'Reboot 2 has been initiated and now completed'\n\n    Remove-Item 'C:\\temp\\Reboot2Initiated.status'\n    Set-Content -Path 'C:\\temp\\Reboot2Completed.status' -Value 'Reboot 2 Completed'\n\n} ElseIf (Test-Path -Path 'C:\\temp\\Reboot2Completed.status') {\n    log 'Reboot 2 has been completed'\n\n}\n",
+                    "$fxv#4": "[CmdletBinding()]\nparam (\n    [Parameter()]\n    [string]\n    $adminUsername,\n\n    [Parameter()]\n    [string]\n    $adminPw,\n\n    [Parameter()]\n    [int]\n    $hciNodeCount,\n\n    [Parameter()]\n    [string]\n    $switchlessStorageConfig = 'switched'\n)\n\nFunction log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-5.log'\n    )\n\n    If (!(Test-Path -Path C:\\temp)) {\n        New-Item -Path C:\\temp -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage5] - $message\"\n}\n\nFunction Test-ADConnection {\n    try {\n        If ((Get-Service -Name 'ADWS' -ErrorAction SilentlyContinue).Status -ne 'Running') { return $false }\n        $env:ADPS_LoadDefaultDrive = 0\n        Import-Module -Name ActiveDirectory -ErrorAction Stop\n        [bool](Get-ADDomainController -Server $env:COMPUTERNAME -ErrorAction SilentlyContinue)\n    } catch {\n        $false\n    }\n}\n\n$ErrorActionPreference = 'Stop'\n\n# create hyperv switches\nlog 'Creating Hyper-V switches...'\n$existingSwitches = Get-VMSwitch\n\nIf ($switchlessStorageConfig -eq 'switched') {\n    log 'Creating Hyper-V switches for switched storage configuration...'\n    If ($existingSwitches.Name -notcontains 'external' ) { New-VMSwitch -Name external -AllowManagementOS:$true -NetAdapterName Ethernet }\n    If ($existingSwitches.Name -notcontains 'hciNodeMgmtInternal' ) { New-VMSwitch -Name hciNodeMgmtInternal -SwitchType Internal -EnableIov $true }\n    If ($existingSwitches.Name -notcontains 'hciNodeStoragePrivate' ) { New-VMSwitch -Name hciNodeStoragePrivate -SwitchType Private -EnableIov $true }\n} ElseIf ($switchlessStorageConfig -eq 'switchless') {\n    If ($hciNodeCount -gt 3) {\n        log -message 'ERROR: Switchless storage configuration is only supported for 3 or fewer HCI nodes. Exiting script...'\n        Write-Error 'ERROR: Switchless storage configuration is only supported for 3 or fewer HCI nodes. Exiting script...'\n        exit 1\n    }\n\n    log 'Creating Hyper-V switches for switchless storage configuration...'\n    If ($existingSwitches.Name -notcontains 'external' ) { New-VMSwitch -Name external -AllowManagementOS:$true -NetAdapterName Ethernet }\n    If ($existingSwitches.Name -notcontains 'hciNodeMgmtInternal' ) { New-VMSwitch -Name hciNodeMgmtInternal -SwitchType Internal -EnableIov $true }\n    If ($existingSwitches.Name -notcontains 'hciNodeStoragePrivateA' ) { New-VMSwitch -Name hciNodeStoragePrivateA -SwitchType Private -EnableIov $true }\n    If ($existingSwitches.Name -notcontains 'hciNodeStoragePrivateB' ) { New-VMSwitch -Name hciNodeStoragePrivateB -SwitchType Private -EnableIov $true }\n    If ($existingSwitches.Name -notcontains 'hciNodeStoragePrivateC' ) { New-VMSwitch -Name hciNodeStoragePrivateC -SwitchType Private -EnableIov $true }\n}\n\n# add IPs for host\nlog 'Adding IPs for host...'\n$existingIPs = Get-NetIPAddress\nIf ($existingIPs.IPAddress -notcontains '172.20.0.1') { New-NetIPAddress -InterfaceAlias 'vEthernet (hciNodeMgmtInternal)' -IPAddress 172.20.0.1 -PrefixLength 24 }\n\n# configure NAT\nlog 'Restarting RemoteAccess service...'\nRestart-Service RemoteAccess\n\nlog 'Configuring NAT...'\n\nnetsh routing ip nat uninstall\nnetsh routing ip nat install\nnetsh routing ip nat set global tcptimeoutmins=1440 udptimeoutmins=1 loglevel=ERROR\nnetsh routing ip nat add interface name=\"vEthernet (external)\" mode=FULL\nIf (!$?) {\n    $message = \"Failed to run netsh command: ''netsh routing ip nat add interface name='vEthernet (external)' mode=FULL''.\"\n    log $message\n    Write-Error $message\n}\nnetsh routing ip nat add interface name=\"vEthernet (hciNodeMgmtInternal)\" mode=PRIVATE\nIf (!$?) {\n    $message = \"Failed to run netsh command: ''netsh routing ip nat add interface name='vEthernet (hciNodeMgmtInternal)' mode=PRIVATE''.\"\n    log $message\n    Write-Error $message\n}\n\n# Verify and retry NAT configuration (JumpStart-inspired reliability pattern)\nlog 'Verifying NAT configuration with retry...'\n$natRetryCount = 0\n$natMaxRetries = 3\nwhile ($natRetryCount -lt $natMaxRetries) {\n    Start-Sleep -Seconds 10\n    $natInterfaces = netsh routing ip nat show interface\n    if ($natInterfaces -match 'external' -and $natInterfaces -match 'hciNodeMgmtInternal') {\n        log \"NAT configuration verified successfully (attempt $($natRetryCount + 1))\"\n        break\n    }\n    $natRetryCount++\n    log \"NAT verification failed (attempt $natRetryCount/$natMaxRetries). Retrying NAT setup...\"\n    Restart-Service RemoteAccess -Force\n    Start-Sleep -Seconds 15\n    netsh routing ip nat uninstall\n    netsh routing ip nat install\n    netsh routing ip nat set global tcptimeoutmins=1440 udptimeoutmins=1 loglevel=ERROR\n    netsh routing ip nat add interface name=\"vEthernet (external)\" mode=FULL\n    netsh routing ip nat add interface name=\"vEthernet (hciNodeMgmtInternal)\" mode=PRIVATE\n}\nif ($natRetryCount -ge $natMaxRetries) {\n    log 'WARNING: NAT configuration could not be fully verified after retries. Proceeding anyway...'\n}\n\n# create DHCP scopes\nlog 'Creating DHCP scopes...'\n$existingScopes = Get-DhcpServerv4Scope\nIf ($existingScopes.name -notcontains 'HCIMgmt') { Add-DhcpServerv4Scope -StartRange 172.20.0.10 -EndRange 172.20.0.250 -Name HCIMgmt -State Active -SubnetMask 255.255.255.0 }\n\n# exclude LCM IP range from DHCP to prevent conflicts during Azure Local cluster deployment\ntry { Add-DhcpServerv4ExclusionRange -ScopeId 172.20.0.0 -StartRange 172.20.0.50 -EndRange 172.20.0.70 } catch { log \"DHCP exclusion range already exists or failed: $_\" }\n\n# test DC connectivity before attempting to authorize DHCP server in AD\nlog 'Testing DC connectivity...'\n$count = 0\nWhile (!(Test-ADConnection) -and $count -lt 120) {\n    Start-Sleep -Seconds 5\n    log 'Waiting for AD Web Services to be available...'\n    $count++\n}\n\n# authorize DHCP servers in AD for DNS updates\nlog 'Authorizing DHCP servers in AD for DNS updates...'\ntry {\n    $existingAuthorizedServers = Get-DhcpServerInDC -ErrorAction Stop\n} catch {\n    log 'Failed to query authorized DHCP servers in AD. Waiting 120 seconds before retrying...'\n    Start-Sleep -Seconds 120\n    $existingAuthorizedServers = Get-DhcpServerInDC\n}\n\nIf ($existingAuthorizedServers.IPAddress -notcontains '172.20.0.1') { Add-DhcpServerInDC -DnsName \"$($env:COMPUTERNAME).hci.local\" -IPAddress 172.20.0.1 }\n\n# set router and dns options for mgmt DHCP scope\nlog 'Setting router and dns options for mgmt DHCP scope...'\nSet-DhcpServerv4OptionValue -ScopeId 172.20.0.0 -DnsDomain hci.local -DnsServer 172.20.0.1 -Router 172.20.0.1\n\n# create HCI node VMs\nlog 'Creating HCI node VMs...'\n$existingVMs = Get-VM\nFor ($i = 1; $i -le $hciNodeCount; $i++) {\n    $hciNodeName = \"hcinode$i\"\n    $hciNodePath = \"C:\\diskMounts\\$hciNodeName\"\n\n    If ($existingVMs.name -notcontains $hciNodeName) { New-VM -Name $hciNodeName -MemoryStartupBytes 32GB -BootDevice VHD -SwitchName hciNodeMgmtInternal -Path C:\\diskMounts\\ -VHDPath \"$hciNodePath\\hci_os.vhdx\" -Generation 2 }\n}\n\n# configure HCI node VMs\nlog 'Configuring HCI node VMs...'\nlog 'Setting VM processor count to 16 and enabling virtualization extensions...'\nGet-VM | Set-VMProcessor -ExposeVirtualizationExtensions $true -Count 8\n\nlog 'Setting VM key protector and enabling TPM...'\nGet-VM | ForEach-Object {\n    If (($_ | Get-VMKeyProtector).Length -eq 4) {\n        log \"Adding key protector for VM '$($_.Name)'\"\n        $_ | Set-VMKeyProtector -NewLocalKeyProtector\n    } Else {\n        log \"Key protector already exists for VM '$($_.Name)'\"\n    }\n\n    If (($_ | Get-VMSecurity).TpmEnabled -eq $false) {\n        log \"Enabling TPM for VM '$($_.Name)'\"\n        $_ | Enable-VMTPM\n    } Else {\n        log \"TPM already enabled for VM '$($_.Name)'\"\n    }\n}\n\n\n# rename first NIC to FABRIC (matches Azure Local ManagementCompute intent)\nlog 'Renaming first network adapter on HCI nodes to FABRIC...'\nif (Get-VMNetworkAdapter -Name 'Network Adapter' -VMName * -ErrorAction SilentlyContinue) { Rename-VMNetworkAdapter -NewName FABRIC -VMName * -Name 'Network Adapter' }\nGet-VM | Get-VMNetworkAdapter -Name 'FABRIC' | Set-VMNetworkAdapter -DeviceNaming On\n\n# add additional NICs to HCI node VMs (FABRIC2 for ManagementCompute, StorageA/StorageB for Storage intent)\nlog 'Adding additional NICs to HCI node VMs...'\nForEach ($existingVM in (Get-VM)) {\n    $existingNICs = Get-VMNetworkAdapter -VM $existingVM\n    # FABRIC2 on management switch - paired with FABRIC for ManagementCompute intent\n    If ($existingNICs.name -notcontains 'FABRIC2') { $existingVM | Add-VMNetworkAdapter -Name FABRIC2 -SwitchName hciNodeMgmtInternal -DeviceNaming On }\n\n    If ($switchlessStorageConfig -eq 'switched') {\n        log \"Adding storage NICs to VM '$($existingVM.name)' for switched storage configuration...\"\n        If ($existingNICs.name -notcontains 'StorageA') { $existingVM | Add-VMNetworkAdapter -Name StorageA -SwitchName hciNodeStoragePrivate -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n        If ($existingNICs.name -notcontains 'StorageB') { $existingVM | Add-VMNetworkAdapter -Name StorageB -SwitchName hciNodeStoragePrivate -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '712' -NativeVlanId 0 }\n    } ElseIf ($switchlessStorageConfig -eq 'switchless') {\n        log \"Adding storage NICs to VM '$($existingVM.name)' for switchless storage configuration...\"\n\n        switch ($existingVM.Name[-1]) {\n            1 {\n                If ($existingNICs.name -notcontains 'StorageA') { $existingVM | Add-VMNetworkAdapter -Name StorageA -SwitchName hciNodeStoragePrivateA -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n                If ($existingNICs.name -notcontains 'StorageB') { $existingVM | Add-VMNetworkAdapter -Name StorageB -SwitchName hciNodeStoragePrivateB -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n            }\n            2 {\n                If ($existingNICs.name -notcontains 'StorageA') { $existingVM | Add-VMNetworkAdapter -Name StorageA -SwitchName hciNodeStoragePrivateA -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n                If ($existingNICs.name -notcontains 'StorageB') { $existingVM | Add-VMNetworkAdapter -Name StorageB -SwitchName hciNodeStoragePrivateC -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n            }\n            3 {\n                If ($existingNICs.name -notcontains 'StorageA') { $existingVM | Add-VMNetworkAdapter -Name StorageA -SwitchName hciNodeStoragePrivateB -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n                If ($existingNICs.name -notcontains 'StorageB') { $existingVM | Add-VMNetworkAdapter -Name StorageB -SwitchName hciNodeStoragePrivateC -DeviceNaming On -Passthru | Set-VMNetworkAdapterVlan -Trunk -AllowedVlanIdList '711' -NativeVlanId 0 }\n            }\n            Default {}\n        }\n    }\n}\n\n# add disks to HCI node VMs\nlog 'Adding disks to HCI node VMs...'\nForeach ($vm in (Get-VM)) {\n    (1..4) | ForEach-Object {\n        $diskPath = \"C:\\diskMounts\\$($vm.Name)\\hciNodeDisk$($_).vhdx\"\n        If (!(Test-Path -Path $diskPath)) {\n            log \"Creating disk: $diskPath\"\n            New-VHD -Path $diskPath -SizeBytes 1TB -Dynamic | Out-Null\n        }\n        If ($VM.HardDrives.Path -notcontains $diskPath) {\n            log \"Adding disk: $diskPath to VM: $($vm.Name)\"\n            Add-VMHardDiskDrive -VMName $vm.Name -ControllerType SCSI -ControllerNumber 0 -ControllerLocation $_ -Path $diskPath | Out-Null\n        }\n    }\n}\n\n# enable mac soofing on HCI node VMs\nlog 'Enabling MAC spoofing on HCI node VMs...'\nGet-VM | Get-VMNetworkAdapter | Set-VMNetworkAdapter -MacAddressSpoofing On\n\n# define unattend.xml for HCI node VMs template\n$unattendSource = @'\n<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<unattend xmlns=\"urn:schemas-microsoft-com:unattend\">\n    <settings pass=\"specialize\">\n        <component name=\"Microsoft-Windows-Shell-Setup\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <ComputerName>$hciNodeName</ComputerName>\n            <RegisteredOrganization>Organization</RegisteredOrganization>\n            <RegisteredOwner>Owner</RegisteredOwner>\n            <TimeZone>UTC</TimeZone>\n        </component>\n        <component name=\"Microsoft-Windows-IE-ESC\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <IEHardenAdmin>false</IEHardenAdmin>\n        </component>\n        <component name=\"Microsoft-Windows-ErrorReportingCore\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <DisableWER>1</DisableWER>\n        </component>\n        <component name=\"Microsoft-Windows-TerminalServices-LocalSessionManager\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <fDenyTSConnections>false</fDenyTSConnections>\n        </component>\n        <component name=\"Microsoft-Windows-TCPIP\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <Interfaces>\n                <Interface wcm:action=\"add\">\n                    <Ipv4Settings>\n                        <DhcpEnabled>true</DhcpEnabled>\n                    </Ipv4Settings>\n                </Interface>\n            </Interfaces>\n        </component>\n    </settings>\n    <settings pass=\"oobeSystem\">\n        <component name=\"Microsoft-Windows-Shell-Setup\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <OOBE>\n                <HideEULAPage>true</HideEULAPage>\n                <HideLocalAccountScreen>true</HideLocalAccountScreen>\n                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>\n                <NetworkLocation>Work</NetworkLocation>\n                <ProtectYourPC>1</ProtectYourPC>\n            </OOBE>\n            <FirstLogonCommands>\n                <SynchronousCommand wcm:action=\"add\">\n                    <CommandLine>powershell.exe -command &quot;Get-NetAdapterAdvancedProperty -DisplayName 'Hyper-V Network Adapter Name' | Foreach-Object {`$_ | Get-NetAdapter | Rename-NetAdapter -NewName `$_.DisplayValue}&quot;</CommandLine>\n                    <Order>1</Order>\n                    <RequiresUserInput>false</RequiresUserInput>\n                </SynchronousCommand>\n                <SynchronousCommand wcm:action=\"add\">\n                    <CommandLine>powershell.exe -command &quot;Enable-WindowsOptionalFeature -Online -FeatureName 'microsoft-hyper-v-online' -all -NoRestart&quot;</CommandLine>\n                    <Order>2</Order>\n                    <RequiresUserInput>false</RequiresUserInput>\n                </SynchronousCommand>\n                <SynchronousCommand wcm:action=\"add\">\n                <CommandLine>powershell.exe -command &quot;Remove-Item -Path &apos;C:\\unattend.xml&apos; -Force&quot;</CommandLine>\n                <Order>3</Order>\n                <RequiresUserInput>false</RequiresUserInput>\n            </SynchronousCommand>\n                <SynchronousCommand wcm:action=\"add\">\n                    <CommandLine>shutdown -r -f -t 0</CommandLine>\n                    <Order>4</Order>\n                    <RequiresUserInput>false</RequiresUserInput>\n            </SynchronousCommand>\n            </FirstLogonCommands>\n            <AutoLogon>\n                <Username>Administrator</Username>\n                <Enabled>true</Enabled>\n                <LogonCount>1</LogonCount>\n                <Password>\n                    <Value>$adminPw</Value>\n                    <PlainText>true</PlainText>\n                </Password>\n            </AutoLogon>\n            <UserAccounts>\n                <AdministratorPassword>\n                    <Value>$adminPw</Value>\n                    <PlainText>True</PlainText>\n                </AdministratorPassword>\n                <LocalAccounts>\n                <LocalAccount wcm:action=\"add\">\n                   <Password>\n                      <Value>$adminPw</Value>\n                      <PlainText>true</PlainText>\n                   </Password>\n                   <Description>HCI Admin User</Description>\n                   <DisplayName>$adminUsername</DisplayName>\n                   <Group>Administrators;Power Users</Group>\n                   <Name>$adminUsername</Name>\n                </LocalAccount>\n                </LocalAccounts>\n            </UserAccounts>\n        </component>\n        <component name=\"Microsoft-Windows-International-Core\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <InputLocale>en-us</InputLocale>\n            <SystemLocale>en-us</SystemLocale>\n            <UILanguage>en-us</UILanguage>\n            <UILanguageFallback>en-us</UILanguageFallback>\n            <UserLocale>en-us</UserLocale>\n        </component>\n    </settings>\n</unattend>\n'@\n\n# inject updated sysp answer file into each HCI node disk\nlog 'Injecting updated sysprep answer file into each HCI node disk...'\nFor ($i = 1; $i -le $hciNodeCount; $i++) {\n    $hciNodeName = \"hciNode$i\"\n    $hciProductKey = ''\n\n    Push-Location c:\\diskMounts\\$hciNodeName\n\n    If (!(Test-Path -Path unattend_injected.status) -and (Get-VM -Name $hciNodeName).State -eq 'Off') {\n        log \"Injecting unattend.xml into HCI node disk '$hciNodeName'...\"\n        $mountedVolume = Mount-VHD .\\hci_os.vhdx -Passthru | Get-Disk | Get-Partition | Get-Volume | Where-Object FileSystemType -EQ 'NTFS'\n\n        $clone = $unattendSource.psobject.copy()\n        $clone = $ExecutionContext.InvokeCommand.ExpandString($clone)\n\n        Set-Content -Path \"$($mountedVolume.DriveLetter):\\unattend.xml\" -Value $clone -Force\n\n        Dismount-VHD .\\hci_os.vhdx\n\n        Set-Content 'unattend_injected.status' -Value 'Unattend.xml injected'\n    } Else {\n        log \"Unattend.xml already injected into HCI node disk '$hciNodeName'.\"\n    }\n\n    Pop-Location\n}\n\n# start HCI node VMs\nIf (Get-VM | Where-Object State -EQ 'Off') {\n    log 'Starting HCI node VMs...'\n    try {\n        $errorActionPreference = 'Stop'\n        Get-VM | Start-VM\n    } catch {\n        log \"Failed to start HCI node VMs. $_\"\n        Write-Error \"Failed to start HCI node VMs. $_\"\n    }\n\n    #wait for vms to boot\n    log 'Waiting 300s for VMs to boot and apply sysprep...'\n    Start-Sleep -Seconds 300\n} Else {\n    log 'HCI node VMs are already running.'\n}\n\n# create DHCP reservations for HCI node VMs management interfaces\nlog 'Checking DHCP reservations for HCI node VMs management interfaces...'\n$existingReservations = Get-DhcpServerv4Reservation -ScopeId 172.20.0.0\nFor ($i = 1; $i -le $hciNodeCount; $i++) {\n    $hciNodeName = \"hciNode$i\"\n    $hciNodeIP = \"172.20.0.$(9 + $i)\"\n    If ($existingReservations.Description -notcontains $hciNodeName) {\n        log \"Creating DHCP reservation for HCI node '$hciNodeName' with IP '$hciNodeIP'...\"\n\n        $fabricNIC = Get-VMNetworkAdapter -VMName $hciNodeName -Name FABRIC\n\n        If ($fabricNIC) {\n            $fabricMac = $fabricNIC.MacAddress -split '(.{2})' -ne '' -join '-'\n\n            log \"Creating DHCP reservation for HCI node '$hciNodeName' with IP '$hciNodeIP' for MAC address '$fabricMac'...\"\n            Add-DhcpServerv4Reservation -ScopeId 172.20.0.0 -Name $hciNodeName -IPAddress $hciNodeIP -ClientId $fabricMac -Description $hciNodeName\n        } Else {\n            log \"Failed to create DHCP reservation for HCI node '$hciNodeName'. Could not find NIC named 'FABRIC'.\"\n            Write-Error \"Failed to create DHCP reservation for HCI node '$hciNodeName'. Could not find NIC named 'FABRIC'.\"\n            exit 1\n        }\n    } Else {\n        log \"DHCP reservation for HCI node '$hciNodeName' already exists.\"\n    }\n}\n",
+                    "$fxv#5": "[CmdletBinding()]\nparam (\n    [Parameter()]\n    [String]\n    $resourceGroupName,\n\n    [Parameter()]\n    [String]\n    $subscriptionId,\n\n    [Parameter()]\n    [String]\n    $tenantId,\n\n    [Parameter()]\n    [String]\n    $location,\n\n    [Parameter()]\n    [String]\n    $accountName,\n\n    [Parameter()]\n    [String]\n    $adminUsername,\n\n    [Parameter()]\n    [String]\n    $adminPw,\n\n    [Parameter()]\n    [String]\n    $arcGatewayId,\n\n    [Parameter()]\n    [String]\n    $domainOUPath = 'OU=HCI,DC=HCI,DC=local',\n\n    [Parameter()]\n    [string]\n    $deploymentUsername,\n\n    [Parameter()]\n    [string]\n    $proxyServerEndpoint, #http://[Proxy_Server_Address]:[Proxy_Port],\n\n    [parameter()]\n    [string]\n    $proxyBypassString, #\"localhost;127.0.0.1;*.contoso.com;node1;node2;192.168.1.*;s-cluster\",\n\n    [Parameter()]\n    [string]\n    $userAssignedManagedIdentityClientId\n)\n\nFunction log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-6.log'\n    )\n\n    If (!(Test-Path -Path 'C:\\temp')) {\n        New-Item -Path 'C:\\temp' -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage6] - $message\"\n}\n\n$ErrorActionPreference = 'Stop'\n\n# export or re-import local administrator credential\n# we do this to support re-run of the template. If deployed, the HCI node password will be set to the password provided in the template, but future re-runs will generate a new password.\nIf (!(Test-Path -Path 'C:\\temp\\hciHostDeployAdminCred.xml')) {\n    log \"Exporting local '$($adminUsername)' credential (for re-use if script is re-run)...\"\n    $adminCred = [pscredential]::new($adminUsername, (ConvertTo-SecureString -AsPlainText -Force $adminPw))\n    $adminCred | Export-Clixml -Path 'C:\\temp\\hciHostDeployAdminCred.xml'\n} Else {\n    log \"Re-importing local '$($adminUsername)' credential...\"\n    $adminCredOld = Import-Clixml -Path 'C:\\temp\\hciHostDeployAdminCred.xml'\n\n    $newCredFileName = 'hciHostDeployAdminCred_{0}.xml' -f (Get-Date -Format 'yyyyMMddHHmmss')\n    log \"Renaming the old credential file to '$newCredFileName' prevent overwriting...\"\n    Rename-Item -Path 'C:\\temp\\hciHostDeployAdminCred.xml' -NewName $newCredFileName\n\n    log \"Exporting local '$($adminUsername)' credential (for re-use if script is re-run)...\"\n    $adminCred = [pscredential]::new($adminUsername, (ConvertTo-SecureString -AsPlainText -Force $adminPw))\n    $adminCred | Export-Clixml -Path 'C:\\temp\\hciHostDeployAdminCred.xml'\n}\n\nIf (!(Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) { Register-PSRepository -Default }\nIf (!(Get-PackageProvider -Name Nuget -ListAvailable -ErrorAction SilentlyContinue)) { Install-PackageProvider -Name NuGet -Confirm:$false -Force }\nSet-PSRepository -Name PSGallery -InstallationPolicy Trusted\n\nInstall-Module Az\n\n# get an access token for the VM MSI, which has been granted rights and will be used for the HCI Arc Initialization\nlog \"Logging in to Azure with user-assigned managed identity '$($userAssignedManagedIdentityClientId)'...\"\nLogin-AzAccount -Identity -Subscription $subscriptionId -AccountId $userAssignedManagedIdentityClientId\n\nlog 'Getting access token for Azure Stack HCI Arc initialization...'\n$tokenResult = Get-AzAccessToken -ResourceUrl 'https://management.azure.com'\n# Handle both old (plain string) and new (SecureString) Az.Accounts token formats\nif ($tokenResult.Token -is [System.Security.SecureString]) {\n    $t = [System.Net.NetworkCredential]::new('', $tokenResult.Token).Password\n} else {\n    $t = $tokenResult.Token\n}\n\n# pre-create AD objects\nlog 'Pre-creating AD objects with deployment username '$deploymentUsername'...'\n$deployUserCred = [pscredential]::new($deploymentUsername, (ConvertTo-SecureString -AsPlainText -Force $adminPw))\n\nInstall-Module AsHciADArtifactsPreCreationTool\nNew-HciAdObjectsPreCreation -AzureStackLCMUserCredential $deployUserCred -AsHciOUName $domainOUPath\n\n## set the LCM deployUser password to the adminPw value - this aligns the password with the KeyVault during re-runs\nlog \"Setting deploy user '$deploymentUsername's password...\"\nSet-AdAccountPassword -Identity $deploymentUsername -NewPassword (ConvertTo-SecureString -AsPlainText -Force $adminPw) -Reset -Confirm:$false\n\n# initialize arc on hci nodes\nlog 'Initializing Azure Arc on HCI nodes...'\n\n# wait for VMs to reach 'Running' state\nlog 'Checking that VMs are running...'\n$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()\nwhile ((Get-VM | Where-Object State -NE 'Running') -and $stopwatch.Elapsed.TotalMinutes -lt 15) {\n    log \"Waiting for HCI node VMs to reach 'Running' state. Current state: $((Get-VM) | Select-Object Name,State)...\"\n    Start-Sleep -Seconds 30\n}\n\nIf ($stopwatch.Elapsed.TotalMinutes -ge 15) {\n    log \"HCI node VMs did not reach 'Running' state within 15 minutes. Exiting...\"\n    Write-Error \"HCI node VMs did not reach 'Running' state within 15 minutes. Exiting...\"\n    Exit 1\n}\n\nlog \"Creating PSSessions to HCI nodes [$((Get-VM).Name -join ',')]...\"\ntry {\n    $VMs = Get-VM\n    If ($adminCredOld) {\n        log 'Using old local administrator credential from exported CliXML...'\n        $localAdminCred = $adminCredOld\n    } Else {\n        log 'Using new local administrator credential from parameter input...'\n        $localAdminCred = $adminCred\n    }\n    $sessions = New-PSSession -VMName $VMs.Name -Credential $localAdminCred -ErrorAction Stop\n\n    log \"Created '$(($sessions | Where-Object State -EQ 'Opened').Count)' PSSessions to HCI nodes [$($VMs.Name -join ',')].\"\n} catch {\n    If ($_ -like '*The credential is invalid*') {\n        log 'Failed to create PSSessions with \"The credential is invalid\" error. This is likely due to the password not matching the local administrator password on the HCI nodes. Retrying with the older passwords...'\n\n        $credFiles = Get-ChildItem -Path 'C:\\temp\\*' -Include 'hciHostDeployAdminCred*.xml' -Exclude 'hciHostDeployAdminCred.xml'\n\n        If ($credFiles.count -eq 0) {\n            log 'No old credential files found. Exiting...'\n            Write-Error 'No old credential files found. Exiting...'\n            Exit 1\n        }\n\n        :retryCreds ForEach ($credFile in $credFiles) {\n            log \"Attempting login with credential file '$($credFile.name)'...\"\n            $localAdminCred = Import-Clixml -Path $credFile.FullName\n\n            try {\n                $sessions = New-PSSession -VMName $VMs.Name -Credential $localAdminCred -ErrorAction Stop\n\n                If (($sessions | Where-Object State -EQ 'Opened').count -eq $VMs.Count) {\n                    log \"Created '$(($sessions | Where-Object State -EQ 'Opened').Count)' PSSessions to HCI nodes [$($VMs.Name -join ',')].\"\n                    break retryCreds\n                }\n            } catch {\n                log \"Failed to create PSSessions with credential file '$($credFile.name)'. Error: $_\"\n                continue\n            } finally {\n                If (($sessions | Where-Object State -EQ 'Opened').count -eq $VMs.Count) {\n                    log \"Created '$(($sessions | Where-Object State -EQ 'Opened').Count)' PSSessions to HCI nodes [$($VMs.Name -join ',')].\"\n                    $adminCredOld = $localAdminCred\n                }\n            }\n\n        }\n    } else {\n        log \"Failed to create PSSessions to HCI nodes [$($VMs.Name -join ',')]. $sessions $_ Exiting...\"\n        Write-Error \"Failed to create PSSessions to HCI nodes [$($VMs.Name -join ',')]. $sessions $_ Exiting...\"\n        Exit 1\n    }\n}\n\n# update local admin password to match the adminPw value\nIf ($adminCredOld) {\n    log 'Updating local administrator password to match the adminPw value...'\n    Invoke-Command -VMName (Get-VM).Name -Credential $adminCredOld {\n        $ErrorActionPreference = 'Stop'\n\n        $adminPw = $args[0]\n        $adminUsername = $args[1]\n\n        Write-Host \"$($env:computerName):Setting local administrator password to match the adminPw value...\"\n        $adminCred = [pscredential]::new($adminUsername, (ConvertTo-SecureString -AsPlainText -Force $adminPw))\n        Set-LocalUser -Name $adminUsername -Password $adminCred.Password -Confirm:$false\n    } -ArgumentList $adminPw, $adminUsername\n} Else {\n    log \"Password for '$($adminUsername)' should already match the adminPw value...\"\n}\n\n# disable IPv6 on all HCI nodes\nlog 'Disabling IPv6 on HCI nodes...'\nInvoke-Command -VMName (Get-VM).Name -Credential $adminCred {\n    reg add hklm\\system\\currentcontrolset\\services\\tcpip6\\parameters /v DisabledComponents /t REG_DWORD /d 0xFF /f\n}\n\n# set proxy settings if provided\nif (![string]::IsNullOrEmpty($proxyServerEndpoint) -and ![string]::IsNullOrEmpty($proxyBypassString)) {\n    log 'Both -proxyServerEndpoiint and -proxyBypassString passed, setting proxy settings...'\n    log \"Proxy Server Endpoint: $proxyServerEndpoint\"\n    log \"Proxy Bypass String: $proxyBypassString\"\n\n    If ($proxyBypassString -eq 'GENERATE_PROXY_BYPASS_DYNAMICALLY') {\n        log 'Generating proxy bypass string dynamically...'\n        $proxyBypassString = '127.0.0.1;localhost;172.20.0.*;*.hci.local;hcicluster;172.20.0.2;172.20.0.3;172.20.0.4;172.20.0.5;*.svc'\n        For ($i = 1; $i -le (Get-VM).count; $i++) {\n            $proxyBypassString += \";hcinode$i\"\n            $proxyBypassString += ';172.20.0.{0}' -f (9 + $i)\n        }\n    }\n\n    log 'Configuring proxy settings on HCI nodes...'\n    $proxyConfigLogs = Invoke-Command -VMName (Get-VM).Name -Credential $adminCred {\n        $ErrorActionPreference = 'Stop'\n\n        $proxyServerEndpoint = $args[0]\n        $proxyBypassString = $args[1]\n\n        ## install winInetProxy module\n        If (!(Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction SilentlyContinue)) { Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force }\n        If (!(Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) { Register-PSRepository -Default }\n        Set-PSRepository -Name PSGallery -InstallationPolicy Trusted\n        If (!(Get-InstalledModule -Name WinInetProxy -ErrorAction SilentlyContinue)) { Install-Module WinInetProxy -Force }\n        Set-PSRepository -Name PSGallery -InstallationPolicy Untrusted\n\n        ## set WinInet proxy settings\n        Set-WinInetProxy -ProxyServer $proxyServerEndpoint -ProxyBypass $proxyBypassString -ProxySettingsPerUser 0\n\n        ## set winhttp proxy settings\n        Set-WinhttpProxy -ProxyServer $proxyServerEndpoint -BypassList $proxyBypassString\n\n        ## set proxy environment variables\n        $proxyBypassStringEnv = $proxyBypassString.replace(';', ',').replace('*', '').replace('172.20.0.*', '172.20.0.0/24')\n        $proxyBypassStringEnv += ',.svc'\n\n        [Environment]::SetEnvironmentVariable('HTTPS_PROXY', $proxyServerEndpoint, 'Machine')\n        [Environment]::SetEnvironmentVariable('HTTP_PROXY', $proxyServerEndpoint, 'Machine')\n        [Environment]::SetEnvironmentVariable('NO_PROXY', $proxyBypassStringEnv, 'Machine')\n\n        Write-Output \"[$($env:COMPUTERNAME)] WinInetProxy Settings: $(Get-WinhttpProxy -Advanced)\"\n        Write-Output \"[$($env:COMPUTERNAME)] WinhttpProxy Settings: $(Get-WinhttpProxy -Default)\"\n\n        Write-Output (\"[{0}] Environment Variables {1}: '{2}'\" -f $env:COMPUTERNAME, 'HTTPS_PROXY', [Environment]::GetEnvironmentVariable('HTTPS_PROXY', 'Machine'))\n        Write-Output (\"[{0}] Environment Variables {1}: '{2}'\" -f $env:COMPUTERNAME, 'HTTP_PROXY', [Environment]::GetEnvironmentVariable('HTTP_PROXY', 'Machine'))\n        Write-Output (\"[{0}] Environment Variables {1}: '{2}'\" -f $env:COMPUTERNAME, 'NO_PROXY', [Environment]::GetEnvironmentVariable('NO_PROXY', 'Machine'))\n\n    } -ArgumentList $proxyServerEndpoint, $proxyBypassString\n\n    $proxyConfigLogs | ForEach-Object {\n        log $_\n    }\n} Else {\n    log \"Skipping proxy settings because both -proxyServerEndpoint and -proxyBypassString were not passed... (proxyServerEndpoint: '$proxyServerEndpoint', proxyBypassString:'$proxyBypassString')\"\n}\n\n## test node internet connection with retry - required for Azure Arc initialization\n$firstVM = Get-VM | Select-Object -First 1\nlog \"Testing node internet connection on VM '$($firstVM.Name)' with retry...\"\n$testNodeInternetConnection = $false\n$internetRetryCount = 0\n$internetMaxRetries = 6\nwhile (!$testNodeInternetConnection -and $internetRetryCount -lt $internetMaxRetries) {\n    try {\n        $testNodeInternetConnection = Invoke-Command -VMName $firstVM.Name -Credential $adminCred {\n            [bool](Invoke-RestMethod ipinfo.io -UseBasicParsing -TimeoutSec 30)\n        } -ErrorAction SilentlyContinue\n    } catch {\n        log \"Internet test attempt $($internetRetryCount + 1) failed: $_\"\n    }\n    if (!$testNodeInternetConnection) {\n        $internetRetryCount++\n        if ($internetRetryCount -lt $internetMaxRetries) {\n            log \"Node '$($firstVM.Name)' internet check failed (attempt $internetRetryCount/$internetMaxRetries). Restarting RRAS NAT and retrying in 30s...\"\n            Restart-Service RemoteAccess -Force -ErrorAction SilentlyContinue\n            Start-Sleep -Seconds 30\n        }\n    }\n}\n\nIf (!$testNodeInternetConnection) {\n    log \"Node '$($firstVM.name)' does not have internet connection after $internetMaxRetries retries. Check RRAS NAT configuration. Exiting...\"\n    Write-Error \"Node '$($firstVM.name)' does not have internet connection after $internetMaxRetries retries. Check RRAS NAT configuration. Exiting...\"\n    Exit 1\n} Else {\n    log \"Node '$($firstVM.name)' has internet connection. Curl IPInfo: '$($testNodeInternetConnection)'\"\n}\n\n## create jobs for each node to initialize Azure Arc\nlog \"Creating Azure Arc initialization jobs for HCI nodes [$((Get-VM).Name -join ',')]. ArcGatewayId: '$arcGatewayId', ProxyServerEndpoint: '$proxyServerEndpoint'...\"\n$arcInitializationJobs = Invoke-Command -VMName (Get-VM).Name -Credential $adminCred {\n    $ErrorActionPreference = 'Stop'\n\n    $t = $args[0]\n    $subscriptionId = $args[1]\n    $resourceGroupName = $args[2]\n    $tenantId = $args[3]\n    $location = $args[4]\n    $accountName = $args[5]\n    $arcGatewayId = $args[6]\n    $proxyServerEndpoint = $args[7]\n    $proxyBypassString = $args[8]\n\n    $optionalParameters = @{}\n\n    If ($arcGatewayId) {\n        $optionalParameters += @{\n            'arcGatewayId' = $arcGatewayId\n        }\n    }\n    If ($proxyServerEndpoint) {\n        $optionalParameters += @{\n            'proxy'       = $proxyServerEndpoint\n            'proxyBypass' = $proxyBypassString\n        }\n    }\n\n    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null\n    If (!(Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) { Register-PSRepository -Default }\n    Set-PSRepository -Name PSGallery -InstallationPolicy Trusted\n    Install-Module Az.Resources\n    Install-Module -Name AzsHCI.ARCinstaller # -RequiredVersion '0.2.2690.99' # hardcode for 2408 testing\n    Set-PSRepository -Name PSGallery -InstallationPolicy Untrusted\n\n    #wait for bootstrap service to be reachable\n    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()\n    While (!(Test-NetConnection -ComputerName '127.0.0.1' -Port 9098 -InformationLevel Quiet) -and $stopwatch.Elapsed.TotalMinutes -lt 30) {\n        Write-Host 'Waiting for bootstrap service at 127.0.0.1:9098 to be reachable...'\n        Start-Sleep -Seconds 30\n    }\n    If ($stopwatch.Elapsed.TotalMinutes -ge 30) {\n        Write-Error 'Bootstrap service at 127.0.0.1:9098 did not become reachable within 30 minutes. Exiting...' -ErrorAction Stop\n    }\n\n    try {\n        # Invoke-AzStackHciArcInitialization -SubscriptionID $subscriptionId -ResourceGroup $resourceGroupName -TenantID $tenantId -Cloud AzureCloud -AccountID $accountName -ArmAccessToken $t -Region $location -ErrorAction Stop @optionalParameters\n\n        function Install-ModuleIfMissing {\n            param(\n                [Parameter(Mandatory = $true)]\n                [string]$Name,\n                [Parameter(Mandatory = $false)]\n                [string]$Repository = 'PSGallery',\n                [Parameter(Mandatory = $false)]\n                [switch]$Force,\n                [Parameter(Mandatory = $false)]\n                [switch]$AllowClobber\n            )\n            $module = Get-Module -Name $Name -ListAvailable\n            if (!$module) {\n                Install-Module -Name $Name -Repository $Repository -Force:$Force -AllowClobber:$AllowClobber\n            }\n        }\n\n        wget -Uri 'https://aka.ms/AzureConnectedMachineAgent' -OutFile \"$env:TEMP\\AzureConnectedMachineAgent.msi\"\n        msiexec /i \"$env:TEMP\\AzureConnectedMachineAgent.msi\" /l*v \"$env:TEMP\\AzureConnectedMachineAgentInstall.log\" /qn\n\n        Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Confirm:$false\n        Install-ModuleIfMissing -Name Az -Repository PSGallery -Force\n        Install-ModuleIfMissing -Name Az.Accounts -Force -AllowClobber\n        Install-ModuleIfMissing -Name Az.ConnectedMachine -Force -AllowClobber\n        Install-ModuleIfMissing -Name Az.Resources -Force -AllowClobber\n\n        $machineName = [System.Net.Dns]::GetHostName()\n        $correlationID = New-Guid\n\n        $azcmagentPath = \"$env:ProgramW6432\\AzureConnectedMachineAgent\\azcmagent.exe\"\n        & \"$azcmagentPath\" --version\n        & \"$azcmagentPath\" connect --resource-group \"$resourceGroupName\" --resource-name \"$machineName\" --tenant-id \"$tenantId\" --location \"$location\" --subscription-id \"$subscriptionId\" --cloud 'AzureCloud' --correlation-id \"$correlationID\" --access-token \"$t\";\n        if ($LASTEXITCODE -ne 0) {\n            throw 'Arc server connection failed'\n        }\n\n        Write-Output 'PUT edge device resource to install mandatory extensions'\n        $uri = \"https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.HybridCompute/machines/$machineName/providers/Microsoft.AzureStackHCI/edgeDevices/default?api-version=2024-04-01\"\n        $body = @{\n            'kind'       = 'HCI';\n            'properties' = @{};\n        }\n        $headers = @{\n            'Authorization' = \"Bearer $t\";\n        }\n        Invoke-RestMethod -Uri $uri -Method Put -Headers $headers -Body ($body | ConvertTo-Json) -ContentType 'application/json'\n\n        Write-Output 'Waiting for Edge device resource to be ready'\n        Start-Sleep -Seconds 600\n        $waitInterval = 60\n        $maxWaitCount = 15\n        $ready = $false\n        for ($waitCount = 0; $job.JobState -ne 'Transferred' -and $waitCount -lt $maxWaitCount; $waitCount++) {\n            $headers = @{\n                'Authorization' = \"Bearer $t\";\n            }\n            try {\n                $response = Invoke-RestMethod -Uri $uri -Method Get -Headers $headers\n                if ($response.properties.provisioningState -eq 'Succeeded') {\n                    $ready = $true\n                    break\n                }\n            } catch {\n                Write-Output \"Failed to get Edge device resource: $_\"\n            } finally {\n                Write-Output 'Waiting for Edge device resource to be ready'\n                Start-Sleep -Seconds $waitInterval\n            }\n        }\n\n        if (!$ready) {\n            throw 'Edge device resource is not ready after 30 minutes.'\n        }\n    } catch {\n        Write-Error $_ -ErrorAction Stop\n    }\n} -AsJob -ArgumentList $t, $subscriptionId, $resourceGroupName, $tenantId, $location, $accountName, $arcGatewayId, $proxyServerEndpoint, $proxyBypassString\n\nlog 'Waiting up to 30 minutes for Azure Arc initialization to complete on nodes...'\n\n$arcInitializationJobs | Wait-Job -Timeout 1800\n\n# check for failed arc initialization jobs\nlog 'Checking status of Azure Arc initialization jobs...'\n$arcInitializationJobs | ForEach-Object {\n    $job = $_\n    log \"[$($job.ComputerName)] Job output (Receive-Job): '$($job | Receive-Job -Keep -ErrorAction Continue | Out-String)'\"\n    Get-Job -Id $job.Id -IncludeChildJob | Receive-Job -ErrorAction SilentlyContinue | ForEach-Object {\n        If ($_.Exception -or $_.state -eq 'Failed') {\n            log \"Azure Arc initialization failed on node '$($job.Location)' with error: $($_.Exception.Message)\"\n            Exit 1\n        } Else {\n            log \"[$($job.ComputerName)] Job output: '$($_ | ConvertTo-Json -Compress)'\"\n\n        }\n    }\n}\n",
+                    "$fxv#6": "param(\n    [Parameter()]\n    [String]\n    $resourceGroupName,\n\n    [Parameter()]\n    [String]\n    $subscriptionId,\n\n    [Parameter()]\n    [int]\n    $hciNodeCount,\n\n    [Parameter()]\n    [String]\n    $userAssignedManagedIdentityClientId\n\n)\nFunction log {\n    Param (\n        [string]$message,\n        [string]$logPath = 'C:\\temp\\hciHostDeploy-7.log'\n    )\n\n    If (!(Test-Path -Path C:\\temp)) {\n        New-Item -Path C:\\temp -ItemType Directory\n    }\n\n    Write-Host $message\n    Add-Content -Path $logPath -Value \"$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') [hciHostStage7] - $message\"\n}\n\n$ErrorActionPreference = 'Stop'\n\n$hciNodeNames = @()\nfor ($i = 1; $i -le $hciNodeCount; $i++) {\n    $hciNodeNames += \"hcinode$i\"\n}\n\nSet-PSRepository -Name PSGallery -InstallationPolicy Trusted\nInstall-Module -Name Az.ConnectedMachine -Force -AllowClobber -Scope CurrentUser -Repository PSGallery -ErrorAction SilentlyContinue\nSet-PSRepository -Name PSGallery -InstallationPolicy Untrusted\n\nlog \"Logging in to Azure with user-assigned managed identity '$($userAssignedManagedIdentityClientId)'...\"\nLogin-AzAccount -Identity -Subscription $subscriptionId -AccountId $userAssignedManagedIdentityClientId\n\nlog \"Waiting for HCI Arc Machines to exist in the resource group '$($resourceGroupName)'...\"\n\n$timer = [System.Diagnostics.Stopwatch]::StartNew()\nWhile (($arcMachines = Get-AzConnectedMachine -ResourceGroupName $resourceGroupName | Where-Object { $_.name -in ($hciNodeNames) }).Count -lt $hciNodeNames.Count -and $timer.Elapsed.TotalMinutes -lt 60) {\n    log \"Found '$($arcMachines.Count)' HCI Arc Machines, waiting for '$($hciNodeNames.Count)' machines for up to 1 hour...\"\n    Start-Sleep -Seconds 30\n}\nIf ($timer.Elapsed.TotalMinutes -gt 60) {\n    log 'HCI Arc Machines did not exist within the 1 hour timeout period'\n    Write-Error 'HCI Arc Machines did not exist within the 1 hour timeout period' -ErrorAction Stop\n    Exit 1\n} Else {\n    log \"All HCI Arc Machines exist in the resource group '$($resourceGroupName)'\"\n}\n\nlog 'Waiting up to two hours for HCI Arc Machine extensions to be installed...'\n$timer = [System.Diagnostics.Stopwatch]::StartNew()\n$allExtensionsReady = $false\nwhile (!$allExtensionsReady -and $timer.Elapsed.TotalMinutes -lt 120) {\n    $allExtensionsReadyCheck = $true\n    foreach ($arcMachine in $arcMachines) {\n        $extensions = Get-AzConnectedMachineExtension -ResourceGroupName $resourceGroupName -MachineName $arcMachine.Name\n        if ($extensions.MachineExtensionType -notcontains 'TelemetryAndDiagnostics' -or $extensions.MachineExtensionType -notcontains 'DeviceManagementExtension' -or $extensions.MachineExtensionType -notcontains 'LcmController' -or $extensions.MachineExtensionType -notcontains 'EdgeRemoteSupport') {\n            log \"Waiting for extensions to be installed on HCI Arc Machine '$($arcMachine.Name)'...\"\n\n            # install extensions if not already installed\n            log \"Installing any missing extensions on HCI Arc Machine '$($arcMachine.Name)'...\"\n            $extensionParams = @{\n                ResourceGroupName = $resourceGroupName\n                MachineName       = $arcMachine.Name\n                Location          = $arcMachine.Location\n                ErrorAction       = 'Continue'\n            }\n\n            # Invoke-AzStackHciArcInitialization seemingly misses installing some extensions some of the time - so we'll install them here if missing\n            If ($extensions.MachineExtensionType -notcontains 'TelemetryAndDiagnostics') {\n                log \"Installing TelemetryAndDiagnostics extension on HCI Arc Machine '$($arcMachine.Name)'...\"\n                New-AzConnectedMachineExtension -Name 'AzureEdgeTelemetryAndDiagnostics' -Publisher 'Microsoft.AzureStack.Observability' -ExtensionType 'TelemetryAndDiagnostics' -NoWait @extensionParams\n            }\n            If ($extensions.MachineExtensionType -notcontains 'DeviceManagementExtension') {\n                log \"Installing DeviceManagementExtension extension on HCI Arc Machine '$($arcMachine.Name)'...\"\n                New-AzConnectedMachineExtension -Name 'AzureEdgeDeviceManagement' -Publisher 'Microsoft.Edge' -ExtensionType 'DeviceManagementExtension' -NoWait @extensionParams\n            }\n            If ($extensions.MachineExtensionType -notcontains 'LcmController') {\n                log \"Installing LcmController extension on HCI Arc Machine '$($arcMachine.Name)'...\"\n                New-AzConnectedMachineExtension -Name 'AzureEdgeLifecycleManager' -Publisher 'Microsoft.AzureStack.Orchestration' -ExtensionType 'LcmController' -NoWait @extensionParams\n            }\n            If ($extensions.MachineExtensionType -notcontains 'EdgeRemoteSupport') {\n                log \"Installing EdgeRemoteSupport extension on HCI Arc Machine '$($arcMachine.Name)'...\"\n                New-AzConnectedMachineExtension -Name 'AzureEdgeRemoteSupport' -Publisher 'Microsoft.AzureStack.Observability' -ExtensionType 'EdgeRemoteSupport' -NoWait @extensionParams\n            }\n\n            $allExtensionsReadyCheck = $false\n            continue\n        } elseIf (($extensionState = $extensions | Where-Object MachineExtensionType -EQ 'TelemetryAndDiagnostics').ProvisioningState -ne 'Succeeded') {\n            log \"Waiting for TelemetryAndDiagnostics extension to be installed on HCI Arc Machine '$($arcMachine.Name)'. Current state: '$($extensionState.ProvisioningState)'...\"\n            $allExtensionsReadyCheck = $false\n        } elseIf (($extensionState = $extensions | Where-Object MachineExtensionType -EQ 'DeviceManagementExtension').ProvisioningState -ne 'Succeeded') {\n            log \"Waiting for DeviceManagementExtension extension to be installed on HCI Arc Machine '$($arcMachine.Name)'. Current state: '$($extensionState.ProvisioningState)'...\"\n            $allExtensionsReadyCheck = $false\n        } elseIf (($extensionState = $extensions | Where-Object MachineExtensionType -EQ 'LcmController').ProvisioningState -ne 'Succeeded') {\n            log \"Waiting for LcmController extension to be installed on HCI Arc Machine '$($arcMachine.Name)'. Current state: '$($extensionState.ProvisioningState)'...\"\n            $allExtensionsReadyCheck = $false\n        } elseIf (($extensionState = $extensions | Where-Object MachineExtensionType -EQ 'EdgeRemoteSupport').ProvisioningState -ne 'Succeeded') {\n            log \"Waiting for EdgeRemoteSupport extension to be installed on HCI Arc Machine '$($arcMachine.Name)'. Current state: '$($extensionState.ProvisioningState)'...\"\n            $allExtensionsReadyCheck = $false\n        } else {\n            log \"All extensions are installed and ready on HCI Arc Machine '$($arcMachine.Name)'\"\n        }\n    }\n    $allExtensionsReady = $allExtensionsReadyCheck\n    If (!$allExtensionsReady) {\n        log 'waiting 30 seconds to check extensions again...'\n        Start-Sleep -Seconds 30\n    }\n}\n\nIf (!$allExtensionsReady) {\n    log 'Extensions did not install within the two hour timeout period'\n    Exit 1\n} Else {\n    log 'All extensions are installed and ready on all HCI Arc Machines'\n}\n\n# import local administrator credential (exported in stage 6)\nlog \"Re-importing local '$($adminUsername)' credential...\"\n$adminCred = Import-Clixml -Path 'C:\\temp\\hciHostDeployAdminCred.xml'\n\n# name net adapters - seems to be required on 2405\nlog 'Renaming network adapters on HCI nodes...'\n$vmNicLocalNamingOut = Invoke-Command -VMName (Get-VM).Name -Credential $adminCred {\n    $ErrorActionPreference = 'Stop'\n\n    Get-NetAdapter | ForEach-Object {\n        $adapter = $_\n\n        try {\n            Write-Output \"Getting Hyper-V network adapter name for '$($adapter.Name)' on VM '$($env:COMPUTERNAME)'...\"\n            $newAdapterName = Get-NetAdapterAdvancedProperty -RegistryKeyword HyperVNetworkAdapterName -Name $adapter.Name | Select-Object -ExpandProperty DisplayValue\n        } catch {\n            Write-Output \"Failed to get Hyper-V network adapter name for '$($adapter.Name)' on VM '$($env:COMPUTERNAME)'. Ensure DeviceNaming is turned on for the VM Network Adapter! $_ Exiting...\"\n            Write-Error \"Failed to get Hyper-V network adapter name for '$($adapter.Name)'  on VM '$($env:COMPUTERNAME)'. Ensure DeviceNaming is turned on for the VM Network Adapter! $_ Exiting...\" -ErrorAction Stop\n            Exit 1\n        }\n\n        If ($adapter.InterfaceAlias -ne $newAdapterName) {\n            Write-Output \"Renaming network adapter '$($adapter.InterfaceAlias)' to '$newAdapterName'  on VM '$($env:COMPUTERNAME)'...\"\n            Rename-NetAdapter -Name $adapter.Name -NewName $newAdapterName\n        } Else {\n            Write-Output \"Network adapter '$($adapter.InterfaceAlias)' is already named correctly on VM '$($env:COMPUTERNAME)'...\"\n        }\n    }\n}\nlog \"VM NIC local naming output: $vmNicLocalNamingOut\"\n\n# change dynamically assigned FABRIC IP addresses to static IPs as required by validation\nlog 'Changing dynamically assigned FABRIC IP addresses to static IPs on HCI nodes...'\n$ipChangeOutput = Invoke-Command -VMName (Get-VM).Name -Credential $adminCred {\n    $ErrorActionPreference = 'Stop'\n\n    $dhcpIpConfig = Get-NetIPConfiguration -InterfaceAlias 'FABRIC'\n    $prefixLength = Get-NetIPAddress -InterfaceAlias 'FABRIC' -AddressFamily IPv4 | Select-Object -ExpandProperty PrefixLength\n    $dnsClientConfig = Get-DnsClientServerAddress -InterfaceAlias 'FABRIC' -AddressFamily IPv4 | Select-Object -ExpandProperty ServerAddresses\n\n    try {\n        If (!(Get-NetIPInterface -InterfaceAlias 'FABRIC' -Dhcp Enabled -ErrorAction SilentlyContinue)) {\n            Write-Output \"[$env:computerName]DHCP is already disabled on network interface 'FABRIC'...\"\n        } Else {\n            Write-Output \"[$env:computerName]Disabling DHCP on network interface 'FABRIC'...\"\n            Set-NetIPInterface -InterfaceAlias 'FABRIC' -Dhcp Disabled\n        }\n    } catch {\n        Write-Output \"[$env:computerName]Failed to disable DHCP on network interface 'FABRIC'. Error message: $_. Exiting...\"\n        Write-Error \"[$env:computerName]Failed to disable DHCP on network interface 'FABRIC'. Error message: $_. Exiting...\" -ErrorAction Stop\n        Exit 1\n    }\n\n    try {\n        If (!(Get-NetIPAddress -IPAddress $dhcpIpConfig.IPv4Address.ipAddress -InterfaceAlias 'FABRIC' -ErrorAction SilentlyContinue)) {\n            Write-Output \"[$env:computerName]Setting static IP address on network interface 'FABRIC'...\"\n            New-NetIPAddress -InterfaceAlias 'FABRIC' -IPAddress $dhcpIpConfig.IPv4Address.ipAddress -DefaultGateway $dhcpIpConfig.Ipv4DefaultGateway.NextHop -AddressFamily IPv4 -PrefixLength $prefixLength\n        } Else {\n            Write-Output \"[$env:computerName]Static IP address already set on network interface 'FABRIC'...\"\n        }\n    } catch {\n        Write-Output \"[$env:computerName]Failed to set static IP address on network interface 'FABRIC'. Error message: $_. Exiting...\"\n        Write-Error \"[$env:computerName]Failed to set static IP address on network interface 'FABRIC'. Error message: $_. Exiting...\" -ErrorAction Stop\n        Exit 1\n    }\n\n    try {\n        Write-Output \"[$env:computerName]Setting DNS server addresses on network interface 'FABRIC' to '$dnsClientConfig'...\"\n        Set-DnsClientServerAddress -InterfaceAlias 'FABRIC' -ResetServerAddresses\n        Set-DnsClientServerAddress -InterfaceAlias 'FABRIC' -ServerAddresses $dnsClientConfig\n    } catch {\n        Write-Output \"[$env:computerName]Failed to set DNS server addresses on network interface 'FABRIC'. Error message: $_. Exiting...\"\n        Write-Error \"[$env:computerName]Failed to set DNS server addresses on network interface 'FABRIC'. Error message: $_. Exiting...\" -ErrorAction Stop\n        Exit 1\n    }\n}\nlog \"IP change output: $ipChangeOutput\"\n\n# change dynamically assigned FABRIC2 IP addresses to static IPs as required by validation\nlog 'Changing dynamically assigned FABRIC2 IP addresses to static IPs on HCI nodes...'\n$ipChangeOutput2 = Invoke-Command -VMName (Get-VM).Name -Credential $adminCred {\n    $ErrorActionPreference = 'Stop'\n\n    $dhcpIpConfig2 = Get-NetIPConfiguration -InterfaceAlias 'FABRIC2'\n    $prefixLength2 = Get-NetIPAddress -InterfaceAlias 'FABRIC2' -AddressFamily IPv4 | Select-Object -ExpandProperty PrefixLength\n\n    try {\n        If (!(Get-NetIPInterface -InterfaceAlias 'FABRIC2' -Dhcp Enabled -ErrorAction SilentlyContinue)) {\n            Write-Output \"[$env:computerName]DHCP is already disabled on network interface 'FABRIC2'...\"\n        } Else {\n            Write-Output \"[$env:computerName]Disabling DHCP on network interface 'FABRIC2'...\"\n            Set-NetIPInterface -InterfaceAlias 'FABRIC2' -Dhcp Disabled\n        }\n    } catch {\n        Write-Output \"[$env:computerName]Failed to disable DHCP on network interface 'FABRIC2'. Error message: $_. Exiting...\"\n        Write-Error \"[$env:computerName]Failed to disable DHCP on network interface 'FABRIC2'. Error message: $_. Exiting...\" -ErrorAction Stop\n        Exit 1\n    }\n\n    try {\n        If (!(Get-NetIPAddress -IPAddress $dhcpIpConfig2.IPv4Address.ipAddress -InterfaceAlias 'FABRIC2' -ErrorAction SilentlyContinue)) {\n            Write-Output \"[$env:computerName]Setting static IP address on network interface 'FABRIC2'...\"\n            New-NetIPAddress -InterfaceAlias 'FABRIC2' -IPAddress $dhcpIpConfig2.IPv4Address.ipAddress -AddressFamily IPv4 -PrefixLength $prefixLength2\n        } Else {\n            Write-Output \"[$env:computerName]Static IP address already set on network interface 'FABRIC2'...\"\n        }\n    } catch {\n        Write-Output \"[$env:computerName]Failed to set static IP address on network interface 'FABRIC2'. Error message: $_. Exiting...\"\n        Write-Error \"[$env:computerName]Failed to set static IP address on network interface 'FABRIC2'. Error message: $_. Exiting...\" -ErrorAction Stop\n        Exit 1\n    }\n}\nlog \"IP change output (FABRIC2): $ipChangeOutput2\"\n"
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+                      "apiVersion": "2023-07-31-preview",
+                      "name": "[parameters('userAssignedIdentityName')]",
+                      "location": "[parameters('location')]"
+                    },
+                    {
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "name": "[guid(subscription().subscriptionId, parameters('userAssignedIdentityName'), 'Owner', resourceGroup().id)]",
+                      "properties": {
+                        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName')), '2023-07-31-preview').principalId]",
+                        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                        "principalType": "ServicePrincipal",
+                        "description": "Role assigned used for Azure Stack HCI IaC testing pipeline - remove if identity no longer exists!"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Network/publicIPAddresses",
+                      "apiVersion": "2024-07-01",
+                      "name": "[format('{0}-natgw-pip', parameters('virtualNetworkName'))]",
+                      "location": "[parameters('location')]",
+                      "sku": {
+                        "name": "Standard"
+                      },
+                      "properties": {
+                        "publicIPAllocationMethod": "Static",
+                        "publicIPAddressVersion": "IPv4"
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Network/natGateways",
+                      "apiVersion": "2024-07-01",
+                      "name": "[format('{0}-natgw', parameters('virtualNetworkName'))]",
+                      "location": "[parameters('location')]",
+                      "sku": {
+                        "name": "Standard"
+                      },
+                      "properties": {
+                        "idleTimeoutInMinutes": 10,
+                        "publicIpAddresses": [
+                          {
+                            "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-natgw-pip', parameters('virtualNetworkName')))]"
+                          }
+                        ]
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-natgw-pip', parameters('virtualNetworkName')))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Network/virtualNetworks",
+                      "apiVersion": "2024-07-01",
+                      "name": "[parameters('virtualNetworkName')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "addressSpace": {
+                          "addressPrefixes": [
+                            "10.0.0.0/24"
+                          ]
+                        },
+                        "subnets": [
+                          {
+                            "name": "subnet01",
+                            "properties": {
+                              "addressPrefix": "10.0.0.0/24",
+                              "natGateway": {
+                                "id": "[resourceId('Microsoft.Network/natGateways', format('{0}-natgw', parameters('virtualNetworkName')))]"
+                              },
+                              "serviceEndpoints": [
+                                {
+                                  "service": "Microsoft.Storage",
+                                  "locations": [
+                                    "[parameters('location')]"
+                                  ]
+                                },
+                                {
+                                  "service": "Microsoft.KeyVault",
+                                  "locations": [
+                                    "[parameters('location')]"
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/natGateways', format('{0}-natgw', parameters('virtualNetworkName')))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Maintenance/maintenanceConfigurations",
+                      "apiVersion": "2023-09-01-preview",
+                      "name": "[coalesce(parameters('maintenanceConfigurationName'), '')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "maintenanceScope": "InGuestPatch",
+                        "maintenanceWindow": {
+                          "recurEvery": "Week Sunday",
+                          "startDateTime": "2020-04-30 08:00",
+                          "duration": "02:00",
+                          "timeZone": "UTC"
+                        },
+                        "installPatches": {
+                          "windowsParameters": {
+                            "classificationsToInclude": [
+                              "Critical",
+                              "Security"
+                            ]
+                          },
+                          "rebootSetting": "IfRequired"
+                        },
+                        "extensionProperties": {
+                          "InGuestPatchMode": "User"
+                        }
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Network/networkSecurityGroups",
+                      "apiVersion": "2020-11-01",
+                      "name": "[parameters('networkSecurityGroupName')]",
+                      "location": "[parameters('location')]"
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachineScaleSets",
+                      "apiVersion": "2024-03-01",
+                      "name": "[parameters('HCIHostVirtualMachineScaleSetName')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "orchestrationMode": "Flexible",
+                        "platformFaultDomainCount": 1
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Network/networkInterfaces",
+                      "apiVersion": "2020-11-01",
+                      "name": "[parameters('networkInterfaceName')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "networkSecurityGroup": {
+                          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]"
+                        },
+                        "ipConfigurations": [
+                          {
+                            "name": "ipConfig01",
+                            "properties": {
+                              "subnet": {
+                                "id": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), '2024-07-01').subnets[0].id]"
+                              },
+                              "privateIPAllocationMethod": "Dynamic"
+                            }
+                          }
+                        ]
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]",
+                        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+                      ]
+                    },
+                    {
+                      "copy": {
+                        "name": "disks",
+                        "count": "[length(range(1, parameters('hciNodeCount')))]"
+                      },
+                      "type": "Microsoft.Compute/disks",
+                      "apiVersion": "2023-10-02",
+                      "name": "[format('{0}{1}', parameters('diskNamePrefix'), string(range(1, parameters('hciNodeCount'))[copyIndex()]))]",
+                      "location": "[parameters('location')]",
+                      "sku": {
+                        "name": "Premium_LRS"
+                      },
+                      "properties": {
+                        "diskSizeGB": 2048,
+                        "networkAccessPolicy": "DenyAll",
+                        "creationData": {
+                          "createOption": "Empty"
+                        }
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines",
+                      "apiVersion": "2024-03-01",
+                      "name": "[parameters('virtualMachineName')]",
+                      "location": "[parameters('location')]",
+                      "identity": {
+                        "type": "UserAssigned",
+                        "userAssignedIdentities": {
+                          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName')))]": {}
+                        }
+                      },
+                      "properties": {
+                        "virtualMachineScaleSet": {
+                          "id": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('HCIHostVirtualMachineScaleSetName'))]"
+                        },
+                        "hardwareProfile": {
+                          "vmSize": "[parameters('hostVMSize')]"
+                        },
+                        "priority": "Regular",
+                        "networkProfile": {
+                          "networkInterfaces": [
+                            {
+                              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceName'))]"
+                            }
+                          ]
+                        },
+                        "storageProfile": {
+                          "copy": [
+                            {
+                              "name": "dataDisks",
+                              "count": "[length(range(1, parameters('hciNodeCount')))]",
+                              "input": {
+                                "lun": "[range(1, parameters('hciNodeCount'))[copyIndex('dataDisks')]]",
+                                "createOption": "Attach",
+                                "caching": "ReadOnly",
+                                "managedDisk": {
+                                  "id": "[resourceId('Microsoft.Compute/disks', format('{0}{1}', parameters('diskNamePrefix'), string(range(1, parameters('hciNodeCount'))[sub(range(1, parameters('hciNodeCount'))[copyIndex('dataDisks')], 1)])))]"
+                                },
+                                "deleteOption": "Delete"
+                              }
+                            }
+                          ],
+                          "imageReference": {
+                            "publisher": "MicrosoftWindowsServer",
+                            "offer": "WindowsServer",
+                            "sku": "2022-datacenter-g2",
+                            "version": "latest"
+                          },
+                          "osDisk": {
+                            "createOption": "FromImage",
+                            "diskSizeGB": 1024,
+                            "deleteOption": "Delete",
+                            "managedDisk": {
+                              "storageAccountType": "Premium_LRS"
+                            }
+                          }
+                        },
+                        "osProfile": {
+                          "adminPassword": "[parameters('localAdminPassword')]",
+                          "adminUsername": "[parameters('localAdminUsername')]",
+                          "computerName": "hciHost01",
+                          "windowsConfiguration": {
+                            "provisionVMAgent": true,
+                            "enableAutomaticUpdates": true,
+                            "patchSettings": {
+                              "patchMode": "AutomaticByPlatform",
+                              "automaticByPlatformSettings": {
+                                "bypassPlatformSafetyChecksOnUserSchedule": true
+                              }
+                            }
+                          }
+                        },
+                        "securityProfile": {
+                          "uefiSettings": {
+                            "secureBootEnabled": true,
+                            "vTpmEnabled": true
+                          },
+                          "securityType": "TrustedLaunch"
+                        },
+                        "licenseType": "Windows_Server"
+                      },
+                      "dependsOn": [
+                        "disks",
+                        "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('HCIHostVirtualMachineScaleSetName'))]",
+                        "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceName'))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Maintenance/configurationAssignments",
+                      "apiVersion": "2023-04-01",
+                      "scope": "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]",
+                      "name": "[parameters('maintenanceConfigurationAssignmentName')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "maintenanceConfigurationId": "[resourceId('Microsoft.Maintenance/maintenanceConfigurations', coalesce(parameters('maintenanceConfigurationName'), ''))]"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Maintenance/maintenanceConfigurations', coalesce(parameters('maintenanceConfigurationName'), ''))]",
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand1')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#0')]"
+                        },
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand2')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#1')]"
+                        },
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/runCommands', parameters('virtualMachineName'), 'runCommand1')]",
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Resources/deploymentScripts",
+                      "apiVersion": "2023-08-01",
+                      "name": "[format('{0}-wait1', parameters('waitDeploymentScriptPrefixName'))]",
+                      "location": "[parameters('location')]",
+                      "kind": "AzurePowerShell",
+                      "properties": {
+                        "azPowerShellVersion": "3.0",
+                        "scriptContent": "Start-Sleep -Seconds 90",
+                        "retentionInterval": "PT6H"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/runCommands', parameters('virtualMachineName'), 'runCommand2')]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand3')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#2')]"
+                        },
+                        "parameters": [
+                          {
+                            "name": "hciVHDXDownloadURL",
+                            "value": ""
+                          },
+                          {
+                            "name": "hciISODownloadURL",
+                            "value": "[parameters('hciISODownloadURL')]"
+                          },
+                          {
+                            "name": "hciNodeCount",
+                            "value": "[string(parameters('hciNodeCount'))]"
+                          }
+                        ],
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]",
+                        "[resourceId('Microsoft.Resources/deploymentScripts', format('{0}-wait1', parameters('waitDeploymentScriptPrefixName')))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand4')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#3')]"
+                        },
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/runCommands', parameters('virtualMachineName'), 'runCommand3')]",
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Resources/deploymentScripts",
+                      "apiVersion": "2023-08-01",
+                      "name": "[format('{0}-wait2', parameters('waitDeploymentScriptPrefixName'))]",
+                      "location": "[parameters('location')]",
+                      "kind": "AzurePowerShell",
+                      "properties": {
+                        "azPowerShellVersion": "3.0",
+                        "scriptContent": "Start-Sleep -Seconds 300 #enough time for AD start-up",
+                        "retentionInterval": "PT6H"
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/runCommands', parameters('virtualMachineName'), 'runCommand4')]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand5')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#4')]"
+                        },
+                        "parameters": [
+                          {
+                            "name": "adminUsername",
+                            "value": "[parameters('localAdminUsername')]"
+                          },
+                          {
+                            "name": "hciNodeCount",
+                            "value": "[string(parameters('hciNodeCount'))]"
+                          },
+                          {
+                            "name": "switchlessStorageConfig",
+                            "value": "[if(parameters('switchlessStorageConfig'), 'switchless', 'switched')]"
+                          }
+                        ],
+                        "protectedParameters": [
+                          {
+                            "name": "adminPw",
+                            "value": "[parameters('localAdminPassword')]"
+                          }
+                        ],
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]",
+                        "[resourceId('Microsoft.Resources/deploymentScripts', format('{0}-wait2', parameters('waitDeploymentScriptPrefixName')))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand6')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#5')]"
+                        },
+                        "parameters": [
+                          {
+                            "name": "location",
+                            "value": "[parameters('location')]"
+                          },
+                          {
+                            "name": "resourceGroupName",
+                            "value": "[resourceGroup().name]"
+                          },
+                          {
+                            "name": "subscriptionId",
+                            "value": "[subscription().subscriptionId]"
+                          },
+                          {
+                            "name": "tenantId",
+                            "value": "[tenant().tenantId]"
+                          },
+                          {
+                            "name": "accountName",
+                            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName')), '2023-07-31-preview').principalId]"
+                          },
+                          {
+                            "name": "adminUsername",
+                            "value": "[parameters('localAdminUsername')]"
+                          },
+                          {
+                            "name": "arcGatewayId",
+                            "value": ""
+                          },
+                          {
+                            "name": "deploymentUsername",
+                            "value": "[parameters('deploymentUsername')]"
+                          },
+                          {
+                            "name": "domainOUPath",
+                            "value": "[parameters('domainOUPath')]"
+                          },
+                          {
+                            "name": "proxyBypassString",
+                            "value": ""
+                          },
+                          {
+                            "name": "proxyServerEndpoint",
+                            "value": ""
+                          },
+                          {
+                            "name": "userAssignedManagedIdentityClientId",
+                            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName')), '2023-07-31-preview').clientId]"
+                          }
+                        ],
+                        "protectedParameters": [
+                          {
+                            "name": "adminPw",
+                            "value": "[parameters('localAdminPassword')]"
+                          }
+                        ],
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/runCommands', parameters('virtualMachineName'), 'runCommand5')]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName'))]",
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Compute/virtualMachines/runCommands",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('{0}/{1}', parameters('virtualMachineName'), 'runCommand7')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "source": {
+                          "script": "[variables('$fxv#6')]"
+                        },
+                        "parameters": [
+                          {
+                            "name": "hciNodeCount",
+                            "value": "[string(parameters('hciNodeCount'))]"
+                          },
+                          {
+                            "name": "resourceGroupName",
+                            "value": "[resourceGroup().name]"
+                          },
+                          {
+                            "name": "subscriptionId",
+                            "value": "[subscription().subscriptionId]"
+                          },
+                          {
+                            "name": "userAssignedManagedIdentityClientId",
+                            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName')), '2023-07-31-preview').clientId]"
+                          }
+                        ],
+                        "treatFailureAsDeploymentFailure": true
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.Compute/virtualMachines/runCommands', parameters('virtualMachineName'), 'runCommand6')]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName'))]",
+                        "[resourceId('Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]"
+                      ]
+                    },
+                    {
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-hcihostmi-roleAssignment_subContributor', uniqueString(deployment().name, parameters('location')))]",
+                      "subscriptionId": "[subscription().subscriptionId]",
+                      "location": "[resourceGroup().location]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "principalId": {
+                            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName')), '2023-07-31-preview').principalId]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.40.2.10011",
+                              "templateHash": "3824400371169904663"
+                            }
+                          },
+                          "parameters": {
+                            "principalId": {
+                              "type": "string"
+                            }
+                          },
+                          "resources": [
+                            {
+                              "type": "Microsoft.Authorization/roleAssignments",
+                              "apiVersion": "2020-04-01-preview",
+                              "name": "[guid(parameters('principalId'), subscription().id, 'Contributor')]",
+                              "properties": {
+                                "principalId": "[parameters('principalId')]",
+                                "principalType": "ServicePrincipal",
+                                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "dependsOn": [
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('userAssignedIdentityName'))]"
+                      ]
+                    }
+                  ],
+                  "outputs": {
+                    "vnetSubnetResourceId": {
+                      "type": "string",
+                      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), '2024-07-01').subnets[0].id]"
+                    }
+                  }
+                }
+              }
+            },
+            "hciClusterPreqs": {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-test-hciclusterreqs', uniqueString(deployment().name, parameters('location')))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "arbDeploymentAppId": {
+                    "value": "[parameters('arbDeploymentAppId')]"
+                  },
+                  "arbDeploymentServicePrincipalSecret": {
+                    "value": "[parameters('arbDeploymentServicePrincipalSecret')]"
+                  },
+                  "arbDeploymentSPObjectId": {
+                    "value": "[parameters('arbDeploymentSPObjectId')]"
+                  },
+                  "clusterWitnessStorageAccountName": {
+                    "value": "[parameters('clusterWitnessStorageAccountName')]"
+                  },
+                  "keyVaultDiagnosticStorageAccountName": {
+                    "value": "[parameters('keyVaultDiagnosticStorageAccountName')]"
+                  },
+                  "deploymentUsername": {
+                    "value": "deployUser"
+                  },
+                  "deploymentUserPassword": {
+                    "value": "[parameters('deploymentUserPassword')]"
+                  },
+                  "keyVaultName": {
+                    "value": "[parameters('keyVaultName')]"
+                  },
+                  "localAdminPassword": {
+                    "value": "[parameters('localAdminPassword')]"
+                  },
+                  "localAdminUsername": {
+                    "value": "Administrator"
+                  },
+                  "logsRetentionInDays": {
+                    "value": 30
+                  },
+                  "softDeleteRetentionDays": {
+                    "value": 30
+                  },
+                  "tenantId": {
+                    "value": "[subscription().tenantId]"
+                  },
+                  "vnetSubnetResourceId": {
+                    "value": "[reference('hciHostDeployment').outputs.vnetSubnetResourceId.value]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.40.2.10011",
+                      "templateHash": "17875009895763037288"
+                    }
+                  },
+                  "parameters": {
+                    "location": {
+                      "type": "string"
+                    },
+                    "clusterWitnessStorageAccountName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the storage account to create as a cluster witness."
+                      }
+                    },
+                    "keyVaultDiagnosticStorageAccountName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the storage account to be created to collect Key Vault diagnostic logs."
+                      }
+                    },
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the Azure Key Vault to create."
+                      }
+                    },
+                    "softDeleteRetentionDays": {
+                      "type": "int",
+                      "defaultValue": 30
+                    },
+                    "logsRetentionInDays": {
+                      "type": "int",
+                      "defaultValue": 30,
+                      "minValue": 0,
+                      "maxValue": 365,
+                      "metadata": {
+                        "description": "Optional. The number of days for the retention in days. A value of 0 will retain the events indefinitely."
+                      }
+                    },
+                    "tenantId": {
+                      "type": "string"
+                    },
+                    "deploymentUsername": {
+                      "type": "string",
+                      "defaultValue": "deployUser"
+                    },
+                    "deploymentUserPassword": {
+                      "type": "securestring"
+                    },
+                    "localAdminUsername": {
+                      "type": "string"
+                    },
+                    "localAdminPassword": {
+                      "type": "securestring"
+                    },
+                    "arbDeploymentAppId": {
+                      "type": "securestring",
+                      "nullable": true
+                    },
+                    "arbDeploymentSPObjectId": {
+                      "type": "securestring",
+                      "nullable": true
+                    },
+                    "arbDeploymentServicePrincipalSecret": {
+                      "type": "securestring",
+                      "nullable": true
+                    },
+                    "vnetSubnetResourceId": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "allowIPtoStorageAndKeyVault": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "usingArcGW": {
+                      "type": "bool",
+                      "defaultValue": false
+                    },
+                    "useSharedKeyVault": {
+                      "type": "bool",
+                      "defaultValue": true
+                    }
+                  },
+                  "variables": {
+                    "deploymentUserSecretValue": "[base64(format('{0}:{1}', parameters('deploymentUsername'), parameters('deploymentUserPassword')))]",
+                    "localAdminSecretValue": "[base64(format('{0}:{1}', parameters('localAdminUsername'), parameters('localAdminPassword')))]",
+                    "arbDeploymentServicePrincipalValue": "[if(and(not(empty(coalesce(parameters('arbDeploymentAppId'), ''))), not(empty(coalesce(parameters('arbDeploymentServicePrincipalSecret'), '')))), base64(format('{0}:{1}', parameters('arbDeploymentAppId'), parameters('arbDeploymentServicePrincipalSecret'))), '')]",
+                    "storageAccountType": "Standard_ZRS"
+                  },
+                  "resources": {
+                    "diagnosticStorageAccount::blobService": {
+                      "type": "Microsoft.Storage/storageAccounts/blobServices",
+                      "apiVersion": "2023-01-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultDiagnosticStorageAccountName'), 'default')]",
+                      "properties": {
+                        "deleteRetentionPolicy": {
+                          "enabled": true,
+                          "days": 7
+                        },
+                        "containerDeleteRetentionPolicy": {
+                          "enabled": true,
+                          "days": 7
+                        }
+                      },
+                      "dependsOn": [
+                        "diagnosticStorageAccount"
+                      ]
+                    },
+                    "witnessStorageAccount::blobService": {
+                      "type": "Microsoft.Storage/storageAccounts/blobServices",
+                      "apiVersion": "2023-01-01",
+                      "name": "[format('{0}/{1}', parameters('clusterWitnessStorageAccountName'), 'default')]",
+                      "properties": {
+                        "deleteRetentionPolicy": {
+                          "enabled": true,
+                          "days": 7
+                        },
+                        "containerDeleteRetentionPolicy": {
+                          "enabled": true,
+                          "days": 7
+                        }
+                      },
+                      "dependsOn": [
+                        "witnessStorageAccount"
+                      ]
+                    },
+                    "keyVault::keyVaultName_domainAdminSecret": {
+                      "condition": "[not(parameters('useSharedKeyVault'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), 'AzureStackLCMUserCredential')]",
+                      "properties": {
+                        "contentType": "Secret",
+                        "value": "[variables('deploymentUserSecretValue')]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "dependsOn": [
+                        "keyVault"
+                      ]
+                    },
+                    "keyVault::keyVaultName_localAdminSecret": {
+                      "condition": "[not(parameters('useSharedKeyVault'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), 'LocalAdminCredential')]",
+                      "properties": {
+                        "contentType": "Secret",
+                        "value": "[variables('localAdminSecretValue')]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "dependsOn": [
+                        "keyVault"
+                      ]
+                    },
+                    "keyVault::keyVaultName_arbDeploymentServicePrincipal": {
+                      "condition": "[and(and(not(parameters('useSharedKeyVault')), not(empty(coalesce(parameters('arbDeploymentAppId'), '')))), not(empty(coalesce(parameters('arbDeploymentServicePrincipalSecret'), ''))))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), 'DefaultARBApplication')]",
+                      "properties": {
+                        "contentType": "Secret",
+                        "value": "[variables('arbDeploymentServicePrincipalValue')]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "dependsOn": [
+                        "keyVault"
+                      ]
+                    },
+                    "keyVault::keyVaultName_storageWitness": {
+                      "condition": "[not(parameters('useSharedKeyVault'))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), 'WitnessStorageKey')]",
+                      "properties": {
+                        "contentType": "Secret",
+                        "value": "[base64(listKeys('witnessStorageAccount', '2023-01-01').keys[0].value)]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "dependsOn": [
+                        "keyVault",
+                        "witnessStorageAccount"
+                      ]
+                    },
+                    "diagnosticStorageAccount": {
+                      "type": "Microsoft.Storage/storageAccounts",
+                      "apiVersion": "2023-01-01",
+                      "name": "[parameters('keyVaultDiagnosticStorageAccountName')]",
+                      "location": "[parameters('location')]",
+                      "sku": {
+                        "name": "[variables('storageAccountType')]"
+                      },
+                      "kind": "StorageV2",
+                      "properties": {
+                        "supportsHttpsTrafficOnly": true,
+                        "allowBlobPublicAccess": false,
+                        "minimumTlsVersion": "TLS1_2",
+                        "networkAcls": {
+                          "bypass": "AzureServices",
+                          "defaultAction": "Deny",
+                          "ipRules": [],
+                          "virtualNetworkRules": []
+                        }
+                      }
+                    },
+                    "witnessStorageAccount": {
+                      "type": "Microsoft.Storage/storageAccounts",
+                      "apiVersion": "2023-01-01",
+                      "name": "[parameters('clusterWitnessStorageAccountName')]",
+                      "location": "[parameters('location')]",
+                      "sku": {
+                        "name": "[variables('storageAccountType')]"
+                      },
+                      "kind": "StorageV2",
+                      "properties": {
+                        "supportsHttpsTrafficOnly": true,
+                        "allowBlobPublicAccess": false,
+                        "minimumTlsVersion": "TLS1_2",
+                        "networkAcls": {
+                          "bypass": "AzureServices",
+                          "defaultAction": "[if(parameters('usingArcGW'), 'Allow', 'Deny')]",
+                          "ipRules": "[if(not(equals(parameters('allowIPtoStorageAndKeyVault'), null())), createArray(createObject('value', parameters('allowIPtoStorageAndKeyVault'))), createArray())]",
+                          "virtualNetworkRules": "[if(not(equals(parameters('vnetSubnetResourceId'), null())), createArray(createObject('id', parameters('vnetSubnetResourceId'))), createArray())]"
+                        }
+                      }
+                    },
+                    "keyVault": {
+                      "type": "Microsoft.KeyVault/vaults",
+                      "apiVersion": "2023-07-01",
+                      "name": "[parameters('keyVaultName')]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "enabledForDeployment": true,
+                        "enabledForTemplateDeployment": true,
+                        "enabledForDiskEncryption": true,
+                        "enableSoftDelete": true,
+                        "softDeleteRetentionInDays": "[parameters('softDeleteRetentionDays')]",
+                        "enableRbacAuthorization": true,
+                        "publicNetworkAccess": "Enabled",
+                        "accessPolicies": [],
+                        "tenantId": "[parameters('tenantId')]",
+                        "sku": {
+                          "name": "standard",
+                          "family": "A"
+                        },
+                        "networkAcls": {
+                          "bypass": "AzureServices",
+                          "defaultAction": "Deny",
+                          "ipRules": "[if(not(equals(parameters('allowIPtoStorageAndKeyVault'), null())), createArray(createObject('value', parameters('allowIPtoStorageAndKeyVault'))), createArray())]",
+                          "virtualNetworkRules": "[if(not(equals(parameters('vnetSubnetResourceId'), null())), createArray(createObject('id', parameters('vnetSubnetResourceId'))), createArray())]"
+                        }
+                      },
+                      "dependsOn": [
+                        "diagnosticStorageAccount"
+                      ]
+                    },
+                    "keyVaultName_Microsoft_Insights_service": {
+                      "type": "microsoft.insights/diagnosticSettings",
+                      "apiVersion": "2016-09-01",
+                      "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
+                      "name": "service",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('keyVaultDiagnosticStorageAccountName'))]",
+                        "logs": [
+                          {
+                            "category": "AuditEvent",
+                            "enabled": true,
+                            "retentionPolicy": {
+                              "enabled": true,
+                              "days": "[parameters('logsRetentionInDays')]"
+                            }
+                          }
+                        ]
+                      },
+                      "dependsOn": [
+                        "diagnosticStorageAccount",
+                        "keyVault"
+                      ]
+                    },
+                    "ARBDeploymentSPNSubscriptionRoleAssignmnent": {
+                      "condition": "[not(empty(coalesce(parameters('arbDeploymentSPObjectId'), '')))]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-test-arbroleassignment', uniqueString(deployment().name, parameters('location')))]",
+                      "subscriptionId": "[subscription().subscriptionId]",
+                      "location": "[resourceGroup().location]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "arbDeploymentSPObjectId": {
+                            "value": "[parameters('arbDeploymentSPObjectId')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.40.2.10011",
+                              "templateHash": "15330173694387796079"
+                            }
+                          },
+                          "parameters": {
+                            "arbDeploymentSPObjectId": {
+                              "type": "securestring"
+                            }
+                          },
+                          "variables": {
+                            "ARBDeploymentRoleID": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7b1f81f9-4196-4058-8aae-762e593270df')]"
+                          },
+                          "resources": [
+                            {
+                              "type": "Microsoft.Authorization/roleAssignments",
+                              "apiVersion": "2022-04-01",
+                              "name": "[guid('ARBServicePrincipalResourceBridgeDeploymentRolePermissions', subscription().id, parameters('arbDeploymentSPObjectId'))]",
+                              "properties": {
+                                "roleDefinitionId": "[variables('ARBDeploymentRoleID')]",
+                                "principalId": "[parameters('arbDeploymentSPObjectId')]",
+                                "principalType": "ServicePrincipal",
+                                "description": "Created by Azure Stack HCI deployment template"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "hciHostDeployment"
+              ]
+            }
+          },
+          "outputs": {
+            "clusterName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the created cluster"
+              },
+              "value": "[parameters('clusterName')]"
+            },
+            "clusterNodeNames": {
+              "type": "array",
+              "metadata": {
+                "description": "The name of the cluster's nodes."
+              },
+              "value": "[variables('clusterNodeNames')]"
+            },
+            "clusterWitnessStorageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the storage account used as the cluster witness."
+              },
+              "value": "[parameters('clusterWitnessStorageAccountName')]"
+            },
+            "domainOUPath": {
+              "type": "string",
+              "metadata": {
+                "description": "The OU path for the domain."
+              },
+              "value": "[variables('domainOUPath')]"
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the created Key Vault."
+              },
+              "value": "[parameters('keyVaultName')]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "resourceGroup"
+      ]
+    },
+    "azlocal": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}-test-clustermodule-{1}', uniqueString(deployment().name, variables('enforcedLocation')), parameters('serviceShort'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[reference('nestedDependencies').outputs.clusterName.value]"
+          },
+          "deploymentUser": {
+            "value": "deployUser"
+          },
+          "deploymentUserPassword": {
+            "value": "[parameters('arbLocalAdminAndDeploymentUserPass')]"
+          },
+          "localAdminUser": {
+            "value": "Administrator"
+          },
+          "localAdminPassword": {
+            "value": "[parameters('arbLocalAdminAndDeploymentUserPass')]"
+          },
+          "servicePrincipalId": {
+            "value": "[parameters('arbDeploymentAppId')]"
+          },
+          "servicePrincipalSecret": {
+            "value": "[parameters('arbDeploymentServicePrincipalSecret')]"
+          },
+          "hciResourceProviderObjectId": {
+            "value": "[parameters('hciResourceProviderObjectId')]"
+          },
+          "deploymentSettings": {
+            "value": {
+              "customLocationName": "[format('{0}{1}-location', parameters('namePrefix'), parameters('serviceShort'))]",
+              "clusterNodeNames": "[reference('nestedDependencies').outputs.clusterNodeNames.value]",
+              "clusterWitnessStorageAccountName": "[reference('nestedDependencies').outputs.clusterWitnessStorageAccountName.value]",
+              "defaultGateway": "192.168.1.1",
+              "deploymentPrefix": "[format('a{0}', take(uniqueString(parameters('namePrefix'), parameters('serviceShort')), 7))]",
+              "dnsServers": [
+                "192.168.1.254"
+              ],
+              "domainFqdn": "jumpstart.local",
+              "domainOUPath": "[reference('nestedDependencies').outputs.domainOUPath.value]",
+              "startingIPAddress": "192.168.1.55",
+              "endingIPAddress": "192.168.1.65",
+              "enableStorageAutoIp": true,
+              "keyVaultName": "[reference('nestedDependencies').outputs.keyVaultName.value]",
+              "networkIntents": [
+                {
+                  "adapter": [
+                    "FABRIC",
+                    "FABRIC2"
+                  ],
+                  "name": "ManagementCompute",
+                  "overrideAdapterProperty": true,
+                  "adapterPropertyOverrides": {
+                    "jumboPacket": "9014",
+                    "networkDirect": "Disabled",
+                    "networkDirectTechnology": "iWARP"
+                  },
+                  "overrideQosPolicy": false,
+                  "qosPolicyOverrides": {
+                    "bandwidthPercentageSMB": "50",
+                    "priorityValue8021ActionCluster": "7",
+                    "priorityValue8021ActionSMB": "3"
+                  },
+                  "overrideVirtualSwitchConfiguration": false,
+                  "virtualSwitchConfigurationOverrides": {
+                    "enableIov": "true",
+                    "loadBalancingAlgorithm": "Dynamic"
+                  },
+                  "trafficType": [
+                    "Management",
+                    "Compute"
+                  ]
+                },
+                {
+                  "adapter": [
+                    "StorageA",
+                    "StorageB"
+                  ],
+                  "name": "Storage",
+                  "overrideAdapterProperty": true,
+                  "adapterPropertyOverrides": {
+                    "jumboPacket": "9014",
+                    "networkDirect": "Disabled",
+                    "networkDirectTechnology": "iWARP"
+                  },
+                  "overrideQosPolicy": true,
+                  "qosPolicyOverrides": {
+                    "bandwidthPercentageSMB": "50",
+                    "priorityValue8021ActionCluster": "7",
+                    "priorityValue8021ActionSMB": "3"
+                  },
+                  "overrideVirtualSwitchConfiguration": false,
+                  "virtualSwitchConfigurationOverrides": {
+                    "enableIov": "true",
+                    "loadBalancingAlgorithm": "Dynamic"
+                  },
+                  "trafficType": [
+                    "Storage"
+                  ]
+                }
+              ],
+              "storageConnectivitySwitchless": false,
+              "storageNetworks": [
+                {
+                  "name": "Storage1Network",
+                  "adapterName": "StorageA",
+                  "vlan": "711"
+                },
+                {
+                  "name": "Storage2Network",
+                  "adapterName": "StorageB",
+                  "vlan": "712"
+                }
+              ],
+              "subnetMask": "255.255.255.0"
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.36.177.2456",
+              "templateHash": "15260394227717230397"
+            },
+            "name": "Azure Stack HCI Cluster",
+            "description": "This module deploys an Azure Stack HCI Cluster on the provided Arc Machines."
+          },
+          "definitions": {
+            "networkIntentType": {
+              "type": "object",
+              "properties": {
+                "adapter": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "Required. The names of the network adapters to include in the intent."
+                  }
+                },
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the network intent."
+                  }
+                },
+                "overrideAdapterProperty": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Specify whether to override the adapter property. Use false by default."
+                  }
+                },
+                "adapterPropertyOverrides": {
+                  "type": "object",
+                  "properties": {
+                    "jumboPacket": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The jumboPacket configuration for the network adapters."
+                      }
+                    },
+                    "networkDirect": {
+                      "type": "string",
+                      "allowedValues": [
+                        "Disabled",
+                        "Enabled"
+                      ],
+                      "metadata": {
+                        "description": "Required. The networkDirect configuration for the network adapters."
+                      }
+                    },
+                    "networkDirectTechnology": {
+                      "type": "string",
+                      "allowedValues": [
+                        "RoCEv2",
+                        "iWARP"
+                      ],
+                      "metadata": {
+                        "description": "Required. The networkDirectTechnology configuration for the network adapters."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. The adapter property overrides for the network intent."
+                  }
+                },
+                "overrideQosPolicy": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Specify whether to override the qosPolicy property. Use false by default."
+                  }
+                },
+                "qosPolicyOverrides": {
+                  "type": "object",
+                  "properties": {
+                    "bandwidthPercentageSMB": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The bandwidthPercentage for the network intent. Recommend 50."
+                      }
+                    },
+                    "priorityValue8021ActionCluster": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Recommend 7."
+                      }
+                    },
+                    "priorityValue8021ActionSMB": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Recommend 3."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. The qosPolicy overrides for the network intent."
+                  }
+                },
+                "overrideVirtualSwitchConfiguration": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Specify whether to override the virtualSwitchConfiguration property. Use false by default."
+                  }
+                },
+                "virtualSwitchConfigurationOverrides": {
+                  "type": "object",
+                  "properties": {
+                    "enableIov": {
+                      "type": "string",
+                      "allowedValues": [
+                        "false",
+                        "true"
+                      ],
+                      "metadata": {
+                        "description": "Required. The enableIov configuration for the network intent."
+                      }
+                    },
+                    "loadBalancingAlgorithm": {
+                      "type": "string",
+                      "allowedValues": [
+                        "Dynamic",
+                        "HyperVPort",
+                        "IPHash"
+                      ],
+                      "metadata": {
+                        "description": "Required. The loadBalancingAlgorithm configuration for the network intent."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Required. The virtualSwitchConfiguration overrides for the network intent."
+                  }
+                },
+                "trafficType": {
+                  "type": "array",
+                  "allowedValues": [
+                    "Compute",
+                    "Management",
+                    "Storage"
+                  ],
+                  "metadata": {
+                    "description": "Required. The traffic types for the network intent."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "storageAdapterIPInfoType": {
+              "type": "object",
+              "properties": {
+                "physicalNode": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The HCI node name."
+                  }
+                },
+                "ipv4Address": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The IPv4 address for the storage adapter."
+                  }
+                },
+                "subnetMask": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The subnet mask for the storage adapter."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "storageNetworksType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the storage network."
+                  }
+                },
+                "adapterName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the storage adapter."
+                  }
+                },
+                "vlan": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The VLAN for the storage adapter."
+                  }
+                },
+                "storageAdapterIPInfo": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/storageAdapterIPInfoType"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The storage adapter IP information for 3-node switchless or manual config deployments."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "securityConfigurationType": {
+              "type": "object",
+              "properties": {
+                "hvciProtection": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable HVCI protection."
+                  }
+                },
+                "drtmProtection": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable DRTM protection."
+                  }
+                },
+                "driftControlEnforced": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable Drift Control enforcement."
+                  }
+                },
+                "credentialGuardEnforced": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable Credential Guard enforcement."
+                  }
+                },
+                "smbSigningEnforced": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable SMB signing enforcement."
+                  }
+                },
+                "smbClusterEncryption": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable SMB cluster encryption."
+                  }
+                },
+                "sideChannelMitigationEnforced": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable Side Channel Mitigation enforcement."
+                  }
+                },
+                "bitlockerBootVolume": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable BitLocker protection for boot volume."
+                  }
+                },
+                "bitlockerDataVolumes": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable BitLocker protection for data volumes."
+                  }
+                },
+                "wdacEnforced": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Enable/Disable WDAC enforcement."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "deploymentSettingsType": {
+              "type": "object",
+              "properties": {
+                "deploymentPrefix": {
+                  "type": "string",
+                  "minLength": 4,
+                  "maxLength": 8,
+                  "metadata": {
+                    "description": "Required. The prefix for the resource for the deployment. This value is used in key vault and storage account names in this template, as well as for the deploymentSettings.properties.deploymentConfiguration.scaleUnits.deploymentData.namingPrefix property which requires regex pattern: ^[a-zA-Z0-9-]{1,8}$."
+                  }
+                },
+                "clusterNodeNames": {
+                  "type": "array",
+                  "metadata": {
+                    "description": "Required. Names of the cluster node Arc Machine resources. These are the name of the Arc Machine resources created when the new HCI nodes were Arc initialized. Example: [hci-node-1, hci-node-2]."
+                  }
+                },
+                "domainFqdn": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The domain name of the Active Directory Domain Services. Example: \"contoso.com\"."
+                  }
+                },
+                "domainOUPath": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The ADDS OU path - ex \"OU=HCI,DC=contoso,DC=com\"."
+                  }
+                },
+                "hvciProtection": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Hypervisor-protected Code Integrity setting."
+                  }
+                },
+                "drtmProtection": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The hardware-dependent Secure Boot setting."
+                  }
+                },
+                "driftControlEnforced": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. When set to true, the security baseline is re-applied regularly."
+                  }
+                },
+                "credentialGuardEnforced": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enables the Credential Guard."
+                  }
+                },
+                "smbSigningEnforced": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. When set to true, the SMB default instance requires sign in for the client and server services."
+                  }
+                },
+                "smbClusterEncryption": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. When set to true, cluster east-west traffic is encrypted."
+                  }
+                },
+                "sideChannelMitigationEnforced": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. When set to true, all the side channel mitigations are enabled."
+                  }
+                },
+                "bitlockerBootVolume": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. When set to true, BitLocker XTS_AES 256-bit encryption is enabled for all data-at-rest on the OS volume of your Azure Stack HCI cluster. This setting is TPM-hardware dependent."
+                  }
+                },
+                "bitlockerDataVolumes": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. When set to true, BitLocker XTS-AES 256-bit encryption is enabled for all data-at-rest on your Azure Stack HCI cluster shared volumes."
+                  }
+                },
+                "wdacEnforced": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Limits the applications and the code that you can run on your Azure Stack HCI cluster."
+                  }
+                },
+                "streamingDataClient": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The metrics data for deploying a HCI cluster."
+                  }
+                },
+                "isEuropeanUnionLocation": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The location data for deploying a HCI cluster."
+                  }
+                },
+                "episodicDataUpload": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The diagnostic data for deploying a HCI cluster."
+                  }
+                },
+                "storageConfigurationMode": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Express",
+                    "InfraOnly",
+                    "KeepStorage"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The storage volume configuration mode. See documentation for details."
+                  }
+                },
+                "subnetMask": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The subnet mask pf the Management Network for the HCI cluster - ex: 255.255.252.0."
+                  }
+                },
+                "defaultGateway": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The default gateway of the Management Network. Example: 192.168.0.1."
+                  }
+                },
+                "startingIPAddress": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The starting IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs."
+                  }
+                },
+                "endingIPAddress": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The ending IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs."
+                  }
+                },
+                "dnsServers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "description": "Required. The DNS servers accessible from the Management Network for the HCI cluster."
+                  }
+                },
+                "networkIntents": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/networkIntentType"
+                  },
+                  "metadata": {
+                    "description": "Required. An array of Network ATC Network Intent objects that define the Compute, Management, and Storage network configuration for the cluster."
+                  }
+                },
+                "storageConnectivitySwitchless": {
+                  "type": "bool",
+                  "metadata": {
+                    "description": "Required. Specify whether the Storage Network connectivity is switched or switchless."
+                  }
+                },
+                "enableStorageAutoIp": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enable storage auto IP assignment. This should be true for most deployments except when deploying a three-node switchless cluster, in which case storage IPs should be configured before deployment and this value set to false."
+                  }
+                },
+                "storageNetworks": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/storageNetworksType"
+                  },
+                  "metadata": {
+                    "description": "Required. An array of JSON objects that define the storage network configuration for the cluster. Each object should contain the adapterName, VLAN properties, and (optionally) IP configurations."
+                  }
+                },
+                "customLocationName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the Custom Location associated with the Arc Resource Bridge for this cluster. This value should reflect the physical location and identifier of the HCI cluster. Example: cl-hci-den-clu01."
+                  }
+                },
+                "clusterWitnessStorageAccountName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the storage account to be used as the witness for the HCI Windows Failover Cluster."
+                  }
+                },
+                "keyVaultName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The name of the key vault to be used for storing secrets for the HCI cluster. This currently needs to be unique per HCI cluster."
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "minLength": 4,
+              "maxLength": 40,
+              "metadata": {
+                "description": "Required. The name of the Azure Stack HCI cluster - this will be the name of your cluster in Azure."
+              }
+            },
+            "clusterADName": {
+              "type": "string",
+              "nullable": true,
+              "minLength": 4,
+              "maxLength": 15,
+              "metadata": {
+                "description": "Optional. The name of the Azure Stack HCI cluster - this must be a valid Active Directory computer name."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all resources."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the resource."
+              }
+            },
+            "deploymentOperations": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "defaultValue": [
+                "Validate",
+                "Deploy"
+              ],
+              "allowedValues": [
+                "Deploy",
+                "Validate"
+              ],
+              "metadata": {
+                "description": "Optional. The cluster deployment operations to execute. Defaults to \"[Validate, Deploy]\"."
+              }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
+            },
+            "deploymentSettings": {
+              "$ref": "#/definitions/deploymentSettingsType",
+              "metadata": {
+                "description": "Required. The deployment settings of the cluster."
+              }
+            },
+            "roleAssignments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Array of role assignments to create."
+              }
+            },
+            "useSharedKeyVault": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Specify whether to use the shared key vault for the HCI cluster."
+              }
+            },
+            "deploymentUser": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The name of the deployment user. Required if useSharedKeyVault is true."
+              }
+            },
+            "deploymentUserPassword": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The password of the deployment user. Required if useSharedKeyVault is true."
+              }
+            },
+            "localAdminUser": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The name of the local admin user. Required if useSharedKeyVault is true."
+              }
+            },
+            "localAdminPassword": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The password of the local admin user. Required if useSharedKeyVault is true."
+              }
+            },
+            "servicePrincipalId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The service principal ID for ARB. Required if useSharedKeyVault is true and need ARB service principal id."
+              }
+            },
+            "servicePrincipalSecret": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Conditional. The service principal secret for ARB. Required if useSharedKeyVault is true and need ARB service principal id."
+              }
+            },
+            "azureStackLCMUserCredentialContentType": {
+              "type": "string",
+              "defaultValue": "Secret",
+              "metadata": {
+                "description": "Optional. Content type of the azure stack lcm user credential."
+              }
+            },
+            "localAdminCredentialContentType": {
+              "type": "string",
+              "defaultValue": "Secret",
+              "metadata": {
+                "description": "Optional. Content type of the local admin credential."
+              }
+            },
+            "witnessStoragekeyContentType": {
+              "type": "string",
+              "defaultValue": "Secret",
+              "metadata": {
+                "description": "Optional. Content type of the witness storage key."
+              }
+            },
+            "defaultARBApplicationContentType": {
+              "type": "string",
+              "defaultValue": "Secret",
+              "metadata": {
+                "description": "Optional. Content type of the default ARB application."
+              }
+            },
+            "azureStackLCMUserCredentialTags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of azure stack LCM user credential."
+              }
+            },
+            "localAdminCredentialTags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the local admin credential."
+              }
+            },
+            "witnessStoragekeyTags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the witness storage key."
+              }
+            },
+            "defaultARBApplicationTags": {
+              "type": "object",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Tags of the default ARB application."
+              }
+            },
+            "keyvaultSubscriptionId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Key vault subscription ID, which is used for for storing secrets for the HCI cluster."
+              }
+            },
+            "keyvaultResourceGroup": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Key vault resource group, which is used for for storing secrets for the HCI cluster."
+              }
+            },
+            "witnessStorageAccountSubscriptionId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Storage account subscription ID, which is used as the witness for the HCI Windows Failover Cluster."
+              }
+            },
+            "witnessStorageAccountResourceGroup": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Storage account resource group, which is used as the witness for the HCI Windows Failover Cluster."
+              }
+            },
+            "hciResourceProviderObjectId": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Required. The service principal object ID of the Azure Stack HCI Resource Provider in this tenant. Can be fetched via `Get-AzADServicePrincipal -ApplicationId 1412d89f-b8a8-4111-b4fd-e82905cbd85d` after the 'Microsoft.AzureStackHCI' provider was registered in the subscription."
+              }
+            },
+            "operationType": {
+              "type": "string",
+              "defaultValue": "ClusterProvisioning",
+              "allowedValues": [
+                "ClusterProvisioning",
+                "ClusterUpgrade"
+              ],
+              "metadata": {
+                "description": "Optional. The intended operation for a cluster."
+              }
+            }
+          },
+          "variables": {
+            "copy": [
+              {
+                "name": "formattedRoleAssignments",
+                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+              },
+              {
+                "name": "arcNodeResourceIds",
+                "count": "[length(parameters('deploymentSettings').clusterNodeNames)]",
+                "input": "[resourceId('Microsoft.HybridCompute/machines', parameters('deploymentSettings').clusterNodeNames[copyIndex('arcNodeResourceIds')])]"
+              }
+            ],
+            "$fxv#0": "@description('Optional. The cluster deployment operations to execute. Defaults to \"[Validate, Deploy]\".')\n@allowed([\n  'Deploy'\n  'Validate'\n])\nparam deploymentOperations string[] = ['Validate', 'Deploy']\n\n@description('Required. The deployment settings of the cluster.')\nparam deploymentSettings deploymentSettingsType\n\n@description('Optional. Specify whether to use the shared key vault for the HCI cluster.')\nparam useSharedKeyVault bool = true\n\n@description('Optional. The intended operation for a cluster.')\n@allowed([\n  'ClusterProvisioning'\n  'ClusterUpgrade'\n])\nparam operationType string = 'ClusterProvisioning'\n\nparam clusterName string\nparam clusterADName string\nparam cloudId string\n\nparam needArbSecret bool\n\n// if deployment operations requested, validation must be performed first so we reverse sort the array\nvar sortedDeploymentOperations = (!empty(deploymentOperations)) ? sort(deploymentOperations, (a, b) => a > b) : []\n\n@batchSize(1)\nmodule deploymentSetting '../deployment-setting/main.bicep' = [\n  for deploymentOperation in sortedDeploymentOperations: if (!empty(deploymentOperation) && !empty(deploymentSettings)) {\n    name: 'deploymentSettings-${deploymentOperation}'\n    params: {\n      cloudId: useSharedKeyVault ? cloudId : null\n      clusterName: clusterName\n      clusterADName: clusterADName\n      operationType: operationType\n      deploymentMode: deploymentOperation\n      clusterNodeNames: deploymentSettings!.clusterNodeNames\n      clusterWitnessStorageAccountName: deploymentSettings!.clusterWitnessStorageAccountName\n      customLocationName: deploymentSettings!.customLocationName\n      defaultGateway: deploymentSettings!.defaultGateway\n      deploymentPrefix: deploymentSettings!.deploymentPrefix\n      dnsServers: deploymentSettings!.dnsServers\n      domainFqdn: deploymentSettings!.domainFqdn\n      domainOUPath: deploymentSettings!.domainOUPath\n      endingIPAddress: deploymentSettings!.endingIPAddress\n      keyVaultName: deploymentSettings!.keyVaultName\n      networkIntents: [\n        for intent in deploymentSettings.networkIntents: {\n          ...intent\n          qosPolicyOverrides: {\n            bandwidthPercentage_SMB: intent.qosPolicyOverrides.bandwidthPercentageSMB\n            priorityValue8021Action_Cluster: intent.qosPolicyOverrides.priorityValue8021ActionCluster\n            priorityValue8021Action_SMB: intent.qosPolicyOverrides.priorityValue8021ActionSMB\n          }\n        }\n      ]\n      startingIPAddress: deploymentSettings!.startingIPAddress\n      storageConnectivitySwitchless: deploymentSettings!.storageConnectivitySwitchless\n      storageNetworks: deploymentSettings!.storageNetworks\n      subnetMask: deploymentSettings!.subnetMask\n      bitlockerBootVolume: deploymentSettings!.?bitlockerBootVolume\n      bitlockerDataVolumes: deploymentSettings!.?bitlockerDataVolumes\n      credentialGuardEnforced: deploymentSettings!.?credentialGuardEnforced\n      driftControlEnforced: deploymentSettings!.?driftControlEnforced\n      drtmProtection: deploymentSettings!.?drtmProtection\n      enableStorageAutoIp: deploymentSettings!.?enableStorageAutoIp\n      episodicDataUpload: deploymentSettings!.?episodicDataUpload\n      hvciProtection: deploymentSettings!.?hvciProtection\n      isEuropeanUnionLocation: deploymentSettings!.?isEuropeanUnionLocation\n      sideChannelMitigationEnforced: deploymentSettings!.?sideChannelMitigationEnforced\n      smbClusterEncryption: deploymentSettings!.?smbClusterEncryption\n      smbSigningEnforced: deploymentSettings!.?smbSigningEnforced\n      storageConfigurationMode: deploymentSettings!.?storageConfigurationMode\n      streamingDataClient: deploymentSettings!.?streamingDataClient\n      wdacEnforced: deploymentSettings!.?wdacEnforced\n      needArbSecret: needArbSecret\n    }\n  }\n]\n\nimport { networkIntentType, storageNetworksType } from 'br/public:avm/res/azure-stack-hci/cluster:0.1.6'\ntype deploymentSettingsType = {\n  @minLength(4)\n  @maxLength(8)\n  @description('Required. The prefix for the resource for the deployment. This value is used in key vault and storage account names in this template, as well as for the deploymentSettings.properties.deploymentConfiguration.scaleUnits.deploymentData.namingPrefix property which requires regex pattern: ^[a-zA-Z0-9-]{1,8}$.')\n  deploymentPrefix: string\n\n  @description('Required. Names of the cluster node Arc Machine resources. These are the name of the Arc Machine resources created when the new HCI nodes were Arc initialized. Example: [hci-node-1, hci-node-2].')\n  clusterNodeNames: array\n\n  @description('Required. The domain name of the Active Directory Domain Services. Example: \"contoso.com\".')\n  domainFqdn: string\n\n  @description('Required. The ADDS OU path - ex \"OU=HCI,DC=contoso,DC=com\".')\n  domainOUPath: string\n\n  @description('Optional. The Hypervisor-protected Code Integrity setting.')\n  hvciProtection: bool?\n\n  @description('Optional. The hardware-dependent Secure Boot setting.')\n  drtmProtection: bool?\n\n  @description('Optional. When set to true, the security baseline is re-applied regularly.')\n  driftControlEnforced: bool?\n\n  @description('Optional. Enables the Credential Guard.')\n  credentialGuardEnforced: bool?\n\n  @description('Optional. When set to true, the SMB default instance requires sign in for the client and server services.')\n  smbSigningEnforced: bool?\n\n  @description('Optional. When set to true, cluster east-west traffic is encrypted.')\n  smbClusterEncryption: bool?\n\n  @description('Optional. When set to true, all the side channel mitigations are enabled.')\n  sideChannelMitigationEnforced: bool?\n\n  @description('Optional. When set to true, BitLocker XTS_AES 256-bit encryption is enabled for all data-at-rest on the OS volume of your Azure Stack HCI cluster. This setting is TPM-hardware dependent.')\n  bitlockerBootVolume: bool?\n\n  @description('Optional. When set to true, BitLocker XTS-AES 256-bit encryption is enabled for all data-at-rest on your Azure Stack HCI cluster shared volumes.')\n  bitlockerDataVolumes: bool?\n\n  @description('Optional. Limits the applications and the code that you can run on your Azure Stack HCI cluster.')\n  wdacEnforced: bool?\n\n  // cluster diagnostics and telemetry configuration\n  @description('Optional. The metrics data for deploying a HCI cluster.')\n  streamingDataClient: bool?\n\n  @description('Optional. The location data for deploying a HCI cluster.')\n  isEuropeanUnionLocation: bool?\n\n  @description('Optional. The diagnostic data for deploying a HCI cluster.')\n  episodicDataUpload: bool?\n\n  // storage configuration\n  @description('Optional. The storage volume configuration mode. See documentation for details.')\n  storageConfigurationMode: ('Express' | 'InfraOnly' | 'KeepStorage')?\n\n  // cluster network configuration details\n  @description('Required. The subnet mask pf the Management Network for the HCI cluster - ex: 255.255.252.0.')\n  subnetMask: string\n\n  @description('Required. The default gateway of the Management Network. Example: 192.168.0.1.')\n  defaultGateway: string\n\n  @description('Required. The starting IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs.')\n  startingIPAddress: string\n\n  @description('Required. The ending IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs.')\n  endingIPAddress: string\n\n  @description('Required. The DNS servers accessible from the Management Network for the HCI cluster.')\n  dnsServers: string[]\n\n  @description('Required. An array of Network ATC Network Intent objects that define the Compute, Management, and Storage network configuration for the cluster.')\n  networkIntents: networkIntentType[]\n\n  @description('Required. Specify whether the Storage Network connectivity is switched or switchless.')\n  storageConnectivitySwitchless: bool\n\n  @description('Optional. Enable storage auto IP assignment. This should be true for most deployments except when deploying a three-node switchless cluster, in which case storage IPs should be configured before deployment and this value set to false.')\n  enableStorageAutoIp: bool?\n\n  @description('Required. An array of JSON objects that define the storage network configuration for the cluster. Each object should contain the adapterName, VLAN properties, and (optionally) IP configurations.')\n  storageNetworks: storageNetworksType[]\n\n  // other cluster configuration parameters\n  @description('Required. The name of the Custom Location associated with the Arc Resource Bridge for this cluster. This value should reflect the physical location and identifier of the HCI cluster. Example: cl-hci-den-clu01.')\n  customLocationName: string\n\n  @description('Required. The name of the storage account to be used as the witness for the HCI Windows Failover Cluster.')\n  clusterWitnessStorageAccountName: string\n\n  @description('Required. The name of the key vault to be used for storing secrets for the HCI cluster. This currently needs to be unique per HCI cluster.')\n  keyVaultName: string\n}\n",
+            "$fxv#1": "metadata name = 'Azure Stack HCI Cluster Deployment Settings'\nmetadata description = 'This module deploys an Azure Stack HCI Cluster Deployment Settings resource.'\n\n@description('Optional. The name of the deployment settings.')\n@allowed([\n  'default'\n])\nparam name string = 'default'\n\n@description('Conditional. The name of the Azure Stack HCI cluster - this will be the name of your cluster in Azure. Required if the template is used in a standalone deployment.')\n@maxLength(40)\n@minLength(4)\nparam clusterName string\n\n@description('Conditional. The name of the Azure Stack HCI cluster - this must be a valid Active Directory computer name. Required if the template is used in a standalone deployment.')\n@maxLength(15)\n@minLength(4)\nparam clusterADName string\n\n@description('Required. First must pass with this parameter set to Validate prior running with it set to Deploy. If either Validation or Deployment phases fail, fix the issue, then resubmit the template with the same deploymentMode to retry.')\n@allowed([\n  'Validate'\n  'Deploy'\n])\nparam deploymentMode string\n\n@minLength(4)\n@maxLength(8)\n@description('Required. The prefix for the resource for the deployment. This value is used in key vault and storage account names in this template, as well as for the deploymentSettings.properties.deploymentConfiguration.scaleUnits.deploymentData.namingPrefix property which requires regex pattern: ^[a-zA-Z0-9-]{1,8}$.')\nparam deploymentPrefix string\n\n@description('Required. Names of the cluster node Arc Machine resources. These are the name of the Arc Machine resources created when the new HCI nodes were Arc initialized. Example: [hci-node-1, hci-node-2].')\nparam clusterNodeNames array\n\n@description('Required. The domain name of the Active Directory Domain Services. Example: \"contoso.com\".')\nparam domainFqdn string\n\n@description('Required. The ADDS OU path - ex \"OU=HCI,DC=contoso,DC=com\".')\nparam domainOUPath string\n\n@description('Optional. The Hypervisor-protected Code Integrity setting.')\nparam hvciProtection bool = true\n\n@description('Optional. The hardware-dependent Secure Boot setting.')\nparam drtmProtection bool = true\n\n@description('Optional. When set to true, the security baseline is re-applied regularly.')\nparam driftControlEnforced bool = false\n\n@description('Optional. Enables the Credential Guard.')\nparam credentialGuardEnforced bool = false\n\n@description('Optional. When set to true, the SMB default instance requires sign in for the client and server services.')\nparam smbSigningEnforced bool = false\n\n@description('Optional. When set to true, cluster east-west traffic is encrypted.')\nparam smbClusterEncryption bool = false\n\n@description('Optional. When set to true, all the side channel mitigations are enabled.')\nparam sideChannelMitigationEnforced bool = false\n\n@description('Optional. When set to true, BitLocker XTS_AES 256-bit encryption is enabled for all data-at-rest on the OS volume of your Azure Stack HCI cluster. This setting is TPM-hardware dependent.')\nparam bitlockerBootVolume bool = false\n\n@description('Optional. When set to true, BitLocker XTS-AES 256-bit encryption is enabled for all data-at-rest on your Azure Stack HCI cluster shared volumes.')\nparam bitlockerDataVolumes bool = false\n\n@description('Optional. Limits the applications and the code that you can run on your Azure Stack HCI cluster.')\nparam wdacEnforced bool = true\n\n// cluster diagnostics and telemetry configuration\n@description('Optional. The metrics data for deploying a HCI cluster.')\nparam streamingDataClient bool = true\n\n@description('Optional. The location data for deploying a HCI cluster.')\nparam isEuropeanUnionLocation bool = false\n\n@description('Optional. The diagnostic data for deploying a HCI cluster.')\nparam episodicDataUpload bool = true\n\n// storage configuration\n@description('Optional. The storage volume configuration mode. See documentation for details.')\n@allowed([\n  'Express'\n  'InfraOnly'\n  'KeepStorage'\n])\nparam storageConfigurationMode string = 'Express'\n\n@description('Required. If true, the service principal secret for ARB is required. If false, the secrets wiil not be required.')\nparam needArbSecret bool\n\n// cluster network configuration details\n@description('Required. The subnet mask pf the Management Network for the HCI cluster - ex: 255.255.252.0.')\nparam subnetMask string\n\n@description('Required. The default gateway of the Management Network. Example: 192.168.0.1.')\nparam defaultGateway string\n\n@description('Required. The starting IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs.')\nparam startingIPAddress string\n\n@description('Required. The ending IP address for the Infrastructure Network IP pool. There must be at least 6 IPs between startingIPAddress and endingIPAddress and this pool should be not include the node IPs.')\nparam endingIPAddress string\n\n@description('Required. The DNS servers accessible from the Management Network for the HCI cluster.')\nparam dnsServers string[]\n\n@description('Required. An array of Network ATC Network Intent objects that define the Compute, Management, and Storage network configuration for the cluster.')\nparam networkIntents array\n\n@description('Required. Specify whether the Storage Network connectivity is switched or switchless.')\nparam storageConnectivitySwitchless bool\n\n@description('Optional. Enable storage auto IP assignment. This should be true for most deployments except when deploying a three-node switchless cluster, in which case storage IPs should be configured before deployment and this value set to false.')\nparam enableStorageAutoIp bool = true\n\n@description('Required. An array of JSON objects that define the storage network configuration for the cluster. Each object should contain the adapterName, VLAN properties, and (optionally) IP configurations.')\nparam storageNetworks array\n\n// other cluster configuration parameters\n@description('Required. The name of the Custom Location associated with the Arc Resource Bridge for this cluster. This value should reflect the physical location and identifier of the HCI cluster. Example: cl-hci-den-clu01.')\nparam customLocationName string\n\n@description('Required. The name of the storage account to be used as the witness for the HCI Windows Failover Cluster.')\nparam clusterWitnessStorageAccountName string\n\n@description('Required. The name of the key vault to be used for storing secrets for the HCI cluster.')\nparam keyVaultName string\n\n@description('Optional. If using a shared key vault or non-legacy secret naming, pass the properties.cloudId guid from the pre-created HCI cluster resource.')\nparam cloudId string?\n\n@description('Optional. The intended operation for a cluster.')\n@allowed([\n  'ClusterProvisioning'\n  'ClusterUpgrade'\n])\nparam operationType string = 'ClusterProvisioning'\n\nvar arcNodeResourceIds = [\n  for (nodeName, index) in clusterNodeNames: resourceId('Microsoft.HybridCompute/machines', nodeName)\n]\n\nvar storageNetworksArray = [\n  for (storageAdapter, index) in storageNetworks: {\n    name: storageAdapter.name\n    networkAdapterName: storageAdapter.adapterName\n    vlanId: storageAdapter.vlan\n    storageAdapterIPInfo: storageAdapter.?storageAdapterIPInfo\n  }\n]\n\nresource cluster 'Microsoft.AzureStackHCI/clusters@2024-04-01' existing = {\n  name: clusterName\n}\n\nvar baseSecretNames = [\n  'LocalAdminCredential'\n  'AzureStackLCMUserCredential'\n  'WitnessStorageKey'\n]\n\nvar allSecretNames = needArbSecret ? concat(baseSecretNames, ['DefaultARBApplication']) : baseSecretNames\n\nresource deploymentSettings 'Microsoft.AzureStackHCI/clusters/deploymentSettings@2024-04-01' = {\n  name: name\n  parent: cluster\n  properties: {\n    arcNodeResourceIds: arcNodeResourceIds\n    deploymentMode: deploymentMode\n    deploymentConfiguration: {\n      version: operationType == 'ClusterUpgrade' ? '10.1.0.0' : '10.0.0.0'\n      scaleUnits: [\n        {\n          deploymentData: {\n            securitySettings: operationType == 'ClusterUpgrade'\n              ? null\n              : {\n                  hvciProtection: hvciProtection\n                  drtmProtection: drtmProtection\n                  driftControlEnforced: driftControlEnforced\n                  credentialGuardEnforced: credentialGuardEnforced\n                  smbSigningEnforced: smbSigningEnforced\n                  smbClusterEncryption: smbClusterEncryption\n                  sideChannelMitigationEnforced: sideChannelMitigationEnforced\n                  bitlockerBootVolume: bitlockerBootVolume\n                  bitlockerDataVolumes: bitlockerDataVolumes\n                  wdacEnforced: wdacEnforced\n                }\n            observability: {\n              streamingDataClient: streamingDataClient\n              euLocation: isEuropeanUnionLocation\n              episodicDataUpload: episodicDataUpload\n            }\n            cluster: {\n              name: clusterADName\n              witnessType: 'Cloud'\n              witnessPath: ''\n              cloudAccountName: clusterWitnessStorageAccountName\n              azureServiceEndpoint: environment().suffixes.storage\n            }\n            storage: {\n              configurationMode: storageConfigurationMode\n            }\n            namingPrefix: deploymentPrefix\n            domainFqdn: domainFqdn\n            infrastructureNetwork: [\n              {\n                subnetMask: subnetMask\n                gateway: defaultGateway\n                ipPools: [\n                  {\n                    startingAddress: startingIPAddress\n                    endingAddress: endingIPAddress\n                  }\n                ]\n                dnsServers: dnsServers\n              }\n            ]\n            physicalNodes: [\n              for hciNode in arcNodeResourceIds: {\n                name: reference(hciNode, '2022-12-27', 'Full').properties.displayName\n                // Getting the IP from the first NIC of the node with a default gateway. Only the first management pNIC should have a gateway defined.\n                // This reference call requires that the 'DeviceManagementExtension' extension be fully initialized on each node, which creates the\n                // edgeDevices sub-resource queried below, containing the IP configuration. View the edgedevice to troubleshoot by appending\n                // `/providers/microsoft.azurestackhci/edgedevices/default` to the end the HCI Arc Machine resource id and using `az resource show --id <id>`\n                ipv4Address: (filter(\n                  reference('${hciNode}/providers/microsoft.azurestackhci/edgeDevices/default', '2024-01-01', 'Full').properties.deviceConfiguration.nicDetails,\n                  nic => nic.?defaultGateway != null\n                ))[0].ip4Address\n              }\n            ]\n            hostNetwork: operationType == 'ClusterUpgrade'\n              ? null\n              : {\n                  intents: networkIntents\n                  storageConnectivitySwitchless: storageConnectivitySwitchless\n                  storageNetworks: storageNetworksArray\n                  enableStorageAutoIp: enableStorageAutoIp\n                }\n            adouPath: domainOUPath\n            secretsLocation: 'https://${keyVaultName}${environment().suffixes.keyvaultDns}'\n            optionalServices: {\n              customLocation: customLocationName\n            }\n            secrets: [\n              for secretName in allSecretNames: {\n                secretName: empty(cloudId) ? secretName : '${clusterName}-${secretName}-${cloudId}'\n                eceSecretName: secretName\n                secretLocation: empty(cloudId)\n                  ? 'https://${keyVaultName}${environment().suffixes.keyvaultDns}/secrets/${secretName}'\n                  : 'https://${keyVaultName}${environment().suffixes.keyvaultDns}/secrets/${clusterName}-${secretName}-${cloudId}'\n              }\n            ]\n          }\n        }\n      ]\n    }\n  }\n}\n\n@description('The name of the cluster deployment settings.')\noutput name string = deploymentSettings.name\n\n@description('The ID of the cluster deployment settings.')\noutput resourceId string = deploymentSettings.id\n\n@description('The resource group of the cluster deployment settings.')\noutput resourceGroupName string = resourceGroup().name\n",
+            "$fxv#2": "#!/bin/bash\n\nset -e  # Exit on any error\n\necho \"Starting HCI deployment script...\"\n\n# Check required environment variables\nif [ -z \"$RESOURCE_GROUP_NAME\" ] || [ -z \"$SUBSCRIPTION_ID\" ] || [ -z \"$CLUSTER_NAME\" ] || [ -z \"$CLUSTER_AD_NAME\" ] || [ -z \"$CLOUD_ID\" ] || [ -z \"$USE_SHARED_KEYVAULT\" ] || [ -z \"$DEPLOYMENT_SETTINGS\" ] || [ -z \"$DEPLOYMENT_SETTING_BICEP_BASE64\" ] || [ -z \"$DEPLOYMENT_SETTING_MAIN_BICEP_BASE64\" ] || [ -z \"$NEED_ARB_SECRET\" ] || [ -z \"$OPERATION_TYPE\" ]; then\n    echo \"Error: Required environment variables are missing\"\n    exit 1\nfi\n\n# Set subscription context\necho \"Setting subscription context to: $SUBSCRIPTION_ID\"\naz account set --subscription \"$SUBSCRIPTION_ID\"\n\n# Create directory structure and decode base64 files\necho \"Creating required directory structure and bicep files...\"\n\n# Create nested directory\nmkdir -p nested\n# Create deployment-setting directory\nmkdir -p deployment-setting\n\n# Decode and create deployment-setting.bicep file\necho \"Creating deployment-setting.bicep file from base64 encoded content...\"\necho \"$DEPLOYMENT_SETTING_BICEP_BASE64\" | base64 -d > nested/deployment-setting.bicep\n\n# Decode and create deployment-setting/main.bicep file\necho \"Creating deployment-setting/main.bicep file from base64 encoded content...\"\necho \"$DEPLOYMENT_SETTING_MAIN_BICEP_BASE64\" | base64 -d > deployment-setting/main.bicep\n\n# Verify the files were created successfully\nif [ ! -f \"nested/deployment-setting.bicep\" ] || [ ! -s \"nested/deployment-setting.bicep\" ]; then\n    echo \"Error: Failed to create nested/deployment-setting.bicep file or file is empty\"\n    exit 1\nfi\n\nif [ ! -f \"deployment-setting/main.bicep\" ] || [ ! -s \"deployment-setting/main.bicep\" ]; then\n    echo \"Error: Failed to create deployment-setting/main.bicep file or file is empty\"\n    exit 1\nfi\n\necho \"✅ All bicep files created successfully\"\necho \"nested/deployment-setting.bicep size: $(wc -c < nested/deployment-setting.bicep) bytes\"\necho \"deployment-setting/main.bicep size: $(wc -c < deployment-setting/main.bicep) bytes\"\n\n# List current directory structure for debugging\necho \"Current directory structure:\"\nfind . -name \"*.bicep\" -type f\n\n# Parse deployment operations into JSON array format\nIFS=',' read -ra OPERATIONS <<< \"$DEPLOYMENT_OPERATIONS\"\necho \"Deployment operations: ${OPERATIONS[@]}\"\n\n# Convert operations array to JSON format\nOPERATIONS_JSON=\"[\"\nfor i in \"${!OPERATIONS[@]}\"; do\n    if [ $i -gt 0 ]; then\n        OPERATIONS_JSON+=\",\"\n    fi\n    OPERATIONS_JSON+=\"\\\"${OPERATIONS[$i]}\\\"\"\ndone\nOPERATIONS_JSON+=\"]\"\n\necho \"Deployment operations JSON: $OPERATIONS_JSON\"\n\n# Convert boolean values to proper JSON format\nUSE_SHARED_KEYVAULT_JSON=$(echo \"$USE_SHARED_KEYVAULT\" | tr '[:upper:]' '[:lower:]')\nif [ \"$USE_SHARED_KEYVAULT_JSON\" = \"true\" ] || [ \"$USE_SHARED_KEYVAULT_JSON\" = \"1\" ]; then\n    USE_SHARED_KEYVAULT_JSON=\"true\"\nelse\n    USE_SHARED_KEYVAULT_JSON=\"false\"\nfi\n\necho \"Use shared key vault: $USE_SHARED_KEYVAULT_JSON\"\n\nNEED_ARB_SECRET_JSON=$(echo \"$NEED_ARB_SECRET\" | tr '[:upper:]' '[:lower:]')\nif [ \"$NEED_ARB_SECRET_JSON\" = \"true\" ] || [ \"$NEED_ARB_SECRET_JSON\" = \"1\" ]; then\n    NEED_ARB_SECRET_JSON=\"true\"\nelse\n    NEED_ARB_SECRET_JSON=\"false\"\nfi\n\necho \"Use shared key vault: $NEED_ARB_SECRET_JSON\"\n\n# Debug: Check the content of DEPLOYMENT_SETTINGS\necho \"Debug: DEPLOYMENT_SETTINGS type check...\"\necho \"First 100 chars of DEPLOYMENT_SETTINGS: ${DEPLOYMENT_SETTINGS:0:100}\"\n\n# Validate if DEPLOYMENT_SETTINGS is valid JSON\nif ! echo \"$DEPLOYMENT_SETTINGS\" | jq empty 2>/dev/null; then\n    echo \"Error: DEPLOYMENT_SETTINGS is not valid JSON\"\n    echo \"Content: $DEPLOYMENT_SETTINGS\"\n    exit 1\nfi\n\n# Create parameter file for deployment\nPARAM_FILE=\"deployment-params.json\"\n\n# Create a proper parameter file with JSON object\necho \"Creating parameter file...\"\ncat > \"$PARAM_FILE\" << EOF\n{\n  \"\\$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#\",\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"deploymentOperations\": {\n      \"value\": $OPERATIONS_JSON\n    },\n    \"deploymentSettings\": {\n      \"value\": $DEPLOYMENT_SETTINGS\n    },\n    \"useSharedKeyVault\": {\n      \"value\": $USE_SHARED_KEYVAULT_JSON\n    },\n    \"clusterName\": {\n      \"value\": \"$CLUSTER_NAME\"\n    },\n    \"clusterADName\": {\n      \"value\": \"$CLUSTER_AD_NAME\"\n    },\n    \"operationType\": {\n      \"value\": \"$OPERATION_TYPE\"\n    },\n    \"cloudId\": {\n      \"value\": \"$CLOUD_ID\"\n    },\n    \"needArbSecret\": {\n      \"value\": $NEED_ARB_SECRET_JSON\n    }\n  }\n}\nEOF\n\n# Validate the parameter file\necho \"Validating parameter file...\"\nif ! jq empty \"$PARAM_FILE\" 2>/dev/null; then\n    echo \"Error: Generated parameter file is not valid JSON\"\n    cat \"$PARAM_FILE\"\n    exit 1\nfi\n\necho \"✅ Parameter file created and validated successfully\"\n\n# Print parameter file content for debugging\necho \"============================================\"\necho \"Parameter file content:\"\necho \"============================================\"\ncat \"$PARAM_FILE\" | jq '.'\necho \"============================================\"\n\n# Check if deployment-settings resource exists\necho \"Checking if deployment-settings resource already exists...\"\n\n# Construct the resource ID for deployment-settings\nDEPLOYMENT_SETTINGS_RESOURCE_ID=\"/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP_NAME/providers/Microsoft.AzureStackHCI/clusters/$CLUSTER_NAME/deploymentSettings/default\"\n\necho \"Checking resource: $DEPLOYMENT_SETTINGS_RESOURCE_ID\"\n\n# Check if the deployment-settings resource exists\n# Redirect both stdout and stderr to suppress all output, only check exit code\nif az resource show --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" >/dev/null 2>&1; then\n    echo \"✅ Deployment-settings resource already exists. Checking status...\"\n\n    # Get the provisioning state and deployment mode\n    PROVISIONING_STATE=$(az resource show --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" --query \"properties.provisioningState\" --output tsv 2>/dev/null)\n    DEPLOYMENT_MODE=$(az resource show --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" --query \"properties.deploymentMode\" --output tsv 2>/dev/null)\n\n    echo \"Resource ID: $DEPLOYMENT_SETTINGS_RESOURCE_ID\"\n    echo \"Provisioning State: $PROVISIONING_STATE\"\n    echo \"Deployment Mode: $DEPLOYMENT_MODE\"\n\n    # First check deployment mode\n    if [ \"$DEPLOYMENT_MODE\" = \"Validate\" ]; then\n        echo \"🗑️  Deployment mode is 'Validate'. Removing the validation resource...\"\n\n        # Delete the resource\n        if az resource delete --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" --verbose; then\n            echo \"✅ Validation resource deleted successfully.\"\n            echo \"📝 Proceeding with deployment...\"\n        else\n            echo \"❌ Failed to delete the validation resource. Please check permissions and try again.\"\n            exit 1\n        fi\n    elif [ \"$DEPLOYMENT_MODE\" = \"Deploy\" ]; then\n        # Check if deployment is successful\n        if [ \"$PROVISIONING_STATE\" = \"Succeeded\" ]; then\n            echo \"✅ Deployment resource is in successful state. Skipping deployment.\"\n\n            # Show existing resource details\n            echo \"Existing deployment-settings details:\"\n            az resource show --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" --query \"{name: name, provisioningState: properties.provisioningState, deploymentMode: properties.deploymentMode}\" --output table 2>/dev/null || echo \"Could not retrieve resource details\"\n\n            exit 0\n        else\n            echo \"❌ Deployment resource exists but is not in successful state!\"\n            echo \"Expected: Succeeded, Actual: $PROVISIONING_STATE\"\n\n            # Show resource details for debugging\n            echo \"Resource details:\"\n            az resource show --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" --query \"{name: name, provisioningState: properties.provisioningState, deploymentMode: properties.deploymentMode}\" --output table 2>/dev/null || echo \"Could not retrieve resource details\"\n\n            exit 1\n        fi\n    else\n        echo \"⚠️  Unknown deployment mode: $DEPLOYMENT_MODE\"\n        echo \"Expected 'Validate' or 'Deploy'\"\n\n        # Show resource details for debugging\n        echo \"Resource details:\"\n        az resource show --ids \"$DEPLOYMENT_SETTINGS_RESOURCE_ID\" --query \"{name: name, provisioningState: properties.provisioningState, deploymentMode: properties.deploymentMode}\" --output table 2>/dev/null || echo \"Could not retrieve resource details\"\n\n        exit 1\n    fi\nelse\n    echo \"📝 Deployment-settings resource does not exist. Proceeding with deployment...\"\nfi\n\n# Execute Bicep deployment\nDEPLOYMENT_NAME=\"hci-deployment-$(date +%s)\"\n\necho \"Starting deployment: $DEPLOYMENT_NAME\"\necho \"Using template: nested/deployment-setting.bicep\"\necho \"Using parameter file: $PARAM_FILE\"\n\n# Check if nested/deployment-setting.bicep file was created successfully\nif [ ! -f \"nested/deployment-setting.bicep\" ]; then\n    echo \"Error: nested/deployment-setting.bicep file was not created successfully\"\n    echo \"Current directory contents:\"\n    ls -la\n    exit 1\nfi\n\necho \"✅ nested/deployment-setting.bicep file found and ready for deployment\"\n\n# Execute deployment with parameter file\naz deployment group create \\\n    --resource-group \"$RESOURCE_GROUP_NAME\" \\\n    --name \"$DEPLOYMENT_NAME\" \\\n    --template-file \"nested/deployment-setting.bicep\" \\\n    --parameters \"@$PARAM_FILE\" \\\n    --verbose\n\nDEPLOYMENT_STATUS=$?\n\nif [ $DEPLOYMENT_STATUS -eq 0 ]; then\n    echo \"✅ Deployment completed successfully\"\n\n    # Get deployment outputs\n    echo \"Deployment outputs:\"\n    az deployment group show \\\n        --resource-group \"$RESOURCE_GROUP_NAME\" \\\n        --name \"$DEPLOYMENT_NAME\" \\\n        --query \"properties.outputs\" \\\n        --output table\nelse\n    echo \"❌ Deployment failed with status: $DEPLOYMENT_STATUS\"\n\n    # Get deployment error details\n    echo \"Deployment error details:\"\n    az deployment group show \\\n        --resource-group \"$RESOURCE_GROUP_NAME\" \\\n        --name \"$DEPLOYMENT_NAME\" \\\n        --query \"properties.error\" \\\n        --output json\n\n    # Also show the deployment operations for more details\n    echo \"Deployment operations:\"\n    az deployment operation group list \\\n        --resource-group \"$RESOURCE_GROUP_NAME\" \\\n        --name \"$DEPLOYMENT_NAME\" \\\n        --query \"[?properties.provisioningState=='Failed'].{operation: operationId, code: properties.statusCode, message: properties.statusMessage}\" \\\n        --output table\n\n    exit $DEPLOYMENT_STATUS\nfi\n\n# Clean up temporary files\nrm -f \"$PARAM_FILE\"\nrm -f \"nested/deployment-setting.bicep\"\nrm -rf \"deployment-setting\"\n\necho \"Completed deployment\"\n\necho \"🎉 HCI deployment completed successfully!\"\n\n# Set output for Bicep usage\ncat > $AZ_SCRIPTS_OUTPUT_PATH << EOF\n{\n  \"status\": \"success\",\n  \"message\": \"Deployment completed successfully\",\n  \"operations\": $OPERATIONS_JSON\n}\nEOF\n",
+            "builtInRoleNames": {
+              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+              "Azure Stack HCI Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'bda0d508-adf1-4af0-9c28-88919fc3ae06')]",
+              "Windows Admin Center Administrator Login": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a6333a3e-0164-44c3-b281-7a577aff287f')]"
+            },
+            "azureConnectedMachineResourceManagerRoleID": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f5819b54-e033-4d82-ac66-4fec3cbf3f4c')]",
+            "readerRoleID": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+            "azureStackHCIDeviceManagementRole": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '865ae368-6a45-4bd1-8fbf-0d5151f56fc1')]",
+            "sortedDeploymentOperations": "[if(not(empty(parameters('deploymentOperations'))), sort(parameters('deploymentOperations'), lambda('a', 'b', greater(lambdaVariables('a'), lambdaVariables('b')))), createArray())]",
+            "managementNetworks": "[filter(parameters('deploymentSettings').networkIntents, lambda('n', contains(lambdaVariables('n').trafficType, 'Management')))]",
+            "managementIntentName": "[if(greater(length(variables('managementNetworks')), 0), variables('managementNetworks')[0].name, '')]"
+          },
+          "resources": {
+            "spConnectedMachineResourceManagerRolePermissions": {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(subscription().subscriptionId, parameters('hciResourceProviderObjectId'), 'ConnectedMachineResourceManagerRolePermissions', resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('azureConnectedMachineResourceManagerRoleID')]",
+                "principalId": "[parameters('hciResourceProviderObjectId')]",
+                "principalType": "ServicePrincipal",
+                "description": "Created by Azure Stack HCI deployment template"
+              }
+            },
+            "nodeAzureConnectedMachineResourceManagerRolePermissions": {
+              "copy": {
+                "name": "nodeAzureConnectedMachineResourceManagerRolePermissions",
+                "count": "[length(variables('arcNodeResourceIds'))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(subscription().subscriptionId, parameters('hciResourceProviderObjectId'), 'azureConnectedMachineResourceManager', variables('arcNodeResourceIds')[copyIndex()], resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('azureConnectedMachineResourceManagerRoleID')]",
+                "principalId": "[reference(variables('arcNodeResourceIds')[copyIndex()], '2023-10-03-preview', 'Full').identity.principalId]",
+                "principalType": "ServicePrincipal",
+                "description": "Created by Azure Stack HCI deployment template"
+              }
+            },
+            "nodeazureStackHCIDeviceManagementRole": {
+              "copy": {
+                "name": "nodeazureStackHCIDeviceManagementRole",
+                "count": "[length(variables('arcNodeResourceIds'))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(subscription().subscriptionId, parameters('hciResourceProviderObjectId'), 'azureStackHCIDeviceManagementRole', variables('arcNodeResourceIds')[copyIndex()], resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('azureStackHCIDeviceManagementRole')]",
+                "principalId": "[reference(variables('arcNodeResourceIds')[copyIndex()], '2023-10-03-preview', 'Full').identity.principalId]",
+                "principalType": "ServicePrincipal",
+                "description": "Created by Azure Stack HCI deployment template"
+              }
+            },
+            "nodereaderRoleIDPermissions": {
+              "copy": {
+                "name": "nodereaderRoleIDPermissions",
+                "count": "[length(variables('arcNodeResourceIds'))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(subscription().subscriptionId, parameters('hciResourceProviderObjectId'), 'reader', variables('arcNodeResourceIds')[copyIndex()], resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('readerRoleID')]",
+                "principalId": "[reference(variables('arcNodeResourceIds')[copyIndex()], '2023-10-03-preview', 'Full').identity.principalId]",
+                "principalType": "ServicePrincipal",
+                "description": "Created by Azure Stack HCI deployment template"
+              }
+            },
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2023-07-01",
+              "name": "[take(format('46d3xbcp.res.azurestackhci-cluster.{0}.{1}', replace('0.1.12', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4)), 64)]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
+            "arcMachines": {
+              "copy": {
+                "name": "arcMachines",
+                "count": "[length(parameters('deploymentSettings').clusterNodeNames)]"
+              },
+              "existing": true,
+              "type": "Microsoft.HybridCompute/machines",
+              "apiVersion": "2024-07-10",
+              "name": "[parameters('deploymentSettings').clusterNodeNames[copyIndex()]]"
+            },
+            "edgeDevices": {
+              "copy": {
+                "name": "edgeDevices",
+                "count": "[length(parameters('deploymentSettings').clusterNodeNames)]"
+              },
+              "type": "Microsoft.AzureStackHCI/edgeDevices",
+              "apiVersion": "2024-02-15-preview",
+              "scope": "[format('Microsoft.HybridCompute/machines/{0}', parameters('deploymentSettings').clusterNodeNames[copyIndex()])]",
+              "name": "default",
+              "kind": "HCI",
+              "properties": {
+                "deviceConfiguration": {
+                  "deviceMetadata": "",
+                  "nicDetails": []
+                }
+              }
+            },
+            "cluster": {
+              "type": "Microsoft.AzureStackHCI/clusters",
+              "apiVersion": "2024-04-01",
+              "name": "[parameters('name')]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "location": "[parameters('location')]",
+              "properties": {},
+              "tags": "[parameters('tags')]",
+              "dependsOn": [
+                "edgeDevices"
+              ]
+            },
+            "managedIdentity": {
+              "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+              "apiVersion": "2023-01-31",
+              "name": "[format('temp-{0}', parameters('name'))]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]"
+            },
+            "roleAssignmentContributor": {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('temp-{0}', parameters('name'))), variables('builtInRoleNames').Contributor, resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('builtInRoleNames').Contributor]",
+                "principalId": "[reference('managedIdentity').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "managedIdentity"
+              ]
+            },
+            "roleAssignmentReader": {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('temp-{0}', parameters('name'))), variables('builtInRoleNames').Reader, resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('builtInRoleNames').Reader]",
+                "principalId": "[reference('managedIdentity').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "managedIdentity"
+              ]
+            },
+            "roleAssignmentRBACAdmin": {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('temp-{0}', parameters('name'))), variables('builtInRoleNames')['Role Based Access Control Administrator'], resourceGroup().id)]",
+              "properties": {
+                "roleDefinitionId": "[variables('builtInRoleNames')['Role Based Access Control Administrator']]",
+                "principalId": "[reference('managedIdentity').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "managedIdentity"
+              ]
+            },
+            "deploymentScript": {
+              "type": "Microsoft.Resources/deploymentScripts",
+              "apiVersion": "2023-08-01",
+              "name": "[format('hci-deployment-script-{0}', uniqueString(resourceGroup().id))]",
+              "location": "[resourceGroup().location]",
+              "kind": "AzureCLI",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                  "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('temp-{0}', parameters('name'))))]": {}
+                }
+              },
+              "properties": {
+                "azCliVersion": "2.50.0",
+                "timeout": "PT5H",
+                "retentionInterval": "P1D",
+                "cleanupPreference": "OnSuccess",
+                "environmentVariables": [
+                  {
+                    "name": "RESOURCE_GROUP_NAME",
+                    "value": "[resourceGroup().name]"
+                  },
+                  {
+                    "name": "SUBSCRIPTION_ID",
+                    "value": "[subscription().subscriptionId]"
+                  },
+                  {
+                    "name": "CLUSTER_NAME",
+                    "value": "[parameters('name')]"
+                  },
+                  {
+                    "name": "CLUSTER_AD_NAME",
+                    "value": "[coalesce(parameters('clusterADName'), parameters('name'))]"
+                  },
+                  {
+                    "name": "CLOUD_ID",
+                    "value": "[reference('cluster').cloudId]"
+                  },
+                  {
+                    "name": "USE_SHARED_KEYVAULT",
+                    "value": "[string(parameters('useSharedKeyVault'))]"
+                  },
+                  {
+                    "name": "DEPLOYMENT_OPERATIONS",
+                    "value": "[join(variables('sortedDeploymentOperations'), ',')]"
+                  },
+                  {
+                    "name": "OPERATION_TYPE",
+                    "value": "[parameters('operationType')]"
+                  },
+                  {
+                    "name": "DEPLOYMENT_SETTINGS",
+                    "value": "[string(parameters('deploymentSettings'))]"
+                  },
+                  {
+                    "name": "DEPLOYMENT_SETTING_BICEP_BASE64",
+                    "value": "[base64(variables('$fxv#0'))]"
+                  },
+                  {
+                    "name": "DEPLOYMENT_SETTING_MAIN_BICEP_BASE64",
+                    "value": "[base64(variables('$fxv#1'))]"
+                  },
+                  {
+                    "name": "NEED_ARB_SECRET",
+                    "value": "[if(or(empty(parameters('servicePrincipalId')), empty(parameters('servicePrincipalSecret'))), string(false()), string(true()))]"
+                  }
+                ],
+                "scriptContent": "[variables('$fxv#2')]"
+              },
+              "dependsOn": [
+                "cluster",
+                "edgeDevices",
+                "managedIdentity",
+                "nodeAzureConnectedMachineResourceManagerRolePermissions",
+                "nodeazureStackHCIDeviceManagementRole",
+                "nodereaderRoleIDPermissions",
+                "roleAssignmentContributor",
+                "roleAssignmentRBACAdmin",
+                "roleAssignmentReader",
+                "secrets",
+                "spConnectedMachineResourceManagerRolePermissions"
+              ]
+            },
+            "cluster_roleAssignments": {
+              "copy": {
+                "name": "cluster_roleAssignments",
+                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[format('Microsoft.AzureStackHCI/clusters/{0}', parameters('name'))]",
+              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.AzureStackHCI/clusters', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+              "properties": {
+                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+              },
+              "dependsOn": [
+                "cluster"
+              ]
+            },
+            "secrets": {
+              "condition": "[parameters('useSharedKeyVault')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-secrets', uniqueString(deployment().name, parameters('location')))]",
+              "subscriptionId": "[coalesce(parameters('keyvaultSubscriptionId'), subscription().subscriptionId)]",
+              "resourceGroup": "[coalesce(parameters('keyvaultResourceGroup'), resourceGroup().name)]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "clusterName": {
+                    "value": "[parameters('name')]"
+                  },
+                  "cloudId": {
+                    "value": "[reference('cluster').cloudId]"
+                  },
+                  "keyVaultName": {
+                    "value": "[parameters('deploymentSettings').keyVaultName]"
+                  },
+                  "storageAccountName": {
+                    "value": "[parameters('deploymentSettings').clusterWitnessStorageAccountName]"
+                  },
+                  "deploymentUser": {
+                    "value": "[parameters('deploymentUser')]"
+                  },
+                  "deploymentUserPassword": {
+                    "value": "[parameters('deploymentUserPassword')]"
+                  },
+                  "localAdminUser": {
+                    "value": "[parameters('localAdminUser')]"
+                  },
+                  "localAdminPassword": {
+                    "value": "[parameters('localAdminPassword')]"
+                  },
+                  "servicePrincipalId": {
+                    "value": "[parameters('servicePrincipalId')]"
+                  },
+                  "servicePrincipalSecret": {
+                    "value": "[parameters('servicePrincipalSecret')]"
+                  },
+                  "azureStackLCMUserCredentialContentType": {
+                    "value": "[parameters('azureStackLCMUserCredentialContentType')]"
+                  },
+                  "localAdminCredentialContentType": {
+                    "value": "[parameters('localAdminCredentialContentType')]"
+                  },
+                  "witnessStoragekeyContentType": {
+                    "value": "[parameters('witnessStoragekeyContentType')]"
+                  },
+                  "defaultARBApplicationContentType": {
+                    "value": "[parameters('defaultARBApplicationContentType')]"
+                  },
+                  "azureStackLCMUserCredentialTags": {
+                    "value": "[parameters('azureStackLCMUserCredentialTags')]"
+                  },
+                  "localAdminCredentialTags": {
+                    "value": "[parameters('localAdminCredentialTags')]"
+                  },
+                  "witnessStoragekeyTags": {
+                    "value": "[parameters('witnessStoragekeyTags')]"
+                  },
+                  "defaultARBApplicationTags": {
+                    "value": "[parameters('defaultARBApplicationTags')]"
+                  },
+                  "witnessStorageAccountResourceGroup": {
+                    "value": "[coalesce(parameters('witnessStorageAccountResourceGroup'), resourceGroup().name)]"
+                  },
+                  "witnessStorageAccountSubscriptionId": {
+                    "value": "[coalesce(parameters('witnessStorageAccountSubscriptionId'), subscription().subscriptionId)]"
+                  },
+                  "hciResourceProviderObjectId": {
+                    "value": "[parameters('hciResourceProviderObjectId')]"
+                  },
+                  "arcNodeResourceIds": {
+                    "value": "[variables('arcNodeResourceIds')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.36.177.2456",
+                      "templateHash": "10008583855790273441"
+                    }
+                  },
+                  "parameters": {
+                    "keyVaultName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the key vault."
+                      }
+                    },
+                    "storageAccountName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the strorage account."
+                      }
+                    },
+                    "clusterName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the cluster."
+                      }
+                    },
+                    "cloudId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The cloud ID."
+                      }
+                    },
+                    "deploymentUser": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the deployment user."
+                      }
+                    },
+                    "deploymentUserPassword": {
+                      "type": "securestring",
+                      "metadata": {
+                        "description": "Required. The password of the deployment user."
+                      }
+                    },
+                    "localAdminUser": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the local admin user."
+                      }
+                    },
+                    "localAdminPassword": {
+                      "type": "securestring",
+                      "metadata": {
+                        "description": "Required. The password of the local admin user."
+                      }
+                    },
+                    "servicePrincipalId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Conditional. The service principal ID for ARB."
+                      }
+                    },
+                    "servicePrincipalSecret": {
+                      "type": "securestring",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Conditional. The service principal secret for ARB."
+                      }
+                    },
+                    "azureStackLCMUserCredentialContentType": {
+                      "type": "string",
+                      "defaultValue": "Secret",
+                      "metadata": {
+                        "description": "Optional. Content type of the azure stack lcm user credential."
+                      }
+                    },
+                    "localAdminCredentialContentType": {
+                      "type": "string",
+                      "defaultValue": "Secret",
+                      "metadata": {
+                        "description": "Optional. Content type of the local admin credential."
+                      }
+                    },
+                    "witnessStoragekeyContentType": {
+                      "type": "string",
+                      "defaultValue": "Secret",
+                      "metadata": {
+                        "description": "Optional. Content type of the witness storage key."
+                      }
+                    },
+                    "defaultARBApplicationContentType": {
+                      "type": "string",
+                      "defaultValue": "Secret",
+                      "metadata": {
+                        "description": "Optional. Content type of the default ARB application."
+                      }
+                    },
+                    "azureStackLCMUserCredentialTags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of azure stack LCM user credential."
+                      }
+                    },
+                    "localAdminCredentialTags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of the local admin credential."
+                      }
+                    },
+                    "witnessStoragekeyTags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of the witness storage key."
+                      }
+                    },
+                    "defaultARBApplicationTags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of the default ARB application."
+                      }
+                    },
+                    "witnessStorageAccountSubscriptionId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Optional. Storage account subscription ID, which is used as the witness for the HCI Windows Failover Cluster."
+                      }
+                    },
+                    "witnessStorageAccountResourceGroup": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Optional. Storage account resource group, which is used as the witness for the HCI Windows Failover Cluster.."
+                      }
+                    },
+                    "hciResourceProviderObjectId": {
+                      "type": "securestring",
+                      "metadata": {
+                        "description": "Required. The service principal object ID of the Azure Stack HCI Resource Provider in this tenant. Can be fetched via `Get-AzADServicePrincipal -ApplicationId 1412d89f-b8a8-4111-b4fd-e82905cbd85d` after the 'Microsoft.AzureStackHCI' provider was registered in the subscription."
+                      }
+                    },
+                    "arcNodeResourceIds": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "Required. Resource ids of the cluster node Arc Machine resources. These are the id of the Arc Machine resources created when the new HCI nodes were Arc initialized."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "keyVaultSecretUserRoleID": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]"
+                  },
+                  "resources": {
+                    "witnessStorageAccount": {
+                      "existing": true,
+                      "type": "Microsoft.Storage/storageAccounts",
+                      "apiVersion": "2023-01-01",
+                      "subscriptionId": "[parameters('witnessStorageAccountSubscriptionId')]",
+                      "resourceGroup": "[parameters('witnessStorageAccountResourceGroup')]",
+                      "name": "[parameters('storageAccountName')]"
+                    },
+                    "keyVault": {
+                      "existing": true,
+                      "type": "Microsoft.KeyVault/vaults",
+                      "apiVersion": "2022-07-01",
+                      "name": "[parameters('keyVaultName')]"
+                    },
+                    "KeyVaultSecretsUserPermissions": {
+                      "copy": {
+                        "name": "KeyVaultSecretsUserPermissions",
+                        "count": "[length(parameters('arcNodeResourceIds'))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.KeyVault/vaults/{0}', parameters('keyVaultName'))]",
+                      "name": "[guid(subscription().subscriptionId, parameters('hciResourceProviderObjectId'), 'keyVaultSecretUser', parameters('arcNodeResourceIds')[copyIndex()], resourceGroup().id)]",
+                      "properties": {
+                        "roleDefinitionId": "[variables('keyVaultSecretUserRoleID')]",
+                        "principalId": "[reference(parameters('arcNodeResourceIds')[copyIndex()], '2023-10-03-preview', 'Full').identity.principalId]",
+                        "principalType": "ServicePrincipal",
+                        "description": "Created by Azure Stack HCI deployment template"
+                      }
+                    },
+                    "azureStackLCMUserCredential": {
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), format('{0}-AzureStackLCMUserCredential-{1}', parameters('clusterName'), parameters('cloudId')))]",
+                      "properties": {
+                        "contentType": "[parameters('azureStackLCMUserCredentialContentType')]",
+                        "value": "[base64(format('{0}:{1}', parameters('deploymentUser'), parameters('deploymentUserPassword')))]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "tags": "[parameters('azureStackLCMUserCredentialTags')]"
+                    },
+                    "localAdminCredential": {
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), format('{0}-LocalAdminCredential-{1}', parameters('clusterName'), parameters('cloudId')))]",
+                      "properties": {
+                        "contentType": "[parameters('localAdminCredentialContentType')]",
+                        "value": "[base64(format('{0}:{1}', parameters('localAdminUser'), parameters('localAdminPassword')))]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "tags": "[parameters('localAdminCredentialTags')]"
+                    },
+                    "witnessStorageKey": {
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), format('{0}-WitnessStorageKey-{1}', parameters('clusterName'), parameters('cloudId')))]",
+                      "properties": {
+                        "contentType": "[parameters('witnessStoragekeyContentType')]",
+                        "value": "[base64(listKeys('witnessStorageAccount', '2023-01-01').keys[0].value)]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "tags": "[parameters('witnessStoragekeyTags')]"
+                    },
+                    "defaultARBApplication": {
+                      "condition": "[and(not(empty(parameters('servicePrincipalId'))), not(empty(parameters('servicePrincipalSecret'))))]",
+                      "type": "Microsoft.KeyVault/vaults/secrets",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('{0}/{1}', parameters('keyVaultName'), format('{0}-DefaultARBApplication-{1}', parameters('clusterName'), parameters('cloudId')))]",
+                      "properties": {
+                        "contentType": "[parameters('defaultARBApplicationContentType')]",
+                        "value": "[base64(format('{0}:{1}', parameters('servicePrincipalId'), parameters('servicePrincipalSecret')))]",
+                        "attributes": {
+                          "enabled": true
+                        }
+                      },
+                      "tags": "[parameters('defaultARBApplicationTags')]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "cluster"
+              ]
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the cluster."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The ID of the cluster."
+              },
+              "value": "[resourceId('Microsoft.AzureStackHCI/clusters', parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the cluster."
+              },
+              "value": "[resourceGroup().name]"
+            },
+            "systemAssignedMIPrincipalId": {
+              "type": "string",
+              "metadata": {
+                "description": "The managed identity of the cluster."
+              },
+              "value": "[reference('cluster', '2024-04-01', 'full').identity.principalId]"
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "The location of the cluster."
+              },
+              "value": "[reference('cluster', '2024-04-01', 'full').location]"
+            },
+            "vSwitchName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the vSwitch."
+              },
+              "value": "[format('ConvergedSwitch({0})', variables('managementIntentName'))]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "nestedDependencies",
+        "resourceGroup"
+      ]
+    },
+    "hciImage": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}-test-mgi-{1}', uniqueString(deployment().name, variables('enforcedLocation')), parameters('serviceShort'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[format('{0}{1}marketplaceimage', parameters('namePrefix'), parameters('serviceShort'))]"
+          },
+          "customLocationResourceId": {
+            "value": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.ExtendedLocation/customLocations', format('{0}{1}-location', parameters('namePrefix'), parameters('serviceShort')))]"
+          },
+          "identifier": {
+            "value": {
+              "offer": "WindowsServer",
+              "publisher": "MicrosoftWindowsServer",
+              "sku": "2022-datacenter-azure-edition"
+            }
+          },
+          "osType": {
+            "value": "Windows"
+          },
+          "version": {
+            "value": {
+              "name": "20348.2461.240510"
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.36.1.42791",
+              "templateHash": "14152740400046034707"
+            },
+            "name": "Azure Stack HCI Marketplace Gallery Image",
+            "description": "This module deploys an Azure Stack HCI Marketplace Gallery Image."
+          },
+          "definitions": {
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the resource to create."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all Resources."
+              }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
+            },
+            "customLocationResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The custom location ID."
+              }
+            },
+            "osType": {
+              "type": "string",
+              "allowedValues": [
+                "Windows",
+                "Linux"
+              ],
+              "metadata": {
+                "description": "Required. Operating system type that the gallery image uses."
+              }
+            },
+            "identifier": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/marketplaceGalleryImages@2025-04-01-preview#properties/properties/properties/identifier"
+                },
+                "description": "Required. The gallery image identifier configuration containing publisher, offer, and SKU."
+              }
+            },
+            "hyperVGeneration": {
+              "type": "string",
+              "defaultValue": "V2",
+              "allowedValues": [
+                "V1",
+                "V2"
+              ],
+              "metadata": {
+                "description": "Optional. The hypervisor generation of the Virtual Machine."
+              }
+            },
+            "cloudInitDataSource": {
+              "type": "string",
+              "nullable": true,
+              "allowedValues": [
+                "NoCloud",
+                "Azure"
+              ],
+              "metadata": {
+                "description": "Optional. Datasource for the gallery image when provisioning with cloud-init."
+              }
+            },
+            "containerResourceId": {
+              "type": "string",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Storage Container resourceId of the storage container to be used for marketplace gallery image."
+              }
+            },
+            "version": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/marketplaceGalleryImages@2025-04-01-preview#properties/properties/properties/version"
+                },
+                "description": "Required. Gallery image version configuration."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/marketplaceGalleryImages@2025-04-01-preview#properties/tags"
+                },
+                "description": "Optional. Tags for the marketplace gallery image."
+              },
+              "nullable": true
+            },
+            "roleAssignments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Array of role assignments to create."
+              }
+            }
+          },
+          "variables": {
+            "copy": [
+              {
+                "name": "formattedRoleAssignments",
+                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+              }
+            ],
+            "builtInRoleNames": {
+              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+            }
+          },
+          "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2024-03-01",
+              "name": "[take(format('46d3xbcp.res.azurestackhci-markplgalleryimg.{0}.{1}', replace('0.1.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4)), 64)]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
+            "marketplaceGalleryImage": {
+              "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+              "apiVersion": "2025-04-01-preview",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "extendedLocation": {
+                "name": "[parameters('customLocationResourceId')]",
+                "type": "CustomLocation"
+              },
+              "properties": {
+                "cloudInitDataSource": "[parameters('cloudInitDataSource')]",
+                "containerId": "[parameters('containerResourceId')]",
+                "hyperVGeneration": "[parameters('hyperVGeneration')]",
+                "identifier": {
+                  "offer": "[parameters('identifier').offer]",
+                  "publisher": "[parameters('identifier').publisher]",
+                  "sku": "[parameters('identifier').sku]"
+                },
+                "osType": "[parameters('osType')]",
+                "version": "[parameters('version')]"
+              }
+            },
+            "marketplaceGalleryImage_roleAssignments": {
+              "copy": {
+                "name": "marketplaceGalleryImage_roleAssignments",
+                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[format('Microsoft.AzureStackHCI/marketplaceGalleryImages/{0}', parameters('name'))]",
+              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.AzureStackHCI/marketplaceGalleryImages', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+              "properties": {
+                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+              },
+              "dependsOn": [
+                "marketplaceGalleryImage"
+              ]
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the marketplace gallery image."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the marketplace gallery image."
+              },
+              "value": "[resourceId('Microsoft.AzureStackHCI/marketplaceGalleryImages', parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the marketplace gallery image."
+              },
+              "value": "[resourceGroup().name]"
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "The location of the marketplace gallery image."
+              },
+              "value": "[reference('marketplaceGalleryImage', '2025-04-01-preview', 'full').location]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "azlocal",
+        "resourceGroup"
+      ]
+    },
+    "testDeployment": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}-vm-{1}', uniqueString(deployment().name, variables('enforcedLocation')), parameters('serviceShort'))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[format('{0}-hc-{1}', uniqueString(deployment().name, variables('enforcedLocation')), parameters('serviceShort'))]"
+          },
+          "location": {
+            "value": "[variables('enforcedLocation')]"
+          },
+          "customLocationResourceId": {
+            "value": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.ExtendedLocation/customLocations', format('{0}{1}-location', parameters('namePrefix'), parameters('serviceShort')))]"
+          },
+          "hardwareProfile": {
+            "value": {
+              "vmSize": "Custom",
+              "memoryMB": 4096,
+              "processors": 2,
+              "dynamicMemoryConfig": {
+                "maximumMemoryMB": 8192,
+                "minimumMemoryMB": 512,
+                "targetMemoryBuffer": 20
+              }
+            }
+          },
+          "networkProfile": {
+            "value": {}
+          },
+          "osProfile": {
+            "value": {
+              "computerName": "[format('{0}{1}vm', parameters('namePrefix'), parameters('serviceShort'))]",
+              "linuxConfiguration": {},
+              "windowsConfiguration": {
+                "enableAutomaticUpdates": true,
+                "provisionVMAgent": true,
+                "provisionVMConfigAgent": true
+              },
+              "adminUsername": "Administrator",
+              "adminPassword": "[parameters('localAdminAndDeploymentUserPass')]"
+            }
+          },
+          "adminPassword": {
+            "value": "[parameters('localAdminAndDeploymentUserPass')]"
+          },
+          "storageProfile": {
+            "value": {
+              "imageReference": {
+                "id": "[reference('hciImage').outputs.resourceId.value]"
+              },
+              "osDisk": {
+                "osType": "Windows"
+              }
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.40.2.10011",
+              "templateHash": "10681649339677827998"
+            },
+            "name": "Azure Stack HCI Virtual Machine Instance",
+            "description": "This module deploys an Azure Stack HCI virtual machine."
+          },
+          "definitions": {
+            "roleAssignmentType": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                  }
+                },
+                "roleDefinitionIdOrName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                  }
+                },
+                "principalId": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                  }
+                },
+                "principalType": {
+                  "type": "string",
+                  "allowedValues": [
+                    "Device",
+                    "ForeignGroup",
+                    "Group",
+                    "ServicePrincipal",
+                    "User"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The principal type of the assigned principal ID."
+                  }
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The description of the role assignment."
+                  }
+                },
+                "condition": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                  }
+                },
+                "conditionVersion": {
+                  "type": "string",
+                  "allowedValues": [
+                    "2.0"
+                  ],
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Version of the condition."
+                  }
+                },
+                "delegatedManagedIdentityResourceId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a role assignment.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the resource to create."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for all Resources."
+              }
+            },
+            "customLocationResourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Resource ID of the associated custom location."
+              }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
+            },
+            "hardwareProfile": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/hardwareProfile"
+                },
+                "description": "Required. Hardware profile configuration."
+              }
+            },
+            "httpProxyConfig": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/httpProxyConfig"
+                },
+                "description": "Optional. HTTP proxy configuration."
+              },
+              "defaultValue": {}
+            },
+            "networkProfile": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/networkProfile"
+                },
+                "description": "Required. Network profile configuration."
+              }
+            },
+            "osProfile": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/osProfile"
+                },
+                "description": "Required. OS profile configuration."
+              }
+            },
+            "securityProfile": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/securityProfile"
+                },
+                "description": "Optional. Security profile configuration."
+              },
+              "defaultValue": {
+                "uefiSettings": {
+                  "secureBootEnabled": true
+                }
+              }
+            },
+            "storageProfile": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.AzureStackHCI/virtualMachineInstances@2025-04-01-preview#properties/properties/properties/storageProfile"
+                },
+                "description": "Required. Storage profile configuration."
+              }
+            },
+            "roleAssignments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentType"
+              },
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Array of role assignments to create."
+              }
+            },
+            "adminPassword": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The password of arc vm. If it is provided, it will be used for the admin account in osProfile."
+              }
+            },
+            "httpProxy": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The HTTP proxy server endpoint to use. If it is provided, it will be used in HttpProxyConfiguration."
+              }
+            },
+            "httpsProxy": {
+              "type": "securestring",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The HTTPS proxy server endpoint to use. If it is provided, it will be used in HttpProxyConfiguration."
+              }
+            }
+          },
+          "variables": {
+            "copy": [
+              {
+                "name": "formattedRoleAssignments",
+                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+              }
+            ],
+            "builtInRoleNames": {
+              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+            },
+            "enableReferencedModulesTelemetry": false
+          },
+          "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2024-03-01",
+              "name": "[format('46d3xbcp.res.azurestackhci-virtualmachineinstance.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
+            "existingMachine": {
+              "existing": true,
+              "type": "Microsoft.HybridCompute/machines",
+              "apiVersion": "2023-10-03-preview",
+              "name": "[parameters('name')]",
+              "dependsOn": [
+                "hybridCompute"
+              ]
+            },
+            "virtualMachineInstance": {
+              "type": "Microsoft.AzureStackHCI/virtualMachineInstances",
+              "apiVersion": "2024-01-01",
+              "scope": "[resourceId('Microsoft.HybridCompute/machines', parameters('name'))]",
+              "name": "default",
+              "extendedLocation": {
+                "type": "CustomLocation",
+                "name": "[parameters('customLocationResourceId')]"
+              },
+              "properties": {
+                "hardwareProfile": {
+                  "memoryMB": "[parameters('hardwareProfile').memoryMB]",
+                  "processors": "[parameters('hardwareProfile').processors]",
+                  "vmSize": "[if(empty(tryGet(parameters('hardwareProfile'), 'vmSize')), 'Custom', tryGet(parameters('hardwareProfile'), 'vmSize'))]",
+                  "dynamicMemoryConfig": "[tryGet(parameters('hardwareProfile'), 'dynamicMemoryConfig')]"
+                },
+                "httpProxyConfig": "[if(empty(parameters('httpProxyConfig')), null(), union(parameters('httpProxyConfig'), createObject('httpProxy', parameters('httpProxy'), 'httpsProxy', parameters('httpsProxy'))))]",
+                "networkProfile": "[parameters('networkProfile')]",
+                "osProfile": "[union(parameters('osProfile'), createObject('adminPassword', parameters('adminPassword')))]",
+                "securityProfile": "[if(empty(parameters('securityProfile')), null(), parameters('securityProfile'))]",
+                "storageProfile": "[parameters('storageProfile')]"
+              },
+              "dependsOn": [
+                "hybridCompute"
+              ]
+            },
+            "virtualMachine_roleAssignments": {
+              "copy": {
+                "name": "virtualMachine_roleAssignments",
+                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[extensionResourceId(resourceId('Microsoft.HybridCompute/machines', parameters('name')), 'Microsoft.AzureStackHCI/virtualMachineInstances', 'default')]",
+              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(extensionResourceId(resourceId('Microsoft.HybridCompute/machines', parameters('name')), 'Microsoft.AzureStackHCI/virtualMachineInstances', 'default'), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+              "properties": {
+                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+              },
+              "dependsOn": [
+                "virtualMachineInstance"
+              ]
+            },
+            "hybridCompute": {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('{0}-deployment', parameters('name'))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[parameters('name')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "kind": {
+                    "value": "HCI"
+                  },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.33.13.18514",
+                      "templateHash": "2332904181907667266"
+                    },
+                    "name": "Hybrid Compute Machines",
+                    "description": "This module deploys an Arc Machine for use with Arc Resource Bridge for Azure Stack HCI or VMware. In these scenarios, this resource module will be used in combination with another resource module to create the require Virtual Machine Instance extension resource on this Arc Machine resource. This module should not be used for other Arc-enabled server scenarios, where the Arc Machine resource is created automatically by the onboarding process."
+                  },
+                  "definitions": {
+                    "lockType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the name of lock."
+                          }
+                        },
+                        "kind": {
+                          "type": "string",
+                          "allowedValues": [
+                            "CanNotDelete",
+                            "None",
+                            "ReadOnly"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the type of lock."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a lock.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.4.1"
+                        }
+                      }
+                    },
+                    "roleAssignmentType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.4.1"
+                        }
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the Arc machine to be created. You should use a unique prefix to reduce name collisions in Active Directory."
+                      }
+                    },
+                    "kind": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. Kind of Arc machine to be created. Possible values are: HCI, SCVMM, VMware."
+                      }
+                    },
+                    "privateLinkScopeResourceId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Conditional. The resource ID of an Arc Private Link Scope which which to associate this machine. Required if you are using Private Link for Arc and your Arc Machine will resolve a Private Endpoint for connectivity to Azure."
+                      }
+                    },
+                    "parentClusterResourceId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Parent cluster resource ID (Azure Stack HCI)."
+                      }
+                    },
+                    "vmId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The GUID of the on-premises virtual machine from your hypervisor."
+                      }
+                    },
+                    "clientPublicKey": {
+                      "type": "securestring",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The Public Key that the client provides to be used during initial resource onboarding."
+                      }
+                    },
+                    "patchMode": {
+                      "type": "string",
+                      "nullable": true,
+                      "allowedValues": [
+                        "AutomaticByPlatform",
+                        "AutomaticByOS",
+                        "Manual",
+                        "ImageDefault"
+                      ],
+                      "metadata": {
+                        "description": "Optional. VM guest patching orchestration mode. 'AutomaticByOS' & 'Manual' are for Windows only, 'ImageDefault' for Linux only."
+                      }
+                    },
+                    "patchAssessmentMode": {
+                      "type": "string",
+                      "defaultValue": "ImageDefault",
+                      "allowedValues": [
+                        "AutomaticByPlatform",
+                        "ImageDefault"
+                      ],
+                      "metadata": {
+                        "description": "Optional. VM guest patching assessment mode. Set it to 'AutomaticByPlatform' to enable automatically check for updates every 24 hours."
+                      }
+                    },
+                    "guestConfiguration": {
+                      "type": "object",
+                      "defaultValue": {},
+                      "metadata": {
+                        "description": "Optional. The guest configuration for the Arc machine. Needs the Guest Configuration extension to be enabled."
+                      }
+                    },
+                    "osType": {
+                      "type": "string",
+                      "nullable": true,
+                      "allowedValues": [
+                        "Windows",
+                        "Linux"
+                      ],
+                      "metadata": {
+                        "description": "Conditional. Required if you are providing OS-type specified configurations, such as patch settings. The chosen OS type, either Windows or Linux."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]",
+                      "metadata": {
+                        "description": "Optional. Location for all resources."
+                      }
+                    },
+                    "lock": {
+                      "$ref": "#/definitions/lockType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The lock settings of the service."
+                      }
+                    },
+                    "roleAssignments": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of role assignments to create."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of the resource."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "copy": [
+                      {
+                        "name": "formattedRoleAssignments",
+                        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                        "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                      }
+                    ],
+                    "linuxConfiguration": {
+                      "patchSettings": "[if(or(equals(parameters('patchMode'), 'AutomaticByPlatform'), equals(parameters('patchMode'), 'ImageDefault')), createObject('patchMode', parameters('patchMode'), 'assessmentMode', parameters('patchAssessmentMode')), null())]"
+                    },
+                    "windowsConfiguration": {
+                      "patchSettings": "[if(or(or(equals(parameters('patchMode'), 'AutomaticByPlatform'), equals(parameters('patchMode'), 'AutomaticByOS')), equals(parameters('patchMode'), 'Manual')), createObject('patchMode', parameters('patchMode'), 'assessmentMode', parameters('patchAssessmentMode')), null())]"
+                    },
+                    "builtInRoleNames": {
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+                      "Arc machine Administrator Login": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '1c0163c0-47e6-4577-8991-ea5c82e286e4')]",
+                      "Arc machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9980e02c-c2be-4d73-94e8-173b1dc7cf3c')]",
+                      "Arc machine User Login": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'fb879df8-f326-4884-b1cf-06f3ad86be52')]",
+                      "Windows Admin Center Administrator Login": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a6333a3e-0164-44c3-b281-7a577aff287f')]"
+                    }
+                  },
+                  "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2023-07-01",
+                      "name": "[format('46d3xbcp.res.hybridcompute-machine.{0}.{1}', replace('0.4.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "machine": {
+                      "type": "Microsoft.HybridCompute/machines",
+                      "apiVersion": "2024-07-10",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "identity": {
+                        "type": "SystemAssigned"
+                      },
+                      "tags": "[parameters('tags')]",
+                      "kind": "[parameters('kind')]",
+                      "properties": {
+                        "osProfile": {
+                          "windowsConfiguration": "[if(equals(parameters('osType'), 'Windows'), variables('windowsConfiguration'), null())]",
+                          "linuxConfiguration": "[if(equals(parameters('osType'), 'Linux'), variables('linuxConfiguration'), null())]"
+                        },
+                        "parentClusterResourceId": "[parameters('parentClusterResourceId')]",
+                        "vmId": "[parameters('vmId')]",
+                        "clientPublicKey": "[parameters('clientPublicKey')]",
+                        "privateLinkScopeResourceId": "[if(not(empty(parameters('privateLinkScopeResourceId'))), parameters('privateLinkScopeResourceId'), null())]"
+                      }
+                    },
+                    "AzureWindowsBaseline": {
+                      "condition": "[not(empty(parameters('guestConfiguration')))]",
+                      "type": "Microsoft.GuestConfiguration/guestConfigurationAssignments",
+                      "apiVersion": "2020-06-25",
+                      "scope": "[format('Microsoft.HybridCompute/machines/{0}', parameters('name'))]",
+                      "name": "[format('gca-{0}', parameters('name'))]",
+                      "location": "[parameters('location')]",
+                      "properties": {
+                        "guestConfiguration": "[parameters('guestConfiguration')]"
+                      },
+                      "dependsOn": [
+                        "machine"
+                      ]
+                    },
+                    "machine_lock": {
+                      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                      "type": "Microsoft.Authorization/locks",
+                      "apiVersion": "2020-05-01",
+                      "scope": "[format('Microsoft.HybridCompute/machines/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                      "properties": {
+                        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                        "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+                      },
+                      "dependsOn": [
+                        "machine"
+                      ]
+                    },
+                    "machine_roleAssignments": {
+                      "copy": {
+                        "name": "machine_roleAssignments",
+                        "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.HybridCompute/machines/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.HybridCompute/machines', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                      "properties": {
+                        "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                        "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                        "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                        "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                        "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                        "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                      },
+                      "dependsOn": [
+                        "machine"
+                      ]
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the machine."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the machine."
+                      },
+                      "value": "[resourceId('Microsoft.HybridCompute/machines', parameters('name'))]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the resource group the VM was created in."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "systemAssignedMIPrincipalId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "The principal ID of the system assigned identity."
+                      },
+                      "value": "[tryGet(tryGet(reference('machine', '2024-07-10', 'full'), 'identity'), 'principalId')]"
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The location the resource was deployed into."
+                      },
+                      "value": "[reference('machine', '2024-07-10', 'full').location]"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the virtual machine instance."
+              },
+              "value": "default"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the virtual machine instance."
+              },
+              "value": "[extensionResourceId(resourceId('Microsoft.HybridCompute/machines', parameters('name')), 'Microsoft.AzureStackHCI/virtualMachineInstances', 'default')]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource group of the virtual machine instance."
+              },
+              "value": "[resourceGroup().name]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "azlocal",
+        "hciImage",
+        "resourceGroup"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds \@secure()\ decorator to the \osProfile\ parameter in \vm/res/azure-stack-hci/virtual-machine-instance\ to prevent \dminPassword\ from being exposed in ARM deployment history (visible in Azure Portal deployment inputs).

## Changes

- **main.bicep**: Added \@secure()\ before \osProfile\ parameter, compiling to \secureObject\ type in ARM template
- **main.json**: Rebuilt - \osProfile\ type changed from \object\ to \secureObject\
- **README.md**: Regenerated to reflect \secureObject\ type for osProfile
- **CHANGELOG.md**: Added v0.1.2 entry
- **tests/e2e/defaults/main.test.bicep**: Removed stale \domainAdminPassword\ reference (removed from shared \dependencies.bicep\ in #6687)
- **tests/e2e/waf-aligned/main.test.bicep**: Same fix as defaults
- **tests/e2e/defaults/main.test.json**: Generated compiled test template
- **tests/e2e/waf-aligned/main.test.json**: Generated compiled test template

## Testing

- Local Pester: **92 passed, 0 failed, 8 skipped**
- CI run: https://github.com/chirag1603/bicep-registry-modules/actions/runs/23644590885
