### PR TITLE
fix(avm/res/azure-stack-hci/virtual-machine-instance): update module metadata description

### DIFF
--- a/avm/res/azure-stack-hci/virtual-machine-instance/CHANGELOG.md
+++ b/avm/res/azure-stack-hci/virtual-machine-instance/CHANGELOG.md
@@ -7,6 +7,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 ### Changes
 
 - Added @secure() decorator to osProfile parameter to prevent adminPassword exposure in ARM deployment history
+- Updated module metadata description for consistency
 
 ### Breaking Changes
 

--- a/avm/res/azure-stack-hci/virtual-machine-instance/README.md
+++ b/avm/res/azure-stack-hci/virtual-machine-instance/README.md
@@ -1,6 +1,6 @@
 # Azure Stack HCI Virtual Machine Instance `[Microsoft.AzureStackHCI/virtualMachineInstances]`
 
-This module deploys an Azure Stack HCI virtual machine.
+This module deploys an Azure Stack HCI Virtual Machine Instance.
 
 You can reference the module as follows:
 ```bicep

--- a/avm/res/azure-stack-hci/virtual-machine-instance/main.bicep
+++ b/avm/res/azure-stack-hci/virtual-machine-instance/main.bicep
@@ -1,5 +1,5 @@
 metadata name = 'Azure Stack HCI Virtual Machine Instance'
-metadata description = 'This module deploys an Azure Stack HCI virtual machine.'
+metadata description = 'This module deploys an Azure Stack HCI Virtual Machine Instance.'
 
 @description('Required. Name of the resource to create.')
 param name string

--- a/avm/res/azure-stack-hci/virtual-machine-instance/main.json
+++ b/avm/res/azure-stack-hci/virtual-machine-instance/main.json
@@ -6,10 +6,10 @@
     "_generator": {
       "name": "bicep",
       "version": "0.40.2.10011",
-      "templateHash": "4963312133934804886"
+      "templateHash": "2762470320903869455"
     },
     "name": "Azure Stack HCI Virtual Machine Instance",
-    "description": "This module deploys an Azure Stack HCI virtual machine."
+    "description": "This module deploys an Azure Stack HCI Virtual Machine Instance."
   },
   "definitions": {
     "roleAssignmentType": {


### PR DESCRIPTION
## Description

Minor update to module metadata description for consistency. This triggers CI validation with `.e2eignore` (per #6964) to enable module publishing.

### Changes
- Updated `metadata description` in `main.bicep` from 'virtual machine' to 'Virtual Machine Instance' for consistency with module name
- Updated CHANGELOG.md
- Regenerated README.md and main.json via `Set-AVMModule`

### Notes
- Module code logic is **unchanged**
- CI deployment tests are skipped via `.e2eignore` (per #6964)
- Ready for review and publish to MCR (target version: **0.1.2**)

### Local Validation Results

\\\
Tests completed in 164.21s
Tests Passed: 92, Failed: 0, Skipped: 8, Inconclusive: 0, NotRun: 0
\\\

<details>
<summary>Pester test details</summary>

- **Target version**: 0.1.2 (patch bump from 0.1.1)
- **MCR existing tags**: 0.1.0, 0.1.1
- **Modified files justifying publish**: main.json
- **Bicep build**: Success (warnings only, no errors)
- **.e2eignore**: Present in \	ests/e2e/defaults/\ and \	ests/e2e/waf-aligned/\
- **Skipped tests (8)**: Deployment tests skipped due to .e2eignore (expected behavior per #6964)

</details>