### PR TITLE
feat: VNET - Updated to latest AVM conventions & API versions and added diverse properties 

### DIFF
--- a/avm/res/network/virtual-network/CHANGELOG.md
+++ b/avm/res/network/virtual-network/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-network/CHANGELOG.md).
 
+## 0.9.0
+
+### Changes
+
+- Added support for `subnet.ipAllocations` & `subnet.serviceGateway`
+- Added support for `peering.enableOnlyIPv6Peering`
+- Added diverse types
+- Updated references of `avm-common-types` to `0.7.0`
+
+### Breaking Changes
+
+- None
+
 ## 0.8.1
 
 ### Changes

--- a/avm/res/network/virtual-network/README.md
+++ b/avm/res/network/virtual-network/README.md
@@ -27,9 +27,9 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
 | `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.insights_diagnosticsettings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)</li></ul> |
-| `Microsoft.Network/virtualNetworks` | 2024-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_virtualnetworks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/virtualNetworks)</li></ul> |
-| `Microsoft.Network/virtualNetworks/subnets` | 2024-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_virtualnetworks_subnets.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/virtualNetworks/subnets)</li></ul> |
-| `Microsoft.Network/virtualNetworks/virtualNetworkPeerings` | 2024-01-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_virtualnetworks_virtualnetworkpeerings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-01-01/virtualNetworks/virtualNetworkPeerings)</li></ul> |
+| `Microsoft.Network/virtualNetworks` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_virtualnetworks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2025-05-01/virtualNetworks)</li></ul> |
+| `Microsoft.Network/virtualNetworks/subnets` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_virtualnetworks_subnets.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2025-05-01/virtualNetworks/subnets)</li></ul> |
+| `Microsoft.Network/virtualNetworks/virtualNetworkPeerings` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_virtualnetworks_virtualnetworkpeerings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2025-05-01/virtualNetworks/virtualNetworkPeerings)</li></ul> |
 
 ## Usage examples
 
@@ -65,8 +65,6 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
       '10.0.0.0/16'
     ]
     name: 'nvnmin001'
-    // Non-required parameters
-    location: '<location>'
   }
 }
 ```
@@ -91,10 +89,6 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
     },
     "name": {
       "value": "nvnmin001"
-    },
-    // Non-required parameters
-    "location": {
-      "value": "<location>"
     }
   }
 }
@@ -115,8 +109,6 @@ param addressPrefixes = [
   '10.0.0.0/16'
 ]
 param name = 'nvnmin001'
