### PR TITLE
fix(ci): harden e2e validation tooling for slow RPs, ARM history eviction, and management groups

### DIFF
--- a/utilities/pipelines/e2eValidation/resourceDeployment/New-TemplateDeployment.ps1
+++ b/utilities/pipelines/e2eValidation/resourceDeployment/New-TemplateDeployment.ps1
@@ -225,8 +225,9 @@ function New-TemplateDeploymentInner {
 
         do {
             # Generate a valid deployment name. Must match ^[-\w\._\(\)]+$
+            # Note: 'HHmmss' (lowercase 'mm' = minutes); previously used 'HHMMss' which is .NET's *month* specifier and produced misleading timestamps.
             do {
-                $deploymentName = ('{0}-t{1}-{2}' -f $deploymentNamePrefix, $retryCount, (Get-Date -Format 'yyyyMMddTHHMMssffffZ'))[0..63] -join ''
+                $deploymentName = ('{0}-t{1}-{2}' -f $deploymentNamePrefix, $retryCount, (Get-Date -Format 'yyyyMMddTHHmmssffffZ'))[0..63] -join ''
             } while ($deploymentName -notmatch '^[-\w\._\(\)]+$')
 
             Write-Verbose "Deploying with deployment name [$deploymentName]" -Verbose
@@ -316,9 +317,20 @@ function New-TemplateDeploymentInner {
                     }
                     $Stoploop = $true
                 } else {
-                    Write-Verbose "Resource deployment Failed.. ($retryCount/$RetryLimit) Retrying in 5 Seconds.. `n"
-                    Write-Verbose ($PSitem.Exception.Message | Out-String) -Verbose
-                    Start-Sleep -Seconds 5
+                    # Error-aware retry:
+                    # - 'RequestConflict' / 'provisioning state is not terminal' indicates the RP is still settling the previous PUT. These RPs (Kusto, Databricks, Cognitive Services with CMK, ...) regularly need >90s. Wait considerably longer before retrying.
+                    # - All other failures use exponential backoff (30s -> 90s -> 240s) instead of a fixed 5s, which is too short for almost any transient-ARM/RP failure.
+                    $exceptionText = ($PSitem.Exception.Message | Out-String)
+                    $isProvisioningStateConflict = $exceptionText -match 'RequestConflict' -or $exceptionText -match 'provisioning state is not terminal'
+                    if ($isProvisioningStateConflict) {
+                        $retrySeconds = 180
+                        Write-Verbose "Resource deployment failed with a non-terminal provisioning state ($retryCount/$RetryLimit). Waiting [$retrySeconds]s for the resource provider to settle before retrying.. `n" -Verbose
+                    } else {
+                        $retrySeconds = @(30, 90, 240)[[Math]::Min($retryCount - 1, 2)]
+                        Write-Verbose "Resource deployment failed ($retryCount/$RetryLimit). Retrying in [$retrySeconds] seconds (exponential backoff).. `n" -Verbose
+                    }
+                    Write-Verbose $exceptionText -Verbose
+                    Start-Sleep -Seconds $retrySeconds
                     $retryCount++
                 }
             }

--- a/utilities/pipelines/e2eValidation/resourceRemoval/helper/Get-DeploymentTargetResourceList.ps1
+++ b/utilities/pipelines/e2eValidation/resourceRemoval/helper/Get-DeploymentTargetResourceList.ps1
@@ -356,7 +356,7 @@ function Get-DeploymentTargetResourceList {
         [string] $Scope,
 
         [Parameter(Mandatory = $false)]
-        [int] $SearchRetryLimit = 40,
+        [int] $SearchRetryLimit = 10,
 
         [Parameter(Mandatory = $false)]
         [int] $SearchRetryInterval = 60

--- a/utilities/pipelines/e2eValidation/resourceRemoval/helper/Invoke-ResourceRemoval.ps1
+++ b/utilities/pipelines/e2eValidation/resourceRemoval/helper/Invoke-ResourceRemoval.ps1
@@ -91,6 +91,46 @@ function Invoke-ResourceRemoval {
             }
             break
         }
