### PR TITLE
Fix: remove requirement empty privateEndpoints for public access

### DIFF
--- a/avm/res/kusto/cluster/CHANGELOG.md
+++ b/avm/res/kusto/cluster/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/kusto/cluster/CHANGELOG.md).
 
+## 0.10.1
+
+### Changes
+
+- Removed the requirement for privateEndpoints to be empty to allow public network access.
+
+### Breaking Changes
+
+- None
+
+
 ## 0.10.0
 
 ### Changes

--- a/avm/res/kusto/cluster/README.md
+++ b/avm/res/kusto/cluster/README.md
@@ -1072,7 +1072,7 @@ param tier = 'Standard'
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. |
 | [`privateEndpoints`](#parameter-privateendpoints) | array | Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. |
-| [`publicIPType`](#parameter-publiciptype) | string | Indicates what public IP type to create - IPv4 (default), or DualStack (both IPv4 and IPv6). |
+| [`publicIPType`](#parameter-publiciptype) | string | Indicates what public IP type to create - IPv4, or DualStack (both IPv4 and IPv6, default). |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 | [`tier`](#parameter-tier) | string | The tier of the Kusto Cluster. |
@@ -2273,7 +2273,7 @@ Tags to be applied on all resources/resource groups in this deployment.
 
 ### Parameter: `publicIPType`
 
-Indicates what public IP type to create - IPv4 (default), or DualStack (both IPv4 and IPv6).
+Indicates what public IP type to create - IPv4, or DualStack (both IPv4 and IPv6, default).
 
 - Required: No
 - Type: string

--- a/avm/res/kusto/cluster/README.md
+++ b/avm/res/kusto/cluster/README.md
@@ -280,6 +280,7 @@ module cluster 'br/public:avm/res/kusto/cluster:<version>' = {
     sku: 'Standard_E2ads_v5'
     // Non-required parameters
     enableDiskEncryption: true
+    enablePublicNetworkAccess: false
     managedIdentities: {
       userAssignedResourceIds: [
         '<managedIdentityResourceId>'
@@ -312,6 +313,9 @@ module cluster 'br/public:avm/res/kusto/cluster:<version>' = {
     "enableDiskEncryption": {
       "value": true
     },
+    "enablePublicNetworkAccess": {
+      "value": false
+    },
     "managedIdentities": {
       "value": {
         "userAssignedResourceIds": [
@@ -338,6 +342,7 @@ param name = 'kcmin0001'
 param sku = 'Standard_E2ads_v5'
 // Non-required parameters
 param enableDiskEncryption = true
+param enablePublicNetworkAccess = false
 param managedIdentities = {
   userAssignedResourceIds: [
     '<managedIdentityResourceId>'

--- a/avm/res/kusto/cluster/main.bicep
+++ b/avm/res/kusto/cluster/main.bicep
@@ -249,7 +249,7 @@ resource kustoCluster 'Microsoft.Kusto/clusters@2024-04-13' = {
       version: 1
     }
     publicIPType: publicIPType
-    publicNetworkAccess: (enablePublicNetworkAccess && empty(privateEndpoints)) ? 'Enabled' : 'Disabled'
+    publicNetworkAccess: enablePublicNetworkAccess ? 'Enabled' : 'Disabled'
     restrictOutboundNetworkAccess: enableRestrictOutboundNetworkAccess ? 'Enabled' : 'Disabled'
     trustedExternalTenants: trustedExternalTenants
     virtualClusterGraduationProperties: virtualClusterGraduationProperties

--- a/avm/res/kusto/cluster/main.bicep
+++ b/avm/res/kusto/cluster/main.bicep
@@ -82,7 +82,7 @@ param autoScaleMax int = 3
   'IPv6'
   'DualStack'
 ])
-@description('Optional. Indicates what public IP type to create - IPv4 (default), or DualStack (both IPv4 and IPv6).')
+@description('Optional. Indicates what public IP type to create - IPv4, or DualStack (both IPv4 and IPv6, default).')
 param publicIPType string = 'DualStack'
 
 @description('Optional. Enable/disable public network access. If disabled, only private endpoint connection is allowed to the Kusto Cluster.')

--- a/avm/res/kusto/cluster/main.json
+++ b/avm/res/kusto/cluster/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "1598019777369498284"
+      "version": "0.42.1.51946",
+      "templateHash": "5777238379871805657"
     },
     "name": "Kusto Cluster",
     "description": "This module deploys a Kusto Cluster."
@@ -1317,7 +1317,7 @@
           "version": 1
         },
         "publicIPType": "[parameters('publicIPType')]",
-        "publicNetworkAccess": "[if(and(parameters('enablePublicNetworkAccess'), empty(parameters('privateEndpoints'))), 'Enabled', 'Disabled')]",
+        "publicNetworkAccess": "[if(parameters('enablePublicNetworkAccess'), 'Enabled', 'Disabled')]",
         "restrictOutboundNetworkAccess": "[if(parameters('enableRestrictOutboundNetworkAccess'), 'Enabled', 'Disabled')]",
         "trustedExternalTenants": "[parameters('trustedExternalTenants')]",
         "virtualClusterGraduationProperties": "[parameters('virtualClusterGraduationProperties')]",
@@ -1442,8 +1442,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "15516949031513950325"
+              "version": "0.42.1.51946",
+              "templateHash": "13852491996694137257"
             },
             "name": "Kusto Cluster Principal Assignments",
             "description": "This module deploys a Kusto Cluster Principal Assignment."
@@ -2246,8 +2246,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "3575126935204689897"
+              "version": "0.42.1.51946",
+              "templateHash": "17586933692653905223"
             },
             "name": "Kusto Cluster Databases",
             "description": "This module deploys a Kusto Cluster Database."
@@ -2471,8 +2471,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "2050858883185100947"
+                      "version": "0.42.1.51946",
+                      "templateHash": "9352555259728054370"
                     },
                     "name": "Kusto Cluster Database Principal Assignments",
                     "description": "This module deploys a Kusto Cluster Database Principal Assignment."

--- a/avm/res/kusto/cluster/main.json
+++ b/avm/res/kusto/cluster/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "5777238379871805657"
+      "templateHash": "17140566750370211159"
     },
     "name": "Kusto Cluster",
     "description": "This module deploys a Kusto Cluster."
@@ -1096,7 +1096,7 @@
         "DualStack"
       ],
       "metadata": {
-        "description": "Optional. Indicates what public IP type to create - IPv4 (default), or DualStack (both IPv4 and IPv6)."
+        "description": "Optional. Indicates what public IP type to create - IPv4, or DualStack (both IPv4 and IPv6, default)."
       }
     },
     "enablePublicNetworkAccess": {

--- a/avm/res/kusto/cluster/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/kusto/cluster/tests/e2e/defaults/main.test.bicep
@@ -52,12 +52,12 @@ module testDeployment '../../../main.bicep' = [
       name: '${namePrefix}${serviceShort}0001'
       sku: 'Standard_E2ads_v5'
       enableDiskEncryption: true
+      enablePublicNetworkAccess: false
       managedIdentities: {
         userAssignedResourceIds: [
           nestedDependencies.outputs.managedIdentityResourceId
         ]
       }
-
     }
   }
 ]

--- a/avm/res/kusto/cluster/version.json
+++ b/avm/res/kusto/cluster/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.10"
+  "version": "0.10.1"
 }

--- a/avm/res/kusto/cluster/version.json
+++ b/avm/res/kusto/cluster/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.10.1"
+  "version": "0.10"
 }


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #123
-->

Fixes #6810

## Pipeline Reference

https://github.com/balliere/bicep-registry-modules/actions/runs/24138235708/job/70432112078

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

Remove requirement for empty privateEndpoints to enable public access

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
