### PR TITLE
fix: avm/res/kusto/cluster - Allow short Kusto database names in principal-assignment

### DIFF
--- a/avm/res/kusto/cluster/CHANGELOG.md
+++ b/avm/res/kusto/cluster/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/kusto/cluster/CHANGELOG.md).
 
+## 0.10.1
+
+### Changes
+
+- Corrected Kusto database name length constraints to match Azure naming rules (1-260 characters). Removed the invalid `@minLength(4)` and `@maxLength(22)` constraints on the `kustoDatabaseName` parameter of the `database/principal-assignment` child module, which previously prevented deploying principal assignments for databases with short names (e.g. "Hub"). Added `@maxLength(260)` to the `name` parameter of the `database` child module and to `kustoDatabaseName` in `database/principal-assignment` to enforce the correct upper bound.
+
+### Breaking Changes
+
+- None
+
 ## 0.10.0
 
 ### Changes

--- a/avm/res/kusto/cluster/database/main.bicep
+++ b/avm/res/kusto/cluster/database/main.bicep
@@ -2,6 +2,7 @@ metadata name = 'Kusto Cluster Databases'
 metadata description = 'This module deploys a Kusto Cluster Database.'
 
 @description('Required. The name of the Kusto Cluster database.')
+@maxLength(260)
 param name string
 
 @description('Conditional. The name of the parent Kusto Cluster. Required if the template is used in a standalone deployment.')

--- a/avm/res/kusto/cluster/database/main.json
+++ b/avm/res/kusto/cluster/database/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "3575126935204689897"
+      "version": "0.42.1.51946",
+      "templateHash": "12660760603122737771"
     },
     "name": "Kusto Cluster Databases",
     "description": "This module deploys a Kusto Cluster Database."
@@ -123,6 +123,7 @@
   "parameters": {
     "name": {
       "type": "string",
+      "maxLength": 260,
       "metadata": {
         "description": "Required. The name of the Kusto Cluster database."
       }
@@ -230,8 +231,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "2050858883185100947"
+              "version": "0.42.1.51946",
+              "templateHash": "16827822378130156294"
             },
             "name": "Kusto Cluster Database Principal Assignments",
             "description": "This module deploys a Kusto Cluster Database Principal Assignment."
@@ -246,8 +247,7 @@
             },
             "kustoDatabaseName": {
               "type": "string",
-              "minLength": 4,
-              "maxLength": 22,
+              "maxLength": 260,
               "metadata": {
                 "description": "Required. The name of the parent Kusto Cluster Database. Required if the template is used in a standalone deployment."
               }

--- a/avm/res/kusto/cluster/database/main.json
+++ b/avm/res/kusto/cluster/database/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "12660760603122737771"
+      "version": "0.43.8.12551",
+      "templateHash": "6784372896250458115"
     },
     "name": "Kusto Cluster Databases",
     "description": "This module deploys a Kusto Cluster Database."
@@ -231,8 +231,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "16827822378130156294"
+              "version": "0.43.8.12551",
+              "templateHash": "661948545988216283"
             },
             "name": "Kusto Cluster Database Principal Assignments",
             "description": "This module deploys a Kusto Cluster Database Principal Assignment."

--- a/avm/res/kusto/cluster/database/principal-assignment/main.bicep
+++ b/avm/res/kusto/cluster/database/principal-assignment/main.bicep
@@ -5,8 +5,7 @@ metadata description = 'This module deploys a Kusto Cluster Database Principal A
 @description('Required. The name of the Kusto cluster.')
 param kustoClusterName string
 
-@minLength(4)
-@maxLength(22)
+@maxLength(260)
 @description('Required. The name of the parent Kusto Cluster Database. Required if the template is used in a standalone deployment.')
 param kustoDatabaseName string
 

