### PR TITLE
AVM-RES: update subscriptionRequired parameter default value to true for api management product

### DIFF
--- a/avm/res/api-management/service/product/CHANGELOG.md
+++ b/avm/res/api-management/service/product/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/api-management/service/product/CHANGELOG.md).
 
+## 0.2.3
+
+### Changes
+
+- Set default value for `subscriptionRequired` parameter to `true`
+
 ## 0.2.2
 
 ### Changes

--- a/avm/res/api-management/service/product/README.md
+++ b/avm/res/api-management/service/product/README.md
@@ -185,7 +185,7 @@ Whether a product subscription is required for accessing APIs included in this p
 
 - Required: No
 - Type: bool
-- Default: `False`
+- Default: `True`
 
 ### Parameter: `subscriptionsLimit`
 

--- a/avm/res/api-management/service/product/main.bicep
+++ b/avm/res/api-management/service/product/main.bicep
@@ -38,7 +38,7 @@ param policies productPolicyType[]?
 param state string = 'published'
 
 @sys.description('Optional. Whether a product subscription is required for accessing APIs included in this product. If true, the product is referred to as "protected" and a valid subscription key is required for a request to an API included in the product to succeed. If false, the product is referred to as "open" and requests to an API included in the product can be made without a subscription key. If property is omitted when creating a new product it\'s value is assumed to be true.')
-param subscriptionRequired bool = false
+param subscriptionRequired bool = true
 
 @sys.description('Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.')
 param subscriptionsLimit int = 1

--- a/avm/res/api-management/service/product/main.json
+++ b/avm/res/api-management/service/product/main.json
@@ -129,7 +129,7 @@
     },
     "subscriptionRequired": {
       "type": "bool",
-      "defaultValue": false,
+      "defaultValue": true,
       "metadata": {
         "description": "Optional. Whether a product subscription is required for accessing APIs included in this product. If true, the product is referred to as \"protected\" and a valid subscription key is required for a request to an API included in the product to succeed. If false, the product is referred to as \"open\" and requests to an API included in the product can be made without a subscription key. If property is omitted when creating a new product it's value is assumed to be true."
       }


### PR DESCRIPTION
## Description

Set API Management Service Products [subscriptionRequired](https://github.com/Azure/bicep-registry-modules/blob/ae9b82ddafe6a3bf29a8580854282ff048200824/avm/res/api-management/service/product/main.bicep#L41) param to default value `true` instead of `false`. As described in its description `If property is omitted when creating a new product it's value is assumed to be true.`.

Fixes #7039 


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