-// Non-required parameters
-param location = '<location>'
 ```
 
 </details>
@@ -143,7 +135,6 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
     name: 'nvnipam001'
     // Non-required parameters
     ipamPoolNumberOfIpAddresses: '254'
-    location: '<location>'
     subnets: [
       {
         ipamPoolPrefixAllocations: [
@@ -208,9 +199,6 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
     "ipamPoolNumberOfIpAddresses": {
       "value": "254"
     },
-    "location": {
-      "value": "<location>"
-    },
     "subnets": {
       "value": [
         {
@@ -269,7 +257,6 @@ param addressPrefixes = [
 param name = 'nvnipam001'
 // Non-required parameters
 param ipamPoolNumberOfIpAddresses = '254'
-param location = '<location>'
 param subnets = [
   {
     ipamPoolPrefixAllocations: [
@@ -331,7 +318,6 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
     ]
     name: 'nvnipv6001'
     // Non-required parameters
-    location: '<location>'
     subnets: [
       {
         addressPrefixes: [
@@ -368,9 +354,6 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
       "value": "nvnipv6001"
     },
     // Non-required parameters
-    "location": {
-      "value": "<location>"
-    },
     "subnets": {
       "value": [
         {
@@ -403,7 +386,6 @@ param addressPrefixes = [
 ]
 param name = 'nvnipv6001'
 // Non-required parameters
-param location = '<location>'
 param subnets = [
   {
     addressPrefixes: [
@@ -458,7 +440,6 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
     ]
     enablePrivateEndpointVNetPolicies: 'Basic'
     flowTimeoutInMinutes: 20
-    location: '<location>'
     lock: {
       kind: 'CanNotDelete'
       name: 'myCustomLockName'
@@ -607,9 +588,6 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
     "flowTimeoutInMinutes": {
       "value": 20
     },
-    "location": {
-      "value": "<location>"
-    },
     "lock": {
       "value": {
         "kind": "CanNotDelete",
@@ -752,7 +730,6 @@ param dnsServers = [
 ]
 param enablePrivateEndpointVNetPolicies = 'Basic'
 param flowTimeoutInMinutes = 20
-param location = '<location>'
 param lock = {
   kind: 'CanNotDelete'
   name: 'myCustomLockName'
@@ -872,7 +849,6 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
     ]
     name: 'nvnpeer001'
     // Non-required parameters
-    location: '<location>'
     peerings: [
       {
         allowForwardedTraffic: true
@@ -932,9 +908,6 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
       "value": "nvnpeer001"
     },
     // Non-required parameters
-    "location": {
-      "value": "<location>"
-    },
     "peerings": {
       "value": [
         {
@@ -994,7 +967,6 @@ param addressPrefixes = [
 ]
 param name = 'nvnpeer001'
 // Non-required parameters
-param location = '<location>'
 param peerings = [
   {
     allowForwardedTraffic: true
@@ -1072,7 +1044,6 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
       '10.0.1.5'
     ]
     flowTimeoutInMinutes: 20
-    location: '<location>'
     subnets: [
       {
         addressPrefix: '<addressPrefix>'
@@ -1177,9 +1148,6 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
     "flowTimeoutInMinutes": {
       "value": 20
     },
-    "location": {
-      "value": "<location>"
-    },
     "subnets": {
       "value": [
         {
@@ -1276,7 +1244,6 @@ param dnsServers = [
   '10.0.1.5'
 ]
 param flowTimeoutInMinutes = 20
-param location = '<location>'
 param subnets = [
   {
     addressPrefix: '<addressPrefix>'
@@ -1355,6 +1322,7 @@ param tags = {
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`enableVmProtection`](#parameter-enablevmprotection) | bool | Indicates if VM protection is enabled for all the subnets in the virtual network. |
 | [`flowTimeoutInMinutes`](#parameter-flowtimeoutinminutes) | int | The flow timeout in minutes for the Virtual Network, which is used to enable connection tracking for intra-VM flows. Possible values are between 4 and 30 minutes. Default value 0 will set the property to null. |
+| [`ipAllocations`](#parameter-ipallocations) | array | Array of IpAllocation which reference this VNET. |
 | [`ipamPoolNumberOfIpAddresses`](#parameter-ipampoolnumberofipaddresses) | string | Number of IP addresses allocated from the pool. To be used only when the addressPrefix param is defined with a resource ID of an IPAM pool. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
@@ -1579,6 +1547,13 @@ The flow timeout in minutes for the Virtual Network, which is used to enable con
 - Default: `0`
 - MaxValue: 30
 
+### Parameter: `ipAllocations`
+
+Array of IpAllocation which reference this VNET.
+
+- Required: No
+- Type: array
+
 ### Parameter: `ipamPoolNumberOfIpAddresses`
 
 Number of IP addresses allocated from the pool. To be used only when the addressPrefix param is defined with a resource ID of an IPAM pool.
@@ -1659,6 +1634,7 @@ Virtual Network Peering configurations.
 | [`allowGatewayTransit`](#parameter-peeringsallowgatewaytransit) | bool | If gateway links can be used in remote virtual networking to link to this virtual network. Default is false. |
 | [`allowVirtualNetworkAccess`](#parameter-peeringsallowvirtualnetworkaccess) | bool | Whether the VMs in the local virtual network space would be able to access the VMs in remote virtual network space. Default is true. |
 | [`doNotVerifyRemoteGateways`](#parameter-peeringsdonotverifyremotegateways) | bool | Do not verify the provisioning state of the remote gateway. Default is true. |
+| [`enableOnlyIPv6Peering`](#parameter-peeringsenableonlyipv6peering) | bool | Whether only Ipv6 address space is peered for subnet peering. |
 | [`name`](#parameter-peeringsname) | string | The Name of VNET Peering resource. If not provided, default value will be peer-localVnetName-remoteVnetName. |
 | [`remotePeeringAllowForwardedTraffic`](#parameter-peeringsremotepeeringallowforwardedtraffic) | bool | Whether the forwarded traffic from the VMs in the local virtual network will be allowed/disallowed in remote virtual network. Default is true. |
 | [`remotePeeringAllowGatewayTransit`](#parameter-peeringsremotepeeringallowgatewaytransit) | bool | If gateway links can be used in remote virtual networking to link to this virtual network. Default is false. |
@@ -1700,6 +1676,13 @@ Whether the VMs in the local virtual network space would be able to access the V
 ### Parameter: `peerings.doNotVerifyRemoteGateways`
 
 Do not verify the provisioning state of the remote gateway. Default is true.
+
+- Required: No
+- Type: bool
+
+### Parameter: `peerings.enableOnlyIPv6Peering`
+
+Whether only Ipv6 address space is peered for subnet peering.
 
 - Required: No
 - Type: bool
@@ -1899,6 +1882,7 @@ An Array of subnets to deploy to the Virtual Network.
 | [`applicationGatewayIPConfigurations`](#parameter-subnetsapplicationgatewayipconfigurations) | array | Application gateway IP configurations of virtual network resource. |
 | [`defaultOutboundAccess`](#parameter-subnetsdefaultoutboundaccess) | bool | Set this property to false to disable default outbound connectivity for all VMs in the subnet. This property can only be set at the time of subnet creation and cannot be updated for an existing subnet. |
 | [`delegation`](#parameter-subnetsdelegation) | string | The delegation to enable on the subnet. |
+| [`ipAllocations`](#parameter-subnetsipallocations) | array | Array of IpAllocation which reference this subnet. |
 | [`natGatewayResourceId`](#parameter-subnetsnatgatewayresourceid) | string | The resource ID of the NAT Gateway to use for the subnet. |
 | [`networkSecurityGroupResourceId`](#parameter-subnetsnetworksecuritygroupresourceid) | string | The resource ID of the network security group to assign to the subnet. |
 | [`privateEndpointNetworkPolicies`](#parameter-subnetsprivateendpointnetworkpolicies) | string | enable or disable apply network policies on private endpoint in the subnet. |
@@ -1907,6 +1891,7 @@ An Array of subnets to deploy to the Virtual Network.
 | [`routeTableResourceId`](#parameter-subnetsroutetableresourceid) | string | The resource ID of the route table to assign to the subnet. |
 | [`serviceEndpointPolicies`](#parameter-subnetsserviceendpointpolicies) | array | An array of service endpoint policies. |
 | [`serviceEndpoints`](#parameter-subnetsserviceendpoints) | array | The service endpoints to enable on the subnet. |
+| [`serviceGateway`](#parameter-subnetsservicegateway) | object | Reference to an existing service gateway. |
 | [`sharingScope`](#parameter-subnetssharingscope) | string | Set this property to Tenant to allow sharing subnet with other subscriptions in your AAD tenant. This property can only be set if defaultOutboundAccess is set to false, both properties can only be set if subnet is empty. |
 
 ### Parameter: `subnets.name`
@@ -1957,6 +1942,13 @@ The delegation to enable on the subnet.
 
 - Required: No
 - Type: string
+
+### Parameter: `subnets.ipAllocations`
+
+Array of IpAllocation which reference this subnet.
+
+- Required: No
+- Type: array
 
 ### Parameter: `subnets.natGatewayResourceId`
 
@@ -2127,6 +2119,13 @@ The service endpoints to enable on the subnet.
 - Required: No
 - Type: array
 
+### Parameter: `subnets.serviceGateway`
+
+Reference to an existing service gateway.
+
+- Required: No
+- Type: object
+
 ### Parameter: `subnets.sharingScope`
 
 Set this property to Tenant to allow sharing subnet with other subscriptions in your AAD tenant. This property can only be set if defaultOutboundAccess is set to false, both properties can only be set if subnet is empty.
@@ -2195,8 +2194,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.2.1` | Remote reference |
-| `br/public:avm/utl/types/avm-common-types:0.6.0` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.7.0` | Remote reference |
 
 ## Notes
 

--- a/avm/res/network/virtual-network/main.bicep
+++ b/avm/res/network/virtual-network/main.bicep
@@ -8,7 +8,7 @@ param name string
 param location string = resourceGroup().location
 
 @description('Required. An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`.')
-param addressPrefixes array
+param addressPrefixes string[]
 
 @description('Optional. Number of IP addresses allocated from the pool. To be used only when the addressPrefix param is defined with a resource ID of an IPAM pool.')
 param ipamPoolNumberOfIpAddresses string?
@@ -42,20 +42,20 @@ param vnetEncryptionEnforcement string = 'AllowUnencrypted'
 @description('Optional. The flow timeout in minutes for the Virtual Network, which is used to enable connection tracking for intra-VM flows. Possible values are between 4 and 30 minutes. Default value 0 will set the property to null.')
 param flowTimeoutInMinutes int = 0
 
-import { diagnosticSettingFullType } from 'br/public:avm/utl/types/avm-common-types:0.2.1'
+import { diagnosticSettingFullType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. The diagnostic settings of the service.')
 param diagnosticSettings diagnosticSettingFullType[]?
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.0'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. The lock settings of the service.')
 param lock lockType?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.2.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
 @description('Optional. Tags of the resource.')
