### PR TITLE
feat(container-app): add traffic splitting support and update to API 2026-01-01

### DIFF
--- a/avm/res/app/container-app/CHANGELOG.md
+++ b/avm/res/app/container-app/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/app/container-app/CHANGELOG.md).
 
+## 0.22.0
+
+### New Features
+
+- Added `traffic` array parameter to support traffic splitting across multiple revisions, enabling blue-green and canary deployment patterns. Closes [#6713](https://github.com/Azure/bicep-registry-modules/issues/6713).
+
+### Changes
+
+- Updated `Microsoft.App/containerApps` and `Microsoft.App/containerApps/authConfigs` API versions from `2025-10-02-preview` to `2026-01-01`.
+- Updated `Microsoft.App/managedEnvironments` API version from `2025-10-02-preview` to `2026-01-01` in all test dependency files.
+
+### Breaking Changes
+
+- **Removed** individual traffic scalar parameters (`trafficLabel`, `trafficLatestRevision`, `trafficRevisionName`, `trafficWeight`) in favor of the new `traffic` array parameter using the resource-derived type. Callers must migrate to the new `traffic` parameter.
+- **Removed** `targetPortHttpScheme` parameter as the property was removed in API version `2026-01-01`.
+
 ## 0.21.0
 
 ### Changes

--- a/avm/res/app/container-app/README.md
+++ b/avm/res/app/container-app/README.md
@@ -23,8 +23,8 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.App/containerApps` | 2025-10-02-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.app_containerapps.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/2025-10-02-preview/containerApps)</li></ul> |
-| `Microsoft.App/containerApps/authConfigs` | 2025-10-02-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.app_containerapps_authconfigs.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/2025-10-02-preview/containerApps/authConfigs)</li></ul> |
+| `Microsoft.App/containerApps` | 2026-01-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.app_containerapps.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/2026-01-01/containerApps)</li></ul> |
+| `Microsoft.App/containerApps/authConfigs` | 2026-01-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.app_containerapps_authconfigs.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/2026-01-01/containerApps/authConfigs)</li></ul> |
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
 | `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.insights_diagnosticsettings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)</li></ul> |
@@ -275,8 +275,12 @@ module containerApp 'br/public:avm/res/app/container-app:<version>' = {
     ingressTransport: 'auto'
     kind: 'functionapp'
     maxInactiveRevisions: 100
-    trafficLatestRevision: true
-    trafficWeight: 100
+    traffic: [
+      {
+        latestRevision: true
+        weight: 100
+      }
+    ]
   }
 }
 ```
@@ -334,11 +338,13 @@ module containerApp 'br/public:avm/res/app/container-app:<version>' = {
     "maxInactiveRevisions": {
       "value": 100
     },
-    "trafficLatestRevision": {
-      "value": true
-    },
-    "trafficWeight": {
-      "value": 100
+    "traffic": {
+      "value": [
+        {
+          "latestRevision": true,
+          "weight": 100
+        }
+      ]
     }
   }
 }
@@ -375,8 +381,12 @@ param ingressTargetPort = 80
 param ingressTransport = 'auto'
 param kind = 'functionapp'
 param maxInactiveRevisions = 100
-param trafficLatestRevision = true
-param trafficWeight = 100
+param traffic = [
+  {
+    latestRevision: true
+    weight: 100
+  }
+]
 ```
 
 </details>
