### PR TITLE
fix: SecurityInsights Setting take ownership and API versions update

### DIFF
--- a/avm/res/security-insights/setting/CHANGELOG.md
+++ b/avm/res/security-insights/setting/CHANGELOG.md
@@ -6,6 +6,17 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Changes
 
+- Updated resource API versions to use latest versions
+- Updated all 'avm-common-types' reference to `0.7.0`
+
+### Breaking Changes
+
+- None
+
+## 0.1.1
+
+### Changes
+
 - Removed deprecated metadata
 
 ### Breaking Changes

--- a/avm/res/security-insights/setting/CHANGELOG.md
+++ b/avm/res/security-insights/setting/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/security-insights/setting/CHANGELOG.md).
 
-## 0.1.1
+## 0.1.2
 
 ### Changes
 

--- a/avm/res/security-insights/setting/ORPHANED.md
+++ b/avm/res/security-insights/setting/ORPHANED.md
@@ -1,4 +1,0 @@
-⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️
-
-- Only security and bug fixes are being handled by the AVM core team at present.
-- If interested in becoming the module owner of this orphaned module (must be Microsoft FTE), please look for the related "orphaned module" GitHub issue [here](https://aka.ms/AVM/OrphanedModules)!

--- a/avm/res/security-insights/setting/README.md
+++ b/avm/res/security-insights/setting/README.md
@@ -442,7 +442,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 
 | Reference | Type |
 | :-- | :-- |
-| `br/public:avm/utl/types/avm-common-types:0.5.1` | Remote reference |
+| `br/public:avm/utl/types/avm-common-types:0.7.0` | Remote reference |
 
 ## Data Collection
 

--- a/avm/res/security-insights/setting/README.md
+++ b/avm/res/security-insights/setting/README.md
@@ -1,10 +1,5 @@
 # Security Insights Settings `[Microsoft.SecurityInsights/settings]`
 
-> ⚠️THIS MODULE IS CURRENTLY ORPHANED.⚠️
->
-> - Only security and bug fixes are being handled by the AVM core team at present.
-> - If interested in becoming the module owner of this orphaned module (must be Microsoft FTE), please look for the related "orphaned module" GitHub issue [here](https://aka.ms/AVM/OrphanedModules)!
-
 This module deploys a Security Insights Setting.
 
 You can reference the module as follows:

--- a/avm/res/security-insights/setting/main.bicep
+++ b/avm/res/security-insights/setting/main.bicep
@@ -1,7 +1,7 @@
 metadata name = 'Security Insights Settings'
 metadata description = 'This module deploys a Security Insights Setting.'
 
-import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
+import { roleAssignmentType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. Array of role assignments to create.')
 param roleAssignments roleAssignmentType[]?
 
@@ -48,7 +48,7 @@ var formattedRoleAssignments = [
 ]
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.securityinsights-setting.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'
@@ -66,7 +66,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
+resource workspace 'Microsoft.OperationalInsights/workspaces@2025-07-01' existing = {
   name: last(split(workspaceResourceId, '/'))
 }
 

--- a/avm/res/security-insights/setting/main.json
+++ b/avm/res/security-insights/setting/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "11393712004636778358"
+      "version": "0.43.8.12551",
+      "templateHash": "14019813704782679930"
     },
     "name": "Security Insights Settings",
     "description": "This module deploys a Security Insights Setting."
@@ -83,7 +83,7 @@
       "metadata": {
         "description": "An AVM-aligned type for a role assignment.",
         "__bicep_imported_from!": {
-          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
         }
       }
     }
@@ -161,7 +161,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.securityinsights-setting.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -181,7 +181,7 @@
     "workspace": {
       "existing": true,
       "type": "Microsoft.OperationalInsights/workspaces",
-      "apiVersion": "2022-10-01",
+      "apiVersion": "2025-07-01",
       "name": "[last(split(parameters('workspaceResourceId'), '/'))]"
     },
     "setting": {

--- a/avm/res/security-insights/setting/tests/e2e/defaults/dependencies.bicep
+++ b/avm/res/security-insights/setting/tests/e2e/defaults/dependencies.bicep
@@ -7,12 +7,12 @@ param managedIdentityName string
 @description('Required. The name of the Workspace to create.')
 param name string
 
-resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-07-01' = {
   name: name
   location: location
 }
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2025-05-31-preview' = {
   name: managedIdentityName
   location: location
 }
@@ -47,7 +47,7 @@ resource sentinel 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' 
 }
 
 // Onboard Sentinel after it has been created
-resource onboardingStates 'Microsoft.SecurityInsights/onboardingStates@2022-12-01-preview' = {
+resource onboardingStates 'Microsoft.SecurityInsights/onboardingStates@2025-09-01' = {
   scope: logAnalyticsWorkspace
   name: 'default'
 }

--- a/avm/res/security-insights/setting/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/security-insights/setting/tests/e2e/defaults/main.test.bicep
@@ -25,7 +25,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/security-insights/setting/tests/e2e/max/dependencies.bicep
+++ b/avm/res/security-insights/setting/tests/e2e/max/dependencies.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 @description('Required. The name of the Workspace to create.')
 param name string
 
-resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-07-01' = {
   name: name
   location: location
 }
@@ -25,7 +25,7 @@ resource sentinel 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' 
 }
 
 // Onboard Sentinel after it has been created
-resource onboardingStates 'Microsoft.SecurityInsights/onboardingStates@2022-12-01-preview' = {
+resource onboardingStates 'Microsoft.SecurityInsights/onboardingStates@2025-09-01' = {
   scope: logAnalyticsWorkspace
   name: 'default'
 }

--- a/avm/res/security-insights/setting/tests/e2e/max/main.test.bicep
+++ b/avm/res/security-insights/setting/tests/e2e/max/main.test.bicep
@@ -26,7 +26,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/security-insights/setting/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/security-insights/setting/tests/e2e/waf-aligned/dependencies.bicep
@@ -4,7 +4,7 @@ param location string = resourceGroup().location
 @description('Required. The name of the Workspace to create.')
 param name string
 
-resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-07-01' = {
   name: name
   location: location
 }
@@ -25,7 +25,7 @@ resource sentinel 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' 
 }
 
 // Onboard Sentinel after it has been created
-resource onboardingStates 'Microsoft.SecurityInsights/onboardingStates@2022-12-01-preview' = {
+resource onboardingStates 'Microsoft.SecurityInsights/onboardingStates@2025-09-01' = {
   scope: logAnalyticsWorkspace
   name: 'default'
 }

--- a/avm/res/security-insights/setting/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/security-insights/setting/tests/e2e/waf-aligned/main.test.bicep
@@ -35,7 +35,7 @@ module nestedDependencies './dependencies.bicep' = {
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }


### PR DESCRIPTION
## Description

- Removed ORPHANED.md and updated README.md as module now has an owner
- Updated resource API versions to use latest versions
- Updated all 'avm-common-types' reference to `0.7.0`

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.security-insights.setting](https://github.com/TomazMlakar/bicep-registry-modules/actions/workflows/avm.res.security-insights.setting.yml/badge.svg?branch=users%2Ftomlakar%2Fsecurity-insights-setting-ownership)](https://github.com/TomazMlakar/bicep-registry-modules/actions/workflows/avm.res.security-insights.setting.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