-param tags object?
+param tags resourceInput<'Microsoft.Network/virtualNetworks@2025-05-01'>.tags?
 
 @description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
@@ -69,6 +69,9 @@ param enableVmProtection bool?
 ])
 @description('Optional. Enables high scale private endpoints for the virtual network. This is necessary if the virtual network requires more than 1000 private endpoints or is peered to virtual networks with a total of more than 4000 private endpoints.')
 param enablePrivateEndpointVNetPolicies string = 'Disabled'
+
+@description('Optional. Array of IpAllocation which reference this VNET.')
+param ipAllocations resourceInput<'Microsoft.Network/virtualNetworks@2025-05-01'>.properties.ipAllocations?
 
 var enableReferencedModulesTelemetry = false
 
@@ -106,7 +109,7 @@ var formattedRoleAssignments = [
 // ============ //
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.network-virtualnetwork.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'
@@ -124,11 +127,12 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
   name: name
   location: location
   tags: tags
   properties: {
+    ipAllocations: ipAllocations
     addressSpace: contains(addressPrefixes[0], '/Microsoft.Network/networkManagers/')
       ? {
           ipamPoolPrefixAllocations: [
@@ -193,6 +197,8 @@ module virtualNetwork_subnets 'subnet/main.bicep' = [
       serviceEndpoints: subnet.?serviceEndpoints
       defaultOutboundAccess: subnet.?defaultOutboundAccess
       sharingScope: subnet.?sharingScope
+      ipAllocations: subnet.?ipAllocations
+      serviceGateway: subnet.?serviceGateway
       enableTelemetry: enableReferencedModulesTelemetry
     }
   }
@@ -216,6 +222,7 @@ module virtualNetwork_peering_local 'virtual-network-peering/main.bicep' = [
       allowVirtualNetworkAccess: peering.?allowVirtualNetworkAccess
       doNotVerifyRemoteGateways: peering.?doNotVerifyRemoteGateways
       useRemoteGateways: peering.?useRemoteGateways
+      enableOnlyIPv6Peering: peering.?enableOnlyIPv6Peering
       enableTelemetry: enableReferencedModulesTelemetry
     }
   }
@@ -243,6 +250,7 @@ module virtualNetwork_peering_remote 'virtual-network-peering/main.bicep' = [
       allowVirtualNetworkAccess: peering.?remotePeeringAllowVirtualNetworkAccess
       doNotVerifyRemoteGateways: peering.?remotePeeringDoNotVerifyRemoteGateways
       useRemoteGateways: peering.?remotePeeringUseRemoteGateways
+      enableOnlyIPv6Peering: peering.?enableOnlyIPv6Peering
       enableTelemetry: enableReferencedModulesTelemetry
     }
   }
@@ -371,6 +379,9 @@ type peeringType = {
 
   @description('Optional. If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. Default is false.')
   remotePeeringUseRemoteGateways: bool?
+
+  @description('Optional. Whether only Ipv6 address space is peered for subnet peering.')
+  enableOnlyIPv6Peering: bool?
 }
 
 @export()
@@ -385,20 +396,10 @@ type subnetType = {
   addressPrefixes: string[]?
 
   @description('Conditional. The address space for the subnet, deployed from IPAM Pool. Required if `addressPrefixes` and `addressPrefix` is empty and the VNet address space configured to use IPAM Pool.')
-  ipamPoolPrefixAllocations: [
-    {
-      @description('Required. The Resource ID of the IPAM pool.')
-      pool: {
-        @description('Required. The Resource ID of the IPAM pool.')
-        id: string
-      }
-      @description('Required. Number of IP addresses allocated from the pool.')
-      numberOfIpAddresses: string
-    }
-  ]?
+  ipamPoolPrefixAllocations: resourceInput<'Microsoft.Network/virtualNetworks/subnets@2025-05-01'>.properties.ipamPoolPrefixAllocations?
 
   @description('Optional. Application gateway IP configurations of virtual network resource.')
-  applicationGatewayIPConfigurations: object[]?
+  applicationGatewayIPConfigurations: resourceInput<'Microsoft.Network/virtualNetworks/subnets@2025-05-01'>.properties.applicationGatewayIPConfigurations?
 
   @description('Optional. The delegation to enable on the subnet.')
   delegation: string?
@@ -422,7 +423,7 @@ type subnetType = {
   routeTableResourceId: string?
 
   @description('Optional. An array of service endpoint policies.')
-  serviceEndpointPolicies: object[]?
+  serviceEndpointPolicies: resourceInput<'Microsoft.Network/virtualNetworks/subnets@2025-05-01'>.properties.serviceEndpointPolicies?
 
   @description('Optional. The service endpoints to enable on the subnet.')
   serviceEndpoints: string[]?
@@ -432,4 +433,10 @@ type subnetType = {
 
   @description('Optional. Set this property to Tenant to allow sharing subnet with other subscriptions in your AAD tenant. This property can only be set if defaultOutboundAccess is set to false, both properties can only be set if subnet is empty.')
   sharingScope: ('DelegatedServices' | 'Tenant')?
+
+  @description('Optional. Array of IpAllocation which reference this subnet.')
+  ipAllocations: resourceInput<'Microsoft.Network/virtualNetworks/subnets@2025-05-01'>.properties.ipAllocations?
+
+  @description('Optional. Reference to an existing service gateway.')
+  serviceGateway: resourceInput<'Microsoft.Network/virtualNetworks/subnets@2025-05-01'>.properties.serviceGateway?
 }

--- a/avm/res/network/virtual-network/main.json
+++ b/avm/res/network/virtual-network/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "4562976504710296836"
+      "templateHash": "3809776526611661309"
     },
     "name": "Virtual Networks",
     "description": "This module deploys a Virtual Network (vNet)."
@@ -111,6 +111,13 @@
           "metadata": {
             "description": "Optional. If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. Default is false."
           }
+        },
+        "enableOnlyIPv6Peering": {
+          "type": "bool",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Whether only Ipv6 address space is peered for subnet peering."
+          }
         }
       },
       "metadata": {
@@ -145,48 +152,23 @@
         },
         "ipamPoolPrefixAllocations": {
           "type": "array",
-          "prefixItems": [
-            {
-              "type": "object",
-              "properties": {
-                "pool": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "metadata": {
-                        "description": "Required. The Resource ID of the IPAM pool."
-                      }
-                    }
-                  },
-                  "metadata": {
-                    "description": "Required. The Resource ID of the IPAM pool."
-                  }
-                },
-                "numberOfIpAddresses": {
-                  "type": "string",
-                  "metadata": {
-                    "description": "Required. Number of IP addresses allocated from the pool."
-                  }
-                }
-              }
-            }
-          ],
-          "items": false,
-          "nullable": true,
           "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/ipamPoolPrefixAllocations"
