### PR TITLE
feat: Publish all child modules of `avm/res/communication/email-service`

### DIFF
--- a/avm/res/communication/email-service/CHANGELOG.md
+++ b/avm/res/communication/email-service/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/communication/email-service/CHANGELOG.md).
 
+## 0.4.5
+
+### Changes
+
+- Publishing child module `avm/res/communication/email-service/domain`.
+- Publishing child module `avm/res/communication/email-service/domain/sender-username`.
+
+### Breaking Changes
+
+- None
+
 ## 0.4.4
 
 ### Changes

--- a/avm/res/communication/email-service/domain/CHANGELOG.md
+++ b/avm/res/communication/email-service/domain/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/communication/email-service/domain/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version - published as standalone child module.
+
+### Breaking Changes
+
+- None

--- a/avm/res/communication/email-service/domain/README.md
+++ b/avm/res/communication/email-service/domain/README.md
@@ -2,12 +2,21 @@
 
 This module deploys an Email Service Domain
 
+You can reference the module as follows:
+```bicep
+module emailService 'br/public:avm/res/communication/email-service/domain:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
 - [Cross-referenced modules](#Cross-referenced-modules)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -37,6 +46,7 @@ This module deploys an Email Service Domain
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`domainManagement`](#parameter-domainmanagement) | string | Describes how the Domain resource is being managed. |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`location`](#parameter-location) | string | Location for all Resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
@@ -73,6 +83,14 @@ Describes how the Domain resource is being managed.
     'CustomerManagedInExchangeOnline'
   ]
   ```
+
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
 
 ### Parameter: `location`
 
@@ -310,3 +328,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 | Reference | Type |
 | :-- | :-- |
 | `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/communication/email-service/domain/main.bicep
+++ b/avm/res/communication/email-service/domain/main.bicep
@@ -41,6 +41,9 @@ import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
 var builtInRoleNames = {
   Contributor: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
   Owner: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
@@ -66,9 +69,30 @@ var formattedRoleAssignments = [
   })
 ]
 
+var enableReferencedModulesTelemetry = false
+
 // ============== //
 // Resources      //
 // ============== //
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.comm-emailservice-domain.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
 
 resource emailService 'Microsoft.Communication/emailServices@2025-09-01' existing = {
   name: emailServiceName
@@ -89,6 +113,7 @@ module domain_senderUsernames 'sender-username/main.bicep' = [
   for (senderUsername, index) in senderUsernames ?? []: {
     name: '${uniqueString(deployment().name, location)}-domain-senderusername-${index}'
     params: {
+      enableTelemetry: enableReferencedModulesTelemetry
       emailServiceName: emailService.name
       domainName: domain.name
       name: senderUsername.name

--- a/avm/res/communication/email-service/domain/main.json
+++ b/avm/res/communication/email-service/domain/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "11316330965372950910"
+      "version": "0.42.1.51946",
+      "templateHash": "17511257420873353477"
     },
     "name": "Email Services Domains",
     "description": "This module deploys an Email Service Domain"
@@ -234,6 +234,13 @@
       "metadata": {
         "description": "Optional. Array of role assignments to create."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "variables": {
@@ -250,9 +257,30 @@
       "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
       "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
       "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
-    }
+    },
+    "enableReferencedModulesTelemetry": false
   },
   "resources": {
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.comm-emailservice-domain.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     "emailService": {
       "existing": true,
       "type": "Microsoft.Communication/emailServices",
@@ -320,6 +348,9 @@
         },
         "mode": "Incremental",
         "parameters": {
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "emailServiceName": {
             "value": "[parameters('emailServiceName')]"
           },
@@ -342,8 +373,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "5118036937740143259"
+              "version": "0.42.1.51946",
+              "templateHash": "1110740650156323191"
             },
             "name": "Sender Usernames",
             "description": "This module deploys an Sender"
@@ -379,9 +410,36 @@
               "metadata": {
                 "description": "Optional. The display name for the senderUsername."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "resources": [
+            {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.comm-emailservice-domsndrusrname.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             {
               "type": "Microsoft.Communication/emailServices/domains/senderUsernames",
               "apiVersion": "2025-09-01",

--- a/avm/res/communication/email-service/domain/sender-username/CHANGELOG.md
+++ b/avm/res/communication/email-service/domain/sender-username/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/communication/email-service/domain/sender-username/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version - published as standalone child module.
+
+### Breaking Changes
+
+- None

--- a/avm/res/communication/email-service/domain/sender-username/README.md
+++ b/avm/res/communication/email-service/domain/sender-username/README.md
@@ -2,11 +2,20 @@
 
 This module deploys an Sender
 
+You can reference the module as follows:
+```bicep
+module emailService 'br/public:avm/res/communication/email-service/domain/sender-username:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -35,6 +44,7 @@ This module deploys an Sender
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`displayName`](#parameter-displayname) | string | The display name for the senderUsername. |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 
 ### Parameter: `name`
 
@@ -72,6 +82,14 @@ The display name for the senderUsername.
 - Type: string
 - Default: `[parameters('username')]`
 
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
+
 ## Outputs
 
 | Output | Type | Description |
@@ -79,3 +97,7 @@ The display name for the senderUsername.
 | `name` | string | The name of the sender username. |
 | `resourceGroupName` | string | The name of the resource group the sender username was created in. |
 | `resourceId` | string | The resource ID of the sender username. |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/communication/email-service/domain/sender-username/main.bicep
+++ b/avm/res/communication/email-service/domain/sender-username/main.bicep
@@ -16,9 +16,31 @@ param username string
 @description('Optional. The display name for the senderUsername.')
 param displayName string = username
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
 // ============== //
 // Resources      //
 // ============== //
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.comm-emailservice-domsndrusrname.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
 
 resource emailService 'Microsoft.Communication/emailServices@2025-09-01' existing = {
   name: emailServiceName

--- a/avm/res/communication/email-service/domain/sender-username/main.json
+++ b/avm/res/communication/email-service/domain/sender-username/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "5118036937740143259"
+      "version": "0.42.1.51946",
+      "templateHash": "1110740650156323191"
     },
     "name": "Sender Usernames",
     "description": "This module deploys an Sender"
@@ -41,9 +41,36 @@
       "metadata": {
         "description": "Optional. The display name for the senderUsername."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "resources": [
+    {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.comm-emailservice-domsndrusrname.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     {
       "type": "Microsoft.Communication/emailServices/domains/senderUsernames",
       "apiVersion": "2025-09-01",

--- a/avm/res/communication/email-service/domain/sender-username/version.json
+++ b/avm/res/communication/email-service/domain/sender-username/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.1"
+}

--- a/avm/res/communication/email-service/domain/version.json
+++ b/avm/res/communication/email-service/domain/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.1"
+}

--- a/avm/res/communication/email-service/main.bicep
+++ b/avm/res/communication/email-service/main.bicep
@@ -58,6 +58,8 @@ var formattedRoleAssignments = [
   })
 ]
 
+var enableReferencedModulesTelemetry = false
+
 // ============== //
 // Resources      //
 // ============== //
@@ -94,6 +96,7 @@ module email_domains 'domain/main.bicep' = [
   for (domain, index) in (domains ?? []): {
     name: '${uniqueString(deployment().name, location)}-email-domain-${index}'
     params: {
+      enableTelemetry: enableReferencedModulesTelemetry
       emailServiceName: email.name
       name: domain.name
       location: location

--- a/avm/res/communication/email-service/main.json
+++ b/avm/res/communication/email-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "5116232625791379014"
+      "version": "0.42.1.51946",
+      "templateHash": "17407632269537315906"
     },
     "name": "Email Services",
     "description": "This module deploys an Email Service"
@@ -321,7 +321,8 @@
       "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
       "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
       "Communication and Email Service Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '09976791-48a7-449e-bb21-39d1a415f350')]"
-    }
+    },
+    "enableReferencedModulesTelemetry": false
   },
   "resources": {
     "avmTelemetry": {
@@ -404,6 +405,9 @@
         },
         "mode": "Incremental",
         "parameters": {
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "emailServiceName": {
             "value": "[parameters('name')]"
           },
@@ -439,8 +443,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "11316330965372950910"
+              "version": "0.42.1.51946",
+              "templateHash": "17511257420873353477"
             },
             "name": "Email Services Domains",
             "description": "This module deploys an Email Service Domain"
@@ -668,6 +672,13 @@
               "metadata": {
                 "description": "Optional. Array of role assignments to create."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "variables": {
@@ -684,9 +695,30 @@
               "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
               "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
               "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
-            }
+            },
+            "enableReferencedModulesTelemetry": false
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.comm-emailservice-domain.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "emailService": {
               "existing": true,
               "type": "Microsoft.Communication/emailServices",
@@ -754,6 +786,9 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  },
                   "emailServiceName": {
                     "value": "[parameters('emailServiceName')]"
                   },
@@ -776,8 +811,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "5118036937740143259"
+                      "version": "0.42.1.51946",
+                      "templateHash": "1110740650156323191"
                     },
                     "name": "Sender Usernames",
                     "description": "This module deploys an Sender"
