### PR TITLE
fix: `avm/res/maintenance/configuration-assignment` Updated e2e deployment tests removing hardcoded maintenance window date

### DIFF
--- a/avm/res/maintenance/configuration-assignment/CHANGELOG.md
+++ b/avm/res/maintenance/configuration-assignment/CHANGELOG.md
@@ -4,8 +4,14 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ## 0.2.1
 
+### Changes
+
 - Re-compiled `main.json` with latest Bicep version.
 - Updated `Microsoft.Resources/deployments` API version to `2025-04-01`.
+
+### Breaking Changes
+
+- None
 
 ## 0.2.0
 

--- a/avm/res/maintenance/configuration-assignment/CHANGELOG.md
+++ b/avm/res/maintenance/configuration-assignment/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/maintenance/configuration-assignment/CHANGELOG.md).
 
+## 0.2.1
+
+- Re-compiled `main.json` with latest Bicep version.
+- Updated `Microsoft.Resources/deployments` API version to `2025-04-01`.
+
 ## 0.2.0
 
 ### Changes

--- a/avm/res/maintenance/configuration-assignment/main.bicep
+++ b/avm/res/maintenance/configuration-assignment/main.bicep
@@ -28,7 +28,7 @@ param filter filterType?
 // =============== //
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.maintenance-configurationassignment.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'

--- a/avm/res/maintenance/configuration-assignment/main.json
+++ b/avm/res/maintenance/configuration-assignment/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "9959582202134377032"
+      "version": "0.43.1.21952",
+      "templateHash": "18345408418316753894"
     },
     "name": "Maintenance Configuration Assignments",
     "description": "This module deploys a Maintenance Configuration Assignment."
@@ -144,7 +144,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.maintenance-configurationassignment.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",

--- a/avm/res/maintenance/configuration-assignment/tests/e2e/filter.defaults/dependencies.bicep
+++ b/avm/res/maintenance/configuration-assignment/tests/e2e/filter.defaults/dependencies.bicep
@@ -4,6 +4,9 @@ param location string = resourceGroup().location
 @description('Required. The name of the Maintenance Configuration to create.')
 param maintenanceConfigurationName string
 
