### PR TITLE
fix: upgrade HCI host VM perf and fix cross-tenant gallery sharing

### DIFF
--- a/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/hciHostDeployment.bicep
+++ b/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/hciHostDeployment.bicep
@@ -2,7 +2,7 @@
 param location string
 
 @description('Optional. The Azure VM size for the HCI Host VM, which must support nested virtualization and have sufficient capacity for the HCI node VMs!')
-param hostVMSize string = 'Standard_E32bds_v5'
+param hostVMSize string = 'Standard_E48bds_v5'
 
 @description('Optional. The number of Azure Stack HCI nodes to deploy.')
 param hciNodeCount int = 2
@@ -298,13 +298,6 @@ resource vm 'Microsoft.Compute/virtualMachines@2024-03-01' = {
           }
         }
       }
-    }
-    securityProfile: {
-      uefiSettings: {
-        secureBootEnabled: true
-        vTpmEnabled: true
-      }
-      securityType: 'TrustedLaunch'
     }
     licenseType: 'Windows_Server'
   }

--- a/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/scripts/hciHostStage5.ps1
+++ b/utilities/e2e-template-assets/module-specific/azure-stack-hci/azureStackHCIHost/scripts/hciHostStage5.ps1
@@ -187,13 +187,15 @@ For ($i = 1; $i -le $hciNodeCount; $i++) {
     $hciNodeName = "hcinode$i"
     $hciNodePath = "C:\diskMounts\$hciNodeName"
 
-    If ($existingVMs.name -notcontains $hciNodeName) { New-VM -Name $hciNodeName -MemoryStartupBytes 32GB -BootDevice VHD -SwitchName hciNodeMgmtInternal -Path C:\diskMounts\ -VHDPath "$hciNodePath\hci_os.vhdx" -Generation 2 }
+    If ($existingVMs.name -notcontains $hciNodeName) { New-VM -Name $hciNodeName -MemoryStartupBytes 48GB -BootDevice VHD -SwitchName hciNodeMgmtInternal -Path C:\diskMounts\ -VHDPath "$hciNodePath\hci_os.vhdx" -Generation 2 }
 }
 
 # configure HCI node VMs
 log 'Configuring HCI node VMs...'
+log 'Stopping VMs before changing processor settings...'
+Get-VM | Stop-VM -Force -TurnOff
 log 'Setting VM processor count to 16 and enabling virtualization extensions...'
-Get-VM | Set-VMProcessor -ExposeVirtualizationExtensions $true -Count 8
+Get-VM | Set-VMProcessor -ExposeVirtualizationExtensions $true -Count 16
 
 log 'Setting VM key protector and enabling TPM...'
 Get-VM | ForEach-Object {


### PR DESCRIPTION
## Description

Follow-up to #6878. Updates the shared HCI test harness to fix cross-tenant gallery image sharing and improve CI performance.

### Changes

| # | File | Change |
|---|------|--------|
| 1 | `utilities/e2e-template-assets/.../hciHostDeployment.bicep` | Upgrade host VM from E32bds_v5 → E48bds_v5 (~13 min faster cluster deployment) |
| 2 | `utilities/e2e-template-assets/.../hciHostDeployment.bicep` | Remove `securityProfile` (TrustedLaunch) — Standard Gen2 gallery images cannot have UEFI settings for cross-tenant sharing |
| 3 | `utilities/e2e-template-assets/.../hciHostStage5.ps1` | Increase nested HCI node resources: 32GB → 48GB RAM, 8 → 16 vCPUs |
| 4 | `utilities/e2e-template-assets/.../hciHostStage5.ps1` | Add `Stop-VM` before `Set-VMProcessor` — `New-VM` auto-starts VMs, and `Set-VMProcessor` cannot change CPU count on running VMs |

### Why remove securityProfile?

The HCI host VM uses a pre-baked gallery image shared cross-tenant. Azure blocks VMGS (Virtual Machine Guest State) blobs from cross-tenant sharing, which means TrustedLaunch images fail. The image was recreated as **Standard Gen2**, which requires removing the entire `securityProfile` block (even disabled UEFI settings cause deployment errors on Standard images).

### Why upgrade VM size?

The E48bds_v5 (48 vCPU) provides more headroom for the nested HCI cluster deployment. With 16 vCPUs per nested node (up from 8), the HCI cluster provisioning completes ~13 minutes faster, keeping the total E2E test time under the 6-hour CI limit.

### Testing

- **WAF-aligned**: Passed in 5h 46m 30s ✅ ([Run #24791047713](https://github.com/chirag1603/bicep-registry-modules/actions/runs/24791047713))
- No module code changes (`main.bicep` unchanged) — only shared test infrastructure

## Pipeline Reference

| Pipeline |
| -------- |
| [Fork CI - WAF Pass](https://github.com/chirag1603/bicep-registry-modules/actions/runs/24791047713) |

## Type of Change

- [x] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

> **Note:** This PR only modifies the shared test harness — no module code or version changes. CHANGELOG/version updates are not applicable.