+            },
             "description": "Conditional. The address space for the subnet, deployed from IPAM Pool. Required if `addressPrefixes` and `addressPrefix` is empty and the VNet address space configured to use IPAM Pool."
-          }
+          },
+          "nullable": true
         },
         "applicationGatewayIPConfigurations": {
           "type": "array",
-          "items": {
-            "type": "object"
-          },
-          "nullable": true,
           "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/applicationGatewayIPConfigurations"
+            },
             "description": "Optional. Application gateway IP configurations of virtual network resource."
-          }
+          },
+          "nullable": true
         },
         "delegation": {
           "type": "string",
@@ -252,13 +234,13 @@
         },
         "serviceEndpointPolicies": {
           "type": "array",
-          "items": {
-            "type": "object"
-          },
-          "nullable": true,
           "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/serviceEndpointPolicies"
+            },
             "description": "Optional. An array of service endpoint policies."
-          }
+          },
+          "nullable": true
         },
         "serviceEndpoints": {
           "type": "array",
@@ -287,6 +269,26 @@
           "metadata": {
             "description": "Optional. Set this property to Tenant to allow sharing subnet with other subscriptions in your AAD tenant. This property can only be set if defaultOutboundAccess is set to false, both properties can only be set if subnet is empty."
           }
+        },
+        "ipAllocations": {
+          "type": "array",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/ipAllocations"
+            },
+            "description": "Optional. Array of IpAllocation which reference this subnet."
+          },
+          "nullable": true
+        },
+        "serviceGateway": {
+          "type": "object",
+          "metadata": {
+            "__bicep_resource_derived_type!": {
+              "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/serviceGateway"
+            },
+            "description": "Optional. Reference to an existing service gateway."
+          },
+          "nullable": true
         }
       },
       "metadata": {
@@ -411,7 +413,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.2.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     },
@@ -448,7 +450,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a lock.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.0"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     },
@@ -523,7 +525,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.2.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     }
@@ -544,6 +546,9 @@
     },
     "addressPrefixes": {
       "type": "array",
+      "items": {
+        "type": "string"
+      },
       "metadata": {
         "description": "Required. An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`."
       }
@@ -654,10 +659,13 @@
     },
     "tags": {
       "type": "object",
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/virtualNetworks@2025-05-01#properties/tags"
+        },
         "description": "Optional. Tags of the resource."
-      }
+      },
+      "nullable": true
     },
     "enableTelemetry": {
       "type": "bool",
@@ -683,6 +691,16 @@
       "metadata": {
         "description": "Optional. Enables high scale private endpoints for the virtual network. This is necessary if the virtual network requires more than 1000 private endpoints or is peered to virtual networks with a total of more than 4000 private endpoints."
       }
+    },
+    "ipAllocations": {
+      "type": "array",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/virtualNetworks@2025-05-01#properties/properties/properties/ipAllocations"
+        },
+        "description": "Optional. Array of IpAllocation which reference this VNET."
+      },
+      "nullable": true
     }
   },
   "variables": {
@@ -707,7 +725,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.network-virtualnetwork.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -726,11 +744,12 @@
     },
     "virtualNetwork": {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2024-05-01",
+      "apiVersion": "2025-05-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
       "properties": {
+        "ipAllocations": "[parameters('ipAllocations')]",
         "addressSpace": "[if(contains(parameters('addressPrefixes')[0], '/Microsoft.Network/networkManagers/'), createObject('ipamPoolPrefixAllocations', createArray(createObject('pool', createObject('id', parameters('addressPrefixes')[0]), 'numberOfIpAddresses', parameters('ipamPoolNumberOfIpAddresses')))), createObject('addressPrefixes', parameters('addressPrefixes')))]",
         "bgpCommunities": "[if(not(empty(parameters('virtualNetworkBgpCommunity'))), createObject('virtualNetworkCommunity', parameters('virtualNetworkBgpCommunity')), null())]",
         "ddosProtectionPlan": "[if(not(empty(parameters('ddosProtectionPlanResourceId'))), createObject('id', parameters('ddosProtectionPlanResourceId')), null())]",
@@ -886,6 +905,12 @@
           "sharingScope": {
             "value": "[tryGet(coalesce(parameters('subnets'), createArray())[copyIndex()], 'sharingScope')]"
           },
+          "ipAllocations": {
+            "value": "[tryGet(coalesce(parameters('subnets'), createArray())[copyIndex()], 'ipAllocations')]"
+          },
+          "serviceGateway": {
+            "value": "[tryGet(coalesce(parameters('subnets'), createArray())[copyIndex()], 'serviceGateway')]"
+          },
           "enableTelemetry": {
             "value": "[variables('enableReferencedModulesTelemetry')]"
           }
@@ -898,7 +923,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "17113728662177315319"
+              "templateHash": "9939044295143750810"
             },
             "name": "Virtual Network Subnets",
             "description": "This module deploys a Virtual Network Subnet."
@@ -975,7 +1000,7 @@
               "metadata": {
                 "description": "An AVM-aligned type for a role assignment.",
                 "__bicep_imported_from!": {
-                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.2.1"
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
                 }
               }
             }
@@ -1002,13 +1027,13 @@
             },
             "ipamPoolPrefixAllocations": {
               "type": "array",
-              "items": {
-                "type": "object"
-              },
-              "nullable": true,
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/ipamPoolPrefixAllocations"
+                },
                 "description": "Conditional. The address space for the subnet, deployed from IPAM Pool. Required if `addressPrefixes` and `addressPrefix` is empty."
-              }
+              },
+              "nullable": true
             },
             "networkSecurityGroupResourceId": {
               "type": "string",
@@ -1102,17 +1127,43 @@
             },
             "applicationGatewayIPConfigurations": {
               "type": "array",
-              "defaultValue": [],
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/applicationGatewayIPConfigurations"
+                },
                 "description": "Optional. Application gateway IP configurations of virtual network resource."
-              }
+              },
+              "nullable": true
             },
             "serviceEndpointPolicies": {
               "type": "array",
-              "defaultValue": [],
               "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/serviceEndpointPolicies"
+                },
                 "description": "Optional. An array of service endpoint policies."
