### PR TITLE
fix: ReadMe Gen - Fixed incorrect section reference if non-parent module

### DIFF
--- a/avm/res/key-vault/vault/access-policy/README.md
+++ b/avm/res/key-vault/vault/access-policy/README.md
@@ -8,7 +8,7 @@ module vault 'br/public:avm/res/key-vault/vault/access-policy:<version>' = {
   params: { (...) }
 }
 ```
-For examples, please refer to the [Usage Examples](#usage-examples) section.
+For examples, please refer to the main module's _Usage Examples_ section.
 
 ## Navigation
 

--- a/avm/res/key-vault/vault/key/README.md
+++ b/avm/res/key-vault/vault/key/README.md
@@ -8,7 +8,7 @@ module vault 'br/public:avm/res/key-vault/vault/key:<version>' = {
   params: { (...) }
 }
 ```
-For examples, please refer to the [Usage Examples](#usage-examples) section.
+For examples, please refer to the main module's _Usage Examples_ section.
 
 ## Navigation
 

--- a/avm/res/key-vault/vault/secret/README.md
+++ b/avm/res/key-vault/vault/secret/README.md
@@ -8,7 +8,7 @@ module vault 'br/public:avm/res/key-vault/vault/secret:<version>' = {
   params: { (...) }
 }
 ```
-For examples, please refer to the [Usage Examples](#usage-examples) section.
+For examples, please refer to the main module's _Usage Examples_ section.
 
 ## Navigation
 

--- a/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
+++ b/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
@@ -2086,7 +2086,7 @@ function Initialize-ReadMe {
             '  params: { (...) }',
             '}',
             '```',
-            $HasUsageExamples ? 'For examples, please refer to the [Usage Examples](#usage-examples) section.' : 'For examples, please refer to the main module''s _Usage Examples_ section.'
+            ($HasUsageExamples ? 'For examples, please refer to the [Usage Examples](#usage-examples) section.' : 'For examples, please refer to the main module''s _Usage Examples_ section.')
         )
     }
 

--- a/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
+++ b/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
@@ -1983,6 +1983,9 @@ Mandatory. The template file content object to crawl data from
 .PARAMETER ForceCacheRefresh
 Optional. Define whether or not to force refresh cache data. Note, the cache automatically expires after 1 day.
 
+.PARAMETER IsParentModule
+Optional. Configures whether the module has any usages examples in its readme worth referencing
+
 .EXAMPLE
 Initialize-ReadMe -ReadMeFilePath 'C:/ResourceModules/modules/sql/managed-instances/administrators/readme.md' -FullModuleIdentifier 'sql/managed-instance/administrator' -TemplateFileContent @{ resource = @{}; ... }
 
@@ -2003,6 +2006,9 @@ function Initialize-ReadMe {
 
         [Parameter(Mandatory = $true)]
         [hashtable] $TemplateFileContent,
+
+        [Parameter(Mandatory = $true)]
+        [bool] $HasUsageExamples,
 
         [Parameter()]
         [switch] $ForceCacheRefresh
@@ -2080,7 +2086,7 @@ function Initialize-ReadMe {
             '  params: { (...) }',
             '}',
             '```',
-            'For examples, please refer to the main module''s _Usage Examples_ section.'
+            $HasUsageExamples ? 'For examples, please refer to the [Usage Examples](#usage-examples) section.' : 'For examples, please refer to the main module''s _Usage Examples_ section.'
         )
     }
 
@@ -2280,6 +2286,12 @@ function Set-ModuleReadMe {
         $notes = @()
     }
 
+    $isMultiScopeChildModule = $moduleRoot -match '[\/|\\](rg|sub|mg)\-scope$'
+    $isMultiScopeParentModule = ((Get-ChildItem -Directory -Path $moduleRoot) | Where-Object { $_.FullName -match '[\/|\\](rg|sub|mg)\-scope$' }).Count -gt 0
+
+    # If it's multi-scope child module, we need to check if its parent has tests
+    $hasTests = (Get-ChildItem -Path ($isMultiScopeChildModule ? (Split-Path $moduleRoot) : $moduleRoot) -Recurse -Filter 'main.test.bicep' -File -Force).count -gt 0
+
     # Initialize readme
     $inputObject = @{
         ReadMeFilePath       = $ReadMeFilePath
@@ -2287,6 +2299,7 @@ function Set-ModuleReadMe {
         TemplateFileContent  = $templateFileContent
         TemplateFilePath     = $TemplateFilePath
         ForceCacheRefresh    = $ForceCacheRefresh
+        HasUsageExamples     = $hasTests
     }
     $readMeFileContent = Initialize-ReadMe @inputObject
 
@@ -2303,11 +2316,6 @@ function Set-ModuleReadMe {
         $readMeFileContent = Set-ResourceTypesSection @inputObject
     }
 
-    $isMultiScopeChildModule = $moduleRoot -match '[\/|\\](rg|sub|mg)\-scope$'
-    $isMultiScopeParentModule = ((Get-ChildItem -Directory -Path $moduleRoot) | Where-Object { $_.FullName -match '[\/|\\](rg|sub|mg)\-scope$' }).Count -gt 0
-
-    # If it's multi-scope child module, we need to check if its parent has tests
-    $hasTests = (Get-ChildItem -Path ($isMultiScopeChildModule ? (Split-Path $moduleRoot) : $moduleRoot) -Recurse -Filter 'main.test.bicep' -File -Force).count -gt 0
 
     if ($SectionsToRefresh -contains 'Usage examples' -and $hasTests) {
         # Handle [Usage examples] section

--- a/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
+++ b/utilities/pipelines/sharedScripts/Set-ModuleReadMe.ps1
@@ -2080,7 +2080,7 @@ function Initialize-ReadMe {
             '  params: { (...) }',
             '}',
             '```',
-            'For examples, please refer to the [Usage Examples](#usage-examples) section.'
+            'For examples, please refer to the main module''s _Usage Examples_ section.'
         )
     }
 


### PR DESCRIPTION
## Description

Currently, all child-module readme files would reference the `# Usage Examples`  section, even though only a subset of modules (most notably parent modules, but also multi-scope modules) actual have this section.

The output is now altered accordingly.

Example of the bug:
<img width="1015" height="374" alt="image" src="https://github.com/user-attachments/assets/35083402-b494-4e06-af00-cab4352465f9" />

The changes initially visible in this PR show the state after
- Running on the authorization/role-assignment module folder with the `-recurse` flag => No change
- Running on the key-vault/vault module folder with the `-recurse` flag => Change only in child modules

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
