### PR TITLE
fix(avm/res/cognitive-services/account): rebuild main.json with Bicep CLI 0.43.8 (follow-up to #7117)

### DIFF
--- a/avm/res/cognitive-services/account/main.json
+++ b/avm/res/cognitive-services/account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "7076304102605375340"
+      "version": "0.43.8.12551",
+      "templateHash": "14321132540300128401"
     },
     "name": "Cognitive Services",
     "description": "This module deploys a Cognitive Service."
@@ -333,6 +333,80 @@
       "metadata": {
         "__bicep_export!": true,
         "description": "Type for network configuration in AI Foundry where virtual network injection occurs to secure scenarios like Agents entirely within a private network."
+      }
+    },
+    "networkAclsType": {
+      "type": "object",
+      "properties": {
+        "bypass": {
+          "type": "string",
+          "allowedValues": [
+            "AzureServices",
+            "None"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Setting for trusted services. Use 'AzureServices' to allow trusted Microsoft services to bypass the firewall."
+          }
+        },
+        "defaultAction": {
+          "type": "string",
+          "allowedValues": [
+            "Allow",
+            "Deny"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The default action when no rule from ipRules and from virtualNetworkRules match. This is only used after the bypass property has been evaluated."
+          }
+        },
+        "ipRules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string",
+                "metadata": {
+                  "description": "Required. An IPv4 address range in CIDR notation, such as '124.56.78.91' (simple IP address) or '124.56.78.0/24' (all addresses that start with 124.56.78)."
+                }
+              }
+            }
+          },
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The list of IP address rules."
+          }
+        },
+        "virtualNetworkRules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "metadata": {
+                  "description": "Required. Full resource id of a vnet subnet, such as '/subscriptions/subid/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'."
+                }
+              },
+              "ignoreMissingVnetServiceEndpoint": {
+                "type": "bool",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Ignore missing vnet service endpoint or not."
+                }
+              }
+            }
+          },
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The list of virtual network rules."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "Type for the network rule set (firewall) governing the accessibility of the Cognitive Services account from specific network locations."
       }
     },
     "_1.secretSetOutputType": {
@@ -1148,7 +1222,7 @@
       }
     },
     "networkAcls": {
-      "type": "object",
+      "$ref": "#/definitions/networkAclsType",
       "nullable": true,
       "metadata": {
         "description": "Optional. A collection of rules governing the accessibility from specific network locations."
@@ -1417,7 +1491,7 @@
       "properties": {
         "allowProjectManagement": "[parameters('allowProjectManagement')]",
         "customSubDomainName": "[parameters('customSubDomainName')]",
-        "networkAcls": "[if(not(empty(coalesce(parameters('networkAcls'), createObject()))), createObject('defaultAction', tryGet(parameters('networkAcls'), 'defaultAction'), 'virtualNetworkRules', coalesce(tryGet(parameters('networkAcls'), 'virtualNetworkRules'), createArray()), 'ipRules', coalesce(tryGet(parameters('networkAcls'), 'ipRules'), createArray())), null())]",
+        "networkAcls": "[if(not(empty(coalesce(parameters('networkAcls'), createObject()))), createObject('bypass', tryGet(parameters('networkAcls'), 'bypass'), 'defaultAction', tryGet(parameters('networkAcls'), 'defaultAction'), 'virtualNetworkRules', coalesce(tryGet(parameters('networkAcls'), 'virtualNetworkRules'), createArray()), 'ipRules', coalesce(tryGet(parameters('networkAcls'), 'ipRules'), createArray())), null())]",
         "networkInjections": "[if(not(empty(parameters('networkInjections'))), createArray(createObject('scenario', tryGet(parameters('networkInjections'), 'scenario'), 'subnetArmId', tryGet(parameters('networkInjections'), 'subnetResourceId'), 'useMicrosoftManagedNetwork', coalesce(tryGet(parameters('networkInjections'), 'useMicrosoftManagedNetwork'), false()))), null())]",
         "publicNetworkAccess": "[if(not(equals(parameters('publicNetworkAccess'), null())), parameters('publicNetworkAccess'), if(not(empty(parameters('networkAcls'))), 'Enabled', 'Disabled'))]",
         "allowedFqdnList": "[parameters('allowedFqdnList')]",
@@ -2233,8 +2307,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "13968722110082077308"
+              "version": "0.43.8.12551",
+              "templateHash": "5801666867026778267"
             }
           },
           "definitions": {


### PR DESCRIPTION
## Description

Follow-up to PR #7117 (which addressed #7062).

The original PR was merged with `main.json` built using Bicep CLI **0.42.1**, which did not emit the new `networkAclsType` user-defined type as a separate type definition. The currently-released Bicep CLI **0.43.8** (used by AVM CI) does emit it. As a result, the `[cognitive-services/account] The [main.json] ARM template should be based on the current [main.bicep] Bicep template` static-validation test fails on the staging branch.

This PR contains a single change: regenerate `main.json` with Bicep CLI 0.43.8. Diff: `+80 / −6` lines, all inside the type-definition block where `networkAclsType` is now declared.

No `main.bicep`, `README.md`, `CHANGELOG.md`, `version.json`, or test changes — purely a build artifact refresh.

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.cognitive-services.account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml/badge.svg?branch=users%2Fcnissanka%2Fcogservice-issue7062)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml) |

## Type of Change

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version *(no version bump required — pure build-artifact refresh on top of the existing 0.15.0 entry)*
