### PR TITLE
fix: `avm/res/compute/image` Update e2e validation outdated images and republish

### DIFF
--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -106,10 +106,6 @@ runs:
             'avm/res/azure-stack-hci/network-interface'          # Failing on resource deletion when trying to delete RBAC at subscription level
             'avm/res/azure-stack-hci/virtual-hard-disk'          # Failing on resource deletion when trying to delete RBAC at subscription level
             'avm/res/azure-stack-hci/virtual-machine-instance'   # Failing on resource deletion when trying to delete RBAC at subscription level
-            'avm/res/compute/image'                              # Failing on resource deletion when trying to delete RBAC at subscription level
-            'avm/res/compute/disk'                               # Failing on resource deletion when trying to delete RBAC at subscription level
-            'avm/res/hybrid-container-service/provisioned-cluster-instance' # Failing on resource deletion when trying to delete RBAC at subscription level
-            'avm/ptn/virtual-machine-images/azure-image-builder' # Failing on resource deletion when trying to delete RBAC at subscription level
           )
           if ($exceptionModulePaths.Contains($modulePath)) {
             $oidcException = 'true'

--- a/avm/res/compute/image/CHANGELOG.md
+++ b/avm/res/compute/image/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/compute/image/CHANGELOG.md).
 
+## 0.3.4
+
+### Changes
+
+- Updated API versions to the latest non-preview versions
+- Regenerated `main.json` with Bicep version `0.43.8`.
+
+### Breaking Changes
+
+- None
+
 ## 0.3.3
 
 ### Changes

--- a/avm/res/compute/image/README.md
+++ b/avm/res/compute/image/README.md
@@ -24,7 +24,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
-| `Microsoft.Compute/images` | 2024-07-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.compute_images.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2024-07-01/images)</li></ul> |
+| `Microsoft.Compute/images` | 2025-11-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.compute_images.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Compute/2025-11-01/images)</li></ul> |
 
 ## Usage examples
 

--- a/avm/res/compute/image/main.bicep
+++ b/avm/res/compute/image/main.bicep
@@ -108,7 +108,7 @@ var formattedRoleAssignments = [
 ]
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.compute-image.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'
@@ -126,7 +126,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableT
   }
 }
 
-resource image 'Microsoft.Compute/images@2024-07-01' = {
+resource image 'Microsoft.Compute/images@2025-11-01' = {
   name: name
   location: location
   tags: tags

--- a/avm/res/compute/image/main.json
+++ b/avm/res/compute/image/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "11188662467536239908"
+      "version": "0.43.8.12551",
+      "templateHash": "5767875992308676101"
     },
     "name": "Images",
     "description": "This module deploys a Compute Image."
@@ -273,7 +273,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.compute-image.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -292,7 +292,7 @@
     },
     "image": {
       "type": "Microsoft.Compute/images",
-      "apiVersion": "2024-07-01",
+      "apiVersion": "2025-11-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -367,7 +367,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('image', '2024-07-01', 'full').location]"
+      "value": "[reference('image', '2025-11-01', 'full').location]"
     }
   }
 }

--- a/avm/res/compute/image/tests/e2e/defaults/dependencies.bicep
+++ b/avm/res/compute/image/tests/e2e/defaults/dependencies.bicep
@@ -19,12 +19,12 @@ param triggerImageDeploymentScriptName string
 @description('Required. The name of the Deployment Script to copy the VHD to a destination storage account.')
 param copyVhdDeploymentScriptName string
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' = {
   name: storageAccountName
   location: location
   kind: 'StorageV2'
@@ -34,9 +34,9 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   properties: {
     allowBlobPublicAccess: false
   }
