### PR TITLE
fix(alz/ama): use unique lock name for PerfOnly VM Insights DCR

### DIFF
--- a/avm/ptn/alz/ama/CHANGELOG.md
+++ b/avm/ptn/alz/ama/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/alz/ama/CHANGELOG.md).
 
+## 0.1.2
+
+### Bug Fixes
+
+- Give the VM Insights PerfOnly lock a unique name (`-perfonly-lock` suffix) to avoid duplicate lock resource name collision with the PerfAndMap lock during Azure Deployment Stacks validation. Fixes [#6794](https://github.com/Azure/bicep-registry-modules/issues/6794).
+
+### Changes
+
+- Updated `avm/res/managed-identity/user-assigned-identity` module reference from `0.4.3` to `0.5.0`.
+- Updated `Microsoft.Resources/deployments` API version from `2024-03-01` to `2024-07-01`.
+
 ## 0.1.1
 
 ### Changes

--- a/avm/ptn/alz/ama/CHANGELOG.md
+++ b/avm/ptn/alz/ama/CHANGELOG.md
@@ -2,16 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/ptn/alz/ama/CHANGELOG.md).
 
-## 0.1.2
-
-### Bug Fixes
-
-- Give the VM Insights PerfOnly lock a unique name (`-perfonly-lock` suffix) to avoid duplicate lock resource name collision with the PerfAndMap lock during Azure Deployment Stacks validation. Fixes [#6794](https://github.com/Azure/bicep-registry-modules/issues/6794).
+## 0.2.0
 
 ### Changes
 
+- Give the VM Insights PerfOnly lock a unique name (`-perfonly-lock` suffix) to avoid duplicate lock resource name collision with the PerfAndMap lock during Azure Deployment Stacks validation. Fixes [#6794](https://github.com/Azure/bicep-registry-modules/issues/6794).
 - Updated `avm/res/managed-identity/user-assigned-identity` module reference from `0.4.3` to `0.5.0`.
 - Updated `Microsoft.Resources/deployments` API version from `2024-03-01` to `2024-07-01`.
+
+### Breaking Changes
+
+- **Lock resource names changed**: The VM Insights PerfAndMap lock name changed from `{lockName|dcrName}-lock` to `{lockName|dcrName}-perfandmap-lock`, and the PerfOnly lock name changed from `{lockName|dcrName}-lock` to `{lockName|dcrName}-perfonly-lock`. This resolves the duplicate name collision in Deployment Stacks. Existing deployments may see old locks deleted and new ones created.
 
 ## 0.1.1
 

--- a/avm/ptn/alz/ama/README.md
+++ b/avm/ptn/alz/ama/README.md
@@ -377,7 +377,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/res/managed-identity/user-assigned-identity:0.4.3` | Remote reference |
+| `br/public:avm/res/managed-identity/user-assigned-identity:0.5.0` | Remote reference |
 | `br/public:avm/utl/types/avm-common-types:0.2.1` | Remote reference |
 
 ## Data Collection

--- a/avm/ptn/alz/ama/main.bicep
+++ b/avm/ptn/alz/ama/main.bicep
@@ -37,7 +37,7 @@ param enableTelemetry bool = true
 // Resources      //
 // ============== //
 
-module userAssignedManagedIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.4.3' = {
+module userAssignedManagedIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.5.0' = {
   name: '${uniqueString(subscription().id, resourceGroup().id, location)}-UserAssignedIdentity'
   params: {
     name: userAssignedIdentityName
@@ -151,7 +151,7 @@ resource dataCollectionRuleVMInsightsPerfOnly 'Microsoft.Insights/dataCollection
 
 resource dataCollectionRuleVMInsightsPerfandMapLock 'Microsoft.Authorization/locks@2020-05-01' = if (lockConfig.?kind != 'None' && !(empty(lockConfig.?name)) && dataCollectionRuleVMInsightsExperience == 'PerfAndMap') {
   scope: dataCollectionRuleVMInsightsPerfAndMap
-  name: lockConfig.?name ?? '${dataCollectionRuleVMInsightsPerfAndMap.name}-lock'
+  name: '${lockConfig.?name ?? dataCollectionRuleVMInsightsPerfAndMap.name}-perfandmap-lock'
   properties: {
     level: lockConfig.?kind ?? 'ReadOnly'
   }
@@ -159,7 +159,7 @@ resource dataCollectionRuleVMInsightsPerfandMapLock 'Microsoft.Authorization/loc
 
 resource dataCollectionRuleVMInsightsPerfOnlyLock 'Microsoft.Authorization/locks@2020-05-01' = if (lockConfig.?kind != 'None' && !(empty(lockConfig.?name)) && dataCollectionRuleVMInsightsExperience == 'PerfOnly') {
   scope: dataCollectionRuleVMInsightsPerfOnly
-  name: lockConfig.?name ?? '${dataCollectionRuleVMInsightsPerfOnly.name}-lock'
+  name: '${lockConfig.?name ?? dataCollectionRuleVMInsightsPerfOnly.name}-perfonly-lock'
   properties: {
     level: lockConfig.?kind ?? 'ReadOnly'
   }
@@ -495,7 +495,7 @@ resource dataCollectionRuleMDFCSQLLock 'Microsoft.Authorization/locks@2020-05-01
 }
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2024-07-01' = if (enableTelemetry) {
   name: '46d3xbcp.ptn.alz-ama.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'

--- a/avm/ptn/alz/ama/main.json
+++ b/avm/ptn/alz/ama/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "11485823259297877576"
+      "version": "0.42.1.51946",
+      "templateHash": "12543915061520801744"
     },
     "name": "avm/ptn/alz/ama",
     "description": "This modules deployes resources for Azure Monitoring Agent (AMA) to be used within Azure Landing Zones"
@@ -224,7 +224,7 @@
       "type": "Microsoft.Authorization/locks",
       "apiVersion": "2020-05-01",
       "scope": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleVMInsightsName'))]",
-      "name": "[coalesce(tryGet(parameters('lockConfig'), 'name'), format('{0}-lock', parameters('dataCollectionRuleVMInsightsName')))]",
+      "name": "[format('{0}-perfandmap-lock', coalesce(tryGet(parameters('lockConfig'), 'name'), parameters('dataCollectionRuleVMInsightsName')))]",
       "properties": {
         "level": "[coalesce(tryGet(parameters('lockConfig'), 'kind'), 'ReadOnly')]"
       },
@@ -237,7 +237,7 @@
       "type": "Microsoft.Authorization/locks",
       "apiVersion": "2020-05-01",
       "scope": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleVMInsightsName'))]",
-      "name": "[coalesce(tryGet(parameters('lockConfig'), 'name'), format('{0}-lock', parameters('dataCollectionRuleVMInsightsName')))]",
+      "name": "[format('{0}-perfonly-lock', coalesce(tryGet(parameters('lockConfig'), 'name'), parameters('dataCollectionRuleVMInsightsName')))]",
       "properties": {
         "level": "[coalesce(tryGet(parameters('lockConfig'), 'kind'), 'ReadOnly')]"
       },
@@ -587,7 +587,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2024-07-01",
       "name": "[format('46d3xbcp.ptn.alz-ama.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -635,7 +635,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.39.26.7824",
-              "templateHash": "1856697743030659118"
+              "templateHash": "7591858083424858339"
             },
             "name": "User Assigned Identities",
             "description": "This module deploys a User Assigned Identity."
@@ -847,6 +847,17 @@
               "metadata": {
                 "description": "Optional. Enable/Disable usage telemetry for module."
               }
+            },
+            "isolationScope": {
+              "type": "string",
+              "nullable": true,
+              "allowedValues": [
+                "None",
+                "Regional"
+              ],
+              "metadata": {
+                "description": "Optional. Enum to configure regional restrictions on identity assignment, as necessary. Allowed values: \"None\", \"Regional\"."
+              }
             }
           },
           "variables": {
@@ -872,7 +883,7 @@
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2024-03-01",
-              "name": "[format('46d3xbcp.res.managedidentity-userassignedidentity.{0}.{1}', replace('0.4.3', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+              "name": "[format('46d3xbcp.res.managedidentity-userassignedidentity.{0}.{1}', replace('0.5.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -893,7 +904,8 @@
               "apiVersion": "2024-11-30",
               "name": "[parameters('name')]",
               "location": "[parameters('location')]",
-              "tags": "[parameters('tags')]"
+              "tags": "[parameters('tags')]",
+              "properties": "[if(not(equals(parameters('isolationScope'), null())), createObject('isolationScope', parameters('isolationScope')), createObject())]"
             },
             "userAssignedIdentity_lock": {
               "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",

--- a/avm/ptn/alz/ama/version.json
+++ b/avm/ptn/alz/ama/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1"
+  "version": "0.2"
 }


### PR DESCRIPTION
## Description

The module defines two conditionally-exclusive lock resources for the VM Insights DCR (`PerfAndMap` and `PerfOnly`). Both generated the same lock name because both DCR resources use the same `dataCollectionRuleVMInsightsName` parameter. While only one deploys at runtime, Azure Deployment Stacks validates all resource IDs before evaluating conditions, causing an `InvalidTemplate` error.

The fix gives both locks distinct names (`-perfandmap-lock` and `-perfonly-lock` suffixes) so the two lock resource IDs never collide during template validation.

Also updated `avm/res/managed-identity/user-assigned-identity` from `0.4.3` to `0.5.0` and `Microsoft.Resources/deployments` API from `2024-03-01` to `2024-07-01`.

Fixes #6794

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.ptn.alz.ama](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.ptn.alz.ama.yml/badge.svg?branch=fix%2Falz-ama-duplicate-lock-names-6794)](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.ptn.alz.ama.yml)

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version