@@ -813,9 +848,36 @@
                       "metadata": {
                         "description": "Optional. The display name for the senderUsername."
                       }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
                     }
                   },
                   "resources": [
+                    {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.comm-emailservice-domsndrusrname.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
                     {
                       "type": "Microsoft.Communication/emailServices/domains/senderUsernames",
                       "apiVersion": "2025-09-01",


### PR DESCRIPTION
## Description

Publish all unpublished child modules of `avm/res/communication/email-service`:
- `avm/res/communication/email-service/domain`
- `avm/res/communication/email-service/domain/sender-username`

Changes per child module:
- Added `enableTelemetry` parameter and `avmTelemetry` resource for telemetry instrumentation
- Created `version.json` (version 0.1)
- Created `CHANGELOG.md` (initial version 0.1.0)

Intermediate parent changes:
- `domain`: Added `enableReferencedModulesTelemetry` variable, passes it to `sender-username` child deployment.

Top-level parent changes:
- Added `enableReferencedModulesTelemetry` variable (value `false`)
- Passes `enableReferencedModulesTelemetry` as `enableTelemetry` to `domain` child module deployment
- Updated CHANGELOG.md (version 0.4.5)

## Pipeline Reference

| Status |
| ------ |
| [![avm.res.communication.email-service](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.email-service.yml/badge.svg?branch=users%2Fkrbar%2Fcmp-email-service)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.communication.email-service.yml) |

## Type of Change

- [ ] Update to CI Environment or utilities (No module changes)
- [x] Feature update (Backwards compatible feature updates, published as MINOR)
- [ ] Breaking changes (Changes that require a MAJOR version bump)
- [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open PRs for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the module readme(s) and compiled bicep file(s)
- [x] I have run the deployment tests and they pass cleanly
- [x] My changes generate no new warnings
- [x] I have updated the Module changelog(s) in `CHANGELOG.md`
