### PR TITLE
feat: Publish all child modules of `avm/res/storage/storage-account`

### DIFF
--- a/avm/res/storage/storage-account/CHANGELOG.md
+++ b/avm/res/storage/storage-account/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/storage/storage-account/CHANGELOG.md).
 
+## 0.32.1
+
+### Changes
+
+- Enabling child module `avm/res/storage/storage-account/blob-service` for publishing
+- Enabling child module `avm/res/storage/storage-account/file-service` for publishing
+- Enabling child module `avm/res/storage/storage-account/queue-service` for publishing
+- Enabling child module `avm/res/storage/storage-account/table-service` for publishing
+- Enabling child module `avm/res/storage/storage-account/object-replication-policy` for publishing
+- Enabling child module `avm/res/storage/storage-account/object-replication-policy/policy` for publishing
+
+### Breaking Changes
+
+- None
+
 ## 0.32.0
 
 ### Changes

--- a/avm/res/storage/storage-account/blob-service/CHANGELOG.md
+++ b/avm/res/storage/storage-account/blob-service/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/storage/storage-account/blob-service/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/storage/storage-account/blob-service/README.md
+++ b/avm/res/storage/storage-account/blob-service/README.md
@@ -2,12 +2,21 @@
 
 This module deploys a Storage Account Blob Service.
 
+You can reference the module as follows:
+```bicep
+module storageAccount 'br/public:avm/res/storage/storage-account/blob-service:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
 - [Cross-referenced modules](#Cross-referenced-modules)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -44,6 +53,7 @@ This module deploys a Storage Account Blob Service.
 | [`deleteRetentionPolicyDays`](#parameter-deleteretentionpolicydays) | int | Indicates the number of days that the deleted blob should be retained. |
 | [`deleteRetentionPolicyEnabled`](#parameter-deleteretentionpolicyenabled) | bool | The blob service properties for blob soft delete. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`isVersioningEnabled`](#parameter-isversioningenabled) | bool | Use versioning to automatically maintain previous versions of your blobs. Cannot be enabled for ADLS Gen2 storage accounts. |
 | [`lastAccessTimeTrackingPolicyEnabled`](#parameter-lastaccesstimetrackingpolicyenabled) | bool | The blob service property to configure last access time based tracking policy. When set to true last access time based tracking is enabled. |
 | [`restorePolicyDays`](#parameter-restorepolicydays) | int | How long this blob can be restored. It should be less than DeleteRetentionPolicy days. |
@@ -576,6 +586,14 @@ Resource ID of the diagnostic log analytics workspace. For security reasons, it 
 - Required: No
 - Type: string
 
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
+
 ### Parameter: `isVersioningEnabled`
 
 Use versioning to automatically maintain previous versions of your blobs. Cannot be enabled for ADLS Gen2 storage accounts.
@@ -624,3 +642,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 | Reference | Type |
 | :-- | :-- |
 | `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/storage/storage-account/blob-service/main.bicep
+++ b/avm/res/storage/storage-account/blob-service/main.bicep
@@ -64,6 +64,28 @@ import { diagnosticSettingFullType } from 'br/public:avm/utl/types/avm-common-ty
 @description('Optional. The diagnostic settings of the service.')
 param diagnosticSettings diagnosticSettingFullType[]?
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.storage-storageaccount-blobservice.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
+
 #disable-next-line no-unused-vars
 var immutabilityValidation = storageAccount.properties.isHnsEnabled == true && isVersioningEnabled
   ? fail('Configuration error: Versioning for blobs cannot be enabled when hierarchical namespace is enabled.')

--- a/avm/res/storage/storage-account/blob-service/main.json
+++ b/avm/res/storage/storage-account/blob-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "468225492069709453"
+      "version": "0.43.8.12551",
+      "templateHash": "1418342778992064276"
     },
     "name": "Storage Account blob Services",
     "description": "This module deploys a Storage Account Blob Service."
@@ -533,6 +533,13 @@
       "metadata": {
         "description": "Optional. The diagnostic settings of the service."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "variables": {
@@ -540,6 +547,26 @@
     "name": "default"
   },
   "resources": {
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.storage-storageaccount-blobservice.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     "storageAccount": {
       "existing": true,
       "type": "Microsoft.Storage/storageAccounts",
@@ -675,8 +702,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "273904034769611992"
+              "version": "0.43.8.12551",
+              "templateHash": "13892898510769883323"
             },
             "name": "Storage Account Blob Containers",
             "description": "This module deploys a Storage Account Blob Container."
@@ -1021,8 +1048,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "15304742179563677019"
+                      "version": "0.43.8.12551",
+                      "templateHash": "1575348769987282949"
                     },
                     "name": "Storage Account Blob Container Immutability Policies",
                     "description": "This module deploys a Storage Account Blob Container Immutability Policy."

--- a/avm/res/storage/storage-account/blob-service/version.json
+++ b/avm/res/storage/storage-account/blob-service/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "0.1"
+}

