### PR TITLE
fix: Make `staticIp` output nullable in `avm/res/app/managed-environment`

### DIFF
--- a/avm/res/app/managed-environment/CHANGELOG.md
+++ b/avm/res/app/managed-environment/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/app/managed-environment/CHANGELOG.md).
 
+## 0.14.0
+
+### Changes
+
+- Fixed `staticIp` output failing to deploy for Managed Environments that do not expose a static IP (e.g., external/non-VNet environments). The output is now nullable and uses safe-dereference (`?.staticIp`).
+
+### Breaking Changes
+
+- `staticIp` output type changed from `string` to `string?` (nullable). Consumers assigning this output to a non-nullable `string` parameter must update to accept `string?`.
+
 ## 0.13.3
 
 ### Changes

--- a/avm/res/app/managed-environment/CHANGELOG.md
+++ b/avm/res/app/managed-environment/CHANGELOG.md
@@ -6,7 +6,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Changes
 
-- Fixed `staticIp` output failing to deploy for Managed Environments that do not expose a static IP (e.g., external/non-VNet environments). The output is now nullable and uses safe-dereference (`?.staticIp`).
+- Fixed `staticIp` output failing to deploy for Managed Environments that do not expose a static IP (e.g., external/non-VNet environments). The output is now nullable and uses safe-dereference (`.?staticIp`).
 
 ### Breaking Changes
 

--- a/avm/res/app/managed-environment/README.md
+++ b/avm/res/app/managed-environment/README.md
@@ -1733,7 +1733,7 @@ Whether or not this Managed Environment is zone-redundant.
 | `name` | string | The name of the Managed Environment. |
 | `resourceGroupName` | string | The name of the resource group the Managed Environment was deployed into. |
 | `resourceId` | string | The resource ID of the Managed Environment. |
-| `staticIp` | string | The IP address of the Managed Environment. |
+| `staticIp` | string | The IP address of the Managed Environment. Only populated for internal Managed Environments deployed into a VNet. |
 | `systemAssignedMIPrincipalId` | string | The principal ID of the system assigned identity. |
 
 ## Cross-referenced modules

--- a/avm/res/app/managed-environment/main.bicep
+++ b/avm/res/app/managed-environment/main.bicep
@@ -316,8 +316,8 @@ output systemAssignedMIPrincipalId string? = managedEnvironment.?identity.?princ
 @description('The Default domain of the Managed Environment.')
 output defaultDomain string = managedEnvironment.properties.defaultDomain
 
-@description('The IP address of the Managed Environment.')
-output staticIp string = managedEnvironment.properties.staticIp
+@description('The IP address of the Managed Environment. Only populated for internal Managed Environments deployed into a VNet.')
+output staticIp string? = managedEnvironment.properties.?staticIp
 
 @description('The domain verification id for custom domains.')
 output domainVerificationId string = managedEnvironment.properties.customDomainConfiguration.customDomainVerificationId

--- a/avm/res/app/managed-environment/main.json
+++ b/avm/res/app/managed-environment/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.1.21952",
-      "templateHash": "6125086988827125765"
+      "version": "0.44.1.10279",
+      "templateHash": "1894076085845317974"
     },
     "name": "App ManagedEnvironments",
     "description": "This module deploys an App Managed Environment (also known as a Container App Environment)."
@@ -760,8 +760,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.1.21952",
-              "templateHash": "2030354432908272164"
+              "version": "0.44.1.10279",
+              "templateHash": "9286430289758242661"
             },
             "name": "App ManagedEnvironments Certificates",
             "description": "This module deploys a App Managed Environment Certificate."
@@ -921,8 +921,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.1.21952",
-              "templateHash": "7145592441049491126"
+              "version": "0.44.1.10279",
+              "templateHash": "17966238704278572892"
             },
             "name": "App ManagedEnvironments Certificates",
             "description": "This module deploys a App Managed Environment Certificate."
@@ -1137,10 +1137,11 @@
     },
     "staticIp": {
       "type": "string",
+      "nullable": true,
       "metadata": {
-        "description": "The IP address of the Managed Environment."
+        "description": "The IP address of the Managed Environment. Only populated for internal Managed Environments deployed into a VNet."
       },
-      "value": "[reference('managedEnvironment').staticIp]"
+      "value": "[tryGet(reference('managedEnvironment'), 'staticIp')]"
     },
     "domainVerificationId": {
       "type": "string",

--- a/avm/res/app/managed-environment/version.json
+++ b/avm/res/app/managed-environment/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.13"
+    "version": "0.14"
 }


### PR DESCRIPTION
## Description

The `staticIp` output of `avm/res/app/managed-environment` reads `managedEnvironment.properties.staticIp` unconditionally. This property is only populated for **internal Managed Environments deployed into a VNet** — for external/non-VNet environments it is absent, and recent ARM behavior fails template validation when reading a missing property as a non-nullable `string`.

Fix: changed the output type from `string` to `string?` and switched to safe-dereference (`managedEnvironment.properties.?staticIp`).

> **Note on versioning:** This is technically a breaking change to the output type (`string` → `string?`), documented under `Breaking Changes` in CHANGELOG. Per AVM pre-1.0 convention in this repo (see e.g. `0.12.0` of this same module, which also shipped breaking changes without bumping to `1.0`), breaking changes are landed via a MINOR bump while the module is < 1.0. Version bumped `0.13` → `0.14`.

Fixes #7172
Closes #7172

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.app.managed-environment](https://github.com/karpikpl/bicep-registry-modules/actions/workflows/avm.res.app.managed-environment.yml/badge.svg?branch=fix%2Fmanaged-environment-staticip-output)](https://github.com/karpikpl/bicep-registry-modules/actions/workflows/avm.res.app.managed-environment.yml) |

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