-  resource blobServices 'blobServices@2022-09-01' = {
+  resource blobServices 'blobServices@2025-01-01' = {
     name: 'default'
-    resource container 'containers@2022-09-01' = {
+    resource container 'containers@2025-01-01' = {
       name: 'vhds'
       properties: {
         publicAccess: 'None'
@@ -59,7 +59,7 @@ resource resourceGroupContributorRole 'Microsoft.Authorization/roleAssignments@2
 }
 
 // Deploy image template
-resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2022-02-14' = {
+resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2025-10-01' = {
   #disable-next-line use-stable-resource-identifiers
   name: '${imageTemplateNamePrefix}-${baseTime}'
   location: location
@@ -79,7 +79,7 @@ resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2022-02-14
       type: 'PlatformImage'
       publisher: 'MicrosoftWindowsDesktop'
       offer: 'Windows-11'
-      sku: 'win11-21h2-avd'
+      sku: 'win11-24h2-avd'
       version: 'latest'
     }
     distribute: [
@@ -99,7 +99,7 @@ resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2022-02-14
 }
 
 // Trigger VHD creation
-resource triggerImageDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource triggerImageDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: triggerImageDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'
@@ -123,7 +123,7 @@ resource triggerImageDeploymentScript 'Microsoft.Resources/deploymentScripts@202
 }
 
 // Copy VHD to destination storage account
-resource copyVhdDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource copyVhdDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: copyVhdDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'

--- a/avm/res/compute/image/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/compute/image/tests/e2e/defaults/main.test.bicep
@@ -31,7 +31,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/compute/image/tests/e2e/max/dependencies.bicep
+++ b/avm/res/compute/image/tests/e2e/max/dependencies.bicep
@@ -28,12 +28,12 @@ param copyVhdDeploymentScriptName string
 @description('Required. The name of the deployment script that waits for a role assignment to propagate.')
 param waitDeploymentScriptName string
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' = {
   name: storageAccountName
   location: location
   kind: 'StorageV2'
@@ -43,9 +43,9 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   properties: {
     allowBlobPublicAccess: false
   }
-  resource blobServices 'blobServices@2022-09-01' = {
+  resource blobServices 'blobServices@2025-01-01' = {
     name: 'default'
-    resource container 'containers@2022-09-01' = {
+    resource container 'containers@2025-01-01' = {
       name: 'vhds'
       properties: {
         publicAccess: 'None'
@@ -68,7 +68,7 @@ resource resourceGroupContributorRole 'Microsoft.Authorization/roleAssignments@2
 }
 
 // Deploy image template
-resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2022-02-14' = {
+resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2025-10-01' = {
   #disable-next-line use-stable-resource-identifiers
   name: '${imageTemplateNamePrefix}-${baseTime}'
   location: location
@@ -88,7 +88,7 @@ resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2022-02-14
       type: 'PlatformImage'
       publisher: 'MicrosoftWindowsDesktop'
       offer: 'Windows-11'
-      sku: 'win11-21h2-avd'
+      sku: 'win11-24h2-avd'
       version: 'latest'
     }
     distribute: [
@@ -108,7 +108,7 @@ resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2022-02-14
 }
 
 // Trigger VHD creation
-resource triggerImageDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource triggerImageDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: triggerImageDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'
@@ -132,7 +132,7 @@ resource triggerImageDeploymentScript 'Microsoft.Resources/deploymentScripts@202
 }
 
 // Copy VHD to destination storage account
-resource copyVhdDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource copyVhdDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: copyVhdDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'
@@ -155,7 +155,7 @@ resource copyVhdDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-
   ]
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' = {
   name: keyVaultName
   location: location
   properties: {
@@ -173,7 +173,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     accessPolicies: []
   }
 
-  resource key 'keys@2022-07-01' = {
+  resource key 'keys@2025-05-01' = {
     name: 'encryptionKey'
     properties: {
       kty: 'RSA'
@@ -195,7 +195,7 @@ resource keyVaultKeyCryptoRole 'Microsoft.Authorization/roleAssignments@2022-04-
 }
 
 // Waiting for the role assignment to propagate
-resource waitForDeployment 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource waitForDeployment 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   dependsOn: [keyVaultKeyCryptoRole]
   name: waitDeploymentScriptName
   location: location
@@ -208,7 +208,7 @@ resource waitForDeployment 'Microsoft.Resources/deploymentScripts@2020-10-01' = 
   }
 }
 
-resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2023-10-02' = {
+resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2025-01-02' = {
   dependsOn: [waitForDeployment]
   name: diskEncryptionSetName
   location: location

--- a/avm/res/compute/image/tests/e2e/max/main.test.bicep
+++ b/avm/res/compute/image/tests/e2e/max/main.test.bicep
@@ -29,7 +29,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }

--- a/avm/res/compute/image/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/compute/image/tests/e2e/waf-aligned/dependencies.bicep
@@ -28,12 +28,12 @@ param copyVhdDeploymentScriptName string
 @description('Required. The name of the deployment script that waits for a role assignment to propagate.')
 param waitDeploymentScriptName string
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: managedIdentityName
   location: location
 }
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' = {
   name: storageAccountName
   location: location
   kind: 'StorageV2'
@@ -43,9 +43,9 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   properties: {
     allowBlobPublicAccess: false
   }
-  resource blobServices 'blobServices@2022-09-01' = {
+  resource blobServices 'blobServices@2025-01-01' = {
     name: 'default'
-    resource container 'containers@2022-09-01' = {
+    resource container 'containers@2025-01-01' = {
       name: 'vhds'
       properties: {
         publicAccess: 'None'
@@ -68,7 +68,7 @@ resource resourceGroupContributorRole 'Microsoft.Authorization/roleAssignments@2
 }
 
 // Deploy image template
-resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2022-02-14' = {
+resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2025-10-01' = {
   #disable-next-line use-stable-resource-identifiers
   name: '${imageTemplateNamePrefix}-${baseTime}'
   location: location
@@ -88,7 +88,7 @@ resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2022-02-14
       type: 'PlatformImage'
       publisher: 'MicrosoftWindowsDesktop'
       offer: 'Windows-11'
-      sku: 'win11-21h2-avd'
+      sku: 'win11-24h2-avd'
       version: 'latest'
     }
     distribute: [
@@ -108,7 +108,7 @@ resource imageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2022-02-14
 }
 
 // Trigger VHD creation
-resource triggerImageDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource triggerImageDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: triggerImageDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'
@@ -132,7 +132,7 @@ resource triggerImageDeploymentScript 'Microsoft.Resources/deploymentScripts@202
 }
 
 // Copy VHD to destination storage account
-resource copyVhdDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource copyVhdDeploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   name: copyVhdDeploymentScriptName
   location: location
   kind: 'AzurePowerShell'
@@ -155,7 +155,7 @@ resource copyVhdDeploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-
   ]
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' = {
   name: keyVaultName
   location: location
   properties: {
@@ -173,7 +173,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
     accessPolicies: []
   }
 
-  resource key 'keys@2022-07-01' = {
+  resource key 'keys@2025-05-01' = {
     name: 'encryptionKey'
     properties: {
       kty: 'RSA'
@@ -195,7 +195,7 @@ resource keyVaultKeyCryptoRole 'Microsoft.Authorization/roleAssignments@2022-04-
 }
 
 // Waiting for the role assignment to propagate
-resource waitForDeployment 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+resource waitForDeployment 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   dependsOn: [keyVaultKeyCryptoRole]
   name: waitDeploymentScriptName
   location: location
@@ -208,7 +208,7 @@ resource waitForDeployment 'Microsoft.Resources/deploymentScripts@2020-10-01' = 
   }
 }
 
-resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2023-10-02' = {
+resource diskEncryptionSet 'Microsoft.Compute/diskEncryptionSets@2025-01-02' = {
   dependsOn: [waitForDeployment]
   name: diskEncryptionSetName
   location: location

--- a/avm/res/compute/image/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/compute/image/tests/e2e/waf-aligned/main.test.bicep
@@ -29,7 +29,7 @@ param namePrefix string = '#_namePrefix_#'
 
 // General resources
 // =================
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   name: resourceGroupName
   location: resourceLocation
 }


### PR DESCRIPTION
## Description

Update outdated image reference skus and versions
Updated API versions to the latest non-preview versions
Regenerated json to enforce publishing

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.compute.image](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.image.yml/badge.svg?branch=users%2Feriqua%2Fimage&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.compute.image.yml) |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
