### PR TITLE
feat: ScalingPlan - Changed `hostPoolReferences` default to `null` when no `hostPoolReferences` are defined.

### DIFF
--- a/avm/res/desktop-virtualization/scaling-plan/CHANGELOG.md
+++ b/avm/res/desktop-virtualization/scaling-plan/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/desktop-virtualization/scaling-plan/CHANGELOG.md).
 
+## 0.5.0
+
+### Changes
+
+- Updated behavior of `hostPoolReferences` parameter to not default to `null` instead of `[]` when no `hostPoolReferences` are defined.
+
+### Breaking Changes
+
+- None
+
 ## 0.4.1
 
 ### Changes

--- a/avm/res/desktop-virtualization/scaling-plan/CHANGELOG.md
+++ b/avm/res/desktop-virtualization/scaling-plan/CHANGELOG.md
@@ -7,6 +7,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 ### Changes
 
 - Updated behavior of `hostPoolReferences` parameter to not default to `null` instead of `[]` when no `hostPoolReferences` are defined.
+- Updated 'avm-common-types version' references to `0.7.0`
 
 ### Breaking Changes
 

--- a/avm/res/desktop-virtualization/scaling-plan/README.md
+++ b/avm/res/desktop-virtualization/scaling-plan/README.md
@@ -1197,7 +1197,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.7.0` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/desktop-virtualization/scaling-plan/main.bicep
+++ b/avm/res/desktop-virtualization/scaling-plan/main.bicep
@@ -35,18 +35,18 @@ param description string = name
 @sys.description('Optional. Tags of the resource.')
 param tags resourceInput<'Microsoft.DesktopVirtualization/scalingPlans@2025-03-01-preview'>.tags?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @sys.description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @sys.description('Optional. The lock settings of the service.')
 param lock lockType?
 
 @sys.description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
 
-import { diagnosticSettingLogsOnlyType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
+import { diagnosticSettingLogsOnlyType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @sys.description('Optional. The database-level diagnostic settings of the service.')
 param diagnosticSettings diagnosticSettingLogsOnlyType[]?
 
@@ -132,7 +132,7 @@ var formattedRoleAssignments = [
 ]
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.desktopvirtualization-scalingplan.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'
@@ -160,10 +160,12 @@ resource scalingPlan 'Microsoft.DesktopVirtualization/scalingPlans@2025-03-01-pr
     hostPoolType: hostPoolType
     exclusionTag: exclusionTag
     schedules: schedules
-    hostPoolReferences: map(hostPoolReferences ?? [], reference => {
-      hostPoolArmPath: reference.hostPoolResourceId
-      scalingPlanEnabled: reference.?scalingPlanEnabled ?? true
-    })
+    hostPoolReferences: !empty(hostPoolReferences)
+      ? map(hostPoolReferences!, reference => {
+          hostPoolArmPath: reference.hostPoolResourceId
+          scalingPlanEnabled: reference.?scalingPlanEnabled ?? true
+        })
+      : null
     description: description
   }
 }

--- a/avm/res/desktop-virtualization/scaling-plan/main.json
+++ b/avm/res/desktop-virtualization/scaling-plan/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "11059595119233380202"
+      "templateHash": "473493090889194432"
     },
     "name": "Azure Virtual Desktop Scaling Plan",
     "description": "This module deploys an Azure Virtual Desktop Scaling Plan."
@@ -127,7 +127,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a diagnostic setting. To be used if only logs are supported by the resource provider.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     },
@@ -164,7 +164,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a lock.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     },
@@ -239,7 +239,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     }
@@ -396,7 +396,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.desktopvirtualization-scalingplan.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -425,7 +425,7 @@
         "hostPoolType": "[parameters('hostPoolType')]",
         "exclusionTag": "[parameters('exclusionTag')]",
         "schedules": "[parameters('schedules')]",
-        "hostPoolReferences": "[map(coalesce(parameters('hostPoolReferences'), createArray()), lambda('reference', createObject('hostPoolArmPath', lambdaVariables('reference').hostPoolResourceId, 'scalingPlanEnabled', coalesce(tryGet(lambdaVariables('reference'), 'scalingPlanEnabled'), true()))))]",
+        "hostPoolReferences": "[if(not(empty(parameters('hostPoolReferences'))), map(parameters('hostPoolReferences'), lambda('reference', createObject('hostPoolArmPath', lambdaVariables('reference').hostPoolResourceId, 'scalingPlanEnabled', coalesce(tryGet(lambdaVariables('reference'), 'scalingPlanEnabled'), true())))), null())]",
         "description": "[parameters('description')]"
       }
     },

--- a/avm/res/desktop-virtualization/scaling-plan/version.json
+++ b/avm/res/desktop-virtualization/scaling-plan/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.4"
+  "version": "0.5"
 }


### PR DESCRIPTION
## Description

Updated behavior of `hostPoolReferences` parameter to not default to `null` instead of `[]` when no `hostPoolReferences` are defined.

Closes #6750

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.desktop-virtualization.scaling-plan](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.scaling-plan.yml/badge.svg?branch=users%2Falsehr%2F6750_hostPoolNull&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.desktop-virtualization.scaling-plan.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
