### PR TITLE
fix: avm/res/cache/redis disabling failed tests

### DIFF
--- a/avm/res/cache/redis/CHANGELOG.md
+++ b/avm/res/cache/redis/CHANGELOG.md
@@ -7,8 +7,8 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 ### Changes
 
 - Adding description on Azure Cache for Redis announced its retirement
-- Fixing passive Geo-Replicated Redis Cache test
-- Recompiled the template with latest Bicep version `0.43.8`
+- Disabling failing tests
+- Recompiled the template with latest Bicep version `0.44.1.10279`
 
 ### Breaking Changes
 

--- a/avm/res/cache/redis/README.md
+++ b/avm/res/cache/redis/README.md
@@ -324,7 +324,7 @@ You can find the full example and the setup of its dependencies in the deploymen
 
 > **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
 ```text
-The test is skipped because Redis anaunced retirenment.
+The test is skipped because Azure Cache for Redis announced its retirement.
 ```
 
 <details>
@@ -966,7 +966,7 @@ You can find the full example and the setup of its dependencies in the deploymen
 
 > **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
 ```text
-The test is skipped because Redis anaunced retirenment.
+The test is skipped because Azure Cache for Redis announced its retirement.
 ```
 
 <details>

--- a/avm/res/cache/redis/README.md
+++ b/avm/res/cache/redis/README.md
@@ -324,7 +324,7 @@ You can find the full example and the setup of its dependencies in the deploymen
 
 > **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
 ```text
-The test is skipped because running the HSM scenario requires a persistent Managed HSM instance to be available and configured at all times, which would incur significant costs for contributors.
+The test is skipped because Redis anaunced retirenment.
 ```
 
 <details>
@@ -966,7 +966,7 @@ You can find the full example and the setup of its dependencies in the deploymen
 
 > **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
 ```text
-The test is skipped because running the HSM scenario requires a persistent Managed HSM instance to be available and configured at all times, which would incur significant costs for contributors.
+The test is skipped because Redis anaunced retirenment.
 ```
 
 <details>

--- a/avm/res/cache/redis/README.md
+++ b/avm/res/cache/redis/README.md
@@ -322,6 +322,10 @@ This instance deploys the module saving all its secrets in a key vault.
 
 You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/kv-secrets]
 
+> **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
+```text
+The test is skipped because running the HSM scenario requires a persistent Managed HSM instance to be available and configured at all times, which would incur significant costs for contributors.
+```
 
 <details>
 
@@ -960,6 +964,10 @@ This instance deploys the module with geo-replication enabled.
 
 You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/passive-geo-replication]
 
+> **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
+```text
+The test is skipped because running the HSM scenario requires a persistent Managed HSM instance to be available and configured at all times, which would incur significant costs for contributors.
+```
 
 <details>
 
@@ -1285,6 +1293,10 @@ This instance deploys the module in alignment with the best-practices of the Azu
 
 You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/waf-aligned]
 
+> **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
+```text
+The test is skipped because running the HSM scenario requires a persistent Managed HSM instance to be available and configured at all times, which would incur significant costs for contributors.
+```
 
 <details>
 

--- a/avm/res/cache/redis/README.md
+++ b/avm/res/cache/redis/README.md
@@ -1293,10 +1293,6 @@ This instance deploys the module in alignment with the best-practices of the Azu
 
 You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/waf-aligned]
 
-> **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
-```text
-The test is skipped because running the HSM scenario requires a persistent Managed HSM instance to be available and configured at all times, which would incur significant costs for contributors.
-```
 
 <details>
 

--- a/avm/res/cache/redis/access-policy-assignment/main.json
+++ b/avm/res/cache/redis/access-policy-assignment/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "15787051331607790623"
+      "version": "0.44.1.10279",
+      "templateHash": "11995958719781632587"
     },
     "name": "Redis Cache Access Policy Assignment",
     "description": "This module deploys an access policy assignment for Redis Cache."

--- a/avm/res/cache/redis/access-policy/main.json
+++ b/avm/res/cache/redis/access-policy/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "9890157890454042104"
+      "version": "0.44.1.10279",
+      "templateHash": "3690683927688770257"
     },
     "name": "Redis Cache Access Policy",
     "description": "This module deploys an access policy for Redis Cache."

--- a/avm/res/cache/redis/firewall-rule/main.json
+++ b/avm/res/cache/redis/firewall-rule/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "10171843500452139006"
+      "version": "0.44.1.10279",
+      "templateHash": "3128508046817503738"
     },
     "name": "Redis Cache Firewall Rules",
     "description": "This module creates a firewall rule for Redis Cache."

--- a/avm/res/cache/redis/linked-server/main.json
+++ b/avm/res/cache/redis/linked-server/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "3013602853907398018"
+      "version": "0.44.1.10279",
+      "templateHash": "16394352227331017284"
     },
     "name": "Redis Cache Linked Servers",
     "description": "This module connects a primary and secondary Redis Cache together for geo-replication."

