### PR TITLE
ci: Refresh allowed e2e test regions from Azure capacity list

### DIFF
--- a/utilities/pipelines/e2eValidation/regionSelector/Get-AvailableResourceLocation.ps1
+++ b/utilities/pipelines/e2eValidation/regionSelector/Get-AvailableResourceLocation.ps1
@@ -34,11 +34,19 @@ function Get-AvailableResourceLocation {
 
         [Parameter(Mandatory = $false)]
         [array] $AllowedRegionsList = @(
+            # Refreshed to currently "green" regions from the Azure capacity list (https://aka.ms/azurecapacity)
+            # per the AVM PG + Core Team sync on 23 Jul 2026. Re-review this list quarterly against the capacity list.
+            'swedencentral',
+            'belgiumcentral',
+            'norwayeast',
+            'eastasia', # Including as Edge Region for services like static-site
+            'polandcentral',
+            'austriaeast',
+            'denmarkeast',
+            'koreacentral',
             'eastus',
-            'uksouth',
-            'northeurope',
-            'germanywestcentral',
-            'eastasia' # Including as Edge Region for services like static-site
+            'centralus',
+            'newzealandnorth'
         ),
 
         [Parameter(Mandatory = $true)]
@@ -53,7 +61,6 @@ function Get-AvailableResourceLocation {
             'brazilsouth',
             'eastus2',
             'japaneast',
-            'koreacentral',
             'qatercentral',
             'southcentralus',
             'switzerlandnorth',


### PR DESCRIPTION
## Description

Refreshes the default `AllowedRegionsList` used by the e2e validation region selector (`utilities/pipelines/e2eValidation/regionSelector/Get-AvailableResourceLocation.ps1`) to the currently "green" regions from the Azure capacity list (https://aka.ms/azurecapacity), as agreed in the AVM PG + Core Team sync on 23 Jul 2026.

`uksouth` is no longer a reliable default and has been a source of avoidable static/deployment test failures, so it has been removed (along with `northeurope` and `germanywestcentral`).

**Changes:**
- Replaced the allowed region set with the refreshed green regions: `swedencentral`, `belgiumcentral`, `norwayeast`, `eastasia` (retained as an edge region), `polandcentral`, `austriaeast`, `denmarkeast`, `koreacentral`, `eastus`, `centralus`, `newzealandnorth`.
- Removed `koreacentral` from `ExcludedRegions` so it can actually be selected for resource modules, since it is now part of the allowed green-region set. (For resource modules, excluded regions are filtered out *before* the allowed-list intersection, so leaving it in both lists would have kept it from ever being picked.)
- Added an inline note pointing to the capacity list and a reminder to re-review the list quarterly.

The effective region for resource modules remains the intersection of this allowed list and per-resource feature availability (via `Get-AzLocation`). Non-`Recommended`/excluded regions continue to be filtered as before.

> Tracked internally in the AVM PG + Core Team backlog (item #178). No `version.json`/module files are affected by this change.

## Pipeline Reference

| Pipeline |
| -------- |
| _N/A — CI/utilities change; no module pipeline is affected._ |

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files. <!-- N/A: no module files affected -->
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings <!-- validated locally: PowerShell parse check + PSScriptAnalyzer clean of new findings; full CI will run on this PR -->
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version <!-- N/A: not a module change -->