### PR TITLE
docs: Clarify `logAnalyticsDestinationType` is unsupported in `avm/res/cdn/profile`

### DIFF
--- a/avm/res/cdn/profile/CHANGELOG.md
+++ b/avm/res/cdn/profile/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cdn/profile/Changelog.md).
 
+## 0.19.3
+
+### Changes
+
+- Documented that the `logAnalyticsDestinationType` property of `diagnosticSettings` is ignored by the platform for CDN profiles, since Azure CDN only emits resource logs in Azure Diagnostics mode.
+
+### Breaking Changes
+
+- None
+
 ## 0.19.2
 
 ### Changes

--- a/avm/res/cdn/profile/README.md
+++ b/avm/res/cdn/profile/README.md
@@ -2528,7 +2528,7 @@ param tags = {
 | :-- | :-- | :-- |
 | [`afdEndpoints`](#parameter-afdendpoints) | array | Array of AFD endpoint objects. |
 | [`customDomains`](#parameter-customdomains) | array | Array of custom domain objects. |
-| [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
+| [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. Note: the `logAnalyticsDestinationType` property is not supported for CDN profiles, as Azure CDN only emits resource logs in Azure Diagnostics mode (see https://learn.microsoft.com/azure/azure-monitor/reference/tables/azurediagnostics#resources-using-azure-diagnostics-mode). Any value provided for this property is ignored. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`endpoint`](#parameter-endpoint) | object | Endpoint properties (see [ref](https://learn.microsoft.com/en-us/azure/templates/microsoft.cdn/profiles/endpoints?pivots=deployment-language-bicep#endpointproperties) for details). |
 | [`location`](#parameter-location) | string | Location for all Resources. |
@@ -3069,7 +3069,7 @@ The name of the secret.
 
 ### Parameter: `diagnosticSettings`
 
-The diagnostic settings of the service.
+The diagnostic settings of the service. Note: the `logAnalyticsDestinationType` property is not supported for CDN profiles, as Azure CDN only emits resource logs in Azure Diagnostics mode (see https://learn.microsoft.com/azure/azure-monitor/reference/tables/azurediagnostics#resources-using-azure-diagnostics-mode). Any value provided for this property is ignored.
 
 - Required: No
 - Type: array

--- a/avm/res/cdn/profile/main.bicep
+++ b/avm/res/cdn/profile/main.bicep
@@ -64,7 +64,7 @@ param roleAssignments roleAssignmentType[]?
 param enableTelemetry bool = true
 
 import { diagnosticSettingFullType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
-@description('Optional. The diagnostic settings of the service.')
+@description('Optional. The diagnostic settings of the service. Note: the `logAnalyticsDestinationType` property is not supported for CDN profiles, as Azure CDN only emits resource logs in Azure Diagnostics mode (see https://learn.microsoft.com/azure/azure-monitor/reference/tables/azurediagnostics#resources-using-azure-diagnostics-mode). Any value provided for this property is ignored.')
 param diagnosticSettings diagnosticSettingFullType[]?
 
 var builtInRoleNames = {

--- a/avm/res/cdn/profile/main.json
+++ b/avm/res/cdn/profile/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "7460501873167160685"
+      "version": "0.43.1.21952",
+      "templateHash": "9451806107229217327"
     },
     "name": "CDN Profiles",
     "description": "This module deploys a CDN Profile."
@@ -1131,7 +1131,7 @@
       },
       "nullable": true,
       "metadata": {
-        "description": "Optional. The diagnostic settings of the service."
+        "description": "Optional. The diagnostic settings of the service. Note: the `logAnalyticsDestinationType` property is not supported for CDN profiles, as Azure CDN only emits resource logs in Azure Diagnostics mode (see https://learn.microsoft.com/azure/azure-monitor/reference/tables/azurediagnostics#resources-using-azure-diagnostics-mode). Any value provided for this property is ignored."
       }
     }
   },
@@ -1307,8 +1307,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "13465865857340956298"
+              "version": "0.43.1.21952",
+              "templateHash": "11436902781078853668"
             },
             "name": "CDN Profiles Endpoints",
             "description": "This module deploys a CDN Profile Endpoint."
@@ -1462,8 +1462,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "15782891658132953779"
+                      "version": "0.43.1.21952",
+                      "templateHash": "1490754851041638567"
                     },
                     "name": "CDN Profiles Endpoints Origins",
                     "description": "This module deploys a CDN Profile Endpoint Origin."
@@ -1738,8 +1738,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "17067345789441883143"
+              "version": "0.43.1.21952",
+              "templateHash": "9350005169817405811"
             },
             "name": "CDN Profiles Secret",
             "description": "This module deploys a CDN Profile Secret."
@@ -1932,8 +1932,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "2921369705336278588"
+              "version": "0.43.1.21952",
+              "templateHash": "6883060219010743162"
             },
             "name": "CDN Profiles Custom Domains",
             "description": "This module deploys a CDN Profile Custom Domains."
@@ -2211,8 +2211,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "488359475522181407"
+              "version": "0.43.1.21952",
+              "templateHash": "6506136652954900600"
             },
             "name": "CDN Profiles Origin Group",
             "description": "This module deploys a CDN Profile Origin Group."
@@ -2555,8 +2555,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "11221742659440577584"
+                      "version": "0.43.1.21952",
+                      "templateHash": "15384076797375871606"
                     },
                     "name": "CDN Profiles Origin",
                     "description": "This module deploys a CDN Profile Origin."