-              }
+              },
+              "nullable": true
+            },
+            "ipAllocations": {
+              "type": "array",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/ipAllocations"
+                },
+                "description": "Optional. Array of IpAllocation which reference this subnet."
+              },
+              "nullable": true
+            },
+            "serviceGateway": {
+              "type": "object",
+              "metadata": {
+                "__bicep_resource_derived_type!": {
+                  "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/serviceGateway"
+                },
+                "description": "Optional. Reference to an existing service gateway."
+              },
+              "nullable": true
             },
             "roleAssignments": {
               "type": "array",
@@ -1153,7 +1204,7 @@
             "avmTelemetry": {
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2024-03-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('46d3xbcp.res.network-virtualnetworksubnet.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
@@ -1173,12 +1224,12 @@
             "virtualNetwork": {
               "existing": true,
               "type": "Microsoft.Network/virtualNetworks",
-              "apiVersion": "2024-01-01",
+              "apiVersion": "2025-05-01",
               "name": "[parameters('virtualNetworkName')]"
             },
             "subnet": {
               "type": "Microsoft.Network/virtualNetworks/subnets",
-              "apiVersion": "2024-05-01",
+              "apiVersion": "2025-05-01",
               "name": "[format('{0}/{1}', parameters('virtualNetworkName'), parameters('name'))]",
               "properties": {
                 "copy": [
@@ -1193,6 +1244,8 @@
                 "addressPrefix": "[parameters('addressPrefix')]",
                 "addressPrefixes": "[parameters('addressPrefixes')]",
                 "ipamPoolPrefixAllocations": "[parameters('ipamPoolPrefixAllocations')]",
+                "ipAllocations": "[parameters('ipAllocations')]",
+                "serviceGateway": "[parameters('serviceGateway')]",
                 "networkSecurityGroup": "[if(not(empty(parameters('networkSecurityGroupResourceId'))), createObject('id', parameters('networkSecurityGroupResourceId')), null())]",
                 "routeTable": "[if(not(empty(parameters('routeTableResourceId'))), createObject('id', parameters('routeTableResourceId')), null())]",
                 "natGateway": "[if(not(empty(parameters('natGatewayResourceId'))), createObject('id', parameters('natGatewayResourceId')), null())]",
@@ -1316,6 +1369,9 @@
           "useRemoteGateways": {
             "value": "[tryGet(coalesce(parameters('peerings'), createArray())[copyIndex()], 'useRemoteGateways')]"
           },
+          "enableOnlyIPv6Peering": {
+            "value": "[tryGet(coalesce(parameters('peerings'), createArray())[copyIndex()], 'enableOnlyIPv6Peering')]"
+          },
           "enableTelemetry": {
             "value": "[variables('enableReferencedModulesTelemetry')]"
           }
@@ -1327,7 +1383,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "18164299966266307814"
+              "templateHash": "13052726848098685116"
             },
             "name": "Virtual Network Peerings",
             "description": "This module deploys a Virtual Network Peering."
@@ -1393,13 +1449,20 @@
               "metadata": {
                 "description": "Optional. If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. Default is false."
               }
+            },
+            "enableOnlyIPv6Peering": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Whether only Ipv6 address space is peered for subnet peering."
+              }
             }
           },
           "resources": [
             {
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2024-03-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('46d3xbcp.res.network-virtualnetwork-peering.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
@@ -1418,10 +1481,11 @@
             },
             {
               "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-              "apiVersion": "2024-01-01",
+              "apiVersion": "2025-05-01",
               "name": "[format('{0}/{1}', parameters('localVnetName'), parameters('name'))]",
               "properties": {
                 "allowForwardedTraffic": "[parameters('allowForwardedTraffic')]",
+                "enableOnlyIPv6Peering": "[parameters('enableOnlyIPv6Peering')]",
                 "allowGatewayTransit": "[parameters('allowGatewayTransit')]",
                 "allowVirtualNetworkAccess": "[parameters('allowVirtualNetworkAccess')]",
                 "doNotVerifyRemoteGateways": "[parameters('doNotVerifyRemoteGateways')]",
@@ -1503,6 +1567,9 @@
           "useRemoteGateways": {
             "value": "[tryGet(coalesce(parameters('peerings'), createArray())[copyIndex()], 'remotePeeringUseRemoteGateways')]"
           },
+          "enableOnlyIPv6Peering": {
+            "value": "[tryGet(coalesce(parameters('peerings'), createArray())[copyIndex()], 'enableOnlyIPv6Peering')]"
+          },
           "enableTelemetry": {
             "value": "[variables('enableReferencedModulesTelemetry')]"
           }
@@ -1514,7 +1581,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "18164299966266307814"
+              "templateHash": "13052726848098685116"
             },
             "name": "Virtual Network Peerings",
             "description": "This module deploys a Virtual Network Peering."
@@ -1580,13 +1647,20 @@
               "metadata": {
                 "description": "Optional. If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. Default is false."
               }
+            },
+            "enableOnlyIPv6Peering": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Whether only Ipv6 address space is peered for subnet peering."
+              }
             }
           },
           "resources": [
             {
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2024-03-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('46d3xbcp.res.network-virtualnetwork-peering.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
@@ -1605,10 +1679,11 @@
             },
             {
               "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-              "apiVersion": "2024-01-01",
+              "apiVersion": "2025-05-01",
               "name": "[format('{0}/{1}', parameters('localVnetName'), parameters('name'))]",
               "properties": {
                 "allowForwardedTraffic": "[parameters('allowForwardedTraffic')]",
+                "enableOnlyIPv6Peering": "[parameters('enableOnlyIPv6Peering')]",
                 "allowGatewayTransit": "[parameters('allowGatewayTransit')]",
                 "allowVirtualNetworkAccess": "[parameters('allowVirtualNetworkAccess')]",
                 "doNotVerifyRemoteGateways": "[parameters('doNotVerifyRemoteGateways')]",
@@ -1697,7 +1772,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('virtualNetwork', '2024-05-01', 'full').location]"
+      "value": "[reference('virtualNetwork', '2025-05-01', 'full').location]"
     }
   }
 }

--- a/avm/res/network/virtual-network/subnet/CHANGELOG.md
+++ b/avm/res/network/virtual-network/subnet/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-network/subnet/CHANGELOG.md).
 
+## 0.2.0
+
+### Changes
+
+- Added support for `ipAllocations` & `serviceGateway`
+- Added diverse types
+
+### Breaking Changes
+
+- None
+
 ## 0.1.3
 
 ### Changes

--- a/avm/res/network/virtual-network/subnet/README.md
+++ b/avm/res/network/virtual-network/subnet/README.md
@@ -24,7 +24,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
-| `Microsoft.Network/virtualNetworks/subnets` | 2024-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_virtualnetworks_subnets.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-05-01/virtualNetworks/subnets)</li></ul> |
+| `Microsoft.Network/virtualNetworks/subnets` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_virtualnetworks_subnets.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2025-05-01/virtualNetworks/subnets)</li></ul> |
 
 ## Parameters
 
