### PR TITLE
feat: `avm/res/cognitive-services/account` support `modelProviderData…

### DIFF
--- a/avm/res/cognitive-services/account/CHANGELOG.md
+++ b/avm/res/cognitive-services/account/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cognitive-services/account/CHANGELOG.md).
 
+## 0.16.0
+
+### Changes
+
+- Added optional `modelProviderData` (`organizationName`, `countryCode`, `industry`) to `deploymentType`, and project it onto `Microsoft.CognitiveServices/accounts/deployments`. This carries the model-provider attestation that the Cognitive Services RP requires for GA partner models such as Anthropic Claude (`model.format == 'Anthropic'`), which it uses to auto-accept the partner's Azure Marketplace offer (fixes [#7197](https://github.com/Azure/bicep-registry-modules/issues/7197))
+- Bumped the `Microsoft.CognitiveServices/accounts/deployments` API version from `@2025-06-01` to `@2026-05-01`, the minimum GA version that accepts `properties.modelProviderData`
+
+### Breaking Changes
+
+- None. `modelProviderData` is optional and only emitted when supplied (via `deployment.?modelProviderData`), so existing first-party (e.g. OpenAI) deployments are unaffected.
+
 ## 0.15.0
 
 ### Changes

--- a/avm/res/cognitive-services/account/CHANGELOG.md
+++ b/avm/res/cognitive-services/account/CHANGELOG.md
@@ -11,7 +11,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Breaking Changes
 
-- None. `modelProviderData` is optional and only emitted when supplied (via `deployment.?modelProviderData`), so existing first-party (e.g. OpenAI) deployments are unaffected.
+- None.
 
 ## 0.15.0
 

--- a/avm/res/cognitive-services/account/README.md
+++ b/avm/res/cognitive-services/account/README.md
@@ -27,7 +27,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
 | `Microsoft.CognitiveServices/accounts` | 2025-06-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.cognitiveservices_accounts.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.CognitiveServices/2025-06-01/accounts)</li></ul> |
 | `Microsoft.CognitiveServices/accounts/commitmentPlans` | 2025-06-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.cognitiveservices_accounts_commitmentplans.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.CognitiveServices/2025-06-01/accounts/commitmentPlans)</li></ul> |
-| `Microsoft.CognitiveServices/accounts/deployments` | 2025-06-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.cognitiveservices_accounts_deployments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.CognitiveServices/2025-06-01/accounts/deployments)</li></ul> |
+| `Microsoft.CognitiveServices/accounts/deployments` | 2026-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.cognitiveservices_accounts_deployments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.CognitiveServices/2026-05-01/accounts/deployments)</li></ul> |
 | `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.insights_diagnosticsettings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)</li></ul> |
 | `Microsoft.KeyVault/vaults/secrets` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.keyvault_vaults_secrets.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2025-05-01/vaults/secrets)</li></ul> |
 | `Microsoft.Network/privateEndpoints` | 2024-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.network_privateendpoints.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Network/2024-10-01/privateEndpoints)</li></ul> |
@@ -41,20 +41,150 @@ The following section provides usage examples for the module, which were used to
 
 >**Note**: To reference the module, please use the following syntax `br/public:avm/res/cognitive-services/account:<version>`.
 
