### PR TITLE
feat: Cognitive Services Account - Add custom RAI policy support [Clo…

### DIFF
--- a/avm/res/cognitive-services/account/CHANGELOG.md
+++ b/avm/res/cognitive-services/account/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cognitive-services/account/CHANGELOG.md).
 
+## 0.16.0
+
+### Changes
+
+- Added `raiPolicies` parameter to create custom Responsible AI (RAI) policies within the cognitive services account. Custom policies are created before model deployments and can be referenced by name from `deployments` via `raiPolicyName` (fixes [#6642](https://github.com/Azure/bicep-registry-modules/issues/6642))
+- Exposed the new `raiPolicyType` user-defined type
+
+### Breaking Changes
+
+- None
+
 ## 0.15.0
 
 ### Changes

--- a/avm/res/cognitive-services/account/README.md
+++ b/avm/res/cognitive-services/account/README.md
@@ -28,6 +28,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | `Microsoft.CognitiveServices/accounts` | 2025-06-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.cognitiveservices_accounts.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.CognitiveServices/2025-06-01/accounts)</li></ul> |
 | `Microsoft.CognitiveServices/accounts/commitmentPlans` | 2025-06-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.cognitiveservices_accounts_commitmentplans.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.CognitiveServices/2025-06-01/accounts/commitmentPlans)</li></ul> |
 | `Microsoft.CognitiveServices/accounts/deployments` | 2025-06-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.cognitiveservices_accounts_deployments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.CognitiveServices/2025-06-01/accounts/deployments)</li></ul> |
+| `Microsoft.CognitiveServices/accounts/raiPolicies` | 2025-06-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.cognitiveservices_accounts_raipolicies.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.CognitiveServices/2025-06-01/accounts/raiPolicies)</li></ul> |
 | `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.insights_diagnosticsettings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)</li></ul> |
 | `Microsoft.KeyVault/vaults/secrets` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.keyvault_vaults_secrets.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2025-05-01/vaults/secrets)</li></ul> |
 | `Microsoft.Network/privateEndpoints` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_privateendpoints.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/privateEndpoints)</li></ul> |
@@ -429,10 +430,34 @@ module account 'br/public:avm/res/cognitive-services/account:<version>' = {
           name: 'gpt-4o'
         }
         name: 'gpt-4o'
+        raiPolicyName: 'custom-rai-policy'
         sku: {
           capacity: 10
           name: 'GlobalStandard'
         }
+      }
+    ]
+    raiPolicies: [
+      {
+        basePolicyName: 'Microsoft.Default'
+        contentFilters: [
+          {
+            blocking: true
+            enabled: true
+            name: 'Hate'
+            severityThreshold: 'High'
+            source: 'Prompt'
+          }
+          {
+            blocking: true
+            enabled: true
+            name: 'Hate'
+            severityThreshold: 'High'
+            source: 'Completion'
+          }
+        ]
+        mode: 'Asynchronous_filter'
+        name: 'custom-rai-policy'
       }
     ]
   }
@@ -470,10 +495,36 @@ module account 'br/public:avm/res/cognitive-services/account:<version>' = {
             "name": "gpt-4o"
           },
           "name": "gpt-4o",
+          "raiPolicyName": "custom-rai-policy",
           "sku": {
             "capacity": 10,
             "name": "GlobalStandard"
           }
+        }
+      ]
+    },
+    "raiPolicies": {
+      "value": [
+        {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "blocking": true,
+              "enabled": true,
+              "name": "Hate",
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "blocking": true,
+              "enabled": true,
+              "name": "Hate",
+              "severityThreshold": "High",
+              "source": "Completion"
+            }
+          ],
+          "mode": "Asynchronous_filter",
+          "name": "custom-rai-policy"
         }
       ]
     }
@@ -503,10 +554,34 @@ param deployments = [
       name: 'gpt-4o'
     }
     name: 'gpt-4o'
+    raiPolicyName: 'custom-rai-policy'
     sku: {
       capacity: 10
       name: 'GlobalStandard'
     }
+  }
+]
+param raiPolicies = [
+  {
+    basePolicyName: 'Microsoft.Default'
+    contentFilters: [
+      {
+        blocking: true
+        enabled: true
+        name: 'Hate'
+        severityThreshold: 'High'
+        source: 'Prompt'
+      }
+      {
+        blocking: true
+        enabled: true
+        name: 'Hate'
+        severityThreshold: 'High'
+        source: 'Completion'
+      }
+    ]
+    mode: 'Asynchronous_filter'
+    name: 'custom-rai-policy'
   }
 ]
 ```
