### PR TITLE
fix: `avm/res/app/container-app` - add `.NET` runtime support to fix env failed state after Portal-enabled .NET stack

### DIFF
--- a/avm/res/app/container-app/CHANGELOG.md
+++ b/avm/res/app/container-app/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/app/container-app/CHANGELOG.md).
 
+## 0.23.0
+
+### Changes
+
+- The `runtime` parameter now uses a custom user-defined type that exposes both the `java` and `dotnet` runtime configurations. This allows callers to set `runtime.dotnet.autoConfigureDataProtection`, which is supported by the underlying Azure API but not yet part of the GA `Microsoft.App/containerApps@2026-01-01` Bicep type definition. Resolves [#7129](https://github.com/Azure/bicep-registry-modules/issues/7129) by allowing the .NET stack configuration to be preserved across deployments (e.g., when the .NET Development Stack has been enabled via the Azure Portal).
+
+### Breaking Changes
+
+- None
+
 ## 0.22.1
 
 ### Changes

--- a/avm/res/app/container-app/README.md
+++ b/avm/res/app/container-app/README.md
@@ -505,6 +505,9 @@ module containerApp 'br/public:avm/res/app/container-app:<version>' = {
       }
     ]
     runtime: {
+      dotnet: {
+        autoConfigureDataProtection: false
+      }
       java: {
         enableMetrics: true
       }
@@ -671,6 +674,9 @@ module containerApp 'br/public:avm/res/app/container-app:<version>' = {
     },
     "runtime": {
       "value": {
+        "dotnet": {
+          "autoConfigureDataProtection": false
+        },
         "java": {
           "enableMetrics": true
         }
@@ -821,6 +827,9 @@ param roleAssignments = [
   }
 ]
 param runtime = {
+  dotnet: {
+    autoConfigureDataProtection: false
+  }
   java: {
     enableMetrics: true
   }
@@ -1265,7 +1274,7 @@ param tags = {
 | [`registries`](#parameter-registries) | array | Collection of private container registry credentials for containers used by the Container app. |
 | [`revisionSuffix`](#parameter-revisionsuffix) | string | User friendly suffix that is appended to the revision name. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
-| [`runtime`](#parameter-runtime) | object | Runtime configuration for the Container App. |
+| [`runtime`](#parameter-runtime) | object | Runtime configuration for the Container App. Supports both Java and .NET runtime configuration. Note: The `dotnet` property is accepted by the Azure backend even though it is not part of the GA `2026-01-01` schema. |
 | [`scaleSettings`](#parameter-scalesettings) | object | The scaling settings of the service. |
 | [`secrets`](#parameter-secrets) | array | The secrets of the Container App. |
 | [`service`](#parameter-service) | object | Dev ContainerApp service type. |
@@ -1931,10 +1940,57 @@ The principal type of the assigned principal ID.
 
 ### Parameter: `runtime`
 
-Runtime configuration for the Container App.
+Runtime configuration for the Container App. Supports both Java and .NET runtime configuration. Note: The `dotnet` property is accepted by the Azure backend even though it is not part of the GA `2026-01-01` schema.
 
 - Required: No
 - Type: object
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`dotnet`](#parameter-runtimedotnet) | object | .NET app configuration. Setting this allows preserving .NET stack settings (e.g., when the .NET Development Stack has been enabled via the Azure Portal) across subsequent deployments. |
+| [`java`](#parameter-runtimejava) | object | Java app configuration. |
+
+### Parameter: `runtime.dotnet`
+
+.NET app configuration. Setting this allows preserving .NET stack settings (e.g., when the .NET Development Stack has been enabled via the Azure Portal) across subsequent deployments.
+
+- Required: No
+- Type: object
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`autoConfigureDataProtection`](#parameter-runtimedotnetautoconfiguredataprotection) | bool | Auto configure the ASP.NET Core Data Protection feature. When enabled, the data protection keys will be persisted in the Container Apps environment. |
+
+### Parameter: `runtime.dotnet.autoConfigureDataProtection`
+
+Auto configure the ASP.NET Core Data Protection feature. When enabled, the data protection keys will be persisted in the Container Apps environment.
+
+- Required: No
+- Type: bool
+
+### Parameter: `runtime.java`
+
+Java app configuration.
+
+- Required: No
+- Type: object
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`enableMetrics`](#parameter-runtimejavaenablemetrics) | bool | Enable jmx core metrics for the java app. |
+
+### Parameter: `runtime.java.enableMetrics`
+
+Enable jmx core metrics for the java app.
+
+- Required: No
+- Type: bool
 
 ### Parameter: `scaleSettings`
 

--- a/avm/res/app/container-app/main.bicep
+++ b/avm/res/app/container-app/main.bicep
@@ -124,8 +124,8 @@ param identitySettings resourceInput<'Microsoft.App/containerApps@2026-01-01'>.p
 @description('Optional. Max inactive revisions a Container App can have.')
 param maxInactiveRevisions int = 0
 
-@description('Optional. Runtime configuration for the Container App.')
-param runtime resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.configuration.runtime?
+@description('Optional. Runtime configuration for the Container App. Supports both Java and .NET runtime configuration. Note: The `dotnet` property is accepted by the Azure backend even though it is not part of the GA `2026-01-01` schema.')
+param runtime runtimeType?
 
 @description('Required. List of container definitions for the Container App.')
 param containers resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.template.containers
@@ -273,6 +273,7 @@ resource containerApp 'Microsoft.App/containerApps@2026-01-01' = {
       maxInactiveRevisions: maxInactiveRevisions
       registries: registries
       secrets: secrets
+      #disable-next-line BCP037 // The 'dotnet' property of 'runtime' is supported by the API but is not yet part of the GA `2026-01-01` Bicep type definition. Required to preserve .NET stack settings (e.g., set via the Azure Portal) across deployments.
       runtime: runtime
     }
   }
@@ -584,4 +585,19 @@ type authConfigType = {
 
   @description('Optional. The configuration settings of the platform of ContainerApp Service Authentication/Authorization.')
   platform: resourceInput<'Microsoft.App/containerApps/authConfigs@2026-01-01'>.properties.platform?
+}
+
+@description('The type for the Container App runtime configuration. Supports both Java and .NET stacks.')
+type runtimeType = {
+  @description('Optional. Java app configuration.')
+  java: {
+    @description('Optional. Enable jmx core metrics for the java app.')
+    enableMetrics: bool?
+  }?
+
+  @description('Optional. .NET app configuration. Setting this allows preserving .NET stack settings (e.g., when the .NET Development Stack has been enabled via the Azure Portal) across subsequent deployments.')
+  dotnet: {
+    @description('Optional. Auto configure the ASP.NET Core Data Protection feature. When enabled, the data protection keys will be persisted in the Container Apps environment.')
+    autoConfigureDataProtection: bool?
+  }?
 }

--- a/avm/res/app/container-app/main.json
+++ b/avm/res/app/container-app/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "8956288048631771620"
+      "version": "0.43.8.12551",
+      "templateHash": "12424832050811640377"
     },
     "name": "Container Apps",
     "description": "This module deploys a Container App."
@@ -548,6 +548,46 @@
         "description": "The type for the container app's authentication configuration."
       }
     },
+    "runtimeType": {
+      "type": "object",
+      "properties": {
+        "java": {
+          "type": "object",
+          "properties": {
+            "enableMetrics": {
+              "type": "bool",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Enable jmx core metrics for the java app."
+              }
+            }
+          },
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Java app configuration."
+          }
+        },
+        "dotnet": {
+          "type": "object",
+          "properties": {
+            "autoConfigureDataProtection": {
+              "type": "bool",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. Auto configure the ASP.NET Core Data Protection feature. When enabled, the data protection keys will be persisted in the Container Apps environment."
+              }
+            }
+          },
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. .NET app configuration. Setting this allows preserving .NET stack settings (e.g., when the .NET Development Stack has been enabled via the Azure Portal) across subsequent deployments."
+          }
+        }
+      },
+      "metadata": {
+        "description": "The type for the Container App runtime configuration. Supports both Java and .NET stacks."
+      }
+    },
     "diagnosticSettingMetricsOnlyType": {
       "type": "object",
       "properties": {
@@ -1055,14 +1095,11 @@
       }
     },
     "runtime": {
-      "type": "object",
+      "$ref": "#/definitions/runtimeType",
+      "nullable": true,
       "metadata": {
-        "__bicep_resource_derived_type!": {
-          "source": "Microsoft.App/containerApps@2026-01-01#properties/properties/properties/configuration/properties/runtime"
-        },
-        "description": "Optional. Runtime configuration for the Container App."
-      },
-      "nullable": true
+        "description": "Optional. Runtime configuration for the Container App. Supports both Java and .NET runtime configuration. Note: The `dotnet` property is accepted by the Azure backend even though it is not part of the GA `2026-01-01` schema."
+      }
     },
     "containers": {
       "type": "array",
@@ -1327,8 +1364,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "5091965340897189324"
+              "version": "0.43.8.12551",
+              "templateHash": "497603915896913778"
             },
             "name": "Container App Auth Configs",
             "description": "This module deploys Container App Auth Configs."

--- a/avm/res/app/container-app/tests/e2e/max/main.test.bicep
+++ b/avm/res/app/container-app/tests/e2e/max/main.test.bicep
@@ -166,8 +166,11 @@ module testDeployment '../../../main.bicep' = [
         }
       ]
       runtime: {
-        java:{
+        java: {
           enableMetrics: true
+        }
+        dotnet: {
+          autoConfigureDataProtection: false
         }
       }
       scaleSettings: {

--- a/avm/res/app/container-app/version.json
+++ b/avm/res/app/container-app/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.22"
+  "version": "0.23"
 }


### PR DESCRIPTION
## Description

Closes #7129.

When the **.NET Development Stack** is enabled on a Container App via the Azure Portal, subsequent deployments of the AVM module fail and the associated **Container Apps Managed Environment** transitions to a `Failed` provisioning state with:

```
Update environment AKS handler failed: 'R' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0..
```

### Root cause

The `runtime` parameter was strictly typed against the GA `Microsoft.App/containerApps@2026-01-01` Bicep schema:

```bicep
param runtime resourceInput<'Microsoft.App/containerApps@2026-01-01'>.properties.configuration.runtime?
```

The GA `2026-01-01` schema only exposes `runtime.java`. However, the Azure backend (and Portal) supports `runtime.dotnet.autoConfigureDataProtection` — see the `2025-10-02-preview` API version where `RuntimeDotnet` is defined ([change log](https://learn.microsoft.com/en-us/azure/templates/Microsoft.App/change-log/containerapps#2025-10-02-preview)).

Because the strict type rejected `dotnet`, callers had no way to set or preserve `runtime.dotnet` in the AVM module, leading to the failure described above whenever the .NET stack had been enabled out-of-band.

### Fix

- Replaced the `runtime` parameter type with a new user-defined `runtimeType` that exposes both `java.enableMetrics` and `dotnet.autoConfigureDataProtection`.
- Added a `#disable-next-line BCP037` on the `runtime: runtime` assignment, since the `dotnet` property is supported by the underlying API but not by the GA `2026-01-01` Bicep type definition.
- Extended the `max` E2E test to include `runtime.dotnet.autoConfigureDataProtection` to provide validation coverage for the new property.
- Bumped the module version from `0.22` to `0.23`.

## Pipeline Reference

[![avm.res.app.container-app](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.res.app.container-app.yml/badge.svg?branch=fix%2Favm-res-app-container-app-runtime-dotnet)](https://github.com/oZakari/bicep-registry-modules/actions/workflows/avm.res.app.container-app.yml)

## Type of Change

- [ ] Update to CI Environment or utilities
- [ ] Azure Verified Module updates:
    - [ ] New Module
    - [x] Minor version bump (`0.22` → `0.23`) - non-breaking change
    - [ ] Major version bump - breaking change
    - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
