### PR TITLE
fix: Azure Health Bot take ownership and API versions update

### DIFF
--- a/avm/res/health-bot/health-bot/CHANGELOG.md
+++ b/avm/res/health-bot/health-bot/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/health-bot/health-bot/CHANGELOG.md).
 
+## 0.4.0
+
+### Changes
+
+- Updated resource API versions to use latest versions
+- Updated all 'avm-common-types' reference to `0.7.0`
+
+### Breaking Changes
+
+- Removed `S1` and added `C1` and `PES` as the allowed `sku` options based on changes in latest resource API version
+
 ## 0.3.2
 
 ### Changes

--- a/avm/res/health-bot/health-bot/ORPHANED.md
+++ b/avm/res/health-bot/health-bot/ORPHANED.md
@@ -1,4 +1,0 @@
-⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️
-
-- Only security and bug fixes are being handled by the AVM core team at present.
-- If interested in becoming the module owner of this orphaned module (must be Microsoft FTE), please look for the related "orphaned module" GitHub issue [here](https://aka.ms/AVM/OrphanedModules)!

--- a/avm/res/health-bot/health-bot/README.md
+++ b/avm/res/health-bot/health-bot/README.md
@@ -1,10 +1,5 @@
 # Azure Health Bots `[Microsoft.HealthBot/healthBots]`
 
-> ⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️
->
-> - Only security and bug fixes are being handled by the AVM core team at present.
-> - If interested in becoming the module owner of this orphaned module (must be Microsoft FTE), please look for the related "orphaned module" GitHub issue [here](https://aka.ms/AVM/OrphanedModules)!
-
 This module deploys an Azure Health Bot.
 
 You can reference the module as follows:
@@ -30,7 +25,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | :-- | :-- | :-- |
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
-| `Microsoft.HealthBot/healthBots` | 2022-08-08 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.healthbot_healthbots.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.HealthBot/2022-08-08/healthBots)</li></ul> |
+| `Microsoft.HealthBot/healthBots` | 2025-11-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.healthbot_healthbots.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.HealthBot/2025-11-01/healthBots)</li></ul> |
 
 ## Usage examples
 
@@ -429,8 +424,9 @@ The name of the Azure Health Bot SKU.
   ```Bicep
   [
     'C0'
+    'C1'
     'F0'
-    'S1'
+    'PES'
   ]
   ```
 
@@ -639,8 +635,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.2.1` | Remote reference |
-| `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.7.0` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/health-bot/health-bot/main.bicep
+++ b/avm/res/health-bot/health-bot/main.bicep
@@ -6,29 +6,30 @@ param name string
 
 @allowed([
   'C0'
+  'C1'
   'F0'
-  'S1'
+  'PES'
 ])
 @description('Required. The name of the Azure Health Bot SKU.')
 param sku string
 
-import { managedIdentityOnlyUserAssignedType } from 'br/public:avm/utl/types/avm-common-types:0.2.1'
+import { managedIdentityOnlyUserAssignedType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. The managed identity definition for this resource.')
 param managedIdentities managedIdentityOnlyUserAssignedType?
 
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
-import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
+import { lockType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. The lock settings of the service.')
 param lock lockType?
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.6.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
 @description('Optional. Tags of the resource.')
-param tags resourceInput<'Microsoft.HealthBot/healthBots@2022-08-08'>.tags?
+param tags resourceInput<'Microsoft.HealthBot/healthBots@2025-11-01'>.tags?
 
 @description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
@@ -72,7 +73,7 @@ var formattedRoleAssignments = [
 ]
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.healthbot-healthbot.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'
@@ -90,7 +91,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource healthBot 'Microsoft.HealthBot/healthBots@2022-08-08' = {
+resource healthBot 'Microsoft.HealthBot/healthBots@2025-11-01' = {
   name: name
   location: location
   tags: tags

--- a/avm/res/health-bot/health-bot/main.json
+++ b/avm/res/health-bot/health-bot/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "255319937837341975"
+      "version": "0.43.8.12551",
+      "templateHash": "4091587132232593823"
     },
     "name": "Azure Health Bots",
     "description": "This module deploys an Azure Health Bot."
@@ -45,7 +45,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a lock.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     },
@@ -66,7 +66,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a managed identity configuration. To be used if only user-assigned identities are supported by the resource provider.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.2.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     },
@@ -141,7 +141,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.6.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     }
@@ -157,8 +157,9 @@
       "type": "string",
       "allowedValues": [
         "C0",
+        "C1",
         "F0",
-        "S1"
+        "PES"
       ],
       "metadata": {
         "description": "Required. The name of the Azure Health Bot SKU."
@@ -199,7 +200,7 @@
       "type": "object",
       "metadata": {
         "__bicep_resource_derived_type!": {
-          "source": "Microsoft.HealthBot/healthBots@2022-08-08#properties/tags"
+          "source": "Microsoft.HealthBot/healthBots@2025-11-01#properties/tags"
         },
         "description": "Optional. Tags of the resource."
       },
@@ -235,7 +236,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.healthbot-healthbot.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -254,7 +255,7 @@
     },
     "healthBot": {
       "type": "Microsoft.HealthBot/healthBots",
-      "apiVersion": "2022-08-08",
+      "apiVersion": "2025-11-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -328,7 +329,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('healthBot', '2022-08-08', 'full').location]"
+      "value": "[reference('healthBot', '2025-11-01', 'full').location]"
     }
   }
 }

--- a/avm/res/health-bot/health-bot/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/health-bot/health-bot/tests/e2e/defaults/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/health-bot/health-bot/tests/e2e/max/dependencies.bicep
+++ b/avm/res/health-bot/health-bot/tests/e2e/max/dependencies.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2025-05-31-preview' = {
   name: managedIdentityName
   location: location
 }

--- a/avm/res/health-bot/health-bot/tests/e2e/max/main.test.bicep
+++ b/avm/res/health-bot/health-bot/tests/e2e/max/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }
@@ -90,8 +90,5 @@ module testDeployment '../../../main.bicep' = [
         ]
       }
     }
-    dependsOn: [
-      nestedDependencies
-    ]
   }
 ]

--- a/avm/res/health-bot/health-bot/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/health-bot/health-bot/tests/e2e/waf-aligned/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/health-bot/health-bot/version.json
+++ b/avm/res/health-bot/health-bot/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.3"
+  "version": "0.4"
 }


### PR DESCRIPTION
## Description

- Removed ORPHANED.md and updated README.md as module now has an owner.
- Updated resource API versions to use latest versions
- Updated all 'avm-common-types' reference to `0.7.0`

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.health-bot.health-bot](https://github.com/TomazMlakar/bicep-registry-modules/actions/workflows/avm.res.health-bot.health-bot.yml/badge.svg?branch=users%2Ftomlakar%2Fhealth-bot-ownership)](https://github.com/TomazMlakar/bicep-registry-modules/actions/workflows/avm.res.health-bot.health-bot.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
