### PR TITLE
fix: `avm/res/sql/server` handle versionless CMK autorotation URIs

### DIFF
--- a/avm/res/sql/server/CHANGELOG.md
+++ b/avm/res/sql/server/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/sql/server/CHANGELOG.md).
 
+## 0.21.3
+
+### Changes
+
+- Fixed server-level customer-managed key autorotation when using a versionless Key Vault key URI
+- Added regression coverage for CMK autorotation without an explicit server key version
+
+### Breaking Changes
+
+- None
+
 ## 0.21.2
 
 ### Changes

--- a/avm/res/sql/server/README.md
+++ b/avm/res/sql/server/README.md
@@ -480,7 +480,6 @@ module server 'br/public:avm/res/sql/server:<version>' = {
       autoRotationEnabled: true
       keyName: '<keyName>'
       keyVaultResourceId: '<keyVaultResourceId>'
-      keyVersion: '<keyVersion>'
     }
     databases: [
       {
@@ -546,8 +545,7 @@ module server 'br/public:avm/res/sql/server:<version>' = {
       "value": {
         "autoRotationEnabled": true,
         "keyName": "<keyName>",
-        "keyVaultResourceId": "<keyVaultResourceId>",
-        "keyVersion": "<keyVersion>"
+        "keyVaultResourceId": "<keyVaultResourceId>"
       }
     },
     "databases": {
@@ -614,7 +612,6 @@ param customerManagedKey = {
   autoRotationEnabled: true
   keyName: '<keyName>'
   keyVaultResourceId: '<keyVaultResourceId>'
-  keyVersion: '<keyVersion>'
 }
 param databases = [
   {

--- a/avm/res/sql/server/auditing-setting/main.json
+++ b/avm/res/sql/server/auditing-setting/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "12956701023461852729"
+      "version": "0.43.8.12551",
+      "templateHash": "9772376778203892337"
     },
     "name": "Azure SQL Server Audit Settings",
     "description": "This module deploys an Azure SQL Server Audit Settings."
@@ -148,8 +148,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "9669967762325474323"
+              "version": "0.43.8.12551",
+              "templateHash": "6781985198792456674"
             }
           },
           "parameters": {

--- a/avm/res/sql/server/database/CHANGELOG.md
+++ b/avm/res/sql/server/database/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/sql/server/database/CHANGELOG.md).
 
+## 0.2.2
+
+### Changes
+
+- Recompiled `main.json` with the latest Bicep version
+
+### Breaking Changes
+
+- None
+
 ## 0.2.1
 
 ### Changes

--- a/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
+++ b/avm/res/sql/server/database/backup-long-term-retention-policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "1616593108309626717"
+      "version": "0.43.8.12551",
+      "templateHash": "12661346280845172269"
     },
     "name": "SQL Server Database Long Term Backup Retention Policies",
     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."

--- a/avm/res/sql/server/database/backup-short-term-retention-policy/main.json
+++ b/avm/res/sql/server/database/backup-short-term-retention-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "14420215760569758925"
+      "version": "0.43.8.12551",
+      "templateHash": "3924283624527887363"
     },
     "name": "Azure SQL Server Database Short Term Backup Retention Policies",
     "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."

--- a/avm/res/sql/server/database/main.json
+++ b/avm/res/sql/server/database/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "16781958177725786003"
+      "version": "0.43.8.12551",
+      "templateHash": "11770000580914899387"
     },
     "name": "SQL Server Database",
     "description": "This module deploys an Azure SQL Server Database."
@@ -878,8 +878,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "14420215760569758925"
+              "version": "0.43.8.12551",
+              "templateHash": "3924283624527887363"
             },
             "name": "Azure SQL Server Database Short Term Backup Retention Policies",
             "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."
@@ -989,8 +989,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "1616593108309626717"
+              "version": "0.43.8.12551",
+              "templateHash": "12661346280845172269"
             },
             "name": "SQL Server Database Long Term Backup Retention Policies",
             "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."