--- a/avm/res/storage/storage-account/file-service/CHANGELOG.md
+++ b/avm/res/storage/storage-account/file-service/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/storage/storage-account/file-service/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/storage/storage-account/file-service/README.md
+++ b/avm/res/storage/storage-account/file-service/README.md
@@ -2,12 +2,21 @@
 
 This module deploys a Storage Account File Share Service.
 
+You can reference the module as follows:
+```bicep
+module storageAccount 'br/public:avm/res/storage/storage-account/file-service:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
 - [Cross-referenced modules](#Cross-referenced-modules)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -32,6 +41,7 @@ This module deploys a Storage Account File Share Service.
 | :-- | :-- | :-- |
 | [`corsRules`](#parameter-corsrules) | array | The List of CORS rules. You can include up to five CorsRule elements in the request. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`name`](#parameter-name) | string | The name of the file service. |
 | [`protocolSettings`](#parameter-protocolsettings) | object | Protocol settings for file service. |
 | [`shareDeleteRetentionPolicy`](#parameter-sharedeleteretentionpolicy) | object | The service properties for soft delete. |
@@ -256,6 +266,14 @@ Resource ID of the diagnostic log analytics workspace. For security reasons, it 
 
 - Required: No
 - Type: string
+
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
 
 ### Parameter: `name`
 
@@ -500,3 +518,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 | :-- | :-- |
 | `br/public:avm/utl/types/avm-common-types:0.6.0` | Remote reference |
 | `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/storage/storage-account/file-service/main.bicep
+++ b/avm/res/storage/storage-account/file-service/main.bicep
@@ -27,6 +27,28 @@ param diagnosticSettings diagnosticSettingFullType[]?
 @description('Optional. File shares to create.')
 param shares fileShareType[]?
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.storage-storageaccount-fileservice.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
+
 var enableReferencedModulesTelemetry = false
 
 // default share accessTier depends on the Storage Account kind: 'Premium' for 'FileStorage' kind (unless V2 where accessTier is not supported so null is supplied), 'TransactionOptimized' otherwise

--- a/avm/res/storage/storage-account/file-service/main.json
+++ b/avm/res/storage/storage-account/file-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "17583198711200998285"
+      "version": "0.43.8.12551",
+      "templateHash": "12258320472418066996"
     },
     "name": "Storage Account File Share Services",
     "description": "This module deploys a Storage Account File Share Service."