+@description('Generated. Do not provide a value. Time used as a basis for e.g. the maintenance window start date.')
+param baseTime string = utcNow('u')
+
 resource maintenanceConfiguration 'Microsoft.Maintenance/maintenanceConfigurations@2023-10-01-preview' = {
   name: maintenanceConfigurationName
   location: location
@@ -13,8 +16,8 @@ resource maintenanceConfiguration 'Microsoft.Maintenance/maintenanceConfiguratio
     }
     maintenanceScope: 'InGuestPatch'
     maintenanceWindow: {
-      startDateTime: '2025-01-09 00:00'
-      expirationDateTime: '2026-01-08 00:00'
+      startDateTime: '${dateTimeAdd(baseTime, 'PT0S', 'yyyy-MM-dd')} 00:00'
+      expirationDateTime: '${dateTimeAdd(baseTime, 'P1M', 'yyyy-MM-dd')} 00:00'
       duration: '03:00'
       timeZone: 'UTC'
       recurEvery: 'Week'

--- a/avm/res/maintenance/configuration-assignment/tests/e2e/filter.tags/dependencies.bicep
+++ b/avm/res/maintenance/configuration-assignment/tests/e2e/filter.tags/dependencies.bicep
@@ -4,6 +4,9 @@ param location string = resourceGroup().location
 @description('Required. The name of the Maintenance Configuration to create.')
 param maintenanceConfigurationName string
 
+@description('Generated. Do not provide a value. Time used as a basis for e.g. the maintenance window start date.')
+param baseTime string = utcNow('u')
+
 resource maintenanceConfiguration 'Microsoft.Maintenance/maintenanceConfigurations@2023-10-01-preview' = {
   name: maintenanceConfigurationName
   location: location
@@ -13,8 +16,8 @@ resource maintenanceConfiguration 'Microsoft.Maintenance/maintenanceConfiguratio
     }
     maintenanceScope: 'InGuestPatch'
     maintenanceWindow: {
-      startDateTime: '2025-01-09 00:00'
-      expirationDateTime: '2026-01-08 00:00'
+      startDateTime: '${dateTimeAdd(baseTime, 'PT0S', 'yyyy-MM-dd')} 00:00'
+      expirationDateTime: '${dateTimeAdd(baseTime, 'P1M', 'yyyy-MM-dd')} 00:00'
       duration: '03:00'
       timeZone: 'UTC'
       recurEvery: 'Week'

--- a/avm/res/maintenance/configuration-assignment/tests/e2e/linvm.waf-aligned/dependencies.bicep
+++ b/avm/res/maintenance/configuration-assignment/tests/e2e/linvm.waf-aligned/dependencies.bicep
@@ -4,6 +4,9 @@ param location string = resourceGroup().location
 @description('Required. The name of the Maintenance Configuration to create.')
 param maintenanceConfigurationName string
 
+@description('Generated. Do not provide a value. Time used as a basis for e.g. the maintenance window start date.')
+param baseTime string = utcNow('u')
+
 @description('Required. The name of the Virtual Network to create.')
 param virtualNetworkName string
 
@@ -66,8 +69,8 @@ resource maintenanceConfiguration 'Microsoft.Maintenance/maintenanceConfiguratio
     }
     maintenanceScope: 'InGuestPatch'
     maintenanceWindow: {
-      startDateTime: '2025-01-09 00:00'
-      expirationDateTime: '2026-01-08 00:00'
+      startDateTime: '${dateTimeAdd(baseTime, 'PT0S', 'yyyy-MM-dd')} 00:00'
+      expirationDateTime: '${dateTimeAdd(baseTime, 'P1M', 'yyyy-MM-dd')} 00:00'
       duration: '03:00'
       timeZone: 'UTC'
       recurEvery: 'Week'

--- a/avm/res/maintenance/configuration-assignment/tests/e2e/winvm.multirg/dependencies_mc.bicep
+++ b/avm/res/maintenance/configuration-assignment/tests/e2e/winvm.multirg/dependencies_mc.bicep
@@ -4,6 +4,9 @@ param location string = resourceGroup().location
 @description('Required. The name of the Maintenance Configuration to create.')
 param maintenanceConfigurationName string
 
+@description('Generated. Do not provide a value. Time used as a basis for e.g. the maintenance window start date.')
+param baseTime string = utcNow('u')
+
 resource maintenanceConfiguration 'Microsoft.Maintenance/maintenanceConfigurations@2023-10-01-preview' = {
   name: maintenanceConfigurationName
   location: location
@@ -13,8 +16,8 @@ resource maintenanceConfiguration 'Microsoft.Maintenance/maintenanceConfiguratio
     }
     maintenanceScope: 'InGuestPatch'
     maintenanceWindow: {
-      startDateTime: '2025-01-09 00:00'
-      expirationDateTime: '2026-01-08 00:00'
+      startDateTime: '${dateTimeAdd(baseTime, 'PT0S', 'yyyy-MM-dd')} 00:00'
+      expirationDateTime: '${dateTimeAdd(baseTime, 'P1M', 'yyyy-MM-dd')} 00:00'
       duration: '03:00'
       timeZone: 'UTC'
       recurEvery: 'Week'


### PR DESCRIPTION
## Description

Closes #6675 
Replaced hardcoded `startDateTime `and `expirationDateTime `values in maintenance configuration assignment e2e test dependencies with dynamic expressions. This prevents test failures caused by expired maintenance windows when re-running tests after the original hardcoded dates have passed.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.maintenance.configuration-assignment](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.configuration-assignment.yml/badge.svg?branch=users%2Feriqua%2Fmcafix&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.maintenance.configuration-assignment.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
