### PR TITLE
fix(avm/res/cognitive-services/account): bump telemetry deployment API to 2025-04-01

### DIFF
--- a/avm/res/cognitive-services/account/CHANGELOG.md
+++ b/avm/res/cognitive-services/account/CHANGELOG.md
@@ -8,6 +8,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 - Added `bypass` property to `networkAcls` so callers can allow trusted Microsoft services (`AzureServices`) through the Cognitive Services firewall (fixes [#7062](https://github.com/Azure/bicep-registry-modules/issues/7062))
 - Replaced the untyped `networkAcls object?` parameter with the strongly-typed `networkAclsType` user-defined type, exposing `bypass`, `defaultAction`, `ipRules` and `virtualNetworkRules`
+- Bumped the AVM telemetry deployment API version from `Microsoft.Resources/deployments@2024-03-01` to `@2025-04-01` to satisfy the `use-recent-api-versions` linter
 
 ### Breaking Changes
 

--- a/avm/res/cognitive-services/account/main.bicep
+++ b/avm/res/cognitive-services/account/main.bicep
@@ -284,7 +284,7 @@ var formattedRoleAssignments = [
 ]
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.cognitiveservices-account.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'

--- a/avm/res/cognitive-services/account/main.json
+++ b/avm/res/cognitive-services/account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "14321132540300128401"
+      "templateHash": "3200005357789722816"
     },
     "name": "Cognitive Services",
     "description": "This module deploys a Cognitive Service."
@@ -1442,7 +1442,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.cognitiveservices-account.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",


### PR DESCRIPTION
## Description

Bumps the AVM telemetry deployment resource API version from `Microsoft.Resources/deployments@2024-03-01` to `@2025-04-01`. Resolves the Bicep linter warning [`use-recent-api-versions`](https://aka.ms/bicep/linter-diagnostics#use-recent-api-versions) for the `avmTelemetry` resource in [`avm/res/cognitive-services/account/main.bicep`](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cognitive-services/account/main.bicep) (the previous version was 827 days old).

`2025-04-01` aligns with the convention used by sibling AVM modules — e.g. `avm/res/analysis-services/server`, `avm/res/sql/managed-instance/*`, `avm/res/network/firewall-policy/rule-collection-group`, `avm/res/maintenance/maintenance-configuration`.

### Changes

- **`main.bicep`** — `avmTelemetry` resource API version `2024-03-01` → `2025-04-01`
- **`main.json`** — regenerated via `Set-AVMModule.ps1` (Bicep CLI 0.43.8)
- **`CHANGELOG.md`** — appended a bullet under the (unreleased) `0.15.0` entry

### Local validation

Static-validation Pester suite was run against the module:

| Total | Passed | Failed | Skipped |
|---|---|---|---|
| 175 | 174 | 0 | 1* |

\* The single skip is the pre-existing `Microsoft.Insights/diagnosticSettings` gap in the `AzureAPICrawler` API-versions file and is unrelated to this change.

The `use-recent-api-versions` warning is no longer emitted for the telemetry deployment.

## Type of Change

- [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`
- [ ] Feature update
- [ ] Breaking changes
- [ ] Update to documentation
- [ ] Update to CI Environment or utilities

## Checklist

- [x] No other open PRs for the same update
- [x] `Set-AVMModule` ran locally to regenerate supporting module files
- [x] Local pipelines / Pester checks run clean
- [x] CHANGELOG.md updated (under the existing unreleased 0.15.0 entry)