-- [Using `AIServices` with `deployments` in parameter set, private endpoints, and network injection](#example-1-using-aiservices-with-deployments-in-parameter-set-private-endpoints-and-network-injection)
-- [Using `AIServices` with `deployments` in parameter set and private endpoints](#example-2-using-aiservices-with-deployments-in-parameter-set-and-private-endpoints)
-- [Using `AIServices` with `deployments` in parameter set](#example-3-using-aiservices-with-deployments-in-parameter-set)
-- [Using managed HSM Customer-Managed-Keys with User-Assigned identity](#example-4-using-managed-hsm-customer-managed-keys-with-user-assigned-identity)
-- [Using Customer-Managed-Keys with System-Assigned identity](#example-5-using-customer-managed-keys-with-system-assigned-identity)
-- [Using Customer-Managed-Keys with User-Assigned identity](#example-6-using-customer-managed-keys-with-user-assigned-identity)
-- [Storing keys of service in key vault](#example-7-storing-keys-of-service-in-key-vault)
-- [Using only defaults](#example-8-using-only-defaults)
-- [Using large parameter set](#example-9-using-large-parameter-set)
-- [Using `OpenAI` and `deployments` in parameter set with private endpoint](#example-10-using-openai-and-deployments-in-parameter-set-with-private-endpoint)
-- [As Speech Service](#example-11-as-speech-service)
-- [WAF-aligned](#example-12-waf-aligned)
+- [Using `AIServices` with a GA partner (Anthropic) `deployments` in parameter set](#example-1-using-aiservices-with-a-ga-partner-anthropic-deployments-in-parameter-set)
+- [Using `AIServices` with `deployments` in parameter set, private endpoints, and network injection](#example-2-using-aiservices-with-deployments-in-parameter-set-private-endpoints-and-network-injection)
+- [Using `AIServices` with `deployments` in parameter set and private endpoints](#example-3-using-aiservices-with-deployments-in-parameter-set-and-private-endpoints)
+- [Using `AIServices` with `deployments` in parameter set](#example-4-using-aiservices-with-deployments-in-parameter-set)
+- [Using managed HSM Customer-Managed-Keys with User-Assigned identity](#example-5-using-managed-hsm-customer-managed-keys-with-user-assigned-identity)
+- [Using Customer-Managed-Keys with System-Assigned identity](#example-6-using-customer-managed-keys-with-system-assigned-identity)
+- [Using Customer-Managed-Keys with User-Assigned identity](#example-7-using-customer-managed-keys-with-user-assigned-identity)
+- [Storing keys of service in key vault](#example-8-storing-keys-of-service-in-key-vault)
+- [Using only defaults](#example-9-using-only-defaults)
+- [Using large parameter set](#example-10-using-large-parameter-set)
+- [Using `OpenAI` and `deployments` in parameter set with private endpoint](#example-11-using-openai-and-deployments-in-parameter-set-with-private-endpoint)
+- [As Speech Service](#example-12-as-speech-service)
+- [WAF-aligned](#example-13-waf-aligned)
 
-### Example 1: _Using `AIServices` with `deployments` in parameter set, private endpoints, and network injection_
+### Example 1: _Using `AIServices` with a GA partner (Anthropic) `deployments` in parameter set_
+
+This instance deploys the module with a GA partner model deployment that carries the required `modelProviderData` attestation.
+
+You can find the full example and the setup of its dependencies in the deployment test folder path [/tests/e2e/ai-model-deployment-anthropic]
+
+
+<details>
+
+<summary>via Bicep module</summary>
+
+```bicep
+module account 'br/public:avm/res/cognitive-services/account:<version>' = {
+  params: {
+    // Required parameters
+    kind: 'AIServices'
+    name: 'csaan002'
+    // Non-required parameters
+    customSubDomainName: 'xcsaanai'
+    deployments: [
+      {
+        model: {
+          format: 'Anthropic'
+          name: 'claude-sonnet-4-6'
+          version: '1'
+        }
+        modelProviderData: {
+          countryCode: 'US'
+          industry: 'technology'
+          organizationName: 'Contoso'
+        }
+        name: 'claude-sonnet-4-6'
+        sku: {
+          capacity: 25
+          name: 'GlobalStandard'
+        }
+      }
+    ]
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via JSON parameters file</summary>
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    // Required parameters
+    "kind": {
+      "value": "AIServices"
+    },
+    "name": {
+      "value": "csaan002"
+    },
+    // Non-required parameters
+    "customSubDomainName": {
+      "value": "xcsaanai"
+    },
+    "deployments": {
+      "value": [
+        {
+          "model": {
+            "format": "Anthropic",
+            "name": "claude-sonnet-4-6",
+            "version": "1"
+          },
+          "modelProviderData": {
+            "countryCode": "US",
+            "industry": "technology",
+            "organizationName": "Contoso"
+          },
+          "name": "claude-sonnet-4-6",
+          "sku": {
+            "capacity": 25,
+            "name": "GlobalStandard"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+</details>
+<p>
+
+<details>
+
+<summary>via Bicep parameters file</summary>
+
+```bicep-params
+using 'br/public:avm/res/cognitive-services/account:<version>'
+
+// Required parameters
+param kind = 'AIServices'
+param name = 'csaan002'
+// Non-required parameters
+param customSubDomainName = 'xcsaanai'
+param deployments = [
+  {
+    model: {
+      format: 'Anthropic'
+      name: 'claude-sonnet-4-6'
+      version: '1'
+    }
+    modelProviderData: {
+      countryCode: 'US'
+      industry: 'technology'
+      organizationName: 'Contoso'
+    }
+    name: 'claude-sonnet-4-6'
+    sku: {
+      capacity: 25
+      name: 'GlobalStandard'
+    }
+  }
+]
+```
+
+</details>
+<p>
+
+### Example 2: _Using `AIServices` with `deployments` in parameter set, private endpoints, and network injection_
 
 This instance deploys the module with the AI model deployment feature, private endpoint, and network injection for agent service.
 
@@ -237,7 +367,7 @@ param publicNetworkAccess = 'Disabled'
 </details>
 <p>
 
-### Example 2: _Using `AIServices` with `deployments` in parameter set and private endpoints_
+### Example 3: _Using `AIServices` with `deployments` in parameter set and private endpoints_
 
 This instance deploys the module with the AI model deployment feature and private endpoint.
 
@@ -403,7 +533,7 @@ param publicNetworkAccess = 'Disabled'
 </details>
 <p>
 
-### Example 3: _Using `AIServices` with `deployments` in parameter set_
+### Example 4: _Using `AIServices` with `deployments` in parameter set_
 
 This instance deploys the module with the AI model deployment feature.
 
@@ -514,7 +644,7 @@ param deployments = [
 </details>
 <p>
 
-### Example 4: _Using managed HSM Customer-Managed-Keys with User-Assigned identity_
+### Example 5: _Using managed HSM Customer-Managed-Keys with User-Assigned identity_
 
 This instance deploys the module with Managed HSM-based Customer Managed Key (CMK) encryption, using a User-Assigned Managed Identity to access the HSM key.
 
@@ -635,7 +765,7 @@ param sku = 'S0'
 </details>
 <p>
 
-### Example 5: _Using Customer-Managed-Keys with System-Assigned identity_
+### Example 6: _Using Customer-Managed-Keys with System-Assigned identity_
 
 This instance deploys the module using Customer-Managed-Keys using a System-Assigned Identity. This required the service to be deployed twice, once as a pre-requisite to create the System-Assigned Identity, and once to use it for accessing the Customer-Managed-Key secret.
 
@@ -740,7 +870,7 @@ param sku = 'S0'
 </details>
 <p>
 
-### Example 6: _Using Customer-Managed-Keys with User-Assigned identity_
+### Example 7: _Using Customer-Managed-Keys with User-Assigned identity_
 
 This instance deploys the module using Customer-Managed-Keys using a User-Assigned Identity to access the Customer-Managed-Key secret.
 
@@ -854,7 +984,7 @@ param sku = 'S0'
 </details>
 <p>
 
-### Example 7: _Storing keys of service in key vault_
+### Example 8: _Storing keys of service in key vault_
 
 This instance deploys the module and stores its keys in a key vault.
 
@@ -941,7 +1071,7 @@ param secretsExportConfiguration = {
 </details>
 <p>
 
-### Example 8: _Using only defaults_
+### Example 9: _Using only defaults_
 
 This instance deploys the module with the minimum set of required parameters.
 
@@ -1003,7 +1133,7 @@ param name = 'csamin001'
 </details>
 <p>
 
-### Example 9: _Using large parameter set_
+### Example 10: _Using large parameter set_
 
 This instance deploys the module with most of its features enabled.
 
@@ -1502,7 +1632,7 @@ param tags = {
 </details>
 <p>
 
-### Example 10: _Using `OpenAI` and `deployments` in parameter set with private endpoint_
+### Example 11: _Using `OpenAI` and `deployments` in parameter set with private endpoint_
 
 This instance deploys the module with the AI model deployment feature and private endpoint.
 
@@ -1659,7 +1789,7 @@ param publicNetworkAccess = 'Disabled'
 </details>
 <p>
 
-### Example 11: _As Speech Service_
+### Example 12: _As Speech Service_
 
 This instance deploys the module as a Speech Service.
 
@@ -1829,7 +1959,7 @@ param tags = {
 </details>
 <p>
 
-### Example 12: _WAF-aligned_
+### Example 13: _WAF-aligned_
 
 This instance deploys the module in alignment with the best-practices of the Azure Well-Architected Framework.
 
@@ -2300,6 +2430,7 @@ Array of deployments about cognitive service accounts to create.
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
+| [`modelProviderData`](#parameter-deploymentsmodelproviderdata) | object | Model-provider attestation. Required by the Cognitive Services RP for GA partner models such as Anthropic Claude (`model.format` == `Anthropic`); the RP uses it to auto-accept the partner's Azure Marketplace offer. Ignored for first-party (e.g. OpenAI) models. |
 | [`name`](#parameter-deploymentsname) | string | Specify the name of cognitive service account deployment. |
 | [`raiPolicyName`](#parameter-deploymentsraipolicyname) | string | The name of RAI policy. |
 | [`sku`](#parameter-deploymentssku) | object | The resource model definition representing SKU. |
@@ -2344,6 +2475,42 @@ The name of Cognitive Services account deployment model.
 The version of Cognitive Services account deployment model. Required if the model does not have a default version.
 
 - Required: No
+- Type: string
+
+### Parameter: `deployments.modelProviderData`
+
+Model-provider attestation. Required by the Cognitive Services RP for GA partner models such as Anthropic Claude (`model.format` == `Anthropic`); the RP uses it to auto-accept the partner's Azure Marketplace offer. Ignored for first-party (e.g. OpenAI) models.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`countryCode`](#parameter-deploymentsmodelproviderdatacountrycode) | string | Two-letter ISO 3166-1 alpha-2 country/region code (e.g. `US`). |
+| [`industry`](#parameter-deploymentsmodelproviderdataindustry) | string | Organization industry, lowercase. RP-validated (e.g. `technology`, `finance`, `healthcare`, `education`, `retail`, `manufacturing`, `government`, `media`, `other`). |
+| [`organizationName`](#parameter-deploymentsmodelproviderdataorganizationname) | string | Legal entity name of the organization deploying the model. |
+
+### Parameter: `deployments.modelProviderData.countryCode`
+
+Two-letter ISO 3166-1 alpha-2 country/region code (e.g. `US`).
+
+- Required: Yes
+- Type: string
+
+### Parameter: `deployments.modelProviderData.industry`
+
+Organization industry, lowercase. RP-validated (e.g. `technology`, `finance`, `healthcare`, `education`, `retail`, `manufacturing`, `government`, `media`, `other`).
+
+- Required: Yes
+- Type: string
+
+### Parameter: `deployments.modelProviderData.organizationName`
+
+Legal entity name of the organization deploying the model.
+
+- Required: Yes
 - Type: string
 
 ### Parameter: `deployments.name`

--- a/avm/res/cognitive-services/account/main.bicep
+++ b/avm/res/cognitive-services/account/main.bicep
@@ -388,7 +388,12 @@ resource cognitiveService 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
 }
 
 @batchSize(1)
-resource cognitiveService_deployments 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = [
+// api-version 2026-05-01 is the minimum GA version that accepts `properties.modelProviderData`
+// (required for GA partner models such as Anthropic Claude). Live-verified deploying Opus 4.8 on a
+// Production EA subscription. It is newer than the current Bicep type catalog, so BCP081 (no
+// pre-deploy property validation) is expected and intentional; it does not block deployment.
+#disable-next-line BCP081
+resource cognitiveService_deployments 'Microsoft.CognitiveServices/accounts/deployments@2026-05-01' = [
   for (deployment, index) in (deployments ?? []): {
     parent: cognitiveService
     name: deployment.?name ?? '${name}-deployments'
@@ -396,6 +401,9 @@ resource cognitiveService_deployments 'Microsoft.CognitiveServices/accounts/depl
       model: deployment.model
       raiPolicyName: deployment.?raiPolicyName
       versionUpgradeOption: deployment.?versionUpgradeOption
+      // Attestation for GA partner models (e.g. Anthropic Claude). Only emitted when
+      // supplied, so OpenAI and other first-party deployments are unaffected.
+      modelProviderData: deployment.?modelProviderData
     }
     sku: deployment.?sku ?? {
       name: 'Standard'
@@ -670,6 +678,18 @@ type deploymentType = {
 
   @description('Optional. The version upgrade option.')
   versionUpgradeOption: string?
+
+  @description('Optional. Model-provider attestation. Required by the Cognitive Services RP for GA partner models such as Anthropic Claude (`model.format` == `Anthropic`); the RP uses it to auto-accept the partner\'s Azure Marketplace offer. Ignored for first-party (e.g. OpenAI) models.')
+  modelProviderData: {
+    @description('Required. Legal entity name of the organization deploying the model.')
+    organizationName: string
+
+    @description('Required. Two-letter ISO 3166-1 alpha-2 country/region code (e.g. `US`).')
+    countryCode: string
+
+    @description('Required. Organization industry, lowercase. RP-validated (e.g. `technology`, `finance`, `healthcare`, `education`, `retail`, `manufacturing`, `government`, `media`, `other`).')
+    industry: string
+  }?
 }
 
 @export()

--- a/avm/res/cognitive-services/account/main.json
+++ b/avm/res/cognitive-services/account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "1543390349360649528"
+      "templateHash": "10758749619964066451"
     },
     "name": "Cognitive Services",
     "description": "This module deploys a Cognitive Service."
@@ -168,6 +168,33 @@
           "nullable": true,
           "metadata": {
             "description": "Optional. The version upgrade option."
+          }
+        },
+        "modelProviderData": {
+          "type": "object",
+          "properties": {
+            "organizationName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Legal entity name of the organization deploying the model."
+              }
+            },
+            "countryCode": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Two-letter ISO 3166-1 alpha-2 country/region code (e.g. `US`)."
+              }
+            },
+            "industry": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Organization industry, lowercase. RP-validated (e.g. `technology`, `finance`, `healthcare`, `education`, `retail`, `manufacturing`, `government`, `media`, `other`)."
+              }
+            }
+          },
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. Model-provider attestation. Required by the Cognitive Services RP for GA partner models such as Anthropic Claude (`model.format` == `Anthropic`); the RP uses it to auto-accept the partner's Azure Marketplace offer. Ignored for first-party (e.g. OpenAI) models."
           }
         }
       },
@@ -1518,12 +1545,13 @@
         "batchSize": 1
       },
       "type": "Microsoft.CognitiveServices/accounts/deployments",
-      "apiVersion": "2025-06-01",
+      "apiVersion": "2026-05-01",
       "name": "[format('{0}/{1}', parameters('name'), coalesce(tryGet(coalesce(parameters('deployments'), createArray())[copyIndex()], 'name'), format('{0}-deployments', parameters('name'))))]",
       "properties": {
         "model": "[coalesce(parameters('deployments'), createArray())[copyIndex()].model]",
         "raiPolicyName": "[tryGet(coalesce(parameters('deployments'), createArray())[copyIndex()], 'raiPolicyName')]",
-        "versionUpgradeOption": "[tryGet(coalesce(parameters('deployments'), createArray())[copyIndex()], 'versionUpgradeOption')]"
+        "versionUpgradeOption": "[tryGet(coalesce(parameters('deployments'), createArray())[copyIndex()], 'versionUpgradeOption')]",
+        "modelProviderData": "[tryGet(coalesce(parameters('deployments'), createArray())[copyIndex()], 'modelProviderData')]"
       },
       "sku": "[coalesce(tryGet(coalesce(parameters('deployments'), createArray())[copyIndex()], 'sku'), createObject('name', 'Standard', 'capacity', 1))]",
       "dependsOn": [

--- a/avm/res/cognitive-services/account/tests/e2e/ai-model-deployment-anthropic/main.test.bicep
+++ b/avm/res/cognitive-services/account/tests/e2e/ai-model-deployment-anthropic/main.test.bicep
@@ -1,0 +1,80 @@
+targetScope = 'subscription'
+
+metadata name = 'Using `AIServices` with a GA partner (Anthropic) `deployments` in parameter set'
+metadata description = 'This instance deploys the module with a GA partner model deployment that carries the required `modelProviderData` attestation.'
+
+// PREREQUISITE: Anthropic/Claude quota is gated by subscription offer type. A Production EA
+// subscription (offer MS-AZR-0017P) receives Anthropic quota; an Enterprise Dev/Test subscription
+// (MS-AZR-0148P) shows the model in the catalog but has 0/0 TPM. This deploy test therefore only
+// succeeds on a Production EA subscription with approved Anthropic quota in `enforcedLocation`.
+// (Confirmed via a Microsoft support case; Opus 4.8 deployed on a Production EA subscription.)
+
+// ========== //
+// Parameters //
+// ========== //
+
+@description('Optional. The name of the resource group to deploy for testing purposes.')
+@maxLength(90)
+param resourceGroupName string = 'dep-${namePrefix}-cognitiveservices.accounts-${serviceShort}-rg'
+
+@description('Optional. The location to deploy resources to.')
+#disable-next-line no-unused-params
+param resourceLocation string = deployment().location
+
+@description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
+param serviceShort string = 'csaan'
+
+@description('Optional. A token to inject into the name of each resource. This value can be automatically injected by the CI.')
+param namePrefix string = '#_namePrefix_#'
+
+// Due to AI Services capacity constraints, this region must be used in the AVM testing subscription
+import { enforcedLocation } from '../../shared/constants.bicep'
+
+// ============ //
+// Dependencies //
+// ============ //
+
+// General resources
+// =================
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
+  name: resourceGroupName
+  location: enforcedLocation
+}
+
+// ============== //
+// Test Execution //
+// ============== //
+
+@batchSize(1)
+module testDeployment '../../../main.bicep' = [
+  for iteration in ['init', 'idem']: {
+    scope: resourceGroup
+    name: '${uniqueString(deployment().name, enforcedLocation)}-test-${serviceShort}-${iteration}-ai'
+    params: {
+      name: '${namePrefix}${serviceShort}002'
+      kind: 'AIServices'
+      customSubDomainName: '${namePrefix}x${serviceShort}ai'
+      deployments: [
+        {
+          name: 'claude-sonnet-4-6'
+          model: {
+            format: 'Anthropic'
+            name: 'claude-sonnet-4-6'
+            version: '1'
+          }
+          sku: {
+            name: 'GlobalStandard'
+            capacity: 25
+          }
+          // Required for GA partner (Anthropic) models: the RP uses this to
+          // auto-accept the Anthropic Azure Marketplace offer.
+          modelProviderData: {
+            organizationName: 'Contoso'
+            countryCode: 'US'
+            industry: 'technology'
+          }
+        }
+      ]
+    }
+  }
+]

--- a/avm/res/cognitive-services/account/version.json
+++ b/avm/res/cognitive-services/account/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.15"
+  "version": "0.16"
 }


### PR DESCRIPTION
…` for GA partner models (Anthropic Claude)

Adds optional `modelProviderData` (`organizationName`, `countryCode`, `industry`) to `deploymentType` and projects it onto `Microsoft.CognitiveServices/accounts/deployments`. This carries the model-provider attestation the Cognitive Services RP requires for GA partner models such as Anthropic Claude (`model.format == 'Anthropic'`); the RP uses it to auto-accept the partner's Azure Marketplace offer.

- Bump `accounts/deployments` API version 2025-06-01 -> 2026-05-01 (minimum GA version that accepts `properties.modelProviderData`). BCP081 is expected/suppressed as the version is newer than the current Bicep type catalog; it does not block deployment.
- Project `modelProviderData: deployment.?modelProviderData` (null-omitted when absent, same mechanics as `raiPolicyName`/`versionUpgradeOption`); first-party (OpenAI) deployments are unaffected.
- Add `ai-model-deployment-anthropic` e2e test.
- Bump module version 0.15 -> 0.16; update CHANGELOG, README, main.json.

Fixes #7197

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #123
-->

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [x] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
