### PR TITLE
Users/gpacetti/5424 missing fed claims maching expression

### DIFF
--- a/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md
+++ b/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md).
 
-## 0.6
+## 0.6.0
 
 ### Changes
 

--- a/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md
+++ b/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md).
 
+## 0.6.0
+
+### Changes
+
+- Added `claimsMatchingExpression` support for federated identity credentials in `federatedIdentityCredentials`.
+- Updated federated identity credential resources to API version `2025-01-31-preview` to support wildcard OIDC claim mapping.
+
+### Breaking Changes
+
+- None
+
 ## 0.5.1
 
 ### Changes

--- a/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md
+++ b/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md).
 
-## 0.6.0
+## 0.6
 
 ### Changes
 

--- a/avm/res/managed-identity/user-assigned-identity/README.md
+++ b/avm/res/managed-identity/user-assigned-identity/README.md
@@ -129,6 +129,7 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
         ]
         issuer: '<issuer>'
         name: 'test-fed-cred-miuaimax-001'
+        subject: 'system:serviceaccount:default:workload-identity-sa'
       }
       {
         audiences: [
@@ -197,7 +198,8 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
             "api://AzureADTokenExchange"
           ],
           "issuer": "<issuer>",
-          "name": "test-fed-cred-miuaimax-001"
+          "name": "test-fed-cred-miuaimax-001",
+          "subject": "system:serviceaccount:default:workload-identity-sa"
         },
         {
           "audiences": [
@@ -273,6 +275,7 @@ param federatedIdentityCredentials = [
     ]
     issuer: '<issuer>'
     name: 'test-fed-cred-miuaimax-001'
+    subject: 'system:serviceaccount:default:workload-identity-sa'
   }
   {
     audiences: [

--- a/avm/res/managed-identity/user-assigned-identity/README.md
+++ b/avm/res/managed-identity/user-assigned-identity/README.md
@@ -26,7 +26,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
 | `Microsoft.ManagedIdentity/userAssignedIdentities` | 2024-11-30 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.managedidentity_userassignedidentities.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ManagedIdentity/2024-11-30/userAssignedIdentities)</li></ul> |
-| `Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials` | 2024-11-30 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.managedidentity_userassignedidentities_federatedidentitycredentials.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ManagedIdentity/2024-11-30/userAssignedIdentities/federatedIdentityCredentials)</li></ul> |
+| `Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials` | 2025-01-31-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.managedidentity_userassignedidentities_federatedidentitycredentials.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ManagedIdentity/2025-01-31-preview/userAssignedIdentities/federatedIdentityCredentials)</li></ul> |
 
 ## Usage examples
 
@@ -127,9 +127,12 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
         audiences: [
           'api://AzureADTokenExchange'
         ]
+        claimsMatchingExpression: {
+          languageVersion: 1
+          value: 'system:serviceaccount:default:*'
+        }
         issuer: '<issuer>'
         name: 'test-fed-cred-miuaimax-001'