@@ -2807,8 +2807,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "2611131179129518028"
+              "version": "0.43.1.21952",
+              "templateHash": "8966266643094712937"
             },
             "name": "CDN Profiles Rule Sets",
             "description": "This module deploys a CDN Profile rule set."
@@ -2979,8 +2979,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "8814243946011640477"
+                      "version": "0.43.1.21952",
+                      "templateHash": "12930386980400641349"
                     },
                     "name": "CDN Profiles Rules",
                     "description": "This module deploys a CDN Profile rule."
@@ -3197,8 +3197,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "6724838222608014866"
+              "version": "0.43.1.21952",
+              "templateHash": "3470267530732764401"
             },
             "name": "CDN Profiles AFD Endpoints",
             "description": "This module deploys a CDN Profile AFD Endpoint."
@@ -3505,8 +3505,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "2394217858101032187"
+                      "version": "0.43.1.21952",
+                      "templateHash": "16338982868678591577"
                     },
                     "name": "CDN Profiles AFD Endpoint Route",
                     "description": "This module deploys a CDN Profile AFD Endpoint route."
@@ -3864,8 +3864,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "16497831096489994077"
+              "version": "0.43.1.21952",
+              "templateHash": "15741706543761130014"
             },
             "name": "CDN Profiles Security Policy",
             "description": "This module deploys a CDN Profile Security Policy."


### PR DESCRIPTION
## Description

Closes #6875.

Azure CDN profiles only emit resource logs in **Azure Diagnostics mode** (see [the Microsoft Learn reference](https://learn.microsoft.com/azure/azure-monitor/reference/tables/azurediagnostics#resources-using-azure-diagnostics-mode)). Resource-specific (a.k.a. `Dedicated`) tables are not supported by the platform — Azure silently ignores `logAnalyticsDestinationType: 'Dedicated'` and falls back to the legacy `AzureDiagnostics` table.

This was confusing for module consumers, who could pass `'Dedicated'` without any error but would not see logs land in resource-specific tables.

### Changes

- Updated the `diagnosticSettings` parameter description in `avm/res/cdn/profile/main.bicep` to document this platform limitation and link to the Microsoft Learn reference.
- Regenerated `README.md` and `main.json`.
- Added `## 0.19.3` entry to the module `CHANGELOG.md`.

No behavioral change at deployment time — the user-supplied value is still passed through to the underlying `Microsoft.Insights/diagnosticSettings` resource (Azure ignores it).

### Pipeline reference

[![avm.res.cdn.profile](https://github.com/gbeaud/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml/badge.svg?branch=LogAnalyticsDestination&event=workflow_dispatch)](https://github.com/gbeaud/bicep-registry-modules/actions/workflows/avm.res.cdn.profile.yml)

### Type of change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

### Checklist

- [x] Updated `CHANGELOG.md`
- [x] Regenerated `README.md` via `Set-AVMModule.ps1`
- [x] Regenerated `main.json`
- [x] No breaking changes