### PR TITLE
fix: avm/res/cache/redis disabling all tests as resource getting retired

### DIFF
--- a/avm/res/cache/redis/CHANGELOG.md
+++ b/avm/res/cache/redis/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cache/redis/CHANGELOG.md).
 
+## 0.17.3
+
+### Changes
+
+- Adding additional description on Azure Cache for Redis announced its retirement
+- Disabling all tests as Azure Cache for Redis announced its retirement and creating new caches is blocked for new customers
+
+### Breaking Changes
+
+- None
+
 ## 0.17.2
 
 ### Changes

--- a/avm/res/cache/redis/README.md
+++ b/avm/res/cache/redis/README.md
@@ -2,8 +2,24 @@
 
 This module deploys a Redis Cache.
 
-Please note that Azure Cache for Redis announced its retirement timeline for all SKUs ([ref](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview)).
+Please note that Azure Cache for Redis announced its retirement timeline for all SKUs ([ref](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-whats-new)).
 We recommend moving your existing Azure Cache for Redis instances to Azure Managed Redis as soon as you can using the `avm/res/cache/redis-enterprise` module.
+
+**Important retirement dates for the Basic, Standard, and Premium tiers deployed by this module (Azure Public Cloud):**
+
+| Date | Description |
+| --- | --- |
+| April 1, 2026 | Creating new caches in Basic, Standard, or Premium tiers is blocked for new customers. |
+| October 1, 2026 | Creating new caches in Basic, Standard, or Premium tiers is blocked for existing customers. |
+| October 1, 2028 | Remaining caches in Basic, Standard, or Premium tiers are turned off. |
+
+**Important retirement dates for Azure Government and Microsoft Azure operated by 21Vianet (Azure in China):**
+
+| Date | Description |
+| --- | --- |
+| October 1, 2026 | Creating new caches in Basic, Standard, or Premium tiers is blocked for new customers. |
+| April 1, 2027 | Creating new caches in Basic, Standard, or Premium tiers is blocked for existing customers. |
+| October 1, 2028 | Remaining caches in Basic, Standard, or Premium tiers are turned off. |
 
 
 You can reference the module as follows:
@@ -64,6 +80,10 @@ This instance deploys the module with clustering enabled.
 
 You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/clustering]
 
+> **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
+```text
+The test is skipped because Azure Cache for Redis announced its retirement.
+```
 
 <details>
 
@@ -154,6 +174,10 @@ This instance deploys the module with the minimum set of required parameters.
 
 You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/defaults]
 
+> **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
+```text
+The test is skipped because Azure Cache for Redis announced its retirement.
+```
 
 <details>
 
@@ -208,6 +232,10 @@ This instance deploys the module with EntraID authentication.
 
 You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/entra-id]
 
+> **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
+```text
+The test is skipped because Azure Cache for Redis announced its retirement.
+```
 
 <details>
 
@@ -415,6 +443,10 @@ This instance deploys the module with most of its features enabled.
 
 You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/max]
 
+> **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
+```text
+The test is skipped because Azure Cache for Redis announced its retirement.
+```
 
 <details>
 
@@ -1090,6 +1122,10 @@ This instance deploys the module with data persistence enabled.
 
 You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/persistence]
 
+> **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
+```text
+The test is skipped because Azure Cache for Redis announced its retirement.
+```
 
 <details>
 
@@ -1213,6 +1249,10 @@ This instance deploys the module with custom Redis configuration.
 
 You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/redis-config]
 
+> **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
+```text
+The test is skipped because Azure Cache for Redis announced its retirement.
+```
 
 <details>
 
@@ -1293,6 +1333,10 @@ This instance deploys the module in alignment with the best-practices of the Azu
 
 You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/waf-aligned]
 
+> **Note**: This test is skipped from the CI deployment validation due to the presence of a `.e2eignore` file in the test folder. The reason for skipping the deployment is:
+```text
+The test is skipped because Azure Cache for Redis announced its retirement.
+```
 
 <details>
 

--- a/avm/res/cache/redis/main.bicep
+++ b/avm/res/cache/redis/main.bicep
@@ -1,8 +1,24 @@
 metadata name = 'Redis Cache'
 metadata description = '''This module deploys a Redis Cache.
 
-Please note that Azure Cache for Redis announced its retirement timeline for all SKUs ([ref](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview)).
+Please note that Azure Cache for Redis announced its retirement timeline for all SKUs ([ref](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-whats-new)).
 We recommend moving your existing Azure Cache for Redis instances to Azure Managed Redis as soon as you can using the `avm/res/cache/redis-enterprise` module.
+
+**Important retirement dates for the Basic, Standard, and Premium tiers deployed by this module (Azure Public Cloud):**
+
+| Date | Description |
+| --- | --- |
+| April 1, 2026 | Creating new caches in Basic, Standard, or Premium tiers is blocked for new customers. |
+| October 1, 2026 | Creating new caches in Basic, Standard, or Premium tiers is blocked for existing customers. |
+| October 1, 2028 | Remaining caches in Basic, Standard, or Premium tiers are turned off. |
+
+**Important retirement dates for Azure Government and Microsoft Azure operated by 21Vianet (Azure in China):**
+
+| Date | Description |
+| --- | --- |
+| October 1, 2026 | Creating new caches in Basic, Standard, or Premium tiers is blocked for new customers. |
+| April 1, 2027 | Creating new caches in Basic, Standard, or Premium tiers is blocked for existing customers. |
+| October 1, 2028 | Remaining caches in Basic, Standard, or Premium tiers are turned off. |
 '''
 
 @description('Optional. The location to deploy the Redis cache service.')

