### PR TITLE
fix: avm/res/cache/redis retirement notification and fixing passive-geo-replication test

### DIFF
--- a/avm/res/cache/redis/CHANGELOG.md
+++ b/avm/res/cache/redis/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cache/redis/CHANGELOG.md).
 
+## 0.17.3
+
+### Changes
+
+- Adding description on Azure Cache for Redis announced its retirement
+
+### Breaking Changes
+
+- None
+
 ## 0.17.2
 
 ### Changes

--- a/avm/res/cache/redis/CHANGELOG.md
+++ b/avm/res/cache/redis/CHANGELOG.md
@@ -2,20 +2,11 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cache/redis/CHANGELOG.md).
 
-## 0.17.3
-
-### Changes
-
-- Adding description on Azure Cache for Redis announced its retirement
-
-### Breaking Changes
-
-- None
-
 ## 0.17.2
 
 ### Changes
 
+- Adding description on Azure Cache for Redis announced its retirement
 - Recompiled the template with latest Bicep version `0.43.8`
 
 ### Breaking Changes

--- a/avm/res/cache/redis/CHANGELOG.md
+++ b/avm/res/cache/redis/CHANGELOG.md
@@ -7,6 +7,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 ### Changes
 
 - Adding description on Azure Cache for Redis announced its retirement
+- Fixing passive Geo-Replicated Redis Cache test
 - Recompiled the template with latest Bicep version `0.43.8`
 
 ### Breaking Changes

--- a/avm/res/cache/redis/README.md
+++ b/avm/res/cache/redis/README.md
@@ -2,6 +2,8 @@
 
 This module deploys a Redis Cache.
 
+Please note that Azure Cache for Redis announced its retirement timeline for all SKUs ([ref(https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview)]). We recommend moving your existing Azure Cache for Redis instances to Azure Managed Redis as soon as you can using the `avm/res/cache/redis-enterprise` module.
+
 You can reference the module as follows:
 ```bicep
 module redis 'br/public:avm/res/cache/redis:<version>' = {

--- a/avm/res/cache/redis/README.md
+++ b/avm/res/cache/redis/README.md
@@ -2,7 +2,9 @@
 
 This module deploys a Redis Cache.
 
-Please note that Azure Cache for Redis announced its retirement timeline for all SKUs ([ref(https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview)]). We recommend moving your existing Azure Cache for Redis instances to Azure Managed Redis as soon as you can using the `avm/res/cache/redis-enterprise` module.
+Please note that Azure Cache for Redis announced its retirement timeline for all SKUs ([ref](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview)).
+We recommend moving your existing Azure Cache for Redis instances to Azure Managed Redis as soon as you can using the `avm/res/cache/redis-enterprise` module.
+
 
 You can reference the module as follows:
 ```bicep

--- a/avm/res/cache/redis/main.bicep
+++ b/avm/res/cache/redis/main.bicep
@@ -1,5 +1,9 @@
 metadata name = 'Redis Cache'
-metadata description = 'This module deploys a Redis Cache.'
+metadata description = '''This module deploys a Redis Cache.
+
+Please note that Azure Cache for Redis announced its retirement timeline for all SKUs ([ref](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview)).
+We recommend moving your existing Azure Cache for Redis instances to Azure Managed Redis as soon as you can using the `avm/res/cache/redis-enterprise` module.
+'''
 
 @description('Optional. The location to deploy the Redis cache service.')
 param location string = resourceGroup().location

--- a/avm/res/cache/redis/main.json
+++ b/avm/res/cache/redis/main.json
@@ -6,10 +6,10 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "12606005479985801650"
+      "templateHash": "15546418526388144145"
     },
     "name": "Redis Cache",
-    "description": "This module deploys a Redis Cache."
+    "description": "This module deploys a Redis Cache.\n\nPlease note that Azure Cache for Redis announced its retirement timeline for all SKUs ([ref](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview)).\nWe recommend moving your existing Azure Cache for Redis instances to Azure Managed Redis as soon as you can using the `avm/res/cache/redis-enterprise` module.\n"
   },
   "definitions": {
     "privateEndpointOutputType": {

--- a/avm/res/cache/redis/tests/e2e/passive-geo-replication/dependencies1.bicep
+++ b/avm/res/cache/redis/tests/e2e/passive-geo-replication/dependencies1.bicep
@@ -35,7 +35,7 @@ resource getPairedRegionScript 'Microsoft.Resources/deploymentScripts@2023-08-01
     }
   }
   properties: {
-    azPowerShellVersion: '14.0'
+    azPowerShellVersion: '11.0'
     retentionInterval: 'P1D'
     arguments: '-Location \\"${location}\\"'
     scriptContent: loadTextContent('../../../../../../../utilities/e2e-template-assets/scripts/Get-PairedRegion.ps1')


### PR DESCRIPTION
## Description

- Adding description on Azure Cache for Redis announced its retirement
- Fixing passive Geo-Replicated Redis Cache test
- Recompiled the template with latest Bicep version `0.43.8`

Fixes #7078 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.cache.redis](https://github.com/TomazMlakar/bicep-registry-modules/actions/workflows/avm.res.cache.redis.yml/badge.svg?branch=users%2Ftomlakar%2Fredis_retirement)](https://github.com/TomazMlakar/bicep-registry-modules/actions/workflows/avm.res.cache.redis.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
