### PR TITLE
fix: avm/res/managed-identity/user-assigned-identity - prevent federated credential deployment name collision

### DIFF
--- a/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md
+++ b/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/CHANGELOG.md).
 
+## 0.6.0
+
+### Changes
+
+- Updated nested deployment naming in the `federated-identity-credential` child deployment to include the parent identity name, improving uniqueness and reducing potential deployment name collisions.
+
+### Breaking Changes
+
+- None
+
 ## 0.5.1
 
 ### Changes

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/CHANGELOG.md).
 
+## 0.2.0
+
+### Changes
+
+- Updated nested telemetry deployment API version alignment and regenerated module artifacts from the current Bicep source.
+
+### Breaking Changes
+
+- None
+
 ## 0.1.0
 
 ### Changes

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/main.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/main.bicep
@@ -20,7 +20,7 @@ param subject string
 param enableTelemetry bool = true
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.managedid-userassignedidcredential.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name), 0, 4)}'
   properties: {
     mode: 'Incremental'

--- a/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/version.json
+++ b/avm/res/managed-identity/user-assigned-identity/federated-identity-credential/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.1"
+  "version": "0.2"
 }

--- a/avm/res/managed-identity/user-assigned-identity/main.bicep
+++ b/avm/res/managed-identity/user-assigned-identity/main.bicep
@@ -67,7 +67,7 @@ var formattedRoleAssignments = [
 var enableReferencedModulesTelemetry = false
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.managedidentity-userassignedidentity.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'
@@ -106,7 +106,7 @@ resource userAssignedIdentity_lock 'Microsoft.Authorization/locks@2020-05-01' = 
 @batchSize(1)
 module userAssignedIdentity_federatedIdentityCredentials 'federated-identity-credential/main.bicep' = [
   for (federatedIdentityCredential, index) in (federatedIdentityCredentials ?? []): {
-    name: '${uniqueString(subscription().id, resourceGroup().id, location)}-UserMSI-FederatedIdentityCred-${index}'
+    name: '${uniqueString(subscription().id, resourceGroup().id, location, userAssignedIdentity.name)}-UserMSI-FederatedIdentityCred-${index}'
     params: {
       name: federatedIdentityCredential.name
       userAssignedIdentityName: userAssignedIdentity.name

--- a/avm/res/managed-identity/user-assigned-identity/main.json
+++ b/avm/res/managed-identity/user-assigned-identity/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "579000068461766281"
+      "version": "0.44.1.10279",
+      "templateHash": "8611422577558834059"
     },
     "name": "User Assigned Identities",
     "description": "This module deploys a User Assigned Identity."
@@ -254,7 +254,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.managedidentity-userassignedidentity.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -324,7 +324,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
-      "name": "[format('{0}-UserMSI-FederatedIdentityCred-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location')), copyIndex())]",
+      "name": "[format('{0}-UserMSI-FederatedIdentityCred-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location'), parameters('name')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -356,8 +356,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "7329546700093028781"
+              "version": "0.44.1.10279",
+              "templateHash": "15166247979040459344"
             },
             "name": "User Assigned Identity Federated Identity Credential",
             "description": "This module deploys a User Assigned Identity Federated Identity Credential."
@@ -405,7 +405,7 @@
             {
               "condition": "[parameters('enableTelemetry')]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2024-03-01",
+              "apiVersion": "2025-04-01",
               "name": "[format('46d3xbcp.res.managedid-userassignedidcredential.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
               "properties": {
                 "mode": "Incremental",

--- a/avm/res/managed-identity/user-assigned-identity/version.json
+++ b/avm/res/managed-identity/user-assigned-identity/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-    "version": "0.5"
+    "version": "0.6"
 }


### PR DESCRIPTION
## Description

Closes #6647

### Changes Made

- Added `userAssignedIdentity.name` to the `uniqueString()` seed in the
  `userAssignedIdentity_federatedIdentityCredentials` module loop.

### Problem

When two or more User-Assigned Managed Identities with federated identity
credentials are deployed into the same resource group and location in a
single or sequential deployment, the nested module names are identical:
uniqueString(subscriptionId, resourceGroupId, location) → same hash for same RG/location
This causes ARM to throw a `DeploymentActive` conflict because it sees
two deployments with the same name running simultaneously.

### Fix

Adding `userAssignedIdentity.name` (the MSI resource name) to the hash
inputs ensures the deployment name is unique per MSI, even when multiple
MSIs are in the same RG/location.

### Before
bicep name: '${uniqueString(subscription().id, resourceGroup().id, location)}-UserMSI-FederatedIdentityCred-${index}'
### After
bicep name: '${uniqueString(subscription().id, resourceGroup().id, location, userAssignedIdentity.name)}-UserMSI-FederatedIdentityCred-${index}'
### Testing

- Verified `bicep lint` passes with 0 warnings
- Verified `bicep build` compiles cleanly
- Manually tested by deploying 3 simultaneous MSIs with federated
  credentials to the same RG — no deployment name collisions observed