@@ -51,6 +51,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | [`defaultOutboundAccess`](#parameter-defaultoutboundaccess) | bool | Set this property to false to disable default outbound connectivity for all VMs in the subnet. This property can only be set at the time of subnet creation and cannot be updated for an existing subnet. |
 | [`delegation`](#parameter-delegation) | string | The delegation to enable on the subnet. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
+| [`ipAllocations`](#parameter-ipallocations) | array | Array of IpAllocation which reference this subnet. |
 | [`natGatewayResourceId`](#parameter-natgatewayresourceid) | string | The resource ID of the NAT Gateway to use for the subnet. |
 | [`networkSecurityGroupResourceId`](#parameter-networksecuritygroupresourceid) | string | The resource ID of the network security group to assign to the subnet. |
 | [`privateEndpointNetworkPolicies`](#parameter-privateendpointnetworkpolicies) | string | Enable or disable apply network policies on private endpoint in the subnet. |
@@ -59,6 +60,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | [`routeTableResourceId`](#parameter-routetableresourceid) | string | The resource ID of the route table to assign to the subnet. |
 | [`serviceEndpointPolicies`](#parameter-serviceendpointpolicies) | array | An array of service endpoint policies. |
 | [`serviceEndpoints`](#parameter-serviceendpoints) | array | The service endpoints to enable on the subnet. |
+| [`serviceGateway`](#parameter-servicegateway) | object | Reference to an existing service gateway. |
 | [`sharingScope`](#parameter-sharingscope) | string | Set this property to Tenant to allow sharing the subnet with other subscriptions in your AAD tenant. This property can only be set if defaultOutboundAccess is set to false, both properties can only be set if the subnet is empty. |
 
 ### Parameter: `name`
@@ -102,7 +104,6 @@ Application gateway IP configurations of virtual network resource.
 
 - Required: No
 - Type: array
-- Default: `[]`
 
 ### Parameter: `defaultOutboundAccess`
 
@@ -125,6 +126,13 @@ Enable/Disable usage telemetry for module.
 - Required: No
 - Type: bool
 - Default: `True`
+
+### Parameter: `ipAllocations`
+
+Array of IpAllocation which reference this subnet.
+
+- Required: No
+- Type: array
 
 ### Parameter: `natGatewayResourceId`
 
@@ -287,7 +295,6 @@ An array of service endpoint policies.
 
 - Required: No
 - Type: array
-- Default: `[]`
 
 ### Parameter: `serviceEndpoints`
 
@@ -296,6 +303,13 @@ The service endpoints to enable on the subnet.
 - Required: No
 - Type: array
 - Default: `[]`
+
+### Parameter: `serviceGateway`
+
+Reference to an existing service gateway.
+
+- Required: No
+- Type: object
 
 ### Parameter: `sharingScope`
 
@@ -328,7 +342,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.2.1` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.7.0` | Remote reference |
 
 ## Notes
 

--- a/avm/res/network/virtual-network/subnet/main.bicep
+++ b/avm/res/network/virtual-network/subnet/main.bicep
@@ -11,7 +11,7 @@ param virtualNetworkName string
 param addressPrefix string?
 
 @description('Conditional. The address space for the subnet, deployed from IPAM Pool. Required if `addressPrefixes` and `addressPrefix` is empty.')
-param ipamPoolPrefixAllocations object[]?
+param ipamPoolPrefixAllocations resourceInput<'Microsoft.Network/virtualNetworks/subnets@2025-05-01'>.properties.ipamPoolPrefixAllocations?
 
 @description('Optional. The resource ID of the network security group to assign to the subnet.')
 param networkSecurityGroupResourceId string?
@@ -54,12 +54,18 @@ param defaultOutboundAccess bool?
 param sharingScope ('DelegatedServices' | 'Tenant')?
 
 @description('Optional. Application gateway IP configurations of virtual network resource.')
-param applicationGatewayIPConfigurations array = []
+param applicationGatewayIPConfigurations resourceInput<'Microsoft.Network/virtualNetworks/subnets@2025-05-01'>.properties.applicationGatewayIPConfigurations?
 
 @description('Optional. An array of service endpoint policies.')
-param serviceEndpointPolicies array = []
+param serviceEndpointPolicies resourceInput<'Microsoft.Network/virtualNetworks/subnets@2025-05-01'>.properties.serviceEndpointPolicies?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.2.1'
+@description('Optional. Array of IpAllocation which reference this subnet.')
+param ipAllocations resourceInput<'Microsoft.Network/virtualNetworks/subnets@2025-05-01'>.properties.ipAllocations?
+
+@description('Optional. Reference to an existing service gateway.')
+param serviceGateway resourceInput<'Microsoft.Network/virtualNetworks/subnets@2025-05-01'>.properties.serviceGateway?
+
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
@@ -96,7 +102,7 @@ var formattedRoleAssignments = [
 ]
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.network-virtualnetworksubnet.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
   properties: {
     mode: 'Incremental'
@@ -114,17 +120,19 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-01-01' existing = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' existing = {
   name: virtualNetworkName
 }
 
-resource subnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' = {
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2025-05-01' = {
   name: name
   parent: virtualNetwork
   properties: {
     addressPrefix: addressPrefix
     addressPrefixes: addressPrefixes
     ipamPoolPrefixAllocations: ipamPoolPrefixAllocations
+    ipAllocations: ipAllocations
+    serviceGateway: serviceGateway
     networkSecurityGroup: !empty(networkSecurityGroupResourceId)
       ? {
           id: networkSecurityGroupResourceId

--- a/avm/res/network/virtual-network/subnet/main.json
+++ b/avm/res/network/virtual-network/subnet/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "13992200806189615656"
+      "version": "0.42.1.51946",
+      "templateHash": "9939044295143750810"
     },
     "name": "Virtual Network Subnets",
     "description": "This module deploys a Virtual Network Subnet."
@@ -83,7 +83,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.2.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     }
@@ -110,13 +110,13 @@
     },
     "ipamPoolPrefixAllocations": {
       "type": "array",
-      "items": {
-        "type": "object"
-      },
-      "nullable": true,
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/ipamPoolPrefixAllocations"
+        },
         "description": "Conditional. The address space for the subnet, deployed from IPAM Pool. Required if `addressPrefixes` and `addressPrefix` is empty."
-      }
+      },
+      "nullable": true
     },
     "networkSecurityGroupResourceId": {
       "type": "string",
@@ -210,17 +210,43 @@
     },
     "applicationGatewayIPConfigurations": {
       "type": "array",
-      "defaultValue": [],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/applicationGatewayIPConfigurations"
+        },
         "description": "Optional. Application gateway IP configurations of virtual network resource."
-      }
+      },
+      "nullable": true
     },
     "serviceEndpointPolicies": {
       "type": "array",
-      "defaultValue": [],
       "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/serviceEndpointPolicies"
+        },
         "description": "Optional. An array of service endpoint policies."
-      }
+      },
+      "nullable": true
+    },
+    "ipAllocations": {
+      "type": "array",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/ipAllocations"
+        },
+        "description": "Optional. Array of IpAllocation which reference this subnet."
+      },
+      "nullable": true
+    },
+    "serviceGateway": {
+      "type": "object",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/virtualNetworks/subnets@2025-05-01#properties/properties/properties/serviceGateway"
+        },
+        "description": "Optional. Reference to an existing service gateway."
+      },
+      "nullable": true
     },
     "roleAssignments": {
       "type": "array",
@@ -261,7 +287,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.network-virtualnetworksubnet.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -281,12 +307,12 @@
     "virtualNetwork": {
       "existing": true,
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2024-01-01",
+      "apiVersion": "2025-05-01",
       "name": "[parameters('virtualNetworkName')]"
     },
     "subnet": {
       "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2024-05-01",
+      "apiVersion": "2025-05-01",
       "name": "[format('{0}/{1}', parameters('virtualNetworkName'), parameters('name'))]",
       "properties": {
         "copy": [
@@ -301,6 +327,8 @@
         "addressPrefix": "[parameters('addressPrefix')]",
         "addressPrefixes": "[parameters('addressPrefixes')]",
         "ipamPoolPrefixAllocations": "[parameters('ipamPoolPrefixAllocations')]",
+        "ipAllocations": "[parameters('ipAllocations')]",
+        "serviceGateway": "[parameters('serviceGateway')]",
         "networkSecurityGroup": "[if(not(empty(parameters('networkSecurityGroupResourceId'))), createObject('id', parameters('networkSecurityGroupResourceId')), null())]",
         "routeTable": "[if(not(empty(parameters('routeTableResourceId'))), createObject('id', parameters('routeTableResourceId')), null())]",
         "natGateway": "[if(not(empty(parameters('natGatewayResourceId'))), createObject('id', parameters('natGatewayResourceId')), null())]",

--- a/avm/res/network/virtual-network/subnet/version.json
+++ b/avm/res/network/virtual-network/subnet/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1"
+  "version": "0.2"
 }

--- a/avm/res/network/virtual-network/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/defaults/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -42,7 +42,6 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
       addressPrefixes: [
         '10.0.0.0/16'
       ]

--- a/avm/res/network/virtual-network/tests/e2e/ipam/dependencies.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/ipam/dependencies.bicep
@@ -7,7 +7,7 @@ param networkManagerName string
 @description('Required. List of IP address prefixes to be used for the IPAM pool.')
 param addressPrefixes array
 
-resource networkManager 'Microsoft.Network/networkManagers@2024-05-01' = {
+resource networkManager 'Microsoft.Network/networkManagers@2025-05-01' = {
   name: networkManagerName
   location: location
   properties: {
@@ -19,7 +19,7 @@ resource networkManager 'Microsoft.Network/networkManagers@2024-05-01' = {
   }
 }
 
-resource networkManagerIpamPool 'Microsoft.Network/networkManagers/ipamPools@2024-05-01' = {
+resource networkManagerIpamPool 'Microsoft.Network/networkManagers/ipamPools@2025-05-01' = {
   name: '${networkManagerName}-ipamPool'
   parent: networkManager
   location: location

--- a/avm/res/network/virtual-network/tests/e2e/ipam/main.test.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/ipam/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -35,7 +35,6 @@ module nestedDependencies 'dependencies.bicep' = {
   name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
   scope: resourceGroup
   params: {
-    location: resourceLocation
     networkManagerName: 'dep-${namePrefix}-vnm-${serviceShort}'
     addressPrefixes: [
       '172.16.0.0/22'
@@ -54,7 +53,6 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
       addressPrefixes: [
         nestedDependencies.outputs.networkManagerIpamPoolId
       ]

--- a/avm/res/network/virtual-network/tests/e2e/ipv6/main.test.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/ipv6/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -42,7 +42,6 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
       addressPrefixes: [
         '10.0.0.0/21'
         'fd00:592b:3014::/64'

--- a/avm/res/network/virtual-network/tests/e2e/max/dependencies.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/max/dependencies.bicep
@@ -13,22 +13,22 @@ param networkSecurityGroupName string
 @description('Required. The name of the Bastion Network Security Group to create.')
 param networkSecurityGroupBastionName string
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
 
-resource routeTable 'Microsoft.Network/routeTables@2023-04-01' = {
+resource routeTable 'Microsoft.Network/routeTables@2025-05-01' = {
   name: routeTableName
   location: location
 }
 
-resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
   name: networkSecurityGroupName
   location: location
 }
 
-resource networkSecurityGroupBastion 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+resource networkSecurityGroupBastion 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
   name: networkSecurityGroupBastionName
   location: location
   properties: {

--- a/avm/res/network/virtual-network/tests/e2e/max/main.test.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/max/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -35,7 +35,6 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
   params: {
-    location: resourceLocation
     managedIdentityName: 'dep-${namePrefix}-msi-${serviceShort}'
     routeTableName: 'dep-${namePrefix}-rt-${serviceShort}'
     networkSecurityGroupName: 'dep-${namePrefix}-nsg-${serviceShort}'
@@ -53,7 +52,6 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
     logAnalyticsWorkspaceName: 'dep-${namePrefix}-law-${serviceShort}'
     eventHubNamespaceEventHubName: 'dep-${namePrefix}-evh-${serviceShort}'
     eventHubNamespaceName: 'dep-${namePrefix}-evhns-${serviceShort}'
-    location: resourceLocation
   }
 }
 
@@ -69,7 +67,6 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
       addressPrefixes: [
         addressPrefix
       ]

--- a/avm/res/network/virtual-network/tests/e2e/vnetPeering/dependencies.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/vnetPeering/dependencies.bicep
@@ -9,7 +9,7 @@ param networkSecurityGroupBastionName string
 
 var addressPrefix = '10.0.0.0/16'
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -29,7 +29,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = {
   }
 }
 
-resource networkSecurityGroupBastion 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+resource networkSecurityGroupBastion 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
   name: networkSecurityGroupBastionName
   location: location
   properties: {

--- a/avm/res/network/virtual-network/tests/e2e/vnetPeering/main.test.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/vnetPeering/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -35,7 +35,6 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   name: '${uniqueString(deployment().name, resourceLocation)}-nestedDependencies'
   params: {
-    location: resourceLocation
     virtualNetworkName: 'dep-${namePrefix}-vnet-${serviceShort}'
     networkSecurityGroupBastionName: 'dep-${namePrefix}-nsg-bastion-${serviceShort}'
   }
@@ -52,7 +51,6 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
       addressPrefixes: [
         '10.1.0.0/24'
       ]

--- a/avm/res/network/virtual-network/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/waf-aligned/dependencies.bicep
@@ -13,22 +13,22 @@ param networkSecurityGroupName string
 @description('Required. The name of the Bastion Network Security Group to create.')
 param networkSecurityGroupBastionName string
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
 
-resource routeTable 'Microsoft.Network/routeTables@2023-04-01' = {
+resource routeTable 'Microsoft.Network/routeTables@2025-05-01' = {
   name: routeTableName
   location: location
 }
 
-resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
   name: networkSecurityGroupName
   location: location
 }
 
-resource networkSecurityGroupBastion 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+resource networkSecurityGroupBastion 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
   name: networkSecurityGroupBastionName
   location: location
   properties: {

--- a/avm/res/network/virtual-network/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/waf-aligned/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -39,7 +39,6 @@ module nestedDependencies 'dependencies.bicep' = {
     routeTableName: 'dep-${namePrefix}-rt-${serviceShort}'
     networkSecurityGroupName: 'dep-${namePrefix}-nsg-${serviceShort}'
     networkSecurityGroupBastionName: 'dep-${namePrefix}-nsg-bastion-${serviceShort}'
-    location: resourceLocation
   }
 }
 
@@ -53,7 +52,6 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
     logAnalyticsWorkspaceName: 'dep-${namePrefix}-law-${serviceShort}'
     eventHubNamespaceEventHubName: 'dep-${namePrefix}-evh-${serviceShort}'
     eventHubNamespaceName: 'dep-${namePrefix}-evhns-${serviceShort}'
-    location: resourceLocation
   }
 }
 
@@ -69,7 +67,6 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
-      location: resourceLocation
       addressPrefixes: [
         addressPrefix
       ]

--- a/avm/res/network/virtual-network/version.json
+++ b/avm/res/network/virtual-network/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.8"
+  "version": "0.9"
 }

--- a/avm/res/network/virtual-network/virtual-network-peering/CHANGELOG.md
+++ b/avm/res/network/virtual-network/virtual-network-peering/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-network/virtual-network-peering/CHANGELOG.md).
 
+## 0.2.0
+
+### Changes
+
+- Added support for `enableOnlyIPv6Peering`
+
+### Breaking Changes
+
+- None
+
 ## 0.1.0
 
 ### Changes

--- a/avm/res/network/virtual-network/virtual-network-peering/README.md
+++ b/avm/res/network/virtual-network/virtual-network-peering/README.md
@@ -21,7 +21,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.Network/virtualNetworks/virtualNetworkPeerings` | 2024-01-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_virtualnetworks_virtualnetworkpeerings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-01-01/virtualNetworks/virtualNetworkPeerings)</li></ul> |
+| `Microsoft.Network/virtualNetworks/virtualNetworkPeerings` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_virtualnetworks_virtualnetworkpeerings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2025-05-01/virtualNetworks/virtualNetworkPeerings)</li></ul> |
 
 ## Parameters
 
@@ -45,6 +45,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | [`allowGatewayTransit`](#parameter-allowgatewaytransit) | bool | If gateway links can be used in remote virtual networking to link to this virtual network. Default is false. |
 | [`allowVirtualNetworkAccess`](#parameter-allowvirtualnetworkaccess) | bool | Whether the VMs in the local virtual network space would be able to access the VMs in remote virtual network space. Default is true. |
 | [`doNotVerifyRemoteGateways`](#parameter-donotverifyremotegateways) | bool | If we need to verify the provisioning state of the remote gateway. Default is true. |
+| [`enableOnlyIPv6Peering`](#parameter-enableonlyipv6peering) | bool | Whether only Ipv6 address space is peered for subnet peering. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`name`](#parameter-name) | string | The Name of VNET Peering resource. If not provided, default value will be localVnetName-remoteVnetName. |
 | [`useRemoteGateways`](#parameter-useremotegateways) | bool | If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. Default is false. |
@@ -94,6 +95,14 @@ If we need to verify the provisioning state of the remote gateway. Default is tr
 - Required: No
 - Type: bool
 - Default: `True`
+
+### Parameter: `enableOnlyIPv6Peering`
+
+Whether only Ipv6 address space is peered for subnet peering.
+
+- Required: No
+- Type: bool
+- Default: `False`
 
 ### Parameter: `enableTelemetry`
 

--- a/avm/res/network/virtual-network/virtual-network-peering/main.bicep
+++ b/avm/res/network/virtual-network/virtual-network-peering/main.bicep
@@ -28,8 +28,11 @@ param doNotVerifyRemoteGateways bool = true
 @description('Optional. If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. Default is false.')
 param useRemoteGateways bool = false
 
+@description('Optional. Whether only Ipv6 address space is peered for subnet peering.')
+param enableOnlyIPv6Peering bool = false
+
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.network-virtualnetwork-peering.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
   properties: {
     mode: 'Incremental'
@@ -47,15 +50,16 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' existing = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' existing = {
   name: localVnetName
 }
 
-resource virtualNetworkPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2024-01-01' = {
+resource virtualNetworkPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2025-05-01' = {
   name: name
   parent: virtualNetwork
   properties: {
     allowForwardedTraffic: allowForwardedTraffic
+    enableOnlyIPv6Peering: enableOnlyIPv6Peering
     allowGatewayTransit: allowGatewayTransit
     allowVirtualNetworkAccess: allowVirtualNetworkAccess
     doNotVerifyRemoteGateways: doNotVerifyRemoteGateways

--- a/avm/res/network/virtual-network/virtual-network-peering/main.json
+++ b/avm/res/network/virtual-network/virtual-network-peering/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "18164299966266307814"
+      "templateHash": "13052726848098685116"
     },
     "name": "Virtual Network Peerings",
     "description": "This module deploys a Virtual Network Peering."
@@ -71,13 +71,20 @@
       "metadata": {
         "description": "Optional. If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway. Default is false."
       }
+    },
+    "enableOnlyIPv6Peering": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Optional. Whether only Ipv6 address space is peered for subnet peering."
+      }
     }
   },
   "resources": [
     {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.network-virtualnetwork-peering.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -96,10 +103,11 @@
     },
     {
       "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-      "apiVersion": "2024-01-01",
+      "apiVersion": "2025-05-01",
       "name": "[format('{0}/{1}', parameters('localVnetName'), parameters('name'))]",
       "properties": {
         "allowForwardedTraffic": "[parameters('allowForwardedTraffic')]",
+        "enableOnlyIPv6Peering": "[parameters('enableOnlyIPv6Peering')]",
         "allowGatewayTransit": "[parameters('allowGatewayTransit')]",
         "allowVirtualNetworkAccess": "[parameters('allowVirtualNetworkAccess')]",
         "doNotVerifyRemoteGateways": "[parameters('doNotVerifyRemoteGateways')]",

--- a/avm/res/network/virtual-network/virtual-network-peering/version.json
+++ b/avm/res/network/virtual-network/virtual-network-peering/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1"
+  "version": "0.2"
 }


### PR DESCRIPTION
## Description

- Added support for `subnet.ipAllocations` & `subnet.serviceGateway`
- Added support for `peering.enableOnlyIPv6Peering`
- Added diverse types
- Updated references of `avm-common-types` to `0.7.0`

Closes #6223 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.network.virtual-network](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network.yml/badge.svg?branch=users%2Falsehr%2FipamPoolPrefixAllocations&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)
