### PR TITLE
feat: Publish child modules of `avm/res/dev-center/devcenter`

### DIFF
--- a/avm/res/dev-center/devcenter/CHANGELOG.md
+++ b/avm/res/dev-center/devcenter/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/dev-center/devcenter/CHANGELOG.md).
 
+## 0.1.2
+
+### Changes
+
+- Publishing child module `avm/res/dev-center/devcenter/attachednetwork`
+- Publishing child module `avm/res/dev-center/devcenter/catalog`
+- Publishing child module `avm/res/dev-center/devcenter/devboxdefinition`
+- Publishing child module `avm/res/dev-center/devcenter/environment-type`
+- Publishing child module `avm/res/dev-center/devcenter/gallery`
+- Publishing child module `avm/res/dev-center/devcenter/project-policy`
+
+### Breaking Changes
+
+- None
+
 ## 0.1.1
 
 ### Changes

--- a/avm/res/dev-center/devcenter/attachednetwork/CHANGELOG.md
+++ b/avm/res/dev-center/devcenter/attachednetwork/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/dev-center/devcenter/attachednetwork/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/dev-center/devcenter/attachednetwork/README.md
+++ b/avm/res/dev-center/devcenter/attachednetwork/README.md
@@ -2,11 +2,20 @@
 
 This module deploys a Dev Center Attached Network.
 
+You can reference the module as follows:
+```bicep
+module devcenter 'br/public:avm/res/dev-center/devcenter/attachednetwork:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -29,6 +38,12 @@ This module deploys a Dev Center Attached Network.
 | :-- | :-- | :-- |
 | [`devcenterName`](#parameter-devcentername) | string | The name of the parent dev center. Required if the template is used in a standalone deployment. |
 
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
+
 ### Parameter: `name`
 
 The name of the attached network.
@@ -50,6 +65,14 @@ The name of the parent dev center. Required if the template is used in a standal
 - Required: Yes
 - Type: string
 
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
+
 ## Outputs
 
 | Output | Type | Description |
@@ -57,3 +80,7 @@ The name of the parent dev center. Required if the template is used in a standal
 | `name` | string | The name of the Dev Center Attached Network. |
 | `resourceGroupName` | string | The name of the resource group the Dev Center Attached Network was created in. |
 | `resourceId` | string | The resource ID of the Dev Center Attached Network. |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/dev-center/devcenter/attachednetwork/main.bicep
+++ b/avm/res/dev-center/devcenter/attachednetwork/main.bicep
@@ -16,9 +16,31 @@ param name string
 @description('Required. The resource ID of the Network Connection you want to attach to the Dev Center.')
 param networkConnectionResourceId string
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
 // ============== //
 // Resources      //
 // ============== //
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.devcenter-devcenter-attachednetwork.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
 
 resource devcenter 'Microsoft.DevCenter/devcenters@2025-02-01' existing = {
   name: devcenterName

--- a/avm/res/dev-center/devcenter/attachednetwork/main.json
+++ b/avm/res/dev-center/devcenter/attachednetwork/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "13843883469270915445"
+      "version": "0.42.1.51946",
+      "templateHash": "13588391753639980537"
     },
     "name": "Dev Center Attached Network",
     "description": "This module deploys a Dev Center Attached Network."
@@ -30,9 +30,36 @@
       "metadata": {
         "description": "Required. The resource ID of the Network Connection you want to attach to the Dev Center."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "resources": [
+    {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.devcenter-devcenter-attachednetwork.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     {
       "type": "Microsoft.DevCenter/devcenters/attachednetworks",
       "apiVersion": "2025-02-01",

--- a/avm/res/dev-center/devcenter/attachednetwork/version.json
+++ b/avm/res/dev-center/devcenter/attachednetwork/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.1"
+}

--- a/avm/res/dev-center/devcenter/catalog/CHANGELOG.md
+++ b/avm/res/dev-center/devcenter/catalog/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/dev-center/devcenter/catalog/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/dev-center/devcenter/catalog/README.md
+++ b/avm/res/dev-center/devcenter/catalog/README.md
@@ -2,11 +2,20 @@
 
 This module deploys a Dev Center Catalog.
 
+You can reference the module as follows:
+```bicep
+module devcenter 'br/public:avm/res/dev-center/devcenter/catalog:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -33,6 +42,7 @@ This module deploys a Dev Center Catalog.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`adoGit`](#parameter-adogit) | object | Azure DevOps Git repository configuration for the catalog. |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`gitHub`](#parameter-github) | object | GitHub repository configuration for the catalog. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`syncType`](#parameter-synctype) | string | Indicates the type of sync that is configured for the catalog. Defaults to "Scheduled". |
@@ -100,6 +110,14 @@ A reference to the Key Vault secret containing a Personal Access Token (PAT) to 
 
 - Required: No
 - Type: string