@@ -2048,6 +2123,7 @@ param tags = {
 | [`networkInjections`](#parameter-networkinjections) | object | Specifies in AI Foundry where virtual network injection occurs to secure scenarios like Agents entirely within a private network. |
 | [`privateEndpoints`](#parameter-privateendpoints) | array | Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. |
 | [`publicNetworkAccess`](#parameter-publicnetworkaccess) | string | Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkAcls are not set. |
+| [`raiPolicies`](#parameter-raipolicies) | array | Array of Responsible AI (RAI) policies to create within the cognitive services account. Custom policies can be referenced by name from `deployments` via the `raiPolicyName` property. |
 | [`restore`](#parameter-restore) | bool | Restore a soft-deleted cognitive service at deployment time. Will fail if no such soft-deleted resource exists. |
 | [`restrictOutboundNetworkAccess`](#parameter-restrictoutboundnetworkaccess) | bool | Restrict outbound network access. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
@@ -3256,6 +3332,168 @@ Whether or not public network access is allowed for this resource. For security 
   [
     'Disabled'
     'Enabled'
+  ]
+  ```
+
+### Parameter: `raiPolicies`
+
+Array of Responsible AI (RAI) policies to create within the cognitive services account. Custom policies can be referenced by name from `deployments` via the `raiPolicyName` property.
+
+- Required: No
+- Type: array
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`name`](#parameter-raipoliciesname) | string | The name of the RAI policy. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`basePolicyName`](#parameter-raipoliciesbasepolicyname) | string | The name of the base RAI policy to derive from. |
+| [`contentFilters`](#parameter-raipoliciescontentfilters) | array | The list of content filters to apply. |
+| [`customBlocklists`](#parameter-raipoliciescustomblocklists) | array | The list of custom blocklists to apply. |
+| [`mode`](#parameter-raipoliciesmode) | string | RAI policy mode. Use 'Asynchronous_filter' after API version 2025-06-01 (equivalent to 'Deferred' in previous versions). |
+
+### Parameter: `raiPolicies.name`
+
+The name of the RAI policy.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `raiPolicies.basePolicyName`
+
+The name of the base RAI policy to derive from.
+
+- Required: No
+- Type: string
+
+### Parameter: `raiPolicies.contentFilters`
+
+The list of content filters to apply.
+
+- Required: No
+- Type: array
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`blocking`](#parameter-raipoliciescontentfiltersblocking) | bool | If blocking would occur. |
+| [`enabled`](#parameter-raipoliciescontentfiltersenabled) | bool | If the content filter is enabled. |
+| [`name`](#parameter-raipoliciescontentfiltersname) | string | Name of the content filter. |
+| [`severityThreshold`](#parameter-raipoliciescontentfiltersseveritythreshold) | string | Level at which content is filtered. |
+| [`source`](#parameter-raipoliciescontentfilterssource) | string | Content source to apply the content filter. |
+
+### Parameter: `raiPolicies.contentFilters.blocking`
+
+If blocking would occur.
+
+- Required: No
+- Type: bool
+
+### Parameter: `raiPolicies.contentFilters.enabled`
+
+If the content filter is enabled.
+
+- Required: No
+- Type: bool
+
+### Parameter: `raiPolicies.contentFilters.name`
+
+Name of the content filter.
+
+- Required: No
+- Type: string
+
+### Parameter: `raiPolicies.contentFilters.severityThreshold`
+
+Level at which content is filtered.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'High'
+    'Low'
+    'Medium'
+  ]
+  ```
+
+### Parameter: `raiPolicies.contentFilters.source`
+
+Content source to apply the content filter.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Completion'
+    'Prompt'
+  ]
+  ```
+
+### Parameter: `raiPolicies.customBlocklists`
+
+The list of custom blocklists to apply.
+
+- Required: No
+- Type: array
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`blocking`](#parameter-raipoliciescustomblocklistsblocking) | bool | If blocking would occur. |
+| [`blocklistName`](#parameter-raipoliciescustomblocklistsblocklistname) | string | Name of the blocklist. |
+| [`source`](#parameter-raipoliciescustomblocklistssource) | string | Content source to apply the blocklist. |
+
+### Parameter: `raiPolicies.customBlocklists.blocking`
+
+If blocking would occur.
+
+- Required: No
+- Type: bool
+
+### Parameter: `raiPolicies.customBlocklists.blocklistName`
+
+Name of the blocklist.
+
+- Required: No
+- Type: string
+
+### Parameter: `raiPolicies.customBlocklists.source`
+
+Content source to apply the blocklist.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Completion'
+    'Prompt'
+  ]
+  ```
+
+### Parameter: `raiPolicies.mode`
+
+RAI policy mode. Use 'Asynchronous_filter' after API version 2025-06-01 (equivalent to 'Deferred' in previous versions).
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Asynchronous_filter'
+    'Blocking'
+    'Default'
+    'Deferred'
   ]
   ```
 

--- a/avm/res/cognitive-services/account/main.bicep
+++ b/avm/res/cognitive-services/account/main.bicep
@@ -133,6 +133,9 @@ param enableTelemetry bool = true
 @description('Optional. Array of deployments about cognitive service accounts to create.')
 param deployments deploymentType[]?
 
+@description('Optional. Array of Responsible AI (RAI) policies to create within the cognitive services account. Custom policies can be referenced by name from `deployments` via the `raiPolicyName` property.')
+param raiPolicies raiPolicyType[]?
+
 @description('Optional. Key vault reference and secret settings for the module\'s secrets export.')
 param secretsExportConfiguration secretsExportConfigurationType?
 
@@ -387,6 +390,19 @@ resource cognitiveService 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
   }
 }
 
+resource cognitiveService_raiPolicies 'Microsoft.CognitiveServices/accounts/raiPolicies@2025-06-01' = [
+  for raiPolicy in (raiPolicies ?? []): {
+    parent: cognitiveService
+    name: raiPolicy.name
+    properties: {
+      basePolicyName: raiPolicy.?basePolicyName
+      contentFilters: raiPolicy.?contentFilters
+      customBlocklists: raiPolicy.?customBlocklists
+      mode: raiPolicy.?mode
+    }
+  }
+]
+
 @batchSize(1)
 resource cognitiveService_deployments 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = [
   for (deployment, index) in (deployments ?? []): {
@@ -401,6 +417,9 @@ resource cognitiveService_deployments 'Microsoft.CognitiveServices/accounts/depl
       name: 'Standard'
       capacity: 1
     }
+    dependsOn: [
+      cognitiveService_raiPolicies
+    ]
   }
 ]
 
@@ -670,6 +689,49 @@ type deploymentType = {
 
   @description('Optional. The version upgrade option.')
   versionUpgradeOption: string?
+}
+
+@export()
+@description('The type for a Responsible AI (RAI) policy.')
+type raiPolicyType = {
+  @description('Required. The name of the RAI policy.')
+  name: string
+
+  @description('Optional. The name of the base RAI policy to derive from.')
+  basePolicyName: string?
+
+  @description('Optional. The list of content filters to apply.')
+  contentFilters: {
+    @description('Optional. Name of the content filter.')
+    name: string?
+
+    @description('Optional. If the content filter is enabled.')
+    enabled: bool?
+
+    @description('Optional. If blocking would occur.')
+    blocking: bool?
+
+    @description('Optional. Level at which content is filtered.')
+    severityThreshold: ('Low' | 'Medium' | 'High')?
+
+    @description('Optional. Content source to apply the content filter.')
+    source: ('Prompt' | 'Completion')?
+  }[]?
+
+  @description('Optional. The list of custom blocklists to apply.')
+  customBlocklists: {
+    @description('Optional. If blocking would occur.')
+    blocking: bool?
+
+    @description('Optional. Name of the blocklist.')
+    blocklistName: string?
+
+    @description('Optional. Content source to apply the blocklist.')
+    source: ('Prompt' | 'Completion')?
+  }[]?
+
+  @description('Optional. RAI policy mode. Use \'Asynchronous_filter\' after API version 2025-06-01 (equivalent to \'Deferred\' in previous versions).')
+  mode: ('Default' | 'Deferred' | 'Blocking' | 'Asynchronous_filter')?
 }
 
 @export()

--- a/avm/res/cognitive-services/account/main.json
+++ b/avm/res/cognitive-services/account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "1543390349360649528"
+      "templateHash": "10712040174836477050"
     },
     "name": "Cognitive Services",
     "description": "This module deploys a Cognitive Service."
@@ -174,6 +174,134 @@
       "metadata": {
         "__bicep_export!": true,
         "description": "The type for a cognitive services account deployment."
+      }
+    },
+    "raiPolicyType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the RAI policy."
+          }
+        },
+        "basePolicyName": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The name of the base RAI policy to derive from."
+          }
+        },
+        "contentFilters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Name of the content filter."
+                }
+              },
+              "enabled": {
+                "type": "bool",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. If the content filter is enabled."
+                }
+              },
+              "blocking": {
+                "type": "bool",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. If blocking would occur."
+                }
+              },
+              "severityThreshold": {
+                "type": "string",
+                "allowedValues": [
+                  "High",
+                  "Low",
+                  "Medium"
+                ],
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Level at which content is filtered."
+                }
+              },
+              "source": {
+                "type": "string",
+                "allowedValues": [
+                  "Completion",
+                  "Prompt"
+                ],
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Content source to apply the content filter."
+                }
+              }
+            }
+          },
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The list of content filters to apply."
+          }
+        },
+        "customBlocklists": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "blocking": {
+                "type": "bool",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. If blocking would occur."
+                }
+              },
+              "blocklistName": {
+                "type": "string",
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Name of the blocklist."
+                }
+              },
+              "source": {
+                "type": "string",
+                "allowedValues": [
+                  "Completion",
+                  "Prompt"
+                ],
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Content source to apply the blocklist."
+                }
+              }
+            }
+          },
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The list of custom blocklists to apply."
+          }
+        },
+        "mode": {
+          "type": "string",
+          "allowedValues": [
+            "Asynchronous_filter",
+            "Blocking",
+            "Default",
+            "Deferred"
+          ],
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. RAI policy mode. Use 'Asynchronous_filter' after API version 2025-06-01 (equivalent to 'Deferred' in previous versions)."
+          }
+        }
+      },
+      "metadata": {
+        "__bicep_export!": true,
+        "description": "The type for a Responsible AI (RAI) policy."
       }
     },
     "endpointType": {
@@ -1359,6 +1487,16 @@
         "description": "Optional. Array of deployments about cognitive service accounts to create."
       }
     },
+    "raiPolicies": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/raiPolicyType"
+      },
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Array of Responsible AI (RAI) policies to create within the cognitive services account. Custom policies can be referenced by name from `deployments` via the `raiPolicyName` property."
+      }
+    },
     "secretsExportConfiguration": {
       "$ref": "#/definitions/secretsExportConfigurationType",
       "nullable": true,
@@ -1510,6 +1648,24 @@
         "cMKUserAssignedIdentity"
       ]
     },
+    "cognitiveService_raiPolicies": {
+      "copy": {
+        "name": "cognitiveService_raiPolicies",
+        "count": "[length(coalesce(parameters('raiPolicies'), createArray()))]"
+      },
+      "type": "Microsoft.CognitiveServices/accounts/raiPolicies",
+      "apiVersion": "2025-06-01",
+      "name": "[format('{0}/{1}', parameters('name'), coalesce(parameters('raiPolicies'), createArray())[copyIndex()].name)]",
+      "properties": {
+        "basePolicyName": "[tryGet(coalesce(parameters('raiPolicies'), createArray())[copyIndex()], 'basePolicyName')]",
+        "contentFilters": "[tryGet(coalesce(parameters('raiPolicies'), createArray())[copyIndex()], 'contentFilters')]",
+        "customBlocklists": "[tryGet(coalesce(parameters('raiPolicies'), createArray())[copyIndex()], 'customBlocklists')]",
+        "mode": "[tryGet(coalesce(parameters('raiPolicies'), createArray())[copyIndex()], 'mode')]"
+      },
+      "dependsOn": [
+        "cognitiveService"
+      ]
+    },
     "cognitiveService_deployments": {
       "copy": {
         "name": "cognitiveService_deployments",
@@ -1527,7 +1683,8 @@
       },
       "sku": "[coalesce(tryGet(coalesce(parameters('deployments'), createArray())[copyIndex()], 'sku'), createObject('name', 'Standard', 'capacity', 1))]",
       "dependsOn": [
-        "cognitiveService"
+        "cognitiveService",
+        "cognitiveService_raiPolicies"
       ]
     },
     "cognitiveService_lock": {

--- a/avm/res/cognitive-services/account/tests/e2e/ai-model-deployment/main.test.bicep
+++ b/avm/res/cognitive-services/account/tests/e2e/ai-model-deployment/main.test.bicep
@@ -48,6 +48,29 @@ module testDeployment '../../../main.bicep' = [
       name: '${namePrefix}${serviceShort}002'
       kind: 'AIServices'
       customSubDomainName: '${namePrefix}x${serviceShort}ai'
+      raiPolicies: [
+        {
+          name: 'custom-rai-policy'
+          basePolicyName: 'Microsoft.Default'
+          mode: 'Asynchronous_filter'
+          contentFilters: [
+            {
+              name: 'Hate'
+              enabled: true
+              blocking: true
+              severityThreshold: 'High'
+              source: 'Prompt'
+            }
+            {
+              name: 'Hate'
+              enabled: true
+              blocking: true
+              severityThreshold: 'High'
+              source: 'Completion'
+            }
+          ]
+        }
+      ]
       deployments: [
         {
           name: 'gpt-4o'
@@ -55,6 +78,7 @@ module testDeployment '../../../main.bicep' = [
             format: 'OpenAI'
             name: 'gpt-4o'
           }
+          raiPolicyName: 'custom-rai-policy'
           sku: {
             name: 'GlobalStandard'
             capacity: 10

--- a/avm/res/cognitive-services/account/version.json
+++ b/avm/res/cognitive-services/account/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.15"
+  "version": "0.16"
 }


### PR DESCRIPTION
## Description

Adds a new `raiPolicies` parameter to the `avm/res/cognitive-services/account` module, enabling the creation of custom Responsible AI (RAI) policies within a Cognitive Services / Azure OpenAI account.

- Custom RAI policies are created **before** model deployments (`dependsOn`), so they can be referenced by name from `deployments` via `raiPolicyName`.
- Introduces an exported `raiPolicyType` user-defined type covering `name`, `basePolicyName`, `contentFilters`, `customBlocklists`, and `mode`.
- Adds a `custom-rai-policy` test case to the `ai-model-deployment` e2e test.
- Bumps the module MINOR version `0.15` → `0.16` and updates `CHANGELOG.md`.

Closes #6642

### Why this module change vs. Azure Policy?

This belongs in the module because it serves the **provisioning plane**, which Azure Policy cannot replace:

- **Author per-workload config:** Teams declare their own custom RAI policies (specific content filters, blocklists, thresholds, mode) inline in their IaC. Azure Policy's `deployIfNotExists` can only stamp a single fixed org baseline — not bespoke per-team policies.
- **Deploy-time name binding & ordering:** A deployment references a policy by name (`raiPolicyName`); the module owns the `dependsOn` so the policy exists before the deployment that uses it. Policy doesn't orchestrate this.
- **Complementary, not competing:** The module is the declarative primitive; Azure Policy (audit/deny/remediate) is the org-wide enforcement layer that *depends on this primitive existing*. You want both — fully offloading to Policy only works for a "one-size-fits-all baseline, no customization" scenario.

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.cognitive-services.account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml/badge.svg?branch=users%2Fcnissanka%2Fcogservice-issue6642)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml) |

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
