### PR TITLE
fix: avm/res/cognitive-services/account - Use a valid default SKU for model deployments (#6561)

### DIFF
--- a/avm/res/cognitive-services/account/CHANGELOG.md
+++ b/avm/res/cognitive-services/account/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cognitive-services/account/CHANGELOG.md).
 
+## 0.14.3
+
+### Changes
+
+- Fixed invalid default `sku` for model deployments. The fallback previously used the account-level SKU name (e.g. `S0`), which is not a valid deployment SKU and caused `The deployment sku name 'S0' is invalid.` errors. The default is now `{ name: 'Standard', capacity: 1 }`.
+
+### Breaking Changes
+
+- None
+
 ## 0.14.2
 
 ### Changes

--- a/avm/res/cognitive-services/account/README.md
+++ b/avm/res/cognitive-services/account/README.md
@@ -8,7 +8,7 @@ module account 'br/public:avm/res/cognitive-services/account:<version>' = {
   params: { (...) }
 }
 ```
-For examples, please refer to the... [Usage Examples](#usage-examples) section.
+For examples, please refer to the [Usage Examples](#usage-examples) section.
 
 ## Navigation
 

--- a/avm/res/cognitive-services/account/README.md
+++ b/avm/res/cognitive-services/account/README.md
@@ -8,7 +8,7 @@ module account 'br/public:avm/res/cognitive-services/account:<version>' = {
   params: { (...) }
 }
 ```
-For examples, please refer to the [Usage Examples](#usage-examples) section.
+For examples, please refer to the... [Usage Examples](#usage-examples) section.
 
 ## Navigation
 

--- a/avm/res/cognitive-services/account/main.bicep
+++ b/avm/res/cognitive-services/account/main.bicep
@@ -397,11 +397,8 @@ resource cognitiveService_deployments 'Microsoft.CognitiveServices/accounts/depl
       versionUpgradeOption: deployment.?versionUpgradeOption
     }
     sku: deployment.?sku ?? {
-      name: sku
-      capacity: sku.?capacity
-      tier: sku.?tier
-      size: sku.?size
-      family: sku.?family
+      name: 'Standard'
+      capacity: 1
     }
   }
 ]

--- a/avm/res/cognitive-services/account/main.json
+++ b/avm/res/cognitive-services/account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "7076304102605375340"
+      "templateHash": "15113237100456941359"
     },
     "name": "Cognitive Services",
     "description": "This module deploys a Cognitive Service."
@@ -1451,7 +1451,7 @@
         "raiPolicyName": "[tryGet(coalesce(parameters('deployments'), createArray())[copyIndex()], 'raiPolicyName')]",
         "versionUpgradeOption": "[tryGet(coalesce(parameters('deployments'), createArray())[copyIndex()], 'versionUpgradeOption')]"
       },
-      "sku": "[coalesce(tryGet(coalesce(parameters('deployments'), createArray())[copyIndex()], 'sku'), createObject('name', parameters('sku'), 'capacity', tryGet(parameters('sku'), 'capacity'), 'tier', tryGet(parameters('sku'), 'tier'), 'size', tryGet(parameters('sku'), 'size'), 'family', tryGet(parameters('sku'), 'family')))]",
+      "sku": "[coalesce(tryGet(coalesce(parameters('deployments'), createArray())[copyIndex()], 'sku'), createObject('name', 'Standard', 'capacity', 1))]",
       "dependsOn": [
         "cognitiveService"
       ]


### PR DESCRIPTION
Closes #6561

## Description

The default `sku` for child `Microsoft.CognitiveServices/accounts/deployments` previously fell back to the account-level `sku` parameter (a `string`, e.g. `S0`), which is not a valid deployment SKU name and produced errors like:

> The deployment sku name 'S0' is invalid.

This PR sets the fallback to a valid model-deployment default and removes the dead `sku.?capacity/.tier/.size/.family` expressions (since `sku` is a `string`, those always evaluated to `null`).

## Changes

- `main.bicep`: default deployment `sku` is now `{ name: 'Standard', capacity: 1 }`.
- `main.json`: recompiled.
- `CHANGELOG.md`: added `0.14.3` entry.

## Module

- `avm/res/cognitive-services/account`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)