### PR TITLE
fix: Remove ITA27 policy

### DIFF
--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -212,39 +212,3 @@ configuration:
                 > **To indicate this PR needs the core team''s attention, apply the "Needs: Core Team 🧞" label!**
                 >
                 > The core team will only review and approve PRs that have this label applied!
-
-      - description: "ITA27 - AVM Bicep GitHub Workflows For All Modules Will Be Triggered"
-        if:
-          - payloadType: Pull_Request
-          - isAction:
-              action: Opened
-          - includesModifiedFiles:
-              files:
-                - .github/actions/templates
-                - .github/workflows/avm.template.module.yml
-                - utilities/pipelines
-              excludedFiles:
-                - utilities/pipelines/platform/Set-AvmGitHubIssueForWorkflow.ps1
-                - utilities/pipelines/platform/Set-AvmGitHubIssueOwnerConfig.ps1
-                - utilities/pipelines/platform/Set-AvmGitHubPrLabels.ps1
-                - utilities/pipelines/platform/Switch-WorkflowState.ps1
-                - utilities/pipelines/platform/Sync-AvmModulesList.ps1
-                - utilities/pipelines/platform/helper/Add-GitHubIssueToProject.ps1
-                - utilities/pipelines/platform/helper/Get-AvmCsvData.ps1
-                - utilities/pipelines/platform/helper/Get-GitHubIssueCommentsList.ps1
-                - utilities/pipelines/platform/helper/Get-GitHubIssueList.ps1
-                - utilities/pipelines/platform/helper/Get-GitHubModuleWorkflowLatestRun.ps1
-                - utilities/pipelines/platform/helper/Get-GitHubModuleWorkflowList.ps1
-                - utilities/pipelines/platform/helper/Get-GithubPrRequestedReviewerTeamNames.ps1
-                - utilities/pipelines/platform/helper/Get-GithubTeamMembersLogin.ps1
-                - utilities/pipelines/platform/helper/Get-RepoInfo.ps1
-                - utilities/pipelines/platform/helper/Split-Array.ps1
-                - utilities/pipelines/platform/deploymentRemoval/Clear-ManagementGroupDeploymentHistory.ps1
-                - utilities/pipelines/platform/deploymentRemoval/Clear-SubscriptionDeploymentHistory.ps1
-        then:
-          - addReply:
-              reply: |
-                > [!WARNING]
-                > **FAO: AVM Core Team**
-                >
-                > When merging this PR it will trigger **all** AVM modules to be triggered! Please consider disabling the GitHub actions prior to merging and then re-enable once merged.


### PR DESCRIPTION
## Description

Remove ITA27 policy, made useless by the recent workflow updates. No need to ping the core team for disabling actions on CI updates not that triggers have been removed

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| N/A |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
