### PR TITLE
fix: Remove 2 modules from OIDC exceptions

### DIFF
--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -106,10 +106,6 @@ runs:
             'avm/res/azure-stack-hci/network-interface'          # Failing on resource deletion when trying to delete RBAC at subscription level
             'avm/res/azure-stack-hci/virtual-hard-disk'          # Failing on resource deletion when trying to delete RBAC at subscription level
             'avm/res/azure-stack-hci/virtual-machine-instance'   # Failing on resource deletion when trying to delete RBAC at subscription level
-            'avm/res/compute/image'                              # Failing on resource deletion when trying to delete RBAC at subscription level
-            'avm/res/compute/disk'                               # Failing on resource deletion when trying to delete RBAC at subscription level
-            'avm/res/hybrid-container-service/provisioned-cluster-instance' # Failing on resource deletion when trying to delete RBAC at subscription level
-            'avm/ptn/virtual-machine-images/azure-image-builder' # Failing on resource deletion when trying to delete RBAC at subscription level
           )
           if ($exceptionModulePaths.Contains($modulePath)) {
             $oidcException = 'true'

--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -106,6 +106,7 @@ runs:
             'avm/res/azure-stack-hci/network-interface'          # Failing on resource deletion when trying to delete RBAC at subscription level
             'avm/res/azure-stack-hci/virtual-hard-disk'          # Failing on resource deletion when trying to delete RBAC at subscription level
             'avm/res/azure-stack-hci/virtual-machine-instance'   # Failing on resource deletion when trying to delete RBAC at subscription level
+            'avm/res/hybrid-container-service/provisioned-cluster-instance' # Failing on resource deletion when trying to delete RBAC at subscription level
           )
           if ($exceptionModulePaths.Contains($modulePath)) {
             $oidcException = 'true'


### PR DESCRIPTION
## Description

Removing 3 modules not requiring exception to OIDC authentication anymore

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
