### PR TITLE
fix: `avm/res/compute/disk` Update e2e validation outdated images and republish

### DIFF
--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -106,10 +106,6 @@ runs:
             'avm/res/azure-stack-hci/network-interface'          # Failing on resource deletion when trying to delete RBAC at subscription level
             'avm/res/azure-stack-hci/virtual-hard-disk'          # Failing on resource deletion when trying to delete RBAC at subscription level
             'avm/res/azure-stack-hci/virtual-machine-instance'   # Failing on resource deletion when trying to delete RBAC at subscription level
-            'avm/res/compute/image'                              # Failing on resource deletion when trying to delete RBAC at subscription level
-            'avm/res/compute/disk'                               # Failing on resource deletion when trying to delete RBAC at subscription level
-            'avm/res/hybrid-container-service/provisioned-cluster-instance' # Failing on resource deletion when trying to delete RBAC at subscription level
-            'avm/ptn/virtual-machine-images/azure-image-builder' # Failing on resource deletion when trying to delete RBAC at subscription level
           )
           if ($exceptionModulePaths.Contains($modulePath)) {
             $oidcException = 'true'

--- a/avm/res/compute/disk/CHANGELOG.md
+++ b/avm/res/compute/disk/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/disk/CHANGELOG.md).
 
+## 0.6.1
+
+### Changes
+
+- Regenerated `main.json` with Bicep version `0.43.8`.
+
+### Breaking Changes
+
+- None
+
 ## 0.6.0
 
 ### Changes

--- a/avm/res/compute/disk/main.bicep
+++ b/avm/res/compute/disk/main.bicep
@@ -192,7 +192,7 @@ var formattedRoleAssignments = [
 ]
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.compute-disk.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'

--- a/avm/res/compute/disk/main.json
+++ b/avm/res/compute/disk/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "16909879589291228930"
+      "version": "0.43.8.12551",
+      "templateHash": "13962850013964542552"
     },
     "name": "Compute Disks",
     "description": "This module deploys a Compute Disk"
@@ -422,7 +422,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.compute-disk.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",

--- a/avm/res/compute/disk/tests/e2e/image/main.test.bicep
+++ b/avm/res/compute/disk/tests/e2e/image/main.test.bicep
@@ -54,7 +54,7 @@ module testDeployment '../../../main.bicep' = [
       sku: 'Standard_LRS'
       availabilityZone: -1
       createOption: 'FromImage'
-      imageReferenceId: '${subscription().id}/Providers/Microsoft.Compute/Locations/westeurope/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2025-datacenter-azure-edition/Versions/26100.32230.260111'
+      imageReferenceId: '${subscription().id}/Providers/Microsoft.Compute/Locations/westeurope/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2025-datacenter-azure-edition/Versions/26100.32230.260111' // Ref to update https://learn.microsoft.com/en-us/azure/virtual-machines/windows/cli-ps-findimage
     }
   }
 ]

--- a/avm/res/compute/disk/tests/e2e/image/main.test.bicep
+++ b/avm/res/compute/disk/tests/e2e/image/main.test.bicep
@@ -54,7 +54,7 @@ module testDeployment '../../../main.bicep' = [
       sku: 'Standard_LRS'
       availabilityZone: -1
       createOption: 'FromImage'
-      imageReferenceId: '${subscription().id}/Providers/Microsoft.Compute/Locations/westeurope/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2022-datacenter-azure-edition/Versions/20348.4830.260305'
+      imageReferenceId: '${subscription().id}/Providers/Microsoft.Compute/Locations/westeurope/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2025-datacenter-azure-edition/Versions/26100.32230.260111'
     }
   }
 ]

--- a/avm/res/compute/disk/tests/e2e/image/main.test.bicep
+++ b/avm/res/compute/disk/tests/e2e/image/main.test.bicep
@@ -54,7 +54,7 @@ module testDeployment '../../../main.bicep' = [
       sku: 'Standard_LRS'
       availabilityZone: -1
       createOption: 'FromImage'
-      imageReferenceId: '${subscription().id}/Providers/Microsoft.Compute/Locations/westeurope/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2022-datacenter-azure-edition/Versions/20348.2461.240510'
+      imageReferenceId: '${subscription().id}/Providers/Microsoft.Compute/Locations/westeurope/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2022-datacenter-azure-edition/Versions/20348.4830.260305'
     }
   }
 ]

--- a/avm/res/compute/disk/tests/e2e/import/dependencies.bicep
+++ b/avm/res/compute/disk/tests/e2e/import/dependencies.bicep
@@ -54,7 +54,7 @@ module roleAssignment 'dependencies_rbac.bicep' = {
 }
 
 // Deploy image template
-resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2024-02-01' = {
+resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2025-10-01' = {
   name: imageTemplateName
   location: location
   identity: {
@@ -73,7 +73,7 @@ resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2024-02-01
       type: 'PlatformImage'
       publisher: 'MicrosoftWindowsDesktop'
       offer: 'Windows-11'
-      sku: 'win11-21h2-avd'
+      sku: 'win11-24h2-avd'
       version: 'latest'
     }
     distribute: [


### PR DESCRIPTION
## Description

Closes #6393 
Update outdated image reference skus and versions
Regenerated json to enforce publishing

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.compute.disk](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk.yml/badge.svg?branch=users%2Feriqua%2Fdisk&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.disk.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