--- a/avm/res/sql/server/elastic-pool/main.json
+++ b/avm/res/sql/server/elastic-pool/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "13020123827134295575"
+      "version": "0.43.8.12551",
+      "templateHash": "12826141547644661350"
     },
     "name": "SQL Server Elastic Pool",
     "description": "This module deploys an Azure SQL Server Elastic Pool."

--- a/avm/res/sql/server/encryption-protector/main.json
+++ b/avm/res/sql/server/encryption-protector/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "17898664712532064313"
+      "version": "0.43.8.12551",
+      "templateHash": "3226695724730285151"
     },
     "name": "Azure SQL Server Encryption Protector",
     "description": "This module deploys an Azure SQL Server Encryption Protector."

--- a/avm/res/sql/server/failover-group/main.json
+++ b/avm/res/sql/server/failover-group/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "14403989670372227788"
+      "version": "0.43.8.12551",
+      "templateHash": "14309622795813551436"
     },
     "name": "Azure SQL Server failover group",
     "description": "This module deploys Azure SQL Server failover group."

--- a/avm/res/sql/server/firewall-rule/main.json
+++ b/avm/res/sql/server/firewall-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "6826609288742338637"
+      "version": "0.43.8.12551",
+      "templateHash": "2602071436491506764"
     },
     "name": "Azure SQL Server Firewall Rule",
     "description": "This module deploys an Azure SQL Server Firewall Rule."

