### PR TITLE
fix: upgrade \vm/res/kubernetes/connected-cluster\ API version to 2026-02-01-preview

### DIFF
--- a/avm/res/kubernetes/connected-cluster/CHANGELOG.md
+++ b/avm/res/kubernetes/connected-cluster/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/kubernetes/connected-cluster/CHANGELOG.md).
 
+## 0.2.0
+
+### Changes
+
+- Upgraded `Microsoft.Kubernetes/connectedClusters` API version from `2024-07-15-preview` to `2026-02-01-preview`
+- Added new optional parameters: `gateway`, `privateLinkScopeResourceId`, `privateLinkState`
+- No breaking changes — all new properties are optional
+
+### Breaking Changes
+
+- None
+
 ## 0.1.1
 
 ### Changes

--- a/avm/res/kubernetes/connected-cluster/README.md
+++ b/avm/res/kubernetes/connected-cluster/README.md
@@ -24,7 +24,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
-| `Microsoft.Kubernetes/connectedClusters` | 2024-07-15-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.kubernetes_connectedclusters.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Kubernetes/2024-07-15-preview/connectedClusters)</li></ul> |
+| `Microsoft.Kubernetes/connectedClusters` | 2026-02-01-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.kubernetes_connectedclusters.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Kubernetes/2026-02-01-preview/connectedClusters)</li></ul> |
 
 ## Usage examples
 
