### PR TITLE
Add hello world Azure DevOps pipeline triggered on tag push

### DIFF
--- a/.azuredevops/pipelines/publish-module.yml
+++ b/.azuredevops/pipelines/publish-module.yml
@@ -1,0 +1,23 @@
+name: Publish-Module
+
+# Trigger only on the push of a tag (no branch CI triggers)
+trigger:
+  branches:
+    exclude:
+      - '*'
+  tags:
+    include:
+      - '*'
+
+pr: none
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  - task: PowerShell@2
+    displayName: Print Hello World
+    inputs:
+      targetType: inline
+      script: |
+        Write-Host 'Hello World'


### PR DESCRIPTION
Adds a new Azure DevOps pipeline at .azuredevops/pipelines/publish-module.yml that triggers on the push of a tag and prints 'Hello World' using PowerShell.