--- a/avm/res/sql/server/key/README.md
+++ b/avm/res/sql/server/key/README.md
@@ -26,9 +26,9 @@ This module deploys an Azure SQL Server Key.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`name`](#parameter-name) | string | The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern. |
+| [`name`](#parameter-name) | string | The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern. Required when using a versionless Key Vault key URI. |
 | [`serverKeyType`](#parameter-serverkeytype) | string | The server key type. |
-| [`uri`](#parameter-uri) | string | The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI is required to be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion'. |
+| [`uri`](#parameter-uri) | string | The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI must be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion' or 'https://YourVaultName.azure.net/keys/YourKeyName'. |
 
 ### Parameter: `serverName`
 
@@ -39,7 +39,7 @@ The name of the parent SQL server. Required if the template is used in a standal
 
 ### Parameter: `name`
 
-The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern.
+The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern. Required when using a versionless Key Vault key URI.
 
 - Required: No
 - Type: string
@@ -61,7 +61,7 @@ The server key type.
 
 ### Parameter: `uri`
 
-The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI is required to be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion'.
+The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI must be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion' or 'https://YourVaultName.azure.net/keys/YourKeyName'.
 
 - Required: No
 - Type: string

--- a/avm/res/sql/server/key/main.bicep
+++ b/avm/res/sql/server/key/main.bicep
@@ -1,7 +1,7 @@
 metadata name = 'Azure SQL Server Keys'
 metadata description = 'This module deploys an Azure SQL Server Key.'
 
-@description('Optional. The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern.')
+@description('Optional. The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern. Required when using a versionless Key Vault key URI.')
 param name string?
 
 @description('Conditional. The name of the parent SQL server. Required if the template is used in a standalone deployment.')
@@ -14,23 +14,28 @@ param serverName string
 ])
 param serverKeyType string = 'ServiceManaged'
 
-@description('Optional. The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI is required to be in this format: \'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion\'.')
+@description('Optional. The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI must be in this format: \'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion\' or \'https://YourVaultName.azure.net/keys/YourKeyName\'.')
 param uri string = ''
 
 var splittedKeyUri = split(uri, '/')
+var keyVersion = splittedKeyUri[?5]
 
 // if serverManaged, use serverManaged, if uri provided use concated uri value
 // MUST match the pattern '<keyVaultName>_<keyName>_<keyVersion>'
-var serverKeyName = empty(uri)
-  ? 'ServiceManaged'
-  : '${split(splittedKeyUri[2], '.')[0]}_${splittedKeyUri[4]}_${splittedKeyUri[5]}'
+var serverKeyName = !empty(name)
+  ? name!
+  : empty(uri)
+      ? 'ServiceManaged'
+      : !empty(keyVersion)
+          ? '${split(splittedKeyUri[2], '.')[0]}_${splittedKeyUri[4]}_${keyVersion!}'
+          : fail('The `name` parameter is required when using a versionless Key Vault key URI.')
 
 resource server 'Microsoft.Sql/servers@2023-08-01' existing = {
   name: serverName
 }
 
 resource key 'Microsoft.Sql/servers/keys@2023-08-01' = {
-  name: name ?? serverKeyName
+  name: serverKeyName
   parent: server
   properties: {
     serverKeyType: serverKeyType

--- a/avm/res/sql/server/key/main.json
+++ b/avm/res/sql/server/key/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "14370289665777691397"
+      "version": "0.43.8.12551",
+      "templateHash": "15519885883438160721"
     },
     "name": "Azure SQL Server Keys",
     "description": "This module deploys an Azure SQL Server Key."
@@ -16,7 +16,7 @@
       "type": "string",
       "nullable": true,
       "metadata": {
-        "description": "Optional. The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern."
+        "description": "Optional. The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern. Required when using a versionless Key Vault key URI."
       }
     },
     "serverName": {
@@ -40,13 +40,14 @@
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Optional. The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI is required to be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion'."
+        "description": "Optional. The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI must be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion' or 'https://YourVaultName.azure.net/keys/YourKeyName'."
       }
     }
   },
   "variables": {
     "splittedKeyUri": "[split(parameters('uri'), '/')]",
-    "serverKeyName": "[if(empty(parameters('uri')), 'ServiceManaged', format('{0}_{1}_{2}', split(variables('splittedKeyUri')[2], '.')[0], variables('splittedKeyUri')[4], variables('splittedKeyUri')[5]))]"
+    "keyVersion": "[tryGet(variables('splittedKeyUri'), 5)]",
+    "serverKeyName": "[if(not(empty(parameters('name'))), parameters('name'), if(empty(parameters('uri')), 'ServiceManaged', if(not(empty(variables('keyVersion'))), format('{0}_{1}_{2}', split(variables('splittedKeyUri')[2], '.')[0], variables('splittedKeyUri')[4], variables('keyVersion')), fail('The `name` parameter is required when using a versionless Key Vault key URI.'))))]"
   },
   "resources": {
     "server": {
@@ -58,7 +59,7 @@
     "key": {
       "type": "Microsoft.Sql/servers/keys",
       "apiVersion": "2023-08-01",
-      "name": "[format('{0}/{1}', parameters('serverName'), coalesce(parameters('name'), variables('serverKeyName')))]",
+      "name": "[format('{0}/{1}', parameters('serverName'), variables('serverKeyName'))]",
       "properties": {
         "serverKeyType": "[parameters('serverKeyType')]",
         "uri": "[parameters('uri')]"
@@ -71,14 +72,14 @@
       "metadata": {
         "description": "The name of the deployed server key."
       },
-      "value": "[coalesce(parameters('name'), variables('serverKeyName'))]"
+      "value": "[variables('serverKeyName')]"
     },
     "resourceId": {
       "type": "string",
       "metadata": {
         "description": "The resource ID of the deployed server key."
       },
-      "value": "[resourceId('Microsoft.Sql/servers/keys', parameters('serverName'), coalesce(parameters('name'), variables('serverKeyName')))]"
+      "value": "[resourceId('Microsoft.Sql/servers/keys', parameters('serverName'), variables('serverKeyName'))]"
     },
     "resourceGroupName": {
       "type": "string",

--- a/avm/res/sql/server/main.json
+++ b/avm/res/sql/server/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "15452000279358180556"
+      "version": "0.43.8.12551",
+      "templateHash": "7426080542562149606"
     },
     "name": "Azure SQL Servers",
     "description": "This module deploys an Azure SQL Server."
@@ -2480,8 +2480,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "16781958177725786003"
+              "version": "0.43.8.12551",
+              "templateHash": "11770000580914899387"
             },
             "name": "SQL Server Database",
             "description": "This module deploys an Azure SQL Server Database."
@@ -3353,8 +3353,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "14420215760569758925"
+                      "version": "0.43.8.12551",
+                      "templateHash": "3924283624527887363"
                     },
                     "name": "Azure SQL Server Database Short Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Short-Term Backup Retention Policy."
@@ -3464,8 +3464,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "1616593108309626717"
+                      "version": "0.43.8.12551",
+                      "templateHash": "12661346280845172269"
                     },
                     "name": "SQL Server Database Long Term Backup Retention Policies",
                     "description": "This module deploys an Azure SQL Server Database Long-Term Backup Retention Policy."
@@ -3674,8 +3674,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "13020123827134295575"
+              "version": "0.43.8.12551",
+              "templateHash": "12826141547644661350"
             },
             "name": "SQL Server Elastic Pool",
             "description": "This module deploys an Azure SQL Server Elastic Pool."