--- a/avm/res/cache/redis/main.json
+++ b/avm/res/cache/redis/main.json
@@ -6,10 +6,10 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "4652581959433378712"
+      "templateHash": "15301708179038813582"
     },
     "name": "Redis Cache",
-    "description": "This module deploys a Redis Cache.\n\nPlease note that Azure Cache for Redis announced its retirement timeline for all SKUs ([ref](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview)).\nWe recommend moving your existing Azure Cache for Redis instances to Azure Managed Redis as soon as you can using the `avm/res/cache/redis-enterprise` module.\n"
+    "description": "This module deploys a Redis Cache.\n\nPlease note that Azure Cache for Redis announced its retirement timeline for all SKUs ([ref](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-whats-new)).\nWe recommend moving your existing Azure Cache for Redis instances to Azure Managed Redis as soon as you can using the `avm/res/cache/redis-enterprise` module.\n\n**Important retirement dates for the Basic, Standard, and Premium tiers deployed by this module (Azure Public Cloud):**\n\n| Date | Description |\n| --- | --- |\n| April 1, 2026 | Creating new caches in Basic, Standard, or Premium tiers is blocked for new customers. |\n| October 1, 2026 | Creating new caches in Basic, Standard, or Premium tiers is blocked for existing customers. |\n| October 1, 2028 | Remaining caches in Basic, Standard, or Premium tiers are turned off. |\n\n**Important retirement dates for Azure Government and Microsoft Azure operated by 21Vianet (Azure in China):**\n\n| Date | Description |\n| --- | --- |\n| October 1, 2026 | Creating new caches in Basic, Standard, or Premium tiers is blocked for new customers. |\n| April 1, 2027 | Creating new caches in Basic, Standard, or Premium tiers is blocked for existing customers. |\n| October 1, 2028 | Remaining caches in Basic, Standard, or Premium tiers are turned off. |\n"
   },
   "definitions": {
     "privateEndpointOutputType": {

--- a/avm/res/cache/redis/tests/e2e/clustering/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/clustering/.e2eignore
@@ -1,0 +1,1 @@
+The test is skipped because Azure Cache for Redis announced its retirement.

--- a/avm/res/cache/redis/tests/e2e/defaults/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/defaults/.e2eignore
@@ -1,0 +1,1 @@
+The test is skipped because Azure Cache for Redis announced its retirement.

--- a/avm/res/cache/redis/tests/e2e/entra-id/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/entra-id/.e2eignore
@@ -1,0 +1,1 @@
+The test is skipped because Azure Cache for Redis announced its retirement.

--- a/avm/res/cache/redis/tests/e2e/max/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/max/.e2eignore
@@ -1,0 +1,1 @@
+The test is skipped because Azure Cache for Redis announced its retirement.

--- a/avm/res/cache/redis/tests/e2e/persistence/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/persistence/.e2eignore
@@ -1,0 +1,1 @@
+The test is skipped because Azure Cache for Redis announced its retirement.

--- a/avm/res/cache/redis/tests/e2e/redis-config/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/redis-config/.e2eignore
@@ -1,0 +1,1 @@
+The test is skipped because Azure Cache for Redis announced its retirement.

--- a/avm/res/cache/redis/tests/e2e/waf-aligned/.e2eignore
+++ b/avm/res/cache/redis/tests/e2e/waf-aligned/.e2eignore
@@ -1,0 +1,1 @@
+The test is skipped because Azure Cache for Redis announced its retirement.


### PR DESCRIPTION
## Description

- Adding additional description on Azure Cache for Redis announced its retirement
- Disabling all tests as Azure Cache for Redis announced its retirement and creating new caches is blocked for new customers

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.cache.redis](https://github.com/TomazMlakar/bicep-registry-modules/actions/workflows/avm.res.cache.redis.yml/badge.svg?branch=users%2Ftomlakar%2Fredis_disable_all_tests)](https://github.com/TomazMlakar/bicep-registry-modules/actions/workflows/avm.res.cache.redis.yml) |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