@@ -425,8 +425,11 @@ param tags = {
 | [`aadProfile`](#parameter-aadprofile) | object | AAD profile for the connected cluster. |
 | [`arcAgentProfile`](#parameter-arcagentprofile) | object | Arc agentry configuration for the provisioned cluster. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
+| [`gateway`](#parameter-gateway) | object | The gateway configuration for routing traffic through a gateway. |
 | [`location`](#parameter-location) | string | Location for all Resources. |
 | [`oidcIssuerProfile`](#parameter-oidcissuerprofile) | object | Open ID Connect (OIDC) Issuer Profile for the connected cluster. |
+| [`privateLinkScopeResourceId`](#parameter-privatelinkscoperesourceid) | string | The resource ID of an Arc Private Link Scope to associate with this cluster for private connectivity. |
+| [`privateLinkState`](#parameter-privatelinkstate) | string | The state of private link on the connected cluster resource. Allowed values: Enabled, Disabled. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`securityProfile`](#parameter-securityprofile) | object | Security profile for the connected cluster. |
 | [`tags`](#parameter-tags) | object | Tags for the cluster resource. |
@@ -573,6 +576,39 @@ Enable/Disable usage telemetry for module.
 - Type: bool
 - Default: `True`
 
+### Parameter: `gateway`
+
+The gateway configuration for routing traffic through a gateway.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`resourceId`](#parameter-gatewayresourceid) | string | The resource ID of the Arc gateway. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`enabled`](#parameter-gatewayenabled) | bool | Whether the gateway is enabled. |
+
+### Parameter: `gateway.resourceId`
+
+The resource ID of the Arc gateway.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `gateway.enabled`
+
+Whether the gateway is enabled.
+
+- Required: No
+- Type: bool
+
 ### Parameter: `location`
 
 Location for all Resources.
@@ -619,6 +655,28 @@ The URL of the self-hosted OIDC issuer.
 
 - Required: No
 - Type: string
+
+### Parameter: `privateLinkScopeResourceId`
+
+The resource ID of an Arc Private Link Scope to associate with this cluster for private connectivity.
+
+- Required: No
+- Type: string
+- Default: `''`
+
+### Parameter: `privateLinkState`
+
+The state of private link on the connected cluster resource. Allowed values: Enabled, Disabled.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Disabled'
+    'Enabled'
+  ]
+  ```
 
 ### Parameter: `roleAssignments`
 

--- a/avm/res/kubernetes/connected-cluster/main.bicep
+++ b/avm/res/kubernetes/connected-cluster/main.bicep
@@ -35,6 +35,19 @@ param securityProfile securityProfileType = {
   }
 }
 
+@description('Optional. The gateway configuration for routing traffic through a gateway.')
+param gateway gatewayType?
+
+@description('Optional. The resource ID of an Arc Private Link Scope to associate with this cluster for private connectivity.')
+param privateLinkScopeResourceId string = ''
+
+@description('Optional. The state of private link on the connected cluster resource. Allowed values: Enabled, Disabled.')
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+param privateLinkState string?
+
 import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
@@ -89,7 +102,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
 }
 
 // Resource definition
-resource connectedCluster 'Microsoft.Kubernetes/connectedClusters@2024-07-15-preview' = {
+resource connectedCluster 'Microsoft.Kubernetes/connectedClusters@2026-02-01-preview' = {
   name: name
   kind: 'ProvisionedCluster'
   location: location
@@ -106,6 +119,9 @@ resource connectedCluster 'Microsoft.Kubernetes/connectedClusters@2024-07-15-pre
     oidcIssuerProfile: oidcIssuerProfile
     securityProfile: securityProfile
     azureHybridBenefit: null
+    gateway: gateway
+    privateLinkScopeResourceId: !empty(privateLinkScopeResourceId) ? privateLinkScopeResourceId : null
+    privateLinkState: privateLinkState
   }
 }
 
@@ -200,4 +216,13 @@ type securityProfileType = {
     @description('Required. Whether workload identity is enabled.')
     enabled: bool
   }
+}
+
+@export()
+@description('The type for gateway configuration.')
+type gatewayType = {
+  @description('Required. The resource ID of the Arc gateway.')
+  resourceId: string
+  @description('Optional. Whether the gateway is enabled.')
+  enabled: bool?
 }

--- a/avm/res/kubernetes/connected-cluster/main.json
+++ b/avm/res/kubernetes/connected-cluster/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "5491532612873693846"
+      "templateHash": "14983314496062140543"
     },
     "name": "Kubernetes Connected Cluster",
     "description": "This module deploys an Azure Arc connected cluster."
@@ -157,6 +157,28 @@
         "description": "The type for security profile configuration."
       }
     },
+    "gatewayType": {
+      "type": "object",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The resource ID of the Arc gateway."
+          }
+        },
+        "enabled": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Whether the gateway is enabled."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The type for gateway configuration."
+      }
+    },
     "roleAssignmentType": {
       "type": "object",
       "properties": {
@@ -297,6 +319,31 @@
         "description": "Optional. Security profile for the connected cluster."
       }
     },
+    "gateway": {
+      "$ref": "#/definitions/gatewayType",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. The gateway configuration for routing traffic through a gateway."
+      }
+    },
+    "privateLinkScopeResourceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional. The resource ID of an Arc Private Link Scope to associate with this cluster for private connectivity."
+      }
+    },
+    "privateLinkState": {
+      "type": "string",
+      "nullable": true,
+      "allowedValues": [
+        "Enabled",
+        "Disabled"
+      ],
+      "metadata": {
+        "description": "Optional. The state of private link on the connected cluster resource. Allowed values: Enabled, Disabled."
+      }
+    },
     "roleAssignments": {
       "type": "array",
       "items": {
@@ -347,7 +394,7 @@
     },
     "connectedCluster": {
       "type": "Microsoft.Kubernetes/connectedClusters",
-      "apiVersion": "2024-07-15-preview",
+      "apiVersion": "2026-02-01-preview",
       "name": "[parameters('name')]",
       "kind": "ProvisionedCluster",
       "location": "[parameters('location')]",
@@ -363,7 +410,10 @@
         "infrastructure": null,
         "oidcIssuerProfile": "[parameters('oidcIssuerProfile')]",
         "securityProfile": "[parameters('securityProfile')]",
-        "azureHybridBenefit": null
+        "azureHybridBenefit": null,
+        "gateway": "[parameters('gateway')]",
+        "privateLinkScopeResourceId": "[if(not(empty(parameters('privateLinkScopeResourceId'))), parameters('privateLinkScopeResourceId'), null())]",
+        "privateLinkState": "[parameters('privateLinkState')]"
       }
     },
     "connectedCluster_roleAssignments": {
@@ -416,7 +466,7 @@
       "metadata": {
         "description": "The location of the connected cluster."
       },
-      "value": "[reference('connectedCluster', '2024-07-15-preview', 'full').location]"
+      "value": "[reference('connectedCluster', '2026-02-01-preview', 'full').location]"
     },
     "systemAssignedMIPrincipalId": {
       "type": "string",
@@ -424,7 +474,7 @@
       "metadata": {
         "description": "The principalId of the connected cluster identity."
       },
-      "value": "[reference('connectedCluster', '2024-07-15-preview', 'full').identity.principalId]"
+      "value": "[reference('connectedCluster', '2026-02-01-preview', 'full').identity.principalId]"
     }
   }
 }

--- a/avm/res/kubernetes/connected-cluster/version.json
+++ b/avm/res/kubernetes/connected-cluster/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1"
+  "version": "0.2"
 }


### PR DESCRIPTION
## Description

Upgrades the \vm/res/kubernetes/connected-cluster\ module API version from \2024-07-15-preview\ to \2026-02-01-preview\ (latest preview). Adds new optional parameters for gateway and private link support.

> **Note:** Preview API retained because the latest stable (\2024-01-01\) lacks \oidcIssuerProfile\ and \securityProfile.workloadIdentity\ which this module already exposes — switching to stable would be a breaking change.

### Changes
| # | File | Change |
|---|------|--------|
| 1 | \main.bicep\ | API \2024-07-15-preview\ → \2026-02-01-preview\; Added optional \gateway\, \privateLinkScopeResourceId\, \privateLinkState\ params; Added \gatewayType\ type definition |
| 2 | \ersion.json\ | Version bump \