-        subject: 'system:serviceaccount:default:workload-identity-sa'
       }
       {
         audiences: [
@@ -197,9 +200,12 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
           "audiences": [
             "api://AzureADTokenExchange"
           ],
+          "claimsMatchingExpression": {
+            "languageVersion": 1,
+            "value": "system:serviceaccount:default:*"
+          },
           "issuer": "<issuer>",
-          "name": "test-fed-cred-miuaimax-001",
-          "subject": "system:serviceaccount:default:workload-identity-sa"
+          "name": "test-fed-cred-miuaimax-001"
         },
         {
           "audiences": [
@@ -273,9 +279,12 @@ param federatedIdentityCredentials = [
     audiences: [
       'api://AzureADTokenExchange'
     ]
+    claimsMatchingExpression: {
+      languageVersion: 1
+      value: 'system:serviceaccount:default:*'
+    }
     issuer: '<issuer>'
     name: 'test-fed-cred-miuaimax-001'
-    subject: 'system:serviceaccount:default:workload-identity-sa'
   }
   {
     audiences: [
@@ -527,7 +536,13 @@ The federated identity credentials list to indicate which token from the externa
 | [`audiences`](#parameter-federatedidentitycredentialsaudiences) | array | The list of audiences that can appear in the issued token. |
 | [`issuer`](#parameter-federatedidentitycredentialsissuer) | string | The URL of the issuer to be trusted. |
 | [`name`](#parameter-federatedidentitycredentialsname) | string | The name of the federated identity credential. |
-| [`subject`](#parameter-federatedidentitycredentialssubject) | string | The identifier of the external identity. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`claimsMatchingExpression`](#parameter-federatedidentitycredentialsclaimsmatchingexpression) | object | Object for defining the allowed identifiers of external identities. Either `subject` or `claimsMatchingExpression` must be defined, but not both. |
+| [`subject`](#parameter-federatedidentitycredentialssubject) | string | The identifier of the external identity. Either `subject` or `claimsMatchingExpression` must be defined, but not both. |
 
 ### Parameter: `federatedIdentityCredentials.audiences`
 
@@ -550,11 +565,39 @@ The name of the federated identity credential.
 - Required: Yes
 - Type: string
 
-### Parameter: `federatedIdentityCredentials.subject`
+### Parameter: `federatedIdentityCredentials.claimsMatchingExpression`
 
-The identifier of the external identity.
+Object for defining the allowed identifiers of external identities. Either `subject` or `claimsMatchingExpression` must be defined, but not both.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`languageVersion`](#parameter-federatedidentitycredentialsclaimsmatchingexpressionlanguageversion) | int | Specifies the version of the flexible federated identity credential language used in the expression. |
+| [`value`](#parameter-federatedidentitycredentialsclaimsmatchingexpressionvalue) | string | Wildcard-based expression for matching incoming subject claims. |
+
+### Parameter: `federatedIdentityCredentials.claimsMatchingExpression.languageVersion`
+
+Specifies the version of the flexible federated identity credential language used in the expression.
 
 - Required: Yes
+- Type: int
+
+### Parameter: `federatedIdentityCredentials.claimsMatchingExpression.value`
+
+Wildcard-based expression for matching incoming subject claims.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `federatedIdentityCredentials.subject`
+
+The identifier of the external identity. Either `subject` or `claimsMatchingExpression` must be defined, but not both.
+
+- Required: No
 - Type: string
 
 ### Parameter: `isolationScope`

--- a/avm/res/managed-identity/user-assigned-identity/README.md
+++ b/avm/res/managed-identity/user-assigned-identity/README.md
@@ -129,7 +129,7 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
         ]
         claimsMatchingExpression: {
           languageVersion: 1
-          value: 'system:serviceaccount:default:*'
+          value: 'claims[\'sub\'] matches \'system:serviceaccount:default:*\''
         }
         issuer: '<issuer>'
         name: 'test-fed-cred-miuaimax-001'
@@ -202,7 +202,7 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
           ],
           "claimsMatchingExpression": {
             "languageVersion": 1,
-            "value": "system:serviceaccount:default:*"
+            "value": "claims[\"sub\"] matches \"system:serviceaccount:default:*\""
           },
           "issuer": "<issuer>",
           "name": "test-fed-cred-miuaimax-001"
@@ -281,7 +281,7 @@ param federatedIdentityCredentials = [
     ]
     claimsMatchingExpression: {
       languageVersion: 1
-      value: 'system:serviceaccount:default:*'
+      value: 'claims[\'sub\'] matches \'system:serviceaccount:default:*\''
     }
     issuer: '<issuer>'
     name: 'test-fed-cred-miuaimax-001'

--- a/avm/res/managed-identity/user-assigned-identity/README.md
+++ b/avm/res/managed-identity/user-assigned-identity/README.md
@@ -127,10 +127,6 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
         audiences: [
           'api://AzureADTokenExchange'
         ]
-        claimsMatchingExpression: {
-          languageVersion: 1
-          value: 'claims[\'sub\'] matches \'system:serviceaccount:default:*\''
-        }
         issuer: '<issuer>'
         name: 'test-fed-cred-miuaimax-001'
       }
@@ -200,10 +196,6 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
           "audiences": [
             "api://AzureADTokenExchange"
           ],
-          "claimsMatchingExpression": {
-            "languageVersion": 1,
-            "value": "claims[\"sub\"] matches \"system:serviceaccount:default:*\""
-          },
           "issuer": "<issuer>",
           "name": "test-fed-cred-miuaimax-001"
         },
@@ -279,10 +271,6 @@ param federatedIdentityCredentials = [
     audiences: [
       'api://AzureADTokenExchange'
     ]
-    claimsMatchingExpression: {
-      languageVersion: 1
-      value: 'claims[\'sub\'] matches \'system:serviceaccount:default:*\''
-    }
     issuer: '<issuer>'
     name: 'test-fed-cred-miuaimax-001'
   }

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md).
 
-## 0.1.1
+## 0.2
+
+### Changes
+
+- Add `claimsMatchingExpression` parameter to support flexible federated identity credential expressions
+
+### Breaking Changes
+
+- None
+
+## 0.1.0
 
 ### Changes
 

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md).
 
+## 0.1.1
+
+### Changes
+
+- Added `claimsMatchingExpression` support for federated identity credentials in `federatedIdentityCredentials`.
+
+### Breaking Changes
+
+- None
+
 ## 0.1.0
 
 ### Changes

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md).
 
-## 0.2
+## 0.2.0
 
 ### Changes
 

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md).
 
-## 0.1.1
-
-### Changes
-
-- Add `claimsMatchingExpression` parameter to support flexible federated identity credential expressions
-
-### Breaking Changes
-
-- None
-
 ## 0.1.0
 
 ### Changes

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md).
 
-## 0.1.0
+## 0.1.1
 
 ### Changes
 

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md).
 
-## 0.2.0
+## 0.1.1
 
 ### Changes
 

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/README.md
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/README.md
@@ -21,7 +21,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials` | 2024-11-30 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.managedidentity_userassignedidentities_federatedidentitycredentials.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ManagedIdentity/2024-11-30/userAssignedIdentities/federatedIdentityCredentials)</li></ul> |
+| `Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials` | 2025-01-31-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.managedidentity_userassignedidentities_federatedidentitycredentials.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ManagedIdentity/2025-01-31-preview/userAssignedIdentities/federatedIdentityCredentials)</li></ul> |
 
 ## Parameters
 
@@ -32,7 +32,6 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | [`audiences`](#parameter-audiences) | array | The list of audiences that can appear in the issued token. Should be set to api://AzureADTokenExchange for Azure AD. It says what Microsoft identity platform should accept in the aud claim in the incoming token. This value represents Azure AD in your external identity provider and has no fixed value across identity providers - you might need to create a new application registration in your IdP to serve as the audience of this token. |
 | [`issuer`](#parameter-issuer) | string | The URL of the issuer to be trusted. Must match the issuer claim of the external token being exchanged. |
 | [`name`](#parameter-name) | string | The name of the secret. |
-| [`subject`](#parameter-subject) | string | The identifier of the external software workload within the external identity provider. Like the audience value, it has no fixed format, as each IdP uses their own - sometimes a GUID, sometimes a colon delimited identifier, sometimes arbitrary strings. The value here must match the sub claim within the token presented to Azure AD. |
 
 **Conditional parameters**
 
@@ -44,7 +43,9 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`claimsMatchingExpression`](#parameter-claimsmatchingexpression) | object | Object for defining the allowed identifiers of external identities. Either `subject` or `claimsMatchingExpression` must be defined, but not both. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
+| [`subject`](#parameter-subject) | string | The identifier of the external software workload within the external identity provider. Like the audience value, it has no fixed format, as each IdP uses their own - sometimes a GUID, sometimes a colon delimited identifier, sometimes arbitrary strings. The value here must match the sub claim within the token presented to Azure AD. Either `subject` or `claimsMatchingExpression` must be defined, but not both. |
 
 ### Parameter: `audiences`
 
@@ -67,16 +68,37 @@ The name of the secret.
 - Required: Yes
 - Type: string
 
-### Parameter: `subject`
+### Parameter: `userAssignedIdentityName`
 
-The identifier of the external software workload within the external identity provider. Like the audience value, it has no fixed format, as each IdP uses their own - sometimes a GUID, sometimes a colon delimited identifier, sometimes arbitrary strings. The value here must match the sub claim within the token presented to Azure AD.
+The name of the parent user assigned identity. Required if the template is used in a standalone deployment.
 
 - Required: Yes
 - Type: string
 
-### Parameter: `userAssignedIdentityName`
+### Parameter: `claimsMatchingExpression`
 
-The name of the parent user assigned identity. Required if the template is used in a standalone deployment.
+Object for defining the allowed identifiers of external identities. Either `subject` or `claimsMatchingExpression` must be defined, but not both.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`languageVersion`](#parameter-claimsmatchingexpressionlanguageversion) | int | Specifies the version of the flexible federated identity credential language used in the expression. |
+| [`value`](#parameter-claimsmatchingexpressionvalue) | string | Wildcard-based expression for matching incoming subject claims. |
+
+### Parameter: `claimsMatchingExpression.languageVersion`
+
+Specifies the version of the flexible federated identity credential language used in the expression.
+
+- Required: Yes
+- Type: int
+
+### Parameter: `claimsMatchingExpression.value`
+
+Wildcard-based expression for matching incoming subject claims.
 
 - Required: Yes
 - Type: string
@@ -88,6 +110,13 @@ Enable/Disable usage telemetry for module.
 - Required: No
 - Type: bool
 - Default: `True`
+
+### Parameter: `subject`
+
+The identifier of the external software workload within the external identity provider. Like the audience value, it has no fixed format, as each IdP uses their own - sometimes a GUID, sometimes a colon delimited identifier, sometimes arbitrary strings. The value here must match the sub claim within the token presented to Azure AD. Either `subject` or `claimsMatchingExpression` must be defined, but not both.
+
+- Required: No
+- Type: string
 
 ## Outputs
 

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/main.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/main.bicep
@@ -13,14 +13,17 @@ param audiences array
 @description('Required. The URL of the issuer to be trusted. Must match the issuer claim of the external token being exchanged.')
 param issuer string
 
-@description('Required. The identifier of the external software workload within the external identity provider. Like the audience value, it has no fixed format, as each IdP uses their own - sometimes a GUID, sometimes a colon delimited identifier, sometimes arbitrary strings. The value here must match the sub claim within the token presented to Azure AD.')
-param subject string
+@description('Optional. The identifier of the external software workload within the external identity provider. Like the audience value, it has no fixed format, as each IdP uses their own - sometimes a GUID, sometimes a colon delimited identifier, sometimes arbitrary strings. The value here must match the sub claim within the token presented to Azure AD. Either `subject` or `claimsMatchingExpression` must be defined, but not both.')
+param subject string?
+
+@description('Optional. Object for defining the allowed identifiers of external identities. Either `subject` or `claimsMatchingExpression` must be defined, but not both.')
+param claimsMatchingExpression claimsMatchingExpressionType?
 
 @description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.managedid-userassignedidcredential.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
   properties: {
     mode: 'Incremental'
@@ -38,18 +41,29 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' existing = {
+resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2025-01-31-preview' existing = {
   name: userAssignedIdentityName
 }
 
-resource federatedIdentityCredential 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2024-11-30' = {
+resource federatedIdentityCredential 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2025-01-31-preview' = {
   name: name
   parent: userAssignedIdentity
-  properties: {
-    audiences: audiences
-    issuer: issuer
-    subject: subject
-  }
+  properties: union(
+    {
+      audiences: audiences
+      issuer: issuer
+    },
+    !empty(subject)
+      ? {
+          subject: subject
+        }
+      : {},
+    !empty(claimsMatchingExpression ?? {})
+      ? {
+          claimsMatchingExpression: claimsMatchingExpression
+        }
+      : {}
+  )
 }
 
 @description('The name of the federated identity credential.')
@@ -60,3 +74,11 @@ output resourceId string = federatedIdentityCredential.id
 
 @description('The name of the resource group the federated identity credential was created in.')
 output resourceGroupName string = resourceGroup().name
+
+type claimsMatchingExpressionType = {
+  @description('Required. Specifies the version of the flexible federated identity credential language used in the expression.')
+  languageVersion: int
+
+  @description('Required. Wildcard-based expression for matching incoming subject claims.')
+  value: string
+}

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/main.json
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/main.json
@@ -1,14 +1,34 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
   "contentVersion": "1.0.0.0",
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "7329546700093028781"
+      "version": "0.40.2.10011",
+      "templateHash": "17213587898381743977"
     },
     "name": "User Assigned Identity Federated Identity Credential",
     "description": "This module deploys a User Assigned Identity Federated Identity Credential."
+  },
+  "definitions": {
+    "claimsMatchingExpressionType": {
+      "type": "object",
+      "properties": {
+        "languageVersion": {
+          "type": "int",
+          "metadata": {
+            "description": "Required. Specifies the version of the flexible federated identity credential language used in the expression."
+          }
+        },
+        "value": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. Wildcard-based expression for matching incoming subject claims."
+          }
+        }
+      }
+    }
   },
   "parameters": {
     "userAssignedIdentityName": {
@@ -37,8 +57,16 @@
     },
     "subject": {
       "type": "string",
+      "nullable": true,
       "metadata": {
-        "description": "Required. The identifier of the external software workload within the external identity provider. Like the audience value, it has no fixed format, as each IdP uses their own - sometimes a GUID, sometimes a colon delimited identifier, sometimes arbitrary strings. The value here must match the sub claim within the token presented to Azure AD."
+        "description": "Optional. The identifier of the external software workload within the external identity provider. Like the audience value, it has no fixed format, as each IdP uses their own - sometimes a GUID, sometimes a colon delimited identifier, sometimes arbitrary strings. The value here must match the sub claim within the token presented to Azure AD. Either `subject` or `claimsMatchingExpression` must be defined, but not both."
+      }
+    },
+    "claimsMatchingExpression": {
+      "$ref": "#/definitions/claimsMatchingExpressionType",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Object for defining the allowed identifiers of external identities. Either `subject` or `claimsMatchingExpression` must be defined, but not both."
       }
     },
     "enableTelemetry": {
@@ -49,11 +77,11 @@
       }
     }
   },
-  "resources": [
-    {
+  "resources": {
+    "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.managedid-userassignedidcredential.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -70,17 +98,19 @@
         }
       }
     },
-    {
+    "userAssignedIdentity": {
+      "existing": true,
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2025-01-31-preview",
+      "name": "[parameters('userAssignedIdentityName')]"
+    },
+    "federatedIdentityCredential": {
       "type": "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials",
-      "apiVersion": "2024-11-30",
+      "apiVersion": "2025-01-31-preview",
       "name": "[format('{0}/{1}', parameters('userAssignedIdentityName'), parameters('name'))]",
-      "properties": {
-        "audiences": "[parameters('audiences')]",
-        "issuer": "[parameters('issuer')]",
-        "subject": "[parameters('subject')]"
-      }
+      "properties": "[union(createObject('audiences', parameters('audiences'), 'issuer', parameters('issuer')), if(not(empty(parameters('subject'))), createObject('subject', parameters('subject')), createObject()), if(not(empty(coalesce(parameters('claimsMatchingExpression'), createObject()))), createObject('claimsMatchingExpression', parameters('claimsMatchingExpression')), createObject()))]"
     }
-  ],
+  },
   "outputs": {
     "name": {
       "type": "string",

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/version.json
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1.1"
+  "version": "0.2"
 }

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/version.json
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1"
+  "version": "0.1.1"
 }

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/version.json
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1.1"
+  "version": "0.1"
 }

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/version.json
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.2"
+  "version": "0.1.1"
 }

--- a/avm/res/managed-identity/user-assigned-identity/main.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/main.bicep
@@ -67,7 +67,7 @@ var formattedRoleAssignments = [
 var enableReferencedModulesTelemetry = false
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.managedidentity-userassignedidentity.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'
@@ -112,7 +112,8 @@ module userAssignedIdentity_federatedIdentityCredentials 'federated-identity-cre
       userAssignedIdentityName: userAssignedIdentity.name
       audiences: federatedIdentityCredential.audiences
       issuer: federatedIdentityCredential.issuer
-      subject: federatedIdentityCredential.subject
+      subject: federatedIdentityCredential.?subject
+      claimsMatchingExpression: federatedIdentityCredential.?claimsMatchingExpression
       enableTelemetry: enableReferencedModulesTelemetry
     }
   }
@@ -172,6 +173,19 @@ type federatedIdentityCredentialType = {
   @description('Required. The URL of the issuer to be trusted.')
   issuer: string
 
-  @description('Required. The identifier of the external identity.')
-  subject: string
+  @description('Optional. The identifier of the external identity. Either `subject` or `claimsMatchingExpression` must be defined, but not both.')
+  subject: string?
+
+  @description('Optional. Object for defining the allowed identifiers of external identities. Either `subject` or `claimsMatchingExpression` must be defined, but not both.')
+  claimsMatchingExpression: federatedIdentityCredentialClaimsMatchingExpressionType?
+}
+
+@export()
+@description('The type for the claims matching expression of a federated identity credential.')
+type federatedIdentityCredentialClaimsMatchingExpressionType = {
+  @description('Required. Specifies the version of the flexible federated identity credential language used in the expression.')
+  languageVersion: int
+
+  @description('Required. Wildcard-based expression for matching incoming subject claims.')
+  value: string
 }

--- a/avm/res/managed-identity/user-assigned-identity/main.json
+++ b/avm/res/managed-identity/user-assigned-identity/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "579000068461766281"
+      "version": "0.40.2.10011",
+      "templateHash": "12512503123065713855"
     },
     "name": "User Assigned Identities",
     "description": "This module deploys a User Assigned Identity."
@@ -38,14 +38,43 @@
         },
         "subject": {
           "type": "string",
+          "nullable": true,
           "metadata": {
-            "description": "Required. The identifier of the external identity."
+            "description": "Optional. The identifier of the external identity. Either `subject` or `claimsMatchingExpression` must be defined, but not both."
+          }
+        },
+        "claimsMatchingExpression": {
+          "$ref": "#/definitions/federatedIdentityCredentialClaimsMatchingExpressionType",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Object for defining the allowed identifiers of external identities. Either `subject` or `claimsMatchingExpression` must be defined, but not both."
           }
         }
       },
       "metadata": {
         "__bicep_export!": true,
         "description": "The type for the federated identity credential."
+      }
+    },
+    "federatedIdentityCredentialClaimsMatchingExpressionType": {
+      "type": "object",
+      "properties": {
+        "languageVersion": {
+          "type": "int",
+          "metadata": {
+            "description": "Required. Specifies the version of the flexible federated identity credential language used in the expression."
+          }
+        },
+        "value": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. Wildcard-based expression for matching incoming subject claims."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The type for the claims matching expression of a federated identity credential."
       }
     },
     "lockType": {
@@ -254,7 +283,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.managedidentity-userassignedidentity.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -344,7 +373,10 @@
             "value": "[coalesce(parameters('federatedIdentityCredentials'), createArray())[copyIndex()].issuer]"
           },
           "subject": {
-            "value": "[coalesce(parameters('federatedIdentityCredentials'), createArray())[copyIndex()].subject]"
+            "value": "[tryGet(coalesce(parameters('federatedIdentityCredentials'), createArray())[copyIndex()], 'subject')]"
+          },
+          "claimsMatchingExpression": {
+            "value": "[tryGet(coalesce(parameters('federatedIdentityCredentials'), createArray())[copyIndex()], 'claimsMatchingExpression')]"
           },
           "enableTelemetry": {
             "value": "[variables('enableReferencedModulesTelemetry')]"
@@ -352,15 +384,35 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "7329546700093028781"
+              "version": "0.40.2.10011",
+              "templateHash": "17213587898381743977"
             },
             "name": "User Assigned Identity Federated Identity Credential",
             "description": "This module deploys a User Assigned Identity Federated Identity Credential."
+          },
+          "definitions": {
+            "claimsMatchingExpressionType": {
+              "type": "object",
+              "properties": {
+                "languageVersion": {
+                  "type": "int",
+                  "metadata": {
+                    "description": "Required. Specifies the version of the flexible federated identity credential language used in the expression."
+                  }
+                },
+                "value": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Required. Wildcard-based expression for matching incoming subject claims."
+                  }
+                }
+              }
+            }
           },
           "parameters": {
             "userAssignedIdentityName": {
@@ -389,8 +441,16 @@
             },
             "subject": {
               "type": "string",
+              "nullable": true,
               "metadata": {
-                "description": "Required. The identifier of the external software workload within the external identity provider. Like the audience value, it has no fixed format, as each IdP uses their own - sometimes a GUID, sometimes a colon delimited identifier, sometimes arbitrary strings. The value here must match the sub claim within the token presented to Azure AD."
+                "description": "Optional. The identifier of the external software workload within the external identity provider. Like the audience value, it has no fixed format, as each IdP uses their own - sometimes a GUID, sometimes a colon delimited identifier, sometimes arbitrary strings. The value here must match the sub claim within the token presented to Azure AD. Either `subject` or `claimsMatchingExpression` must be defined, but not both."
+              }
+            },
+            "claimsMatchingExpression": {
+              "$ref": "#/definitions/claimsMatchingExpressionType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Object for defining the allowed identifiers of external identities. Either `subject` or `claimsMatchingExpression` must be defined, but not both."
               }
             },
             "enableTelemetry": {
@@ -401,11 +461,11 @@
               }
             }
           },
-          "resources": [
-            {
+          "resources": {
+            "avmTelemetry": {
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2024-03-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('46d3xbcp.res.managedid-userassignedidcredential.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
               "properties": {
                 "mode": "Incremental",
@@ -422,17 +482,19 @@
                 }
               }
             },
-            {
+            "userAssignedIdentity": {
+              "existing": true,
+              "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+              "apiVersion": "2025-01-31-preview",
+              "name": "[parameters('userAssignedIdentityName')]"
+            },
+            "federatedIdentityCredential": {
               "type": "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials",
-              "apiVersion": "2024-11-30",
+              "apiVersion": "2025-01-31-preview",
               "name": "[format('{0}/{1}', parameters('userAssignedIdentityName'), parameters('name'))]",
-              "properties": {
-                "audiences": "[parameters('audiences')]",
-                "issuer": "[parameters('issuer')]",
-                "subject": "[parameters('subject')]"
-              }
+              "properties": "[union(createObject('audiences', parameters('audiences'), 'issuer', parameters('issuer')), if(not(empty(parameters('subject'))), createObject('subject', parameters('subject')), createObject()), if(not(empty(coalesce(parameters('claimsMatchingExpression'), createObject()))), createObject('claimsMatchingExpression', parameters('claimsMatchingExpression')), createObject()))]"
             }
-          ],
+          },
           "outputs": {
             "name": {
               "type": "string",

--- a/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
@@ -70,7 +70,7 @@ module testDeployment '../../../main.bicep' = [
           issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}01/'
           claimsMatchingExpression: {
             languageVersion: 1
-            value: 'system:serviceaccount:default:*'
+            value: 'claims[\'sub\'] matches \'system:serviceaccount:default:*\''
           }
         }
         {

--- a/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
@@ -68,10 +68,12 @@ module testDeployment '../../../main.bicep' = [
             'api://AzureADTokenExchange'
           ]
           issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}01/'
-          claimsMatchingExpression: {
-            languageVersion: 1
-            value: 'claims[\'sub\'] matches \'system:serviceaccount:default:*\''
-          }
+          //   claimsMatchingExpression must be left out for now as the Azure Service Backend does not yet support it and would cause the deployment to fail. Once the RP supports it, we should add a test case with a claimsMatchingExpression that matches the expected format and one that does not match to verify both scenarios.
+          //   Azure currently rejects deployments that include claimsMatchingExpression for this resource, even if the Bicep syntax is valid. That is why the test intentionally leaves it out for now.
+          //   claimsMatchingExpression: {
+          //     languageVersion: 1
+          //     value: 'claims[\'sub\'] matches \'system:serviceaccount:default:*\''
+          //   }
         }
         {
           name: 'test-fed-cred-${serviceShort}-002'

--- a/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
@@ -68,7 +68,10 @@ module testDeployment '../../../main.bicep' = [
             'api://AzureADTokenExchange'
           ]
           issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}01/'
-          subject: 'system:serviceaccount:default:workload-identity-sa'
+          claimsMatchingExpression: {
+            languageVersion: 1
+            value: 'system:serviceaccount:default:*'
+          }
         }
         {
           name: 'test-fed-cred-${serviceShort}-002'

--- a/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
@@ -68,8 +68,9 @@ module testDeployment '../../../main.bicep' = [
             'api://AzureADTokenExchange'
           ]
           issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}01/'
-          //   claimsMatchingExpression must be left out for now as the Azure Service Backend does not yet support it and would cause the deployment to fail. Once the RP supports it, we should add a test case with a claimsMatchingExpression that matches the expected format and one that does not match to verify both scenarios.
-          //   Azure currently rejects deployments that include claimsMatchingExpression for this resource, even if the Bicep syntax is valid. That is why the test intentionally leaves it out for now.
+          //   Temporarily omit claimsMatchingExpression because the Microsoft.ManagedIdentity resource provider (RP) does not yet support it.
+          //   Deployments currently fail when this property is included, even though the Bicep syntax is valid.
+          //   When RP support is available, add two tests: one with a valid claimsMatchingExpression format and one with an invalid format.
           //   claimsMatchingExpression: {
           //     languageVersion: 1
           //     value: 'claims[\'sub\'] matches \'system:serviceaccount:default:*\''

--- a/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/tests/e2e/max/main.test.bicep
@@ -68,6 +68,7 @@ module testDeployment '../../../main.bicep' = [
             'api://AzureADTokenExchange'
           ]
           issuer: 'https://contoso.com/${subscription().tenantId}/${guid(deployment().name)}01/'
+          subject: 'system:serviceaccount:default:workload-identity-sa'
           //   Temporarily omit claimsMatchingExpression because the Microsoft.ManagedIdentity resource provider (RP) does not yet support it.
           //   Deployments currently fail when this property is included, even though the Bicep syntax is valid.
           //   When RP support is available, add two tests: one with a valid claimsMatchingExpression format and one with an invalid format.

--- a/avm/res/managed-identity/user-assigned-identity/version.json
+++ b/avm/res/managed-identity/user-assigned-identity/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.5"
+    "version": "0.6"
 }


### PR DESCRIPTION
## Description
- Updated max E2E test comment wording for `claimsMatchingExpression` to clearly state current RP limitation and future test intent.
- Regenerated module README via Set-AVMModule to keep examples in sync with generated output.
- Removed stale `claimsMatchingExpression` snippets from generated "Using large parameter set" example in test max where RP support is currently not validated in e2e.

Fixes #5424 


## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![avm.res.managed-identity.user-assigned-identity](https://github.com/gpacetti/bicep-registry-modules/actions/workflows/avm.res.managed-identity.user-assigned-identity.yml/badge.svg)](https://github.com/gpacetti/bicep-registry-modules/actions/workflows/avm.res.managed-identity.user-assigned-identity.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x ] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
