### PR TITLE
feat: clarifies the deployment of replica sets

### DIFF
--- a/avm/res/aad/domain-service/README.md
+++ b/avm/res/aad/domain-service/README.md
@@ -94,6 +94,10 @@ module domainService 'br/public:avm/res/aad/domain-service:<version>' = {
         location: '<location>'
         subnetId: '<subnetId>'
       }
+      {
+        location: '<location>'
+        subnetId: '<subnetId>'
+      }
     ]
     tags: {
       Environment: 'Non-Prod'
@@ -177,6 +181,10 @@ module domainService 'br/public:avm/res/aad/domain-service:<version>' = {
         {
           "location": "<location>",
           "subnetId": "<subnetId>"
+        },
+        {
+          "location": "<location>",
+          "subnetId": "<subnetId>"
         }
       ]
     },
@@ -238,6 +246,10 @@ param name = 'aaddswaf001'
 param pfxCertificate = '<pfxCertificate>'
 param pfxCertificatePassword = '<pfxCertificatePassword>'
 param replicaSets = [
+  {
+    location: '<location>'
+    subnetId: '<subnetId>'
+  }
   {
     location: '<location>'
     subnetId: '<subnetId>'
@@ -1006,6 +1018,11 @@ In order to provision Entra Domain Services, the Service Principal that has been
     | AllowLDAPs | TCP | `*` | `VirtualNetwork` | `5986` | `*` |
 - Associating a route table to the AADDS subnet is not recommended
 - The network used for AADDS must have its [DNS Servers configured](https://learn.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-configure-networking#configure-dns-servers-in-the-peered-virtual-network) (e.g. with IPs `10.0.1.4` & `10.0.1.5`)
+
+### Replica Set
+
+Replica Sets are not provisioned during the initial deployment. Once the first Replica Set has been deployed, additional Replica Sets will be provisioned.
+You can deploy any additional virtual networks, subnets and NSGs required during the initial deployment.
 
 ### Create self-signed certificate for secure LDAP
 Follow the below PowerShell commands to get base64 encoded string of a self-signed certificate (with a `pfxCertificatePassword`)

--- a/avm/res/aad/domain-service/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/aad/domain-service/tests/e2e/waf-aligned/dependencies.bicep
@@ -32,7 +32,7 @@ var replicaAadsSubnetAddressPrefix = cidrSubnet(replicaAddressPrefix, 24, 1)
 // Networking resources
 // =================
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-01-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-07-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -71,7 +71,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-01-01' = {
   }
 }
 
-resource replicaVirtualNetwork 'Microsoft.Network/virtualNetworks@2025-01-01' = {
+resource replicaVirtualNetwork 'Microsoft.Network/virtualNetworks@2025-07-01' = {
   name: replicaVirtualNetworkName
   location: replicaLocation
   properties: {
@@ -110,7 +110,7 @@ resource replicaVirtualNetwork 'Microsoft.Network/virtualNetworks@2025-01-01' = 
   }
 }
 
-resource virtualNetworkPeeringToReplica 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2025-01-01' = {
+resource virtualNetworkPeeringToReplica 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2025-07-01' = {
   name: 'aadds-vnetpeering-${replicaVirtualNetworkName}'
   parent: virtualNetwork
   properties: {
@@ -124,7 +124,7 @@ resource virtualNetworkPeeringToReplica 'Microsoft.Network/virtualNetworks/virtu
   }
 }
 
-resource virtualNetworkPeeringFromReplica 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2025-01-01' = {
+resource virtualNetworkPeeringFromReplica 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2025-07-01' = {
   name: 'aadds-vnetpeering-${virtualNetworkName}'
   parent: replicaVirtualNetwork
   properties: {
@@ -138,7 +138,7 @@ resource virtualNetworkPeeringFromReplica 'Microsoft.Network/virtualNetworks/vir
   }
 }
 
-resource nsgAaddSubnet 'Microsoft.Network/networkSecurityGroups@2025-01-01' = {
+resource nsgAaddSubnet 'Microsoft.Network/networkSecurityGroups@2025-07-01' = {
   name: '${virtualNetworkName}-aadds-subnet-nsg'
   location: location
   properties: {
@@ -199,7 +199,7 @@ resource nsgAaddSubnet 'Microsoft.Network/networkSecurityGroups@2025-01-01' = {
   }
 }
 
-resource replicaNsgAaddSubnet 'Microsoft.Network/networkSecurityGroups@2025-01-01' = {
+resource replicaNsgAaddSubnet 'Microsoft.Network/networkSecurityGroups@2025-07-01' = {
   name: '${replicaVirtualNetworkName}-aadds-subnet-nsg'
   location: replicaLocation
   properties: {
@@ -270,7 +270,7 @@ resource group 'Microsoft.Graph/servicePrincipals@v1.0' = {
   displayName: 'Domain Controller Services'
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' = {
   name: keyVaultName
   location: location
   properties: {

--- a/avm/res/aad/domain-service/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/aad/domain-service/tests/e2e/waf-aligned/main.test.bicep
@@ -67,7 +67,7 @@ module diagnosticDependencies '../../../../../../../utilities/e2e-template-asset
 // Test Execution //
 // ============== //
 
-resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: last(split(nestedDependencies.outputs.keyVaultResourceId, '/'))
   scope: resourceGroup
 }
@@ -115,11 +115,11 @@ module testDeployment '../../../main.bicep' = {
         location: resourceLocation
         subnetId: nestedDependencies.outputs.subnetResourceId
       }
-      // replicaset currently are not working, when deployed via Bicep
-      // {
-      //   location: replicaLocation
-      //   subnetId: nestedDependencies.outputs.replicaSubnetResourceId
-      // }
+      // The initial deployment ignores the replica (without an error), but the replica is deployed in a second iteration.
+      {
+        location: replicaLocation
+        subnetId: nestedDependencies.outputs.replicaSubnetResourceId
+      }
     ]
     tags: {
       'hidden-title': 'This is visible in the resource name'


### PR DESCRIPTION
## Description

Adds documentation for deploying Replica Sets.

Closes #2543 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.aad.domain-service](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.aad.domain-service.yml/badge.svg?branch=aadds-replica-set-documentation)](https://github.com/ReneHezser/bicep-registry-modules/actions/workflows/avm.res.aad.domain-service.yml) |

## Type of Change

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version