--- a/avm/res/kusto/cluster/database/principal-assignment/main.json
+++ b/avm/res/kusto/cluster/database/principal-assignment/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "2050858883185100947"
+      "version": "0.42.1.51946",
+      "templateHash": "16827822378130156294"
     },
     "name": "Kusto Cluster Database Principal Assignments",
     "description": "This module deploys a Kusto Cluster Database Principal Assignment."
@@ -20,8 +20,7 @@
     },
     "kustoDatabaseName": {
       "type": "string",
-      "minLength": 4,
-      "maxLength": 22,
+      "maxLength": 260,
       "metadata": {
         "description": "Required. The name of the parent Kusto Cluster Database. Required if the template is used in a standalone deployment."
       }

--- a/avm/res/kusto/cluster/database/principal-assignment/main.json
+++ b/avm/res/kusto/cluster/database/principal-assignment/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "16827822378130156294"
+      "version": "0.43.8.12551",
+      "templateHash": "661948545988216283"
     },
     "name": "Kusto Cluster Database Principal Assignments",
     "description": "This module deploys a Kusto Cluster Database Principal Assignment."

--- a/avm/res/kusto/cluster/main.json
+++ b/avm/res/kusto/cluster/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "1598019777369498284"
+      "version": "0.43.8.12551",
+      "templateHash": "7997316299650402853"
     },
     "name": "Kusto Cluster",
     "description": "This module deploys a Kusto Cluster."
@@ -1442,8 +1442,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "15516949031513950325"
+              "version": "0.43.8.12551",
+              "templateHash": "9742318645267541363"
             },
             "name": "Kusto Cluster Principal Assignments",
             "description": "This module deploys a Kusto Cluster Principal Assignment."
@@ -2246,8 +2246,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "3575126935204689897"
+              "version": "0.43.8.12551",
+              "templateHash": "6784372896250458115"
             },
             "name": "Kusto Cluster Databases",
             "description": "This module deploys a Kusto Cluster Database."
@@ -2364,6 +2364,7 @@
           "parameters": {
             "name": {
               "type": "string",
+              "maxLength": 260,
               "metadata": {
                 "description": "Required. The name of the Kusto Cluster database."
               }
@@ -2471,8 +2472,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "2050858883185100947"
+                      "version": "0.43.8.12551",
+                      "templateHash": "661948545988216283"
                     },
                     "name": "Kusto Cluster Database Principal Assignments",
                     "description": "This module deploys a Kusto Cluster Database Principal Assignment."
@@ -2487,8 +2488,7 @@
                     },
                     "kustoDatabaseName": {
                       "type": "string",
-                      "minLength": 4,
-                      "maxLength": 22,
+                      "maxLength": 260,
                       "metadata": {
                         "description": "Required. The name of the parent Kusto Cluster Database. Required if the template is used in a standalone deployment."
                       }

--- a/avm/res/kusto/cluster/principal-assignment/main.json
+++ b/avm/res/kusto/cluster/principal-assignment/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "15516949031513950325"
+      "version": "0.43.8.12551",
+      "templateHash": "9742318645267541363"
     },
     "name": "Kusto Cluster Principal Assignments",
     "description": "This module deploys a Kusto Cluster Principal Assignment."


### PR DESCRIPTION
## Description

Fixes #7108

The `database/principal-assignment` child module of `avm/res/kusto/cluster` declared `@minLength(4)` and `@maxLength(22)` on the `kustoDatabaseName` parameter. Azure Kusto database names do not have those length constraints (the ARM resource definition for `Microsoft.Kusto/clusters/databases` only enforces pattern `^.*$` on `name`), so these constraints incorrectly blocked deployments when the parent database name was 1–3 characters (e.g. `Hub`, as used by the FinOps Hub solution).

This PR removes the invalid `@minLength(4)` and `@maxLength(22)` decorators from the `kustoDatabaseName` parameter so principal assignments can be created against databases with any valid Kusto database name.

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.kusto.cluster](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.res.kusto.cluster.yml/badge.svg)](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.res.kusto.cluster.yml) |

## Type of Change

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version