@@ -4854,8 +4854,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "6826609288742338637"
+              "version": "0.43.8.12551",
+              "templateHash": "2602071436491506764"
             },
             "name": "Azure SQL Server Firewall Rule",
             "description": "This module deploys an Azure SQL Server Firewall Rule."
@@ -4961,8 +4961,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "11378553975041019859"
+              "version": "0.43.8.12551",
+              "templateHash": "12690262809526446016"
             },
             "name": "Azure SQL Server Virtual Network Rules",
             "description": "This module deploys an Azure SQL Server Virtual Network Rule."
@@ -5083,8 +5083,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "17925146373535954470"
+              "version": "0.43.8.12551",
+              "templateHash": "15738852699687322632"
             },
             "name": "Azure SQL Server Security Alert Policies",
             "description": "This module deploys an Azure SQL Server Security Alert Policy."
@@ -5258,8 +5258,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "271996853569266956"
+              "version": "0.43.8.12551",
+              "templateHash": "16329360340386949169"
             },
             "name": "Azure SQL Server Vulnerability Assessments",
             "description": "This module deploys an Azure SQL Server Vulnerability Assessment."
@@ -5386,8 +5386,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "17102686291937449378"
+                      "version": "0.43.8.12551",
+                      "templateHash": "12780761655518868811"
                     }
                   },
                   "parameters": {
@@ -5482,8 +5482,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "14370289665777691397"
+              "version": "0.43.8.12551",
+              "templateHash": "15519885883438160721"
             },
             "name": "Azure SQL Server Keys",
             "description": "This module deploys an Azure SQL Server Key."