+
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
 
 ### Parameter: `gitHub`
 
@@ -188,3 +206,7 @@ Resource tags to apply to the catalog.
 | `name` | string | The name of the catalog. |
 | `resourceGroupName` | string | The name of the resource group the catalog was created in. |
 | `resourceId` | string | The resource ID of the catalog. |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/dev-center/devcenter/catalog/main.bicep
+++ b/avm/res/dev-center/devcenter/catalog/main.bicep
@@ -32,9 +32,31 @@ param tags resourceInput<'Microsoft.DevCenter/devcenters/catalogs@2025-02-01'>.t
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
 // ============== //
 // Resources      //
 // ============== //
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.devcenter-devcenter-catalog.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
 
 resource devCenter 'Microsoft.DevCenter/devcenters@2025-02-01' existing = {
   name: devcenterName

--- a/avm/res/dev-center/devcenter/catalog/main.json
+++ b/avm/res/dev-center/devcenter/catalog/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "12539544528259564928"
+      "version": "0.42.1.51946",
+      "templateHash": "3680370706040254171"
     },
     "name": "Dev Center Catalog",
     "description": "This module deploys a Dev Center Catalog."
@@ -105,9 +105,36 @@
       "metadata": {
         "description": "Optional. Location for all resources."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "resources": {
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.devcenter-devcenter-catalog.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     "devCenter": {
       "existing": true,
       "type": "Microsoft.DevCenter/devcenters",

--- a/avm/res/dev-center/devcenter/catalog/version.json
+++ b/avm/res/dev-center/devcenter/catalog/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.1"
+}

--- a/avm/res/dev-center/devcenter/devboxdefinition/CHANGELOG.md
+++ b/avm/res/dev-center/devcenter/devboxdefinition/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/dev-center/devcenter/devboxdefinition/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/dev-center/devcenter/devboxdefinition/README.md
+++ b/avm/res/dev-center/devcenter/devboxdefinition/README.md
@@ -2,11 +2,20 @@
 
 This module deploys a Dev Center DevBox Definition.
 
+You can reference the module as follows:
+```bicep
+module devcenter 'br/public:avm/res/dev-center/devcenter/devboxdefinition:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -34,6 +43,7 @@ This module deploys a Dev Center DevBox Definition.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`hibernateSupport`](#parameter-hibernatesupport) | string | Settings for hibernation support. |
 | [`location`](#parameter-location) | string | Location for the DevBox definition. Defaults to resource group location. |
 | [`tags`](#parameter-tags) | object | Tags for the DevBox definition. |
@@ -108,6 +118,14 @@ The name of the parent dev center. Required if the template is used in a standal
 - Required: Yes
 - Type: string
 
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
+
 ### Parameter: `hibernateSupport`
 
 Settings for hibernation support.
@@ -146,3 +164,7 @@ Tags for the DevBox definition.
 | `name` | string | The name of the DevBox Definition. |
 | `resourceGroupName` | string | The name of the resource group the DevBox Definition was created in. |
 | `resourceId` | string | The resource ID of the DevBox Definition. |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/dev-center/devcenter/devboxdefinition/main.bicep
+++ b/avm/res/dev-center/devcenter/devboxdefinition/main.bicep
@@ -28,9 +28,31 @@ param tags resourceInput<'Microsoft.DevCenter/devcenters/devboxdefinitions@2025-
 @description('Optional. Location for the DevBox definition. Defaults to resource group location.')
 param location string = resourceGroup().location
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
 // ============== //
 // Resources      //
 // ============== //
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.devcenter-devcenter-devboxdefinition.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
 
 resource devcenter 'Microsoft.DevCenter/devcenters@2025-02-01' existing = {
   name: devcenterName

--- a/avm/res/dev-center/devcenter/devboxdefinition/main.json
+++ b/avm/res/dev-center/devcenter/devboxdefinition/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "11306941776906804346"
+      "version": "0.42.1.51946",
+      "templateHash": "14912799610781600876"
     },
     "name": "Dev Center DevBox Definition",
     "description": "This module deploys a Dev Center DevBox Definition."
@@ -103,9 +103,36 @@
       "metadata": {
         "description": "Optional. Location for the DevBox definition. Defaults to resource group location."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "resources": {
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.devcenter-devcenter-devboxdefinition.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     "devcenter": {
       "existing": true,
       "type": "Microsoft.DevCenter/devcenters",

--- a/avm/res/dev-center/devcenter/devboxdefinition/version.json
+++ b/avm/res/dev-center/devcenter/devboxdefinition/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.1"
+}

--- a/avm/res/dev-center/devcenter/environment-type/CHANGELOG.md
+++ b/avm/res/dev-center/devcenter/environment-type/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/dev-center/devcenter/environment-type/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/dev-center/devcenter/environment-type/README.md
+++ b/avm/res/dev-center/devcenter/environment-type/README.md
@@ -2,11 +2,20 @@
 
 This module deploys a Dev Center Environment Type.
 
+You can reference the module as follows:
+```bicep
+module devcenter 'br/public:avm/res/dev-center/devcenter/environment-type:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -33,6 +42,7 @@ This module deploys a Dev Center Environment Type.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`displayName`](#parameter-displayname) | string | The display name of the environment type. |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`tags`](#parameter-tags) | object | Tags of the resource. |
 
 ### Parameter: `name`
@@ -56,6 +66,14 @@ The display name of the environment type.
 - Required: No
 - Type: string
 
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
+
 ### Parameter: `tags`
 
 Tags of the resource.
@@ -70,3 +88,7 @@ Tags of the resource.
 | `name` | string | The name of the Dev Center Environment Type. |
 | `resourceGroupName` | string | The name of the resource group the Dev Center Environment Type was created in. |
 | `resourceId` | string | The resource ID of the Dev Center Environment Type. |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/dev-center/devcenter/environment-type/main.bicep
+++ b/avm/res/dev-center/devcenter/environment-type/main.bicep
@@ -17,9 +17,31 @@ param displayName string?
 @description('Optional. Tags of the resource.')
 param tags resourceInput<'Microsoft.DevCenter/devcenters/environmentTypes@2025-02-01'>.tags?
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
 // ============== //
 // Resources      //
 // ============== //
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.devcenter-devcenter-environmenttype.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
 
 resource devcenter 'Microsoft.DevCenter/devcenters@2025-02-01' existing = {
   name: devcenterName

--- a/avm/res/dev-center/devcenter/environment-type/main.json
+++ b/avm/res/dev-center/devcenter/environment-type/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "16871277095184279220"
+      "version": "0.42.1.51946",
+      "templateHash": "3051305686783252428"
     },
     "name": "Dev Center Environment Type",
     "description": "This module deploys a Dev Center Environment Type."
@@ -40,9 +40,36 @@
         "description": "Optional. Tags of the resource."
       },
       "nullable": true
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "resources": {
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.devcenter-devcenter-environmenttype.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     "devcenter": {
       "existing": true,
       "type": "Microsoft.DevCenter/devcenters",

--- a/avm/res/dev-center/devcenter/environment-type/version.json
+++ b/avm/res/dev-center/devcenter/environment-type/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.1"
+}

--- a/avm/res/dev-center/devcenter/gallery/CHANGELOG.md
+++ b/avm/res/dev-center/devcenter/gallery/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/dev-center/devcenter/gallery/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/dev-center/devcenter/gallery/README.md
+++ b/avm/res/dev-center/devcenter/gallery/README.md
@@ -2,11 +2,20 @@
 
 This module deploys a Dev Center Gallery.
 
+You can reference the module as follows:
+```bicep
+module devcenter 'br/public:avm/res/dev-center/devcenter/gallery:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -35,6 +44,7 @@ This module deploys a Dev Center Gallery.
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`devCenterIdentityPrincipalId`](#parameter-devcenteridentityprincipalid) | string | The principal ID of the Dev Center identity (system or user) that will be assigned the "Contributor" role on the backing Azure Compute Gallery. This is only required if the Dev Center identity has not been granted the right permissions on the gallery. The portal experience handles this automatically. Note that the identity performing the deployment must have permissions to perform role assignments on the resource group of the gallery to assign the role, otherwise the deployment will fail. |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 
 ### Parameter: `galleryResourceId`
 
@@ -64,6 +74,14 @@ The principal ID of the Dev Center identity (system or user) that will be assign
 - Required: No
 - Type: string
 
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
+
 ## Outputs
 
 | Output | Type | Description |
@@ -71,3 +89,7 @@ The principal ID of the Dev Center identity (system or user) that will be assign
 | `name` | string | The name of the Dev Center Gallery. |
 | `resourceGroupName` | string | The name of the resource group the Dev Center Gallery was created in. |
 | `resourceId` | string | The resource ID of the Dev Center Gallery. |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/dev-center/devcenter/gallery/main.bicep
+++ b/avm/res/dev-center/devcenter/gallery/main.bicep
@@ -19,9 +19,31 @@ param galleryResourceId string
 @description('Optional. The principal ID of the Dev Center identity (system or user) that will be assigned the "Contributor" role on the backing Azure Compute Gallery. This is only required if the Dev Center identity has not been granted the right permissions on the gallery. The portal experience handles this automatically. Note that the identity performing the deployment must have permissions to perform role assignments on the resource group of the gallery to assign the role, otherwise the deployment will fail.')
 param devCenterIdentityPrincipalId string?
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
 // ============== //
 // Resources      //
 // ============== //
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.devcenter-devcenter-gallery.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
 
 resource devcenter 'Microsoft.DevCenter/devcenters@2025-02-01' existing = {
   name: devcenterName

--- a/avm/res/dev-center/devcenter/gallery/main.json
+++ b/avm/res/dev-center/devcenter/gallery/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "14979298774085357836"
+      "version": "0.42.1.51946",
+      "templateHash": "3185085488318130955"
     },
     "name": "Dev Center Gallery",
     "description": "This module deploys a Dev Center Gallery."
@@ -38,9 +38,36 @@
       "metadata": {
         "description": "Optional. The principal ID of the Dev Center identity (system or user) that will be assigned the \"Contributor\" role on the backing Azure Compute Gallery. This is only required if the Dev Center identity has not been granted the right permissions on the gallery. The portal experience handles this automatically. Note that the identity performing the deployment must have permissions to perform role assignments on the resource group of the gallery to assign the role, otherwise the deployment will fail."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "resources": {
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.devcenter-devcenter-gallery.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     "devcenter": {
       "existing": true,
       "type": "Microsoft.DevCenter/devcenters",
@@ -83,8 +110,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "10662300869810178511"
+              "version": "0.42.1.51946",
+              "templateHash": "7157912435937751695"
             }
           },
           "parameters": {

--- a/avm/res/dev-center/devcenter/gallery/version.json
+++ b/avm/res/dev-center/devcenter/gallery/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.1"
+}

--- a/avm/res/dev-center/devcenter/main.bicep
+++ b/avm/res/dev-center/devcenter/main.bicep
@@ -64,8 +64,6 @@ param devboxDefinitions devboxDefinitionType[]?
 @description('Optional. The projects to create in the Dev Center. A project is the point of access to Microsoft Dev Box for the development team members. A project contains dev box pools, which specify the dev box definitions and network connections used when dev boxes are created. Each project is associated with a single dev center. When you associate a project with a dev center, all the settings at the dev center level are applied to the project automatically.')
 param projects projectType[]?
 
-var enableReferencedModulesTelemetry = false
-
 var formattedUserAssignedIdentities = reduce(
   map((managedIdentities.?userAssignedResourceIds ?? []), (id) => { '${id}': {} }),
   {},
@@ -130,6 +128,8 @@ var formattedRoleAssignments = [
   })
 ]
 
+var enableReferencedModulesTelemetry = false
+
 // ============== //
 // Resources      //
 // ============== //
@@ -172,6 +172,7 @@ module project_catalog 'catalog/main.bicep' = [
     params: {
       name: catalog.name
       devcenterName: devcenter.name
+      enableTelemetry: enableReferencedModulesTelemetry
       gitHub: catalog.?gitHub
       adoGit: catalog.?adoGit
       syncType: catalog.?syncType
@@ -186,6 +187,7 @@ module devcenter_environmentType 'environment-type/main.bicep' = [
     name: '${uniqueString(deployment().name, location)}-Devcenter-EnvironmentType-${index}'
     params: {
       devcenterName: devcenter.name
+      enableTelemetry: enableReferencedModulesTelemetry
       name: environmentType.name
       tags: environmentType.?tags
       displayName: environmentType.?displayName
@@ -198,6 +200,7 @@ module devcenter_gallery 'gallery/main.bicep' = [
     name: '${uniqueString(deployment().name, location)}-Devcenter-Gallery-${index}'
     params: {
       devcenterName: devcenter.name
+      enableTelemetry: enableReferencedModulesTelemetry
       name: gallery.name
       galleryResourceId: gallery.galleryResourceId
       devCenterIdentityPrincipalId: gallery.?devCenterIdentityPrincipalId
@@ -210,6 +213,7 @@ module devcenter_attachedNetwork 'attachednetwork/main.bicep' = [
     name: '${uniqueString(deployment().name, location)}-Devcenter-AttachedNetwork-${index}'
     params: {
       devcenterName: devcenter.name
+      enableTelemetry: enableReferencedModulesTelemetry
       name: attachedNetwork.name
       networkConnectionResourceId: attachedNetwork.networkConnectionResourceId
     }
@@ -221,6 +225,7 @@ module devcenter_devboxDefinition 'devboxdefinition/main.bicep' = [
     name: '${uniqueString(deployment().name, location)}-Devcenter-DevboxDefinition-${index}'
     params: {
       devcenterName: devcenter.name
+      enableTelemetry: enableReferencedModulesTelemetry
       name: devboxDefinition.name
       imageResourceId: devboxDefinition.imageResourceId
       sku: devboxDefinition.sku
@@ -296,6 +301,7 @@ module devCenter_projectPolicy 'project-policy/main.bicep' = [
     name: '${uniqueString(deployment().name, location)}-Devcenter-ProjectPolicy-${index}'
     params: {
       devcenterName: devcenter.name
+      enableTelemetry: enableReferencedModulesTelemetry
       name: projectPolicy.name
       resourcePolicies: projectPolicy.?resourcePolicies
       projectsResourceIdOrName: projectPolicy.?projectsResourceIdOrName

--- a/avm/res/dev-center/devcenter/main.json
+++ b/avm/res/dev-center/devcenter/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "17517153231489106701"
+      "version": "0.42.1.51946",
+      "templateHash": "7048667881884408078"
     },
     "name": "Dev Center",
     "description": "This module deploys an Azure Dev Center."
@@ -1457,7 +1457,6 @@
         "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
       }
     ],
-    "enableReferencedModulesTelemetry": false,
     "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
     "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned,UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
     "builtInRoleNames": {
@@ -1472,7 +1471,8 @@
       "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
       "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
       "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
-    }
+    },
+    "enableReferencedModulesTelemetry": false
   },
   "resources": {
     "avmTelemetry": {
@@ -1606,6 +1606,9 @@
           "devcenterName": {
             "value": "[parameters('name')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "gitHub": {
             "value": "[tryGet(coalesce(parameters('catalogs'), createArray())[copyIndex()], 'gitHub')]"
           },
@@ -1629,8 +1632,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "12539544528259564928"
+              "version": "0.42.1.51946",
+              "templateHash": "3680370706040254171"
             },
             "name": "Dev Center Catalog",
             "description": "This module deploys a Dev Center Catalog."
@@ -1729,9 +1732,36 @@
               "metadata": {
                 "description": "Optional. Location for all resources."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.devcenter-devcenter-catalog.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "devCenter": {
               "existing": true,
               "type": "Microsoft.DevCenter/devcenters",
@@ -1803,6 +1833,9 @@
           "devcenterName": {
             "value": "[parameters('name')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "name": {
             "value": "[coalesce(parameters('environmentTypes'), createArray())[copyIndex()].name]"
           },
@@ -1820,8 +1853,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "16871277095184279220"
+              "version": "0.42.1.51946",
+              "templateHash": "3051305686783252428"
             },
             "name": "Dev Center Environment Type",
             "description": "This module deploys a Dev Center Environment Type."
@@ -1855,9 +1888,36 @@
                 "description": "Optional. Tags of the resource."
               },
               "nullable": true
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.devcenter-devcenter-environmenttype.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "devcenter": {
               "existing": true,
               "type": "Microsoft.DevCenter/devcenters",
@@ -1920,6 +1980,9 @@
           "devcenterName": {
             "value": "[parameters('name')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "name": {
             "value": "[coalesce(parameters('galleries'), createArray())[copyIndex()].name]"
           },
@@ -1937,8 +2000,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "14979298774085357836"
+              "version": "0.42.1.51946",
+              "templateHash": "3185085488318130955"
             },
             "name": "Dev Center Gallery",
             "description": "This module deploys a Dev Center Gallery."
@@ -1970,9 +2033,36 @@
               "metadata": {
                 "description": "Optional. The principal ID of the Dev Center identity (system or user) that will be assigned the \"Contributor\" role on the backing Azure Compute Gallery. This is only required if the Dev Center identity has not been granted the right permissions on the gallery. The portal experience handles this automatically. Note that the identity performing the deployment must have permissions to perform role assignments on the resource group of the gallery to assign the role, otherwise the deployment will fail."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.devcenter-devcenter-gallery.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "devcenter": {
               "existing": true,
               "type": "Microsoft.DevCenter/devcenters",
@@ -2015,8 +2105,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "10662300869810178511"
+                      "version": "0.42.1.51946",
+                      "templateHash": "7157912435937751695"
                     }
                   },
                   "parameters": {
@@ -2096,6 +2186,9 @@
           "devcenterName": {
             "value": "[parameters('name')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "name": {
             "value": "[coalesce(parameters('attachedNetworks'), createArray())[copyIndex()].name]"
           },
@@ -2109,8 +2202,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "13843883469270915445"
+              "version": "0.42.1.51946",
+              "templateHash": "13588391753639980537"
             },
             "name": "Dev Center Attached Network",
             "description": "This module deploys a Dev Center Attached Network."
@@ -2135,9 +2228,36 @@
               "metadata": {
                 "description": "Required. The resource ID of the Network Connection you want to attach to the Dev Center."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "resources": [
+            {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.devcenter-devcenter-attachednetwork.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             {
               "type": "Microsoft.DevCenter/devcenters/attachednetworks",
               "apiVersion": "2025-02-01",
@@ -2193,6 +2313,9 @@
           "devcenterName": {
             "value": "[parameters('name')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "name": {
             "value": "[coalesce(parameters('devboxDefinitions'), createArray())[copyIndex()].name]"
           },
@@ -2219,8 +2342,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "11306941776906804346"
+              "version": "0.42.1.51946",
+              "templateHash": "14912799610781600876"
             },
             "name": "Dev Center DevBox Definition",
             "description": "This module deploys a Dev Center DevBox Definition."
@@ -2317,9 +2440,36 @@
               "metadata": {
                 "description": "Optional. Location for the DevBox definition. Defaults to resource group location."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.devcenter-devcenter-devboxdefinition.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "devcenter": {
               "existing": true,
               "type": "Microsoft.DevCenter/devcenters",
@@ -2397,6 +2547,9 @@
           "devcenterName": {
             "value": "[parameters('name')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "name": {
             "value": "[coalesce(parameters('projectPolicies'), createArray())[copyIndex()].name]"
           },
@@ -2414,8 +2567,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "5941982233391462523"
+              "version": "0.42.1.51946",
+              "templateHash": "1774290065834363730"
             },
             "name": "Dev Center Project Policy",
             "description": "This module deploys a Dev Center Project Policy."
@@ -2501,6 +2654,13 @@
               "metadata": {
                 "description": "Optional. Project names or resource IDs that will be in scope of this project policy. Project names can be used if the project is in the same resource group as the Dev Center. If the project is in a different resource group or subscription, the full resource ID must be provided. If not provided, the policy status will be set to \"Unassigned\"."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "variables": {
@@ -2513,6 +2673,26 @@
             ]
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.devcenter-devcenter-projectpolicy.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "devcenter": {
               "existing": true,
               "type": "Microsoft.DevCenter/devcenters",

--- a/avm/res/dev-center/devcenter/project-policy/CHANGELOG.md
+++ b/avm/res/dev-center/devcenter/project-policy/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/dev-center/devcenter/project-policy/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/dev-center/devcenter/project-policy/README.md
+++ b/avm/res/dev-center/devcenter/project-policy/README.md
@@ -2,11 +2,20 @@
 
 This module deploys a Dev Center Project Policy.
 
+You can reference the module as follows:
+```bicep
+module devcenter 'br/public:avm/res/dev-center/devcenter/project-policy:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -33,6 +42,7 @@ This module deploys a Dev Center Project Policy.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`projectsResourceIdOrName`](#parameter-projectsresourceidorname) | array | Project names or resource IDs that will be in scope of this project policy. Project names can be used if the project is in the same resource group as the Dev Center. If the project is in a different resource group or subscription, the full resource ID must be provided. If not provided, the policy status will be set to "Unassigned". |
 
 ### Parameter: `name`
@@ -108,6 +118,14 @@ The name of the parent dev center. Required if the template is used in a standal
 - Required: Yes
 - Type: string
 
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
+
 ### Parameter: `projectsResourceIdOrName`
 
 Project names or resource IDs that will be in scope of this project policy. Project names can be used if the project is in the same resource group as the Dev Center. If the project is in a different resource group or subscription, the full resource ID must be provided. If not provided, the policy status will be set to "Unassigned".
@@ -122,3 +140,7 @@ Project names or resource IDs that will be in scope of this project policy. Proj
 | `name` | string | The name of the Dev Center Project Policy. |
 | `resourceGroupName` | string | The name of the resource group the Dev Center Project Policy was created in. |
 | `resourceId` | string | The resource ID of the Dev Center Project Policy. |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/dev-center/devcenter/project-policy/main.bicep
+++ b/avm/res/dev-center/devcenter/project-policy/main.bicep
@@ -19,6 +19,9 @@ param resourcePolicies resourcePolicyType[]
 @description('Optional. Project names or resource IDs that will be in scope of this project policy. Project names can be used if the project is in the same resource group as the Dev Center. If the project is in a different resource group or subscription, the full resource ID must be provided. If not provided, the policy status will be set to "Unassigned".')
 param projectsResourceIdOrName string[]?
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
 // Resolve project names to resource IDs
 var projectResourceIds = [
   for projectResourceIdOrName in (projectsResourceIdOrName ?? []): startsWith(
@@ -32,6 +35,25 @@ var projectResourceIds = [
 // ============== //
 // Resources      //
 // ============== //
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.devcenter-devcenter-projectpolicy.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
 
 resource devcenter 'Microsoft.DevCenter/devcenters@2025-02-01' existing = {
   name: devcenterName

--- a/avm/res/dev-center/devcenter/project-policy/main.json
+++ b/avm/res/dev-center/devcenter/project-policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "5941982233391462523"
+      "version": "0.42.1.51946",
+      "templateHash": "1774290065834363730"
     },
     "name": "Dev Center Project Policy",
     "description": "This module deploys a Dev Center Project Policy."
@@ -92,6 +92,13 @@
       "metadata": {
         "description": "Optional. Project names or resource IDs that will be in scope of this project policy. Project names can be used if the project is in the same resource group as the Dev Center. If the project is in a different resource group or subscription, the full resource ID must be provided. If not provided, the policy status will be set to \"Unassigned\"."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "variables": {
@@ -104,6 +111,26 @@
     ]
   },
   "resources": {
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.devcenter-devcenter-projectpolicy.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     "devcenter": {
       "existing": true,
       "type": "Microsoft.DevCenter/devcenters",

--- a/avm/res/dev-center/devcenter/project-policy/version.json
+++ b/avm/res/dev-center/devcenter/project-policy/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.1"
+}


### PR DESCRIPTION
## Description

Publish all child modules of `avm/res/dev-center/devcenter`:

- `avm/res/dev-center/devcenter/attachednetwork`
- `avm/res/dev-center/devcenter/catalog`
- `avm/res/dev-center/devcenter/devboxdefinition`
- `avm/res/dev-center/devcenter/environment-type`
- `avm/res/dev-center/devcenter/gallery`
- `avm/res/dev-center/devcenter/project-policy`

Changes:
- Added `enableTelemetry` parameter and `avmTelemetry` resource to all 6 child modules
- Added `enableReferencedModulesTelemetry` variable to parent module (passes to child deployments)
- Created `version.json` (0.1) and `CHANGELOG.md` for all 6 child modules
- Bumped parent CHANGELOG to 0.1.2

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.dev-center.devcenter](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.devcenter.yml/badge.svg?branch=users%2Fkrbar%2Fcmp-devcenter)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.dev-center.devcenter.yml) |

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version