@@ -421,12 +421,39 @@
       "metadata": {
         "description": "Optional. File shares to create."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "variables": {
     "enableReferencedModulesTelemetry": false
   },
   "resources": {
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.storage-storageaccount-fileservice.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     "storageAccount": {
       "existing": true,
       "type": "Microsoft.Storage/storageAccounts",
@@ -539,8 +566,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "10353179772982843397"
+              "version": "0.43.8.12551",
+              "templateHash": "11171285871703640979"
             },
             "name": "Storage Account File Shares",
             "description": "This module deploys a Storage Account File Share."

--- a/avm/res/storage/storage-account/file-service/version.json
+++ b/avm/res/storage/storage-account/file-service/version.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+    "version": "0.1"
+}

--- a/avm/res/storage/storage-account/main.bicep
+++ b/avm/res/storage/storage-account/main.bicep
@@ -655,6 +655,7 @@ module storageAccount_blobServices 'blob-service/main.bicep' = if (!empty(blobSe
   name: '${uniqueString(deployment().name, location)}-Storage-BlobServices'
   params: {
     storageAccountName: storageAccount.name
+    enableTelemetry: enableReferencedModulesTelemetry
     containers: blobServices.?containers
     automaticSnapshotPolicyEnabled: blobServices.?automaticSnapshotPolicyEnabled
     changeFeedEnabled: blobServices.?changeFeedEnabled
@@ -680,6 +681,7 @@ module storageAccount_fileServices 'file-service/main.bicep' = if (!empty(fileSe
   name: '${uniqueString(deployment().name, location)}-Storage-FileServices'
   params: {
     storageAccountName: storageAccount.name
+    enableTelemetry: enableReferencedModulesTelemetry
     diagnosticSettings: fileServices.?diagnosticSettings
     protocolSettings: fileServices.?protocolSettings
     shareDeleteRetentionPolicy: fileServices.?shareDeleteRetentionPolicy
@@ -693,6 +695,7 @@ module storageAccount_queueServices 'queue-service/main.bicep' = if (!empty(queu
   name: '${uniqueString(deployment().name, location)}-Storage-QueueServices'
   params: {
     storageAccountName: storageAccount.name
+    enableTelemetry: enableReferencedModulesTelemetry
     diagnosticSettings: queueServices.?diagnosticSettings
     queues: queueServices.?queues
     corsRules: queueServices.?corsRules
@@ -704,6 +707,7 @@ module storageAccount_tableServices 'table-service/main.bicep' = if (!empty(tabl
   name: '${uniqueString(deployment().name, location)}-Storage-TableServices'
   params: {
     storageAccountName: storageAccount.name
+    enableTelemetry: enableReferencedModulesTelemetry
     diagnosticSettings: tableServices.?diagnosticSettings
     tables: tableServices.?tables
     corsRules: tableServices.?corsRules
@@ -761,6 +765,7 @@ module storageAccount_objectReplicationPolicies 'object-replication-policy/main.
     name: '${uniqueString(deployment().name, location)}-Storage-ObjRepPolicy-${index}'
     params: {
       storageAccountName: storageAccount.name
+      enableTelemetry: enableReferencedModulesTelemetry
       destinationAccountResourceId: policy.destinationStorageAccountResourceId
       enableMetrics: policy.?enableMetrics ?? false
       rules: policy.?rules

--- a/avm/res/storage/storage-account/main.json
+++ b/avm/res/storage/storage-account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "545234552347756391"
+      "version": "0.43.8.12551",
+      "templateHash": "2298729188278058082"
     },
     "name": "Storage Accounts",
     "description": "This module deploys a Storage Account."
@@ -3173,8 +3173,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "4000605059554016072"
+              "version": "0.43.8.12551",
+              "templateHash": "17869772322174816849"
             },
             "name": "Storage Account Management Policies",
             "description": "This module deploys a Storage Account Management Policy."
@@ -3315,8 +3315,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "1801226901235196767"
+              "version": "0.43.8.12551",
+              "templateHash": "7543331724257456291"
             },
             "name": "Storage Account Local Users",
             "description": "This module deploys a Storage Account Local User, which is used for SFTP authentication."
@@ -3521,6 +3521,9 @@
           "storageAccountName": {
             "value": "[parameters('name')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "containers": {
             "value": "[tryGet(parameters('blobServices'), 'containers')]"
           },
@@ -3580,8 +3583,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "468225492069709453"
+              "version": "0.43.8.12551",
+              "templateHash": "1418342778992064276"
             },
             "name": "Storage Account blob Services",
             "description": "This module deploys a Storage Account Blob Service."
@@ -4108,6 +4111,13 @@
               "metadata": {
                 "description": "Optional. The diagnostic settings of the service."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "variables": {
@@ -4115,6 +4125,26 @@
             "name": "default"
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.storage-storageaccount-blobservice.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "storageAccount": {
               "existing": true,
               "type": "Microsoft.Storage/storageAccounts",
@@ -4250,8 +4280,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "273904034769611992"
+                      "version": "0.43.8.12551",
+                      "templateHash": "13892898510769883323"
                     },
                     "name": "Storage Account Blob Containers",
                     "description": "This module deploys a Storage Account Blob Container."
@@ -4596,8 +4626,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.41.2.15936",
-                              "templateHash": "15304742179563677019"
+                              "version": "0.43.8.12551",
+                              "templateHash": "1575348769987282949"
                             },
                             "name": "Storage Account Blob Container Immutability Policies",
                             "description": "This module deploys a Storage Account Blob Container Immutability Policy."
@@ -4780,6 +4810,9 @@
           "storageAccountName": {
             "value": "[parameters('name')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "diagnosticSettings": {
             "value": "[tryGet(parameters('fileServices'), 'diagnosticSettings')]"
           },
@@ -4803,8 +4836,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "17583198711200998285"
+              "version": "0.43.8.12551",
+              "templateHash": "12258320472418066996"
             },
             "name": "Storage Account File Share Services",
             "description": "This module deploys a Storage Account File Share Service."
@@ -5219,12 +5252,39 @@
               "metadata": {
                 "description": "Optional. File shares to create."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "variables": {
             "enableReferencedModulesTelemetry": false
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.storage-storageaccount-fileservice.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "storageAccount": {
               "existing": true,
               "type": "Microsoft.Storage/storageAccounts",
@@ -5337,8 +5397,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "10353179772982843397"
+                      "version": "0.43.8.12551",
+                      "templateHash": "11171285871703640979"
                     },
                     "name": "Storage Account File Shares",
                     "description": "This module deploys a Storage Account File Share."
@@ -5805,6 +5865,9 @@
           "storageAccountName": {
             "value": "[parameters('name')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "diagnosticSettings": {
             "value": "[tryGet(parameters('queueServices'), 'diagnosticSettings')]"
           },
@@ -5822,8 +5885,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "9644461291744477521"
+              "version": "0.43.8.12551",
+              "templateHash": "9845945724695568246"
             },
             "name": "Storage Account Queue Services",
             "description": "This module deploys a Storage Account Queue Service."
@@ -6159,6 +6222,13 @@
               "metadata": {
                 "description": "Optional. The diagnostic settings of the service."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "variables": {
@@ -6166,6 +6236,26 @@
             "enableReferencedModulesTelemetry": false
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.storage-storageaccount-queueservice.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "storageAccount": {
               "existing": true,
               "type": "Microsoft.Storage/storageAccounts",
@@ -6258,8 +6348,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "12812824360066955039"
+                      "version": "0.43.8.12551",
+                      "templateHash": "9034200385522529102"
                     },
                     "name": "Storage Account Queues",
                     "description": "This module deploys a Storage Account Queue."
@@ -6541,6 +6631,9 @@
           "storageAccountName": {
             "value": "[parameters('name')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "diagnosticSettings": {
             "value": "[tryGet(parameters('tableServices'), 'diagnosticSettings')]"
           },
@@ -6558,8 +6651,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "10320403358700650147"
+              "version": "0.43.8.12551",
+              "templateHash": "5595119576231882588"
             },
             "name": "Storage Account Table Services",
             "description": "This module deploys a Storage Account Table Service."
@@ -6885,6 +6978,13 @@
               "metadata": {
                 "description": "Optional. The diagnostic settings of the service."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "variables": {
@@ -6892,6 +6992,26 @@
             "enableReferencedModulesTelemetry": false
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.storage-storageaccount-tableservice.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "storageAccount": {
               "existing": true,
               "type": "Microsoft.Storage/storageAccounts",
@@ -6981,8 +7101,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "11362260974696477885"
+                      "version": "0.43.8.12551",
+                      "templateHash": "2665764378010529822"
                     },
                     "name": "Storage Account Table",
                     "description": "This module deploys a Storage Account Table."
@@ -7262,8 +7382,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "13227497656004178962"
+              "version": "0.43.8.12551",
+              "templateHash": "16161247111847907410"
             }
           },
           "definitions": {
@@ -7399,6 +7519,9 @@
           "storageAccountName": {
             "value": "[parameters('name')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "destinationAccountResourceId": {
             "value": "[coalesce(parameters('objectReplicationPolicies'), createArray())[copyIndex()].destinationStorageAccountResourceId]"
           },
@@ -7416,8 +7539,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "1894366578172550759"
+              "version": "0.43.8.12551",
+              "templateHash": "3655544249543700974"
             },
             "name": "Storage Account Object Replication Policy",
             "description": "This module deploys a Storage Account Object Replication Policy for both the source account and destination account."
@@ -7517,15 +7640,43 @@
               "metadata": {
                 "description": "Required. Rules for the object replication policy."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "variables": {
+            "enableReferencedModulesTelemetry": false,
             "destAccountResourceIdParts": "[split(parameters('destinationAccountResourceId'), '/')]",
             "destAccountName": "[if(not(empty(variables('destAccountResourceIdParts'))), last(variables('destAccountResourceIdParts')), parameters('destinationAccountResourceId'))]",
             "destAccountSubscription": "[if(greater(length(variables('destAccountResourceIdParts')), 2), variables('destAccountResourceIdParts')[2], subscription().subscriptionId)]",
             "destAccountResourceGroupName": "[if(greater(length(variables('destAccountResourceIdParts')), 4), variables('destAccountResourceIdParts')[4], resourceGroup().name)]"
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.storage-storacct-objectreplpolicy.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "storageAccount": {
               "existing": true,
               "type": "Microsoft.Storage/storageAccounts",
@@ -7559,6 +7710,9 @@
                   "enableMetrics": {
                     "value": "[parameters('enableMetrics')]"
                   },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  },
                   "rules": {
                     "value": "[parameters('rules')]"
                   }
@@ -7570,8 +7724,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "14995722372031126283"
+                      "version": "0.43.8.12551",
+                      "templateHash": "7022142554546647566"
                     },
                     "name": "Storage Account Object Replication Policy",
                     "description": "This module deploys a Storage Account Object Replication Policy for a provided storage account."
@@ -7674,9 +7828,36 @@
                       "metadata": {
                         "description": "Required. Rules for the object replication policy."
                       }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
                     }
                   },
                   "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.storage-storacct-objectreplpolicypol.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
                     "storageAccount": {
                       "existing": true,
                       "type": "Microsoft.Storage/storageAccounts",
@@ -7770,6 +7951,9 @@
                   "enableMetrics": {
                     "value": "[parameters('enableMetrics')]"
                   },
+                  "enableTelemetry": {
+                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                  },
                   "rules": {
                     "copy": [
                       {
@@ -7787,8 +7971,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "14995722372031126283"
+                      "version": "0.43.8.12551",
+                      "templateHash": "7022142554546647566"
                     },
                     "name": "Storage Account Object Replication Policy",
                     "description": "This module deploys a Storage Account Object Replication Policy for a provided storage account."
@@ -7891,9 +8075,36 @@
                       "metadata": {
                         "description": "Required. Rules for the object replication policy."
                       }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
                     }
                   },
                   "resources": {
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.storage-storacct-objectreplpolicypol.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
                     "storageAccount": {
                       "existing": true,
                       "type": "Microsoft.Storage/storageAccounts",

--- a/avm/res/storage/storage-account/object-replication-policy/CHANGELOG.md
+++ b/avm/res/storage/storage-account/object-replication-policy/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/storage/storage-account/object-replication-policy/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/storage/storage-account/object-replication-policy/README.md
+++ b/avm/res/storage/storage-account/object-replication-policy/README.md
@@ -2,11 +2,20 @@
 
 This module deploys a Storage Account Object Replication Policy for both the source account and destination account.
 
+You can reference the module as follows:
+```bicep
+module storageAccount 'br/public:avm/res/storage/storage-account/object-replication-policy:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -29,6 +38,7 @@ This module deploys a Storage Account Object Replication Policy for both the sou
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`enableMetrics`](#parameter-enablemetrics) | bool | Whether metrics are enabled for the object replication policy. |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`name`](#parameter-name) | string | Name of the policy. |
 
 ### Parameter: `destinationAccountResourceId`
@@ -122,6 +132,14 @@ Whether metrics are enabled for the object replication policy.
 - Required: No
 - Type: bool
 
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
+
 ### Parameter: `name`
 
 Name of the policy.
@@ -136,3 +154,7 @@ Name of the policy.
 | `objectReplicationPolicyId` | string | Resource ID of the created Object Replication Policy in the source account. |
 | `policyId` | string | Policy ID of the created Object Replication Policy in the source account. |
 | `resourceGroupName` | string | Resource group name of the provisioned resources. |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/storage/storage-account/object-replication-policy/main.bicep
+++ b/avm/res/storage/storage-account/object-replication-policy/main.bicep
@@ -18,6 +18,30 @@ import { objectReplicationPolicyRuleType } from 'policy/main.bicep'
 @description('Required. Rules for the object replication policy.')
 param rules objectReplicationPolicyRuleType[]
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.storage-storacct-objectreplpolicy.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
+
+var enableReferencedModulesTelemetry = false
+
 resource storageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' existing = {
   name: storageAccountName
 }
@@ -43,6 +67,7 @@ module destinationPolicy 'policy/main.bicep' = {
     sourceStorageAccountResourceId: storageAccount.id
     destinationAccountResourceId: destinationAccountResourceId
     enableMetrics: enableMetrics
+    enableTelemetry: enableReferencedModulesTelemetry
     rules: rules
   }
 }
@@ -58,6 +83,7 @@ module sourcePolicy 'policy/main.bicep' = {
     sourceStorageAccountResourceId: storageAccount.id
     destinationAccountResourceId: destinationAccountResourceId
     enableMetrics: enableMetrics
+    enableTelemetry: enableReferencedModulesTelemetry
     rules: [
       for (rule, i) in rules: union(rule, {
         ruleId: destinationPolicy.outputs.rules[i].ruleId

--- a/avm/res/storage/storage-account/object-replication-policy/main.json
+++ b/avm/res/storage/storage-account/object-replication-policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "1894366578172550759"
+      "version": "0.43.8.12551",
+      "templateHash": "3655544249543700974"
     },
     "name": "Storage Account Object Replication Policy",
     "description": "This module deploys a Storage Account Object Replication Policy for both the source account and destination account."
@@ -106,15 +106,43 @@
       "metadata": {
         "description": "Required. Rules for the object replication policy."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "variables": {
+    "enableReferencedModulesTelemetry": false,
     "destAccountResourceIdParts": "[split(parameters('destinationAccountResourceId'), '/')]",
     "destAccountName": "[if(not(empty(variables('destAccountResourceIdParts'))), last(variables('destAccountResourceIdParts')), parameters('destinationAccountResourceId'))]",
     "destAccountSubscription": "[if(greater(length(variables('destAccountResourceIdParts')), 2), variables('destAccountResourceIdParts')[2], subscription().subscriptionId)]",
     "destAccountResourceGroupName": "[if(greater(length(variables('destAccountResourceIdParts')), 4), variables('destAccountResourceIdParts')[4], resourceGroup().name)]"
   },
   "resources": {
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.storage-storacct-objectreplpolicy.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     "storageAccount": {
       "existing": true,
       "type": "Microsoft.Storage/storageAccounts",
@@ -148,6 +176,9 @@
           "enableMetrics": {
             "value": "[parameters('enableMetrics')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "rules": {
             "value": "[parameters('rules')]"
           }
@@ -159,8 +190,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "14995722372031126283"
+              "version": "0.43.8.12551",
+              "templateHash": "7022142554546647566"
             },
             "name": "Storage Account Object Replication Policy",
             "description": "This module deploys a Storage Account Object Replication Policy for a provided storage account."
@@ -263,9 +294,36 @@
               "metadata": {
                 "description": "Required. Rules for the object replication policy."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.storage-storacct-objectreplpolicypol.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "storageAccount": {
               "existing": true,
               "type": "Microsoft.Storage/storageAccounts",
@@ -359,6 +417,9 @@
           "enableMetrics": {
             "value": "[parameters('enableMetrics')]"
           },
+          "enableTelemetry": {
+            "value": "[variables('enableReferencedModulesTelemetry')]"
+          },
           "rules": {
             "copy": [
               {
@@ -376,8 +437,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "14995722372031126283"
+              "version": "0.43.8.12551",
+              "templateHash": "7022142554546647566"
             },
             "name": "Storage Account Object Replication Policy",
             "description": "This module deploys a Storage Account Object Replication Policy for a provided storage account."
@@ -480,9 +541,36 @@
               "metadata": {
                 "description": "Required. Rules for the object replication policy."
               }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
             }
           },
           "resources": {
+            "avmTelemetry": {
+              "condition": "[parameters('enableTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[format('46d3xbcp.res.storage-storacct-objectreplpolicypol.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": [],
+                  "outputs": {
+                    "telemetry": {
+                      "type": "String",
+                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                    }
+                  }
+                }
+              }
+            },
             "storageAccount": {
               "existing": true,
               "type": "Microsoft.Storage/storageAccounts",

--- a/avm/res/storage/storage-account/object-replication-policy/policy/CHANGELOG.md
+++ b/avm/res/storage/storage-account/object-replication-policy/policy/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/storage/storage-account/object-replication-policy/policy/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/storage/storage-account/object-replication-policy/policy/README.md
+++ b/avm/res/storage/storage-account/object-replication-policy/policy/README.md
@@ -2,11 +2,20 @@
 
 This module deploys a Storage Account Object Replication Policy for a provided storage account.
 
+You can reference the module as follows:
+```bicep
+module storageAccount 'br/public:avm/res/storage/storage-account/object-replication-policy/policy:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -31,6 +40,7 @@ This module deploys a Storage Account Object Replication Policy for a provided s
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`enableMetrics`](#parameter-enablemetrics) | bool | Whether metrics are enabled for the object replication policy. |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 
 ### Parameter: `destinationAccountResourceId`
 
@@ -137,6 +147,14 @@ Whether metrics are enabled for the object replication policy.
 - Required: No
 - Type: bool
 
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
+
 ## Outputs
 
 | Output | Type | Description |
@@ -145,3 +163,7 @@ Whether metrics are enabled for the object replication policy.
 | `policyId` | string | Policy ID of the created Object Replication Policy. |
 | `resourceGroupName` | string | Resource group name of the provisioned resources. |
 | `rules` | array | Rules created Object Replication Policy. |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/storage/storage-account/object-replication-policy/policy/main.bicep
+++ b/avm/res/storage/storage-account/object-replication-policy/policy/main.bicep
@@ -20,6 +20,28 @@ param enableMetrics bool?
 @description('Required. Rules for the object replication policy.')
 param rules objectReplicationPolicyRuleType[]
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.storage-storacct-objectreplpolicypol.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
+
 resource storageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' existing = {
   name: storageAccountName
 }

--- a/avm/res/storage/storage-account/object-replication-policy/policy/main.json
+++ b/avm/res/storage/storage-account/object-replication-policy/policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "14995722372031126283"
+      "version": "0.43.8.12551",
+      "templateHash": "7022142554546647566"
     },
     "name": "Storage Account Object Replication Policy",
     "description": "This module deploys a Storage Account Object Replication Policy for a provided storage account."
@@ -109,9 +109,36 @@
       "metadata": {
         "description": "Required. Rules for the object replication policy."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "resources": {
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.storage-storacct-objectreplpolicypol.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     "storageAccount": {
       "existing": true,
       "type": "Microsoft.Storage/storageAccounts",

--- a/avm/res/storage/storage-account/object-replication-policy/policy/version.json
+++ b/avm/res/storage/storage-account/object-replication-policy/policy/version.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+    "version": "0.1"
+}

--- a/avm/res/storage/storage-account/object-replication-policy/version.json
+++ b/avm/res/storage/storage-account/object-replication-policy/version.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+    "version": "0.1"
+}

--- a/avm/res/storage/storage-account/queue-service/CHANGELOG.md
+++ b/avm/res/storage/storage-account/queue-service/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/storage/storage-account/queue-service/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/storage/storage-account/queue-service/README.md
+++ b/avm/res/storage/storage-account/queue-service/README.md
@@ -2,12 +2,21 @@
 
 This module deploys a Storage Account Queue Service.
 
+You can reference the module as follows:
+```bicep
+module storageAccount 'br/public:avm/res/storage/storage-account/queue-service:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
 - [Cross-referenced modules](#Cross-referenced-modules)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -32,6 +41,7 @@ This module deploys a Storage Account Queue Service.
 | :-- | :-- | :-- |
 | [`corsRules`](#parameter-corsrules) | array | The List of CORS rules. You can include up to five CorsRule elements in the request. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`queues`](#parameter-queues) | array | Queues to create. |
 
 ### Parameter: `storageAccountName`
@@ -254,6 +264,14 @@ Resource ID of the diagnostic log analytics workspace. For security reasons, it 
 - Required: No
 - Type: string
 
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
+
 ### Parameter: `queues`
 
 Queues to create.
@@ -401,3 +419,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 | Reference | Type |
 | :-- | :-- |
 | `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/storage/storage-account/queue-service/main.bicep
+++ b/avm/res/storage/storage-account/queue-service/main.bicep
@@ -15,6 +15,28 @@ import { diagnosticSettingFullType } from 'br/public:avm/utl/types/avm-common-ty
 @description('Optional. The diagnostic settings of the service.')
 param diagnosticSettings diagnosticSettingFullType[]?
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.storage-storageaccount-queueservice.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
+
 // The name of the queue services
 var name = 'default'
 

--- a/avm/res/storage/storage-account/queue-service/main.json
+++ b/avm/res/storage/storage-account/queue-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "9644461291744477521"
+      "version": "0.43.8.12551",
+      "templateHash": "9845945724695568246"
     },
     "name": "Storage Account Queue Services",
     "description": "This module deploys a Storage Account Queue Service."
@@ -342,6 +342,13 @@
       "metadata": {
         "description": "Optional. The diagnostic settings of the service."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "variables": {
@@ -349,6 +356,26 @@
     "enableReferencedModulesTelemetry": false
   },
   "resources": {
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.storage-storageaccount-queueservice.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     "storageAccount": {
       "existing": true,
       "type": "Microsoft.Storage/storageAccounts",
@@ -441,8 +468,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "12812824360066955039"
+              "version": "0.43.8.12551",
+              "templateHash": "9034200385522529102"
             },
             "name": "Storage Account Queues",
             "description": "This module deploys a Storage Account Queue."

--- a/avm/res/storage/storage-account/queue-service/version.json
+++ b/avm/res/storage/storage-account/queue-service/version.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+    "version": "0.1"
+}

--- a/avm/res/storage/storage-account/table-service/CHANGELOG.md
+++ b/avm/res/storage/storage-account/table-service/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/storage/storage-account/table-service/CHANGELOG.md).
+
+## 0.1.0
+
+### Changes
+
+- Initial version
+
+### Breaking Changes
+
+- None

--- a/avm/res/storage/storage-account/table-service/README.md
+++ b/avm/res/storage/storage-account/table-service/README.md
@@ -2,12 +2,21 @@
 
 This module deploys a Storage Account Table Service.
 
+You can reference the module as follows:
+```bicep
+module storageAccount 'br/public:avm/res/storage/storage-account/table-service:<version>' = {
+  params: { (...) }
+}
+```
+For examples, please refer to the [Usage Examples](#usage-examples) section.
+
 ## Navigation
 
 - [Resource Types](#Resource-Types)
 - [Parameters](#Parameters)
 - [Outputs](#Outputs)
 - [Cross-referenced modules](#Cross-referenced-modules)
+- [Data Collection](#Data-Collection)
 
 ## Resource Types
 
@@ -32,6 +41,7 @@ This module deploys a Storage Account Table Service.
 | :-- | :-- | :-- |
 | [`corsRules`](#parameter-corsrules) | array | The List of CORS rules. You can include up to five CorsRule elements in the request. |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
+| [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`tables`](#parameter-tables) | array | Tables to create. |
 
 ### Parameter: `storageAccountName`
@@ -254,6 +264,14 @@ Resource ID of the diagnostic log analytics workspace. For security reasons, it 
 - Required: No
 - Type: string
 
+### Parameter: `enableTelemetry`
+
+Enable/Disable usage telemetry for module.
+
+- Required: No
+- Type: bool
+- Default: `True`
+
 ### Parameter: `tables`
 
 Tables to create.
@@ -392,3 +410,7 @@ This section gives you an overview of all local-referenced module files (i.e., o
 | Reference | Type |
 | :-- | :-- |
 | `br/public:avm/utl/types/avm-common-types:0.6.1` | Remote reference |
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the [repository](https://aka.ms/avm/telemetry). There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/avm/res/storage/storage-account/table-service/main.bicep
+++ b/avm/res/storage/storage-account/table-service/main.bicep
@@ -15,6 +15,28 @@ import { diagnosticSettingFullType } from 'br/public:avm/utl/types/avm-common-ty
 @description('Optional. The diagnostic settings of the service.')
 param diagnosticSettings diagnosticSettingFullType[]?
 
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
+#disable-next-line no-deployments-resources
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.storage-storageaccount-tableservice.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
+        }
+      }
+    }
+  }
+}
+
 // The name of the table service
 var name = 'default'
 

--- a/avm/res/storage/storage-account/table-service/main.json
+++ b/avm/res/storage/storage-account/table-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "10320403358700650147"
+      "version": "0.43.8.12551",
+      "templateHash": "5595119576231882588"
     },
     "name": "Storage Account Table Services",
     "description": "This module deploys a Storage Account Table Service."
@@ -332,6 +332,13 @@
       "metadata": {
         "description": "Optional. The diagnostic settings of the service."
       }
+    },
+    "enableTelemetry": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Optional. Enable/Disable usage telemetry for module."
+      }
     }
   },
   "variables": {
@@ -339,6 +346,26 @@
     "enableReferencedModulesTelemetry": false
   },
   "resources": {
+    "avmTelemetry": {
+      "condition": "[parameters('enableTelemetry')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('46d3xbcp.res.storage-storageaccount-tableservice.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [],
+          "outputs": {
+            "telemetry": {
+              "type": "String",
+              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+            }
+          }
+        }
+      }
+    },
     "storageAccount": {
       "existing": true,
       "type": "Microsoft.Storage/storageAccounts",
@@ -428,8 +455,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "11362260974696477885"
+              "version": "0.43.8.12551",
+              "templateHash": "2665764378010529822"
             },
             "name": "Storage Account Table",
             "description": "This module deploys a Storage Account Table."

--- a/avm/res/storage/storage-account/table-service/version.json
+++ b/avm/res/storage/storage-account/table-service/version.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+    "version": "0.1"
+}


### PR DESCRIPTION
## Description

Enable child module publishing for all unpublished child modules of `avm/res/storage/storage-account`:

- `avm/res/storage/storage-account/blob-service`
- `avm/res/storage/storage-account/file-service`
- `avm/res/storage/storage-account/queue-service`
- `avm/res/storage/storage-account/table-service`
- `avm/res/storage/storage-account/object-replication-policy`
- `avm/res/storage/storage-account/object-replication-policy/policy`

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.storage.storage-account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml/badge.svg?branch=users%2Fkrbar%2Fcmp-storage)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.storage.storage-account.yml) |

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version