@@ -5493,7 +5493,7 @@
               "type": "string",
               "nullable": true,
               "metadata": {
-                "description": "Optional. The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern."
+                "description": "Optional. The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern. Required when using a versionless Key Vault key URI."
               }
             },
             "serverName": {
@@ -5517,13 +5517,14 @@
               "type": "string",
               "defaultValue": "",
               "metadata": {
-                "description": "Optional. The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI is required to be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion'."
+                "description": "Optional. The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI must be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion' or 'https://YourVaultName.azure.net/keys/YourKeyName'."
               }
             }
           },
           "variables": {
             "splittedKeyUri": "[split(parameters('uri'), '/')]",
-            "serverKeyName": "[if(empty(parameters('uri')), 'ServiceManaged', format('{0}_{1}_{2}', split(variables('splittedKeyUri')[2], '.')[0], variables('splittedKeyUri')[4], variables('splittedKeyUri')[5]))]"
+            "keyVersion": "[tryGet(variables('splittedKeyUri'), 5)]",
+            "serverKeyName": "[if(not(empty(parameters('name'))), parameters('name'), if(empty(parameters('uri')), 'ServiceManaged', if(not(empty(variables('keyVersion'))), format('{0}_{1}_{2}', split(variables('splittedKeyUri')[2], '.')[0], variables('splittedKeyUri')[4], variables('keyVersion')), fail('The `name` parameter is required when using a versionless Key Vault key URI.'))))]"
           },
           "resources": {
             "server": {
@@ -5535,7 +5536,7 @@
             "key": {
               "type": "Microsoft.Sql/servers/keys",
               "apiVersion": "2023-08-01",
-              "name": "[format('{0}/{1}', parameters('serverName'), coalesce(parameters('name'), variables('serverKeyName')))]",
+              "name": "[format('{0}/{1}', parameters('serverName'), variables('serverKeyName'))]",
               "properties": {
                 "serverKeyType": "[parameters('serverKeyType')]",
                 "uri": "[parameters('uri')]"
@@ -5548,14 +5549,14 @@
               "metadata": {
                 "description": "The name of the deployed server key."
               },
-              "value": "[coalesce(parameters('name'), variables('serverKeyName'))]"
+              "value": "[variables('serverKeyName')]"
             },
             "resourceId": {
               "type": "string",
               "metadata": {
                 "description": "The resource ID of the deployed server key."
               },
-              "value": "[resourceId('Microsoft.Sql/servers/keys', parameters('serverName'), coalesce(parameters('name'), variables('serverKeyName')))]"
+              "value": "[resourceId('Microsoft.Sql/servers/keys', parameters('serverName'), variables('serverKeyName'))]"
             },
             "resourceGroupName": {
               "type": "string",
@@ -5600,8 +5601,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "14370289665777691397"
+              "version": "0.43.8.12551",
+              "templateHash": "15519885883438160721"
             },
             "name": "Azure SQL Server Keys",
             "description": "This module deploys an Azure SQL Server Key."
@@ -5611,7 +5612,7 @@
               "type": "string",
               "nullable": true,
               "metadata": {
-                "description": "Optional. The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern."
+                "description": "Optional. The name of the key. Must follow the [<keyVaultName>_<keyName>_<keyVersion>] pattern. Required when using a versionless Key Vault key URI."
               }
             },
             "serverName": {
@@ -5635,13 +5636,14 @@
               "type": "string",
               "defaultValue": "",
               "metadata": {
-                "description": "Optional. The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI is required to be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion'."
+                "description": "Optional. The URI of the server key. If the ServerKeyType is AzureKeyVault, then the URI is required. The AKV URI must be in this format: 'https://YourVaultName.azure.net/keys/YourKeyName/YourKeyVersion' or 'https://YourVaultName.azure.net/keys/YourKeyName'."
               }
             }
           },
           "variables": {
             "splittedKeyUri": "[split(parameters('uri'), '/')]",
-            "serverKeyName": "[if(empty(parameters('uri')), 'ServiceManaged', format('{0}_{1}_{2}', split(variables('splittedKeyUri')[2], '.')[0], variables('splittedKeyUri')[4], variables('splittedKeyUri')[5]))]"
+            "keyVersion": "[tryGet(variables('splittedKeyUri'), 5)]",
+            "serverKeyName": "[if(not(empty(parameters('name'))), parameters('name'), if(empty(parameters('uri')), 'ServiceManaged', if(not(empty(variables('keyVersion'))), format('{0}_{1}_{2}', split(variables('splittedKeyUri')[2], '.')[0], variables('splittedKeyUri')[4], variables('keyVersion')), fail('The `name` parameter is required when using a versionless Key Vault key URI.'))))]"
           },
           "resources": {
             "server": {
@@ -5653,7 +5655,7 @@
             "key": {
               "type": "Microsoft.Sql/servers/keys",
               "apiVersion": "2023-08-01",
-              "name": "[format('{0}/{1}', parameters('serverName'), coalesce(parameters('name'), variables('serverKeyName')))]",
+              "name": "[format('{0}/{1}', parameters('serverName'), variables('serverKeyName'))]",
               "properties": {
                 "serverKeyType": "[parameters('serverKeyType')]",
                 "uri": "[parameters('uri')]"
@@ -5666,14 +5668,14 @@
               "metadata": {
                 "description": "The name of the deployed server key."
               },
-              "value": "[coalesce(parameters('name'), variables('serverKeyName'))]"
+              "value": "[variables('serverKeyName')]"
             },
             "resourceId": {
               "type": "string",
               "metadata": {
                 "description": "The resource ID of the deployed server key."
               },
-              "value": "[resourceId('Microsoft.Sql/servers/keys', parameters('serverName'), coalesce(parameters('name'), variables('serverKeyName')))]"
+              "value": "[resourceId('Microsoft.Sql/servers/keys', parameters('serverName'), variables('serverKeyName'))]"
             },
             "resourceGroupName": {
               "type": "string",
@@ -5720,8 +5722,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "17898664712532064313"
+              "version": "0.43.8.12551",
+              "templateHash": "3226695724730285151"
             },
             "name": "Azure SQL Server Encryption Protector",
             "description": "This module deploys an Azure SQL Server Encryption Protector."
@@ -5852,8 +5854,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "12956701023461852729"
+              "version": "0.43.8.12551",
+              "templateHash": "9772376778203892337"
             },
             "name": "Azure SQL Server Audit Settings",
             "description": "This module deploys an Azure SQL Server Audit Settings."
@@ -5995,8 +5997,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "9669967762325474323"
+                      "version": "0.43.8.12551",
+                      "templateHash": "6781985198792456674"
                     }
                   },
                   "parameters": {
@@ -6083,8 +6085,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "13696935636826567929"
+              "version": "0.43.8.12551",
+              "templateHash": "3852390215310069788"
             }
           },
           "definitions": {
@@ -6249,8 +6251,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "14403989670372227788"
+              "version": "0.43.8.12551",
+              "templateHash": "14309622795813551436"
             },
             "name": "Azure SQL Server failover group",
             "description": "This module deploys Azure SQL Server failover group."