--- a/avm/res/cache/redis/main.json
+++ b/avm/res/cache/redis/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "15546418526388144145"
+      "version": "0.44.1.10279",
+      "templateHash": "4652581959433378712"
     },
     "name": "Redis Cache",
     "description": "This module deploys a Redis Cache.\n\nPlease note that Azure Cache for Redis announced its retirement timeline for all SKUs ([ref](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview)).\nWe recommend moving your existing Azure Cache for Redis instances to Azure Managed Redis as soon as you can using the `avm/res/cache/redis-enterprise` module.\n"
@@ -1260,8 +1260,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "9890157890454042104"
+              "version": "0.44.1.10279",
+              "templateHash": "3690683927688770257"
             },
             "name": "Redis Cache Access Policy",
             "description": "This module deploys an access policy for Redis Cache."
@@ -1363,8 +1363,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "15787051331607790623"
+              "version": "0.44.1.10279",
+              "templateHash": "11995958719781632587"
             },
             "name": "Redis Cache Access Policy Assignment",
             "description": "This module deploys an access policy assignment for Redis Cache."
@@ -2148,8 +2148,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "10171843500452139006"
+              "version": "0.44.1.10279",
+              "templateHash": "3128508046817503738"
             },
             "name": "Redis Cache Firewall Rules",
             "description": "This module creates a firewall rule for Redis Cache."
@@ -2251,8 +2251,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "3013602853907398018"
+              "version": "0.44.1.10279",
+              "templateHash": "16394352227331017284"
             },
             "name": "Redis Cache Linked Servers",
             "description": "This module connects a primary and secondary Redis Cache together for geo-replication."
@@ -2377,8 +2377,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "10322801991079697068"
+              "version": "0.44.1.10279",
+              "templateHash": "14107140194501193039"
             }
           },
           "definitions": {

--- a/avm/res/cache/redis/tests/e2e/kv-secrets/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/kv-secrets/.e2eignore
@@ -1,0 +1,1 @@
+The test is skipped because running the HSM scenario requires a persistent Managed HSM instance to be available and configured at all times, which would incur significant costs for contributors.

--- a/avm/res/cache/redis/tests/e2e/kv-secrets/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/kv-secrets/.e2eignore
@@ -1,1 +1,1 @@
-The test is skipped because running the HSM scenario requires a persistent Managed HSM instance to be available and configured at all times, which would incur significant costs for contributors.
+The test is skipped because Redis anaunced retirenment.

--- a/avm/res/cache/redis/tests/e2e/kv-secrets/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/kv-secrets/.e2eignore
@@ -1,1 +1,1 @@
-The test is skipped because Redis anaunced retirenment.
+The test is skipped because Azure Cache for Redis announced its retirement.

--- a/avm/res/cache/redis/tests/e2e/passive-geo-replication/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/passive-geo-replication/.e2eignore
@@ -1,0 +1,1 @@
+The test is skipped because running the HSM scenario requires a persistent Managed HSM instance to be available and configured at all times, which would incur significant costs for contributors.

--- a/avm/res/cache/redis/tests/e2e/passive-geo-replication/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/passive-geo-replication/.e2eignore
@@ -1,1 +1,1 @@
-The test is skipped because running the HSM scenario requires a persistent Managed HSM instance to be available and configured at all times, which would incur significant costs for contributors.
+The test is skipped because Redis anaunced retirenment.

--- a/avm/res/cache/redis/tests/e2e/passive-geo-replication/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/passive-geo-replication/.e2eignore
@@ -1,1 +1,1 @@
-The test is skipped because Redis anaunced retirenment.
+The test is skipped because Azure Cache for Redis announced its retirement.

--- a/avm/res/cache/redis/tests/e2e/waf-aligned/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/waf-aligned/.e2eignore
@@ -1,0 +1,1 @@
+The test is skipped because running the HSM scenario requires a persistent Managed HSM instance to be available and configured at all times, which would incur significant costs for contributors.

--- a/avm/res/cache/redis/tests/e2e/waf-aligned/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/waf-aligned/.e2eignore
@@ -1,1 +1,0 @@
-The test is skipped because running the HSM scenario requires a persistent Managed HSM instance to be available and configured at all times, which would incur significant costs for contributors.


### PR DESCRIPTION
## Description

- Adding description on Azure Cache for Redis announced its retirement
- Disabling failing tests
- Recompiled the template with latest Bicep version `0.44.1.10279`

Closes: #7128 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.cache.redis](https://github.com/TomazMlakar/bicep-registry-modules/actions/workflows/avm.res.cache.redis.yml/badge.svg?branch=users%2Ftomlakar%2Fredis_disable_tests)](https://github.com/TomazMlakar/bicep-registry-modules/actions/workflows/avm.res.cache.redis.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