+        'Microsoft.Management/managementGroups' {
+            $managementGroupId = Split-Path $ResourceId -Leaf
+
+            # Management groups can only be deleted when empty (no child subscriptions and no child management groups).
+            # The generic Remove-AzResource path returns BadRequest 'Cannot delete non-empty management group' and the
+            # outer retry loop just hits the same error 3 times. Empty the group first, then remove it.
+            $expandedGroup = Get-AzManagementGroup -GroupName $managementGroupId -Expand -Recurse -ErrorAction 'SilentlyContinue'
+            if (-not $expandedGroup) {
+                Write-Verbose ('[/] Management group [{0}] not found (already removed). Skipping.' -f $managementGroupId) -Verbose
+                break
+            }
+
+            # 1. Move any direct child subscriptions to the AVM decom group, mirroring the Microsoft.Subscription/aliases handler.
+            $childSubs = $expandedGroup.Children | Where-Object { $_.Type -eq '/subscriptions' }
+            foreach ($childSub in $childSubs) {
+                $childSubId = $childSub.Name
+                if (-not (Get-AzManagementGroupSubscription -GroupName 'bicep-lz-vending-automation-decom' -SubscriptionId $childSubId -ErrorAction 'SilentlyContinue')) {
+                    Write-Verbose ('[*] Moving child subscription [{0}] from management group [{1}] to [bicep-lz-vending-automation-decom]' -f $childSubId, $managementGroupId) -Verbose
+                    if ($PSCmdlet.ShouldProcess("Subscription [$childSubId] from [$managementGroupId] to [bicep-lz-vending-automation-decom]", 'Move')) {
+                        $null = New-AzManagementGroupSubscription -GroupName 'bicep-lz-vending-automation-decom' -SubscriptionId $childSubId -ErrorAction 'SilentlyContinue'
+                    }
+                }
+            }
+
+            # 2. Remove any direct child management groups recursively (depth-first via the same handler).
+            $childGroups = $expandedGroup.Children | Where-Object { $_.Type -eq 'Microsoft.Management/managementGroups' }
+            foreach ($childGroup in $childGroups) {
+                $childGroupResourceId = '/providers/Microsoft.Management/managementGroups/{0}' -f $childGroup.Name
+                Write-Verbose ('[*] Recursively removing child management group [{0}]' -f $childGroup.Name) -Verbose
+                if ($PSCmdlet.ShouldProcess("Child management group [$($childGroup.Name)]", 'Remove')) {
+                    Invoke-ResourceRemoval -ResourceId $childGroupResourceId -Type 'Microsoft.Management/managementGroups'
+                }
+            }
+
+            # 3. Now remove the (hopefully empty) management group itself.
+            if ($PSCmdlet.ShouldProcess("Management group [$managementGroupId]", 'Remove')) {
+                $null = Remove-AzManagementGroup -GroupName $managementGroupId -ErrorAction 'Stop'
+            }
+            break
+        }
         'Microsoft.Compute/diskEncryptionSets' {
             # Pre-Removal
             # -----------

--- a/utilities/pipelines/e2eValidation/resourceRemoval/helper/Remove-Deployment.ps1
+++ b/utilities/pipelines/e2eValidation/resourceRemoval/helper/Remove-Deployment.ps1
@@ -165,17 +165,26 @@ function Remove-Deployment {
 
         # Remove resources
         # ================
+        $resourcesProcessedCount = 0
         if ($resourcesToRemove.Count -gt 0) {
             if ($PSCmdlet.ShouldProcess(('[{0}] resources' -f (($resourcesToRemove -is [array]) ? $resourcesToRemove.Count : 1)), 'Remove')) {
                 Remove-ResourceList -ResourcesToRemove $resourcesToRemove
+                $resourcesProcessedCount = $resourcesToRemove.Count
             }
         } else {
             Write-Verbose 'Found [0] resources to remove'
         }
 
-        # In case any deployment was not resolved as planned we finally want to throw an exception to make this visible in the pipeline
+        # When some deployment names could not be resolved (e.g. ARM evicted the deployment-history record),
+        # only fail the job when *no* resources were resolved & processed at all. If we did successfully clean
+        # up the resolvable deployments, an unresolvable historical name does not represent leaked Azure
+        # state and should not turn a green cleanup into a red job. Surface it as a warning instead.
         if ($resolveResult.resolveError) {
-            throw ('The following error was thrown while resolving the original deployment names: [{0}]' -f $resolveResult.resolveError)
+            if ($resourcesProcessedCount -gt 0) {
+                Write-Warning ('Some deployment names could not be resolved, but [{0}] resources from other deployments were processed successfully. Unresolvable names: [{1}]' -f $resourcesProcessedCount, $resolveResult.resolveError)
+            } else {
+                throw ('The following error was thrown while resolving the original deployment names: [{0}]' -f $resolveResult.resolveError)
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Hardens the e2e validation tooling against three independent CI flakiness defects discussed in #6981. All changes are scoped to `utilities/pipelines/e2eValidation/`; no module code is touched.

This is a draft for the AVM core team to review — opening as a draft so the design discussion can happen on the issue/PR before this is considered for merge.

## Changes

### 1. `utilities/pipelines/e2eValidation/resourceDeployment/New-TemplateDeployment.ps1`

- Replace the fixed `Start-Sleep -Seconds 5` retry wait with **exponential backoff** of `30s / 90s / 240s` for generic deployment failures.
- When the failure is `RequestConflict` / `"provisioning state is not terminal"` (the AVM-standard `init`/`idem` idempotency hits this on slow RPs like Kusto, Databricks, Cognitive Services with CMK), apply a dedicated **180s** wait instead.
- Fix the deployment-name timestamp format string `'yyyyMMddTHHMMssffffZ'` → `'yyyyMMddTHHmmssffffZ'`. The second `MM` in the original is .NET's *month* specifier, not minutes (cosmetic — uniqueness was preserved by the `ffff` and `t{retry}` portions — but worth correcting).

### 2. `utilities/pipelines/e2eValidation/resourceRemoval/helper/Remove-Deployment.ps1`

When `$resolveResult.resolveError` is set (some deployment names couldn't be resolved, typically because ARM evicted them from history), only `throw` if **zero** resources were processed. If we successfully cleaned up the resolvable deployments, surface the unresolved name(s) as a `Write-Warning` and let the job pass. This fixes red jobs *after* a fully successful cleanup (recently observed on `avm/ptn/security/security-center` waf-aligned).

### 3. `utilities/pipelines/e2eValidation/resourceRemoval/helper/Get-DeploymentTargetResourceList.ps1`

Reduce `SearchRetryLimit` default from `40` → `10` (10 × 60 s = 10 min). ARM history records appear within seconds when they exist at all; 40 min of polling on an unresolvable record contributed ~40 of a recently-observed 49-minute job runtime.

### 4. `utilities/pipelines/e2eValidation/resourceRemoval/helper/Invoke-ResourceRemoval.ps1`

Add a `Microsoft.Management/managementGroups` handler that:
1. Enumerates child subscriptions via `Get-AzManagementGroup -Expand -Recurse` and moves each into `bicep-lz-vending-automation-decom` (mirrors the existing `Microsoft.Subscription/aliases` branch).
2. Recursively invokes itself on child management groups.
3. Then calls `Remove-AzManagementGroup`.

Without this, `Microsoft.Management/managementGroups` falls through to the generic `Remove-AzResource` path, which ARM rejects with `BadRequest: Cannot delete non-empty management group`. The outer retry loop just sees the same error 3 times. This was blocking PR #6980 on `avm/ptn/mgmt-groups/subscription-placement/defaults`.

## Testing

These are CI-only utility scripts and there is no local Pester coverage in the repo for `New-TemplateDeployment.ps1` / `Remove-Deployment.ps1` / `Invoke-ResourceRemoval.ps1`. Validation is by:

- Re-running the affected workflows against this branch:
  - `avm.res.kusto.cluster` (Problem 1 — `cmk-uami` test).
  - `avm.ptn.security.security-center` (Problem 2 — `waf-aligned` cleanup phase).
  - `avm.ptn.mgmt-groups.subscription-placement` (Problem 3 — `defaults` cleanup phase).
- The change in (1) is purely an increase in wait time on failure paths; it cannot regress a green deployment.
- The change in (2) only relaxes a `throw` to a `Write-Warning` when at least one resource was successfully removed. The previous behavior is preserved when zero resources resolved.
- The change in (3) shortens a polling cap; if the AVM team prefers a different number, this is a single-line tweak.
- The change in (4) only adds a new switch arm — existing handlers are not modified.

## Linked issue

Closes #6981 (review hub for the three problems).

## Note for reviewers

I'm intentionally opening this as a draft so the AVM core team can decide:
- Whether the proposed exponential backoff numbers (`30/90/240`, `180` for `RequestConflict`) are reasonable, or whether they'd prefer a different curve / a config knob.
- Whether `SearchRetryLimit` should be `10`, or some other value.
- Whether `bicep-lz-vending-automation-decom` is the correct decom target for child subs of arbitrary mgmt-group tests, or whether this should be parameterized.

Happy to iterate based on review feedback.