--- a/avm/res/sql/server/security-alert-policy/main.json
+++ b/avm/res/sql/server/security-alert-policy/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "17925146373535954470"
+      "version": "0.43.8.12551",
+      "templateHash": "15738852699687322632"
     },
     "name": "Azure SQL Server Security Alert Policies",
     "description": "This module deploys an Azure SQL Server Security Alert Policy."

--- a/avm/res/sql/server/tests/e2e/cmk-uami/main.test.bicep
+++ b/avm/res/sql/server/tests/e2e/cmk-uami/main.test.bicep
@@ -73,7 +73,6 @@ module testDeployment '../../../main.bicep' = [
       customerManagedKey: {
         keyVaultResourceId: nestedDependencies.outputs.keyVaultResourceId
         keyName: nestedDependencies.outputs.keyVaultKeyName
-        keyVersion: last(split(nestedDependencies.outputs.keyVaultEncryptionKeyUrl, '/'))
         autoRotationEnabled: true
       }
       databases: [

--- a/avm/res/sql/server/virtual-network-rule/main.json
+++ b/avm/res/sql/server/virtual-network-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "11378553975041019859"
+      "version": "0.43.8.12551",
+      "templateHash": "12690262809526446016"
     },
     "name": "Azure SQL Server Virtual Network Rules",
     "description": "This module deploys an Azure SQL Server Virtual Network Rule."

--- a/avm/res/sql/server/vulnerability-assessment/main.json
+++ b/avm/res/sql/server/vulnerability-assessment/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "271996853569266956"
+      "version": "0.43.8.12551",
+      "templateHash": "16329360340386949169"
     },
     "name": "Azure SQL Server Vulnerability Assessments",
     "description": "This module deploys an Azure SQL Server Vulnerability Assessment."
@@ -133,8 +133,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "17102686291937449378"
+              "version": "0.43.8.12551",
+              "templateHash": "12780761655518868811"
             }
           },
           "parameters": {


### PR DESCRIPTION
## Description

This PR fixes a regression where server-level CMK deployments with `autoRotationEnabled: true` and no explicit `keyVersion` could fail for software-backed Key Vault keys. The child key module was still deriving the server key name from a `versionless` URI instead of honoring the explicit name passed from the parent module.

This change updates the key module to support that `autorotation` path correctly and adds regression coverage for the scenario.

Fixes #7073

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |

Due to MCAPS policy enforcement, my pipelines are failing when the test creates an SQL audit setting backed by a storage - which is the default, so basically with a few exceptions, all other tests are failing in my MCAPS subscription - any idea how to avoid that would be appreciated.

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