@@ -1262,12 +1272,8 @@ param tags = {
 | [`serviceBinds`](#parameter-servicebinds) | array | List of container app services bound to the app. |
 | [`stickySessionsAffinity`](#parameter-stickysessionsaffinity) | string | Bool indicating if the Container App should enable session affinity. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
-| [`targetPortHttpScheme`](#parameter-targetporthttpscheme) | string | Whether an http app listens on http or https. |
 | [`terminationGracePeriodSeconds`](#parameter-terminationgraceperiodseconds) | int | The termination grace period for the container app. |
-| [`trafficLabel`](#parameter-trafficlabel) | string | Associates a traffic label with a revision. Label name should be consist of lower case alphanumeric characters or dashes. |
-| [`trafficLatestRevision`](#parameter-trafficlatestrevision) | bool | Indicates that the traffic weight belongs to a latest stable revision. |
-| [`trafficRevisionName`](#parameter-trafficrevisionname) | string | Name of a revision. |
-| [`trafficWeight`](#parameter-trafficweight) | int | Traffic weight assigned to a revision. |
+| [`traffic`](#parameter-traffic) | array | Traffic weight configuration for routing traffic across revisions. Each entry specifies a revision (or latest) and its traffic percentage. Supports blue-green and canary deployment patterns. |
 | [`volumes`](#parameter-volumes) | array | List of volume definitions for the Container App. |
 | [`workloadProfileName`](#parameter-workloadprofilename) | string | Workload profile name to pin for container app execution. |
 
@@ -2150,13 +2156,6 @@ Tags of the resource.
 - Required: No
 - Type: object
 
-### Parameter: `targetPortHttpScheme`
-
-Whether an http app listens on http or https.
-
-- Required: No
-- Type: string
-
 ### Parameter: `terminationGracePeriodSeconds`
 
 The termination grace period for the container app.
@@ -2164,36 +2163,12 @@ The termination grace period for the container app.
 - Required: No
 - Type: int
 
-### Parameter: `trafficLabel`
+### Parameter: `traffic`
 
-Associates a traffic label with a revision. Label name should be consist of lower case alphanumeric characters or dashes.
-
-- Required: No
-- Type: string
-- Default: `'label-1'`
-
-### Parameter: `trafficLatestRevision`
-
-Indicates that the traffic weight belongs to a latest stable revision.
+Traffic weight configuration for routing traffic across revisions. Each entry specifies a revision (or latest) and its traffic percentage. Supports blue-green and canary deployment patterns.
 
 - Required: No
-- Type: bool
-- Default: `True`
-
-### Parameter: `trafficRevisionName`
-
-Name of a revision.
-
-- Required: No
-- Type: string
-
-### Parameter: `trafficWeight`
-
-Traffic weight assigned to a revision.
-
-- Required: No
-- Type: int
-- Default: `100`
+- Type: array
 
 ### Parameter: `volumes`
 

--- a/avm/res/app/container-app/auth-config/README.md
+++ b/avm/res/app/container-app/auth-config/README.md
@@ -12,7 +12,7 @@ This module deploys Container App Auth Configs.
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.App/containerApps/authConfigs` | 2025-10-02-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.app_containerapps_authconfigs.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/2025-10-02-preview/containerApps/authConfigs)</li></ul> |
+| `Microsoft.App/containerApps/authConfigs` | 2026-01-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.app_containerapps_authconfigs.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/2026-01-01/containerApps/authConfigs)</li></ul> |
 
 ## Parameters
 

--- a/avm/res/app/container-app/auth-config/main.bicep
+++ b/avm/res/app/container-app/auth-config/main.bicep
@@ -5,32 +5,32 @@ metadata description = 'This module deploys Container App Auth Configs.'
 param containerAppName string
 
 @description('Optional. The configuration settings of the secrets references of encryption key and signing key for ContainerApp Service Authentication/Authorization.')
-param encryptionSettings resourceInput<'Microsoft.App/containerApps/authConfigs@2025-10-02-preview'>.properties.encryptionSettings?
+param encryptionSettings resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.encryptionSettings?
 
 @description('Optional. The configuration settings that determines the validation flow of users using Service Authentication and/or Authorization.')
-param globalValidation resourceInput<'Microsoft.App/containerApps/authConfigs@2025-10-02-preview'>.properties.globalValidation?
+param globalValidation resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.globalValidation?
 
 @description('Optional. The configuration settings of the HTTP requests for authentication and authorization requests made against ContainerApp Service Authentication/Authorization.')
-param httpSettings resourceInput<'Microsoft.App/containerApps/authConfigs@2025-10-02-preview'>.properties.httpSettings?
+param httpSettings resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.httpSettings?
 
 @description('Optional. The configuration settings of each of the identity providers used to configure ContainerApp Service Authentication/Authorization.')
-param identityProviders resourceInput<'Microsoft.App/containerApps/authConfigs@2025-10-02-preview'>.properties.identityProviders?
+param identityProviders resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.identityProviders?
 
 @description('Optional. The configuration settings of the login flow of users using ContainerApp Service Authentication/Authorization.')
-param login resourceInput<'Microsoft.App/containerApps/authConfigs@2025-10-02-preview'>.properties.login?
+param login resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.login?
 
 @description('Optional. The configuration settings of the platform of ContainerApp Service Authentication/Authorization.')
-param platform resourceInput<'Microsoft.App/containerApps/authConfigs@2025-10-02-preview'>.properties.platform?
+param platform resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.platform?
 
 // =============== //
 //    Resources    //
 // =============== //
 
-resource containerApp 'Microsoft.App/containerApps@2025-10-02-preview' existing = {
+resource containerApp 'Microsoft.App/containerApps@2026-01-01' existing = {
   name: containerAppName
 }
 
-resource containerAppAuthConfigs 'Microsoft.App/containerApps/authConfigs@2025-10-02-preview' = {
+resource containerAppAuthConfigs 'Microsoft.App/containerApps/authConfigs@2026-01-01' = {
   name: 'current'
   parent: containerApp
   properties: {

--- a/avm/res/app/container-app/auth-config/main.json
+++ b/avm/res/app/container-app/auth-config/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "6701687065881133945"
+      "version": "0.42.1.51946",
+      "templateHash": "12173377941230147433"
     },
     "name": "Container App Auth Configs",
     "description": "This module deploys Container App Auth Configs."
@@ -22,7 +22,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/encryptionSettings"
+          "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/encryptionSettings"
         },
         "description": "Optional. The configuration settings of the secrets references of encryption key and signing key for ContainerApp Service Authentication/Authorization."
       },
@@ -32,7 +32,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/globalValidation"
+          "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/globalValidation"
         },
         "description": "Optional. The configuration settings that determines the validation flow of users using Service Authentication and/or Authorization."
       },
@@ -42,7 +42,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/httpSettings"
+          "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/httpSettings"
         },
         "description": "Optional. The configuration settings of the HTTP requests for authentication and authorization requests made against ContainerApp Service Authentication/Authorization."
       },
@@ -52,7 +52,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/identityProviders"
+          "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/identityProviders"
         },
         "description": "Optional. The configuration settings of each of the identity providers used to configure ContainerApp Service Authentication/Authorization."
       },
@@ -62,7 +62,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/login"
+          "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/login"
         },
         "description": "Optional. The configuration settings of the login flow of users using ContainerApp Service Authentication/Authorization."
       },
@@ -72,7 +72,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/platform"
+          "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/platform"
         },
         "description": "Optional. The configuration settings of the platform of ContainerApp Service Authentication/Authorization."
       },
@@ -83,12 +83,12 @@
     "containerApp": {
       "existing": true,
       "type": "Microsoft.App/containerApps",
-      "apiVersion": "2025-10-02-preview",
+      "apiVersion": "2026-01-01",
       "name": "[parameters('containerAppName')]"
     },
     "containerAppAuthConfigs": {
       "type": "Microsoft.App/containerApps/authConfigs",
-      "apiVersion": "2025-10-02-preview",
+      "apiVersion": "2026-01-01",
       "name": "[format('{0}/{1}', parameters('containerAppName'), 'current')]",
       "properties": {
         "encryptionSettings": "[parameters('encryptionSettings')]",

--- a/avm/res/app/container-app/main.bicep
+++ b/avm/res/app/container-app/main.bicep
@@ -49,7 +49,7 @@ param stickySessionsAffinity string = 'none'
 param ingressTransport string = 'auto'
 
 @description('Optional. Dev ContainerApp service type.')
-param service resourceInput<'Microsoft.App/containerApps@2025-10-02-preview'>.properties.configuration.service?
+param service resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.configuration.service?
 
 @description('Optional. Toggle to include the service configuration.')
 param includeAddOns bool = false
@@ -62,9 +62,6 @@ param ingressAllowInsecure bool = true
 
 @description('Optional. Target Port in containers for traffic from ingress.')
 param ingressTargetPort int = 80
-
-@description('Optional. Whether an http app listens on http or https.')
-param targetPortHttpScheme resourceInput<'Microsoft.App/containerApps@2025-10-02-preview'>.properties.configuration.ingress.targetPortHttpScheme?
 
 @description('Optional. The scaling settings of the service.')
 param scaleSettings scaleType = {
@@ -90,10 +87,10 @@ import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 param lock lockType?
 
 @description('Optional. Tags of the resource.')
-param tags resourceInput<'Microsoft.App/containerApps@2025-10-02-preview'>.tags?
+param tags resourceInput<'Microsoft.App/containerApps@2026-01-01'>.tags?
 
 @description('Optional. Collection of private container registry credentials for containers used by the Container app.')
-param registries resourceInput<'Microsoft.App/containerApps@2025-10-02-preview'>.properties.configuration.registries?
+param registries resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.configuration.registries?
 
 import { managedIdentityAllType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
 @description('Optional. The managed identity definition for this resource.')
@@ -107,46 +104,37 @@ param roleAssignments roleAssignmentType[]?
 param enableTelemetry bool = true
 
 @description('Optional. Custom domain bindings for Container App hostnames.')
-param customDomains resourceInput<'Microsoft.App/containerApps@2025-10-02-preview'>.properties.configuration.ingress.customDomains?
+param customDomains resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.configuration.ingress.customDomains?
 
 @description('Optional. Exposed Port in containers for TCP traffic from ingress.')
 param exposedPort int = 0
 
 @description('Optional. Rules to restrict incoming IP address.')
-param ipSecurityRestrictions resourceInput<'Microsoft.App/containerApps@2025-10-02-preview'>.properties.configuration.ingress.ipSecurityRestrictions?
+param ipSecurityRestrictions resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.configuration.ingress.ipSecurityRestrictions?
 
-@description('Optional. Associates a traffic label with a revision. Label name should be consist of lower case alphanumeric characters or dashes.')
-param trafficLabel string = 'label-1'
-
-@description('Optional. Indicates that the traffic weight belongs to a latest stable revision.')
-param trafficLatestRevision bool = true
-
-@description('Optional. Name of a revision.')
-param trafficRevisionName string?
-
-@description('Optional. Traffic weight assigned to a revision.')
-param trafficWeight int = 100
+@description('Optional. Traffic weight configuration for routing traffic across revisions. Each entry specifies a revision (or latest) and its traffic percentage. Supports blue-green and canary deployment patterns.')
+param traffic resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.configuration.ingress.traffic?
 
 @description('Optional. Dapr configuration for the Container App.')
-param dapr resourceInput<'Microsoft.App/containerApps@2025-10-02-preview'>.properties.configuration.dapr?
+param dapr resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.configuration.dapr?
 
 @description('Optional. Settings for Managed Identities that are assigned to the Container App. If a Managed Identity is not specified here, default settings will be used.')
-param identitySettings resourceInput<'Microsoft.App/containerApps@2025-07-01'>.properties.configuration.identitySettings?
+param identitySettings resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.configuration.identitySettings?
 
 @description('Optional. Max inactive revisions a Container App can have.')
 param maxInactiveRevisions int = 0
 
 @description('Optional. Runtime configuration for the Container App.')
-param runtime resourceInput<'Microsoft.App/containerApps@2025-10-02-preview'>.properties.configuration.runtime?
+param runtime resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.configuration.runtime?
 
 @description('Required. List of container definitions for the Container App.')
-param containers resourceInput<'Microsoft.App/containerApps@2025-10-02-preview'>.properties.template.containers
+param containers resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.template.containers
 
 @description('Optional. The termination grace period for the container app.')
 param terminationGracePeriodSeconds int?
 
 @description('Optional. List of specialized containers that run before app containers.')
-param initContainersTemplate resourceInput<'Microsoft.App/containerApps@2025-10-02-preview'>.properties.template.initContainers?
+param initContainersTemplate resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.template.initContainers?
 
 @description('Optional. The secrets of the Container App.')
 param secrets secretType[]?
@@ -155,7 +143,7 @@ param secrets secretType[]?
 param revisionSuffix string?
 
 @description('Optional. List of volume definitions for the Container App.')
-param volumes resourceInput<'Microsoft.App/containerApps@2025-10-02-preview'>.properties.template.volumes?
+param volumes resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.template.volumes?
 
 @description('Optional. Workload profile name to pin for container app execution.')
 param workloadProfileName string?
@@ -230,7 +218,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableT
   }
 }
 
-resource containerApp 'Microsoft.App/containerApps@2025-10-02-preview' = {
+resource containerApp 'Microsoft.App/containerApps@2026-01-01' = {
   name: name
   tags: tags
   kind: kind
@@ -273,20 +261,10 @@ resource containerApp 'Microsoft.App/containerApps@2025-10-02-preview' = {
             external: ingressExternal
             ipSecurityRestrictions: ipSecurityRestrictions
             targetPort: ingressTargetPort
-            targetPortHttpScheme: targetPortHttpScheme
             stickySessions: {
               affinity: stickySessionsAffinity
             }
-            traffic: ingressTransport != 'tcp'
-              ? [
-                  {
-                    label: trafficLabel
-                    latestRevision: trafficLatestRevision
-                    revisionName: trafficRevisionName
-                    weight: trafficWeight
-                  }
-                ]
-              : null
+            traffic: ingressTransport != 'tcp' ? traffic : null
             transport: ingressTransport
           }
       service: includeAddOns ? service : null
@@ -587,20 +565,20 @@ type secretType = {
 @description('The type for the container app\'s authentication configuration.')
 type authConfigType = {
   @description('Optional. The configuration settings of the secrets references of encryption key and signing key for ContainerApp Service Authentication/Authorization.')
-  encryptionSettings: resourceInput<'Microsoft.App/containerApps/authConfigs@2025-10-02-preview'>.properties.encryptionSettings?
+  encryptionSettings: resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.encryptionSettings?
 
   @description('Optional. The configuration settings that determines the validation flow of users using Service Authentication and/or Authorization.')
-  globalValidation: resourceInput<'Microsoft.App/containerApps/authConfigs@2025-10-02-preview'>.properties.globalValidation?
+  globalValidation: resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.globalValidation?
 
   @description('Optional. The configuration settings of the HTTP requests for authentication and authorization requests made against ContainerApp Service Authentication/Authorization.')
-  httpSettings: resourceInput<'Microsoft.App/containerApps/authConfigs@2025-10-02-preview'>.properties.httpSettings?
+  httpSettings: resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.httpSettings?
 
   @description('Optional. The configuration settings of each of the identity providers used to configure ContainerApp Service Authentication/Authorization.')
-  identityProviders: resourceInput<'Microsoft.App/containerApps/authConfigs@2025-10-02-preview'>.properties.identityProviders?
+  identityProviders: resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.identityProviders?
 
   @description('Optional. The configuration settings of the login flow of users using ContainerApp Service Authentication/Authorization.')
-  login: resourceInput<'Microsoft.App/containerApps/authConfigs@2025-10-02-preview'>.properties.login?
+  login: resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.login?
 
   @description('Optional. The configuration settings of the platform of ContainerApp Service Authentication/Authorization.')
-  platform: resourceInput<'Microsoft.App/containerApps/authConfigs@2025-10-02-preview'>.properties.platform?
+  platform: resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.platform?
 }

--- a/avm/res/app/container-app/main.json
+++ b/avm/res/app/container-app/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "17674599659033742727"
+      "version": "0.42.1.51946",
+      "templateHash": "10470890886683317319"
     },
     "name": "Container Apps",
     "description": "This module deploys a Container App."
@@ -486,7 +486,7 @@
           "type": "object",
           "metadata": {
             "__bicep_resource_derived_type!": {
-              "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/encryptionSettings"
+              "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/encryptionSettings"
             },
             "description": "Optional. The configuration settings of the secrets references of encryption key and signing key for ContainerApp Service Authentication/Authorization."
           },
@@ -496,7 +496,7 @@
           "type": "object",
           "metadata": {
             "__bicep_resource_derived_type!": {
-              "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/globalValidation"
+              "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/globalValidation"
             },
             "description": "Optional. The configuration settings that determines the validation flow of users using Service Authentication and/or Authorization."
           },
@@ -506,7 +506,7 @@
           "type": "object",
           "metadata": {
             "__bicep_resource_derived_type!": {
-              "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/httpSettings"
+              "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/httpSettings"
             },
             "description": "Optional. The configuration settings of the HTTP requests for authentication and authorization requests made against ContainerApp Service Authentication/Authorization."
           },
@@ -516,7 +516,7 @@
           "type": "object",
           "metadata": {
             "__bicep_resource_derived_type!": {
-              "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/identityProviders"
+              "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/identityProviders"
             },
             "description": "Optional. The configuration settings of each of the identity providers used to configure ContainerApp Service Authentication/Authorization."
           },
@@ -526,7 +526,7 @@
           "type": "object",
           "metadata": {
             "__bicep_resource_derived_type!": {
-              "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/login"
+              "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/login"
             },
             "description": "Optional. The configuration settings of the login flow of users using ContainerApp Service Authentication/Authorization."
           },
@@ -536,7 +536,7 @@
           "type": "object",
           "metadata": {
             "__bicep_resource_derived_type!": {
-              "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/platform"
+              "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/platform"
             },
             "description": "Optional. The configuration settings of the platform of ContainerApp Service Authentication/Authorization."
           },
@@ -865,7 +865,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2025-10-02-preview#properties/properties/properties/configuration/properties/service"
+          "source": "Microsoft.App/containerApps@2026-01-01#properties/properties/properties/configuration/properties/service"
         },
         "description": "Optional. Dev ContainerApp service type."
       },
@@ -901,16 +901,6 @@
       "metadata": {
         "description": "Optional. Target Port in containers for traffic from ingress."
       }
-    },
-    "targetPortHttpScheme": {
-      "type": "string",
-      "metadata": {
-        "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2025-10-02-preview#properties/properties/properties/configuration/properties/ingress/properties/targetPortHttpScheme"
-        },
-        "description": "Optional. Whether an http app listens on http or https."
-      },
-      "nullable": true
     },
     "scaleSettings": {
       "$ref": "#/definitions/scaleType",
@@ -960,7 +950,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2025-10-02-preview#properties/tags"
+          "source": "Microsoft.App/containerApps@2026-01-01#properties/tags"
         },
         "description": "Optional. Tags of the resource."
       },
@@ -970,7 +960,7 @@
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2025-10-02-preview#properties/properties/properties/configuration/properties/registries"
+          "source": "Microsoft.App/containerApps@2026-01-01#properties/properties/properties/configuration/properties/registries"
         },
         "description": "Optional. Collection of private container registry credentials for containers used by the Container app."
       },
@@ -1004,7 +994,7 @@
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2025-10-02-preview#properties/properties/properties/configuration/properties/ingress/properties/customDomains"
+          "source": "Microsoft.App/containerApps@2026-01-01#properties/properties/properties/configuration/properties/ingress/properties/customDomains"
         },
         "description": "Optional. Custom domain bindings for Container App hostnames."
       },
@@ -1021,45 +1011,27 @@
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2025-10-02-preview#properties/properties/properties/configuration/properties/ingress/properties/ipSecurityRestrictions"
+          "source": "Microsoft.App/containerApps@2026-01-01#properties/properties/properties/configuration/properties/ingress/properties/ipSecurityRestrictions"
         },
         "description": "Optional. Rules to restrict incoming IP address."
       },
       "nullable": true
     },
-    "trafficLabel": {
-      "type": "string",
-      "defaultValue": "label-1",
+    "traffic": {
+      "type": "array",
       "metadata": {
-        "description": "Optional. Associates a traffic label with a revision. Label name should be consist of lower case alphanumeric characters or dashes."
-      }
-    },
-    "trafficLatestRevision": {
-      "type": "bool",
-      "defaultValue": true,
-      "metadata": {
-        "description": "Optional. Indicates that the traffic weight belongs to a latest stable revision."
-      }
-    },
-    "trafficRevisionName": {
-      "type": "string",
-      "nullable": true,
-      "metadata": {
-        "description": "Optional. Name of a revision."
-      }
-    },
-    "trafficWeight": {
-      "type": "int",
-      "defaultValue": 100,
-      "metadata": {
-        "description": "Optional. Traffic weight assigned to a revision."
-      }
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.App/containerApps@2026-01-01#properties/properties/properties/configuration/properties/ingress/properties/traffic"
+        },
+        "description": "Optional. Traffic weight configuration for routing traffic across revisions. Each entry specifies a revision (or latest) and its traffic percentage. Supports blue-green and canary deployment patterns."
+      },
+      "nullable": true
     },
     "dapr": {
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2025-10-02-preview#properties/properties/properties/configuration/properties/dapr"
+          "source": "Microsoft.App/containerApps@2026-01-01#properties/properties/properties/configuration/properties/dapr"
         },
         "description": "Optional. Dapr configuration for the Container App."
       },
@@ -1069,7 +1041,7 @@
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2025-07-01#properties/properties/properties/configuration/properties/identitySettings"
+          "source": "Microsoft.App/containerApps@2026-01-01#properties/properties/properties/configuration/properties/identitySettings"
         },
         "description": "Optional. Settings for Managed Identities that are assigned to the Container App. If a Managed Identity is not specified here, default settings will be used."
       },
@@ -1086,7 +1058,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2025-10-02-preview#properties/properties/properties/configuration/properties/runtime"
+          "source": "Microsoft.App/containerApps@2026-01-01#properties/properties/properties/configuration/properties/runtime"
         },
         "description": "Optional. Runtime configuration for the Container App."
       },
@@ -1096,7 +1068,7 @@
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2025-10-02-preview#properties/properties/properties/template/properties/containers"
+          "source": "Microsoft.App/containerApps@2026-01-01#properties/properties/properties/template/properties/containers"
         },
         "description": "Required. List of container definitions for the Container App."
       }
@@ -1112,7 +1084,7 @@
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2025-10-02-preview#properties/properties/properties/template/properties/initContainers"
+          "source": "Microsoft.App/containerApps@2026-01-01#properties/properties/properties/template/properties/initContainers"
         },
         "description": "Optional. List of specialized containers that run before app containers."
       },
@@ -1139,7 +1111,7 @@
       "type": "array",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2025-10-02-preview#properties/properties/properties/template/properties/volumes"
+          "source": "Microsoft.App/containerApps@2026-01-01#properties/properties/properties/template/properties/volumes"
         },
         "description": "Optional. List of volume definitions for the Container App."
       },
@@ -1212,7 +1184,7 @@
     },
     "containerApp": {
       "type": "Microsoft.App/containerApps",
-      "apiVersion": "2025-10-02-preview",
+      "apiVersion": "2026-01-01",
       "name": "[parameters('name')]",
       "tags": "[parameters('tags')]",
       "kind": "[parameters('kind')]",
@@ -1234,7 +1206,7 @@
           "activeRevisionsMode": "[parameters('activeRevisionsMode')]",
           "dapr": "[parameters('dapr')]",
           "identitySettings": "[parameters('identitySettings')]",
-          "ingress": "[if(parameters('disableIngress'), null(), createObject('additionalPortMappings', parameters('additionalPortMappings'), 'allowInsecure', if(not(equals(parameters('ingressTransport'), 'tcp')), parameters('ingressAllowInsecure'), false()), 'customDomains', parameters('customDomains'), 'corsPolicy', if(and(not(equals(parameters('corsPolicy'), null())), not(equals(parameters('ingressTransport'), 'tcp'))), createObject('allowCredentials', coalesce(tryGet(parameters('corsPolicy'), 'allowCredentials'), false()), 'allowedHeaders', coalesce(tryGet(parameters('corsPolicy'), 'allowedHeaders'), createArray()), 'allowedMethods', coalesce(tryGet(parameters('corsPolicy'), 'allowedMethods'), createArray()), 'allowedOrigins', coalesce(tryGet(parameters('corsPolicy'), 'allowedOrigins'), createArray()), 'exposeHeaders', coalesce(tryGet(parameters('corsPolicy'), 'exposeHeaders'), createArray()), 'maxAge', tryGet(parameters('corsPolicy'), 'maxAge')), null()), 'clientCertificateMode', if(not(equals(parameters('ingressTransport'), 'tcp')), parameters('clientCertificateMode'), null()), 'exposedPort', parameters('exposedPort'), 'external', parameters('ingressExternal'), 'ipSecurityRestrictions', parameters('ipSecurityRestrictions'), 'targetPort', parameters('ingressTargetPort'), 'targetPortHttpScheme', parameters('targetPortHttpScheme'), 'stickySessions', createObject('affinity', parameters('stickySessionsAffinity')), 'traffic', if(not(equals(parameters('ingressTransport'), 'tcp')), createArray(createObject('label', parameters('trafficLabel'), 'latestRevision', parameters('trafficLatestRevision'), 'revisionName', parameters('trafficRevisionName'), 'weight', parameters('trafficWeight'))), null()), 'transport', parameters('ingressTransport')))]",
+          "ingress": "[if(parameters('disableIngress'), null(), createObject('additionalPortMappings', parameters('additionalPortMappings'), 'allowInsecure', if(not(equals(parameters('ingressTransport'), 'tcp')), parameters('ingressAllowInsecure'), false()), 'customDomains', parameters('customDomains'), 'corsPolicy', if(and(not(equals(parameters('corsPolicy'), null())), not(equals(parameters('ingressTransport'), 'tcp'))), createObject('allowCredentials', coalesce(tryGet(parameters('corsPolicy'), 'allowCredentials'), false()), 'allowedHeaders', coalesce(tryGet(parameters('corsPolicy'), 'allowedHeaders'), createArray()), 'allowedMethods', coalesce(tryGet(parameters('corsPolicy'), 'allowedMethods'), createArray()), 'allowedOrigins', coalesce(tryGet(parameters('corsPolicy'), 'allowedOrigins'), createArray()), 'exposeHeaders', coalesce(tryGet(parameters('corsPolicy'), 'exposeHeaders'), createArray()), 'maxAge', tryGet(parameters('corsPolicy'), 'maxAge')), null()), 'clientCertificateMode', if(not(equals(parameters('ingressTransport'), 'tcp')), parameters('clientCertificateMode'), null()), 'exposedPort', parameters('exposedPort'), 'external', parameters('ingressExternal'), 'ipSecurityRestrictions', parameters('ipSecurityRestrictions'), 'targetPort', parameters('ingressTargetPort'), 'stickySessions', createObject('affinity', parameters('stickySessionsAffinity')), 'traffic', if(not(equals(parameters('ingressTransport'), 'tcp')), parameters('traffic'), null()), 'transport', parameters('ingressTransport')))]",
           "service": "[if(parameters('includeAddOns'), parameters('service'), null())]",
           "maxInactiveRevisions": "[parameters('maxInactiveRevisions')]",
           "registries": "[parameters('registries')]",
@@ -1351,8 +1323,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "6701687065881133945"
+              "version": "0.42.1.51946",
+              "templateHash": "12173377941230147433"
             },
             "name": "Container App Auth Configs",
             "description": "This module deploys Container App Auth Configs."
@@ -1368,7 +1340,7 @@
               "type": "object",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/encryptionSettings"
+                  "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/encryptionSettings"
                 },
                 "description": "Optional. The configuration settings of the secrets references of encryption key and signing key for ContainerApp Service Authentication/Authorization."
               },
@@ -1378,7 +1350,7 @@
               "type": "object",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/globalValidation"
+                  "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/globalValidation"
                 },
                 "description": "Optional. The configuration settings that determines the validation flow of users using Service Authentication and/or Authorization."
               },
@@ -1388,7 +1360,7 @@
               "type": "object",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/httpSettings"
+                  "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/httpSettings"
                 },
                 "description": "Optional. The configuration settings of the HTTP requests for authentication and authorization requests made against ContainerApp Service Authentication/Authorization."
               },
@@ -1398,7 +1370,7 @@
               "type": "object",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/identityProviders"
+                  "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/identityProviders"
                 },
                 "description": "Optional. The configuration settings of each of the identity providers used to configure ContainerApp Service Authentication/Authorization."
               },
@@ -1408,7 +1380,7 @@
               "type": "object",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/login"
+                  "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/login"
                 },
                 "description": "Optional. The configuration settings of the login flow of users using ContainerApp Service Authentication/Authorization."
               },
@@ -1418,7 +1390,7 @@
               "type": "object",
               "metadata": {
                 "__bicep_resource_derived_type!": {
-                  "source": "Microsoft.App/containerApps/authConfigs@2025-10-02-preview#properties/properties/properties/platform"
+                  "source": "Microsoft.App/containerApps/authConfigs@2026-01-01#properties/properties/properties/platform"
                 },
                 "description": "Optional. The configuration settings of the platform of ContainerApp Service Authentication/Authorization."
               },
@@ -1429,12 +1401,12 @@
             "containerApp": {
               "existing": true,
               "type": "Microsoft.App/containerApps",
-              "apiVersion": "2025-10-02-preview",
+              "apiVersion": "2026-01-01",
               "name": "[parameters('containerAppName')]"
             },
             "containerAppAuthConfigs": {
               "type": "Microsoft.App/containerApps/authConfigs",
-              "apiVersion": "2025-10-02-preview",
+              "apiVersion": "2026-01-01",
               "name": "[format('{0}/{1}', parameters('containerAppName'), 'current')]",
               "properties": {
                 "encryptionSettings": "[parameters('encryptionSettings')]",
@@ -1511,14 +1483,14 @@
       "metadata": {
         "description": "The principal ID of the system assigned identity."
       },
-      "value": "[tryGet(tryGet(reference('containerApp', '2025-10-02-preview', 'full'), 'identity'), 'principalId')]"
+      "value": "[tryGet(tryGet(reference('containerApp', '2026-01-01', 'full'), 'identity'), 'principalId')]"
     },
     "location": {
       "type": "string",
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('containerApp', '2025-10-02-preview', 'full').location]"
+      "value": "[reference('containerApp', '2026-01-01', 'full').location]"
     }
   }
 }

--- a/avm/res/app/container-app/tests/e2e/defaults/dependencies.bicep
+++ b/avm/res/app/container-app/tests/e2e/defaults/dependencies.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 @description('Required. The name of the Managed Environment to create.')
 param managedEnvironmentName string
 
-resource managedEnvironment 'Microsoft.App/managedEnvironments@2025-10-02-preview' = {
+resource managedEnvironment 'Microsoft.App/managedEnvironments@2026-01-01' = {
   name: managedEnvironmentName
   location: location
   properties: {}

--- a/avm/res/app/container-app/tests/e2e/disable-ingress/dependencies.bicep
+++ b/avm/res/app/container-app/tests/e2e/disable-ingress/dependencies.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 @description('Required. The name of the Managed Environment to create.')
 param managedEnvironmentName string
 
-resource managedEnvironment 'Microsoft.App/managedEnvironments@2025-10-02-preview' = {
+resource managedEnvironment 'Microsoft.App/managedEnvironments@2026-01-01' = {
   name: managedEnvironmentName
   location: location
   properties: {}

--- a/avm/res/app/container-app/tests/e2e/function-optimized/dependencies.bicep
+++ b/avm/res/app/container-app/tests/e2e/function-optimized/dependencies.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 @description('Required. The name of the Managed Environment to create.')
 param managedEnvironmentName string
 
-resource managedEnvironment 'Microsoft.App/managedEnvironments@2025-10-02-preview' = {
+resource managedEnvironment 'Microsoft.App/managedEnvironments@2026-01-01' = {
   name: managedEnvironmentName
   location: location
   properties: {}

--- a/avm/res/app/container-app/tests/e2e/function-optimized/main.test.bicep
+++ b/avm/res/app/container-app/tests/e2e/function-optimized/main.test.bicep
@@ -58,8 +58,12 @@ module testDeployment '../../../main.bicep' = [
       ingressTransport:'auto'
       ingressAllowInsecure: false
       exposedPort: 0
-      trafficWeight: 100
-      trafficLatestRevision: true
+      traffic: [
+        {
+          weight: 100
+          latestRevision: true
+        }
+      ]
       maxInactiveRevisions: 100
       containers: [
         {

--- a/avm/res/app/container-app/tests/e2e/max/dependencies.bicep
+++ b/avm/res/app/container-app/tests/e2e/max/dependencies.bicep
@@ -17,7 +17,7 @@ param myCustomKeyVaultSecret string = newGuid()
 @description('Required. The name of the managed identity to create.')
 param managedIdentityName string
 
-resource managedEnvironment 'Microsoft.App/managedEnvironments@2025-10-02-preview' = {
+resource managedEnvironment 'Microsoft.App/managedEnvironments@2026-01-01' = {
   name: managedEnvironmentName
   location: location
   properties: {

--- a/avm/res/app/container-app/tests/e2e/vnet/dependencies.bicep
+++ b/avm/res/app/container-app/tests/e2e/vnet/dependencies.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 @description('Required. The name of the Managed Environment to create.')
 param managedEnvironmentName string
 
-resource managedEnvironment 'Microsoft.App/managedEnvironments@2025-07-01' = {
+resource managedEnvironment 'Microsoft.App/managedEnvironments@2026-01-01' = {
   name: managedEnvironmentName
   location: location
   properties: {

--- a/avm/res/app/container-app/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/app/container-app/tests/e2e/waf-aligned/dependencies.bicep
@@ -7,7 +7,7 @@ param managedEnvironmentName string
 @description('Required. The name of the managed identity to create.')
 param managedIdentityName string
 
-resource managedEnvironment 'Microsoft.App/managedEnvironments@2025-10-02-preview' = {
+resource managedEnvironment 'Microsoft.App/managedEnvironments@2026-01-01' = {
   name: managedEnvironmentName
   location: location
   properties: {

--- a/avm/res/app/container-app/version.json
+++ b/avm/res/app/container-app/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.21"
+  "version": "0.22"
 }


### PR DESCRIPTION
## Description

Adds support for traffic splitting across revisions in the Container App module, enabling blue-green and canary deployment patterns.

The previous implementation hardcoded traffic routing to a single entry using four scalar params (`trafficLabel`, `trafficWeight`, `trafficLatestRevision`, `trafficRevisionName`). This made it impossible to split traffic across multiple revisions.

The new `traffic` array parameter uses the resource-derived type and supports multiple entries:

```bicep
traffic: [
  { latestRevision: true, weight: 80 }
  { revisionName: 'previous', weight: 20 }
]
```

Also updated all `Microsoft.App` API versions from `2025-10-02-preview` to `2026-01-01` (latest stable). The `targetPortHttpScheme` parameter was removed as it no longer exists in the `2026-01-01` API.

Closes #6713

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.app.container-app](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.res.app.container-app.yml/badge.svg?branch=feat%2Fcontainer-app-traffic-splitting-6713)](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.res.app.container-app.yml)

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version