### PR TITLE
feat(avm/res/cognitive-services/account): add Defender for AI toggle

### DIFF
--- a/avm/res/cognitive-services/account/CHANGELOG.md
+++ b/avm/res/cognitive-services/account/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/cognitive-services/account/CHANGELOG.md).
 
+## 0.16.0
+
+### Changes
+
+- Added the `enableDefenderForAI` parameter to enable or disable Microsoft Defender for AI (`Microsoft.CognitiveServices/accounts/defenderForAISettings`) on the account. When not set, the Defender for AI settings are left unmanaged by the module (fixes [#6603](https://github.com/Azure/bicep-registry-modules/issues/6603))
+
+### Breaking Changes
+
+- None
+
 ## 0.15.1
 
 ### Changes

--- a/avm/res/cognitive-services/account/README.md
+++ b/avm/res/cognitive-services/account/README.md
@@ -27,6 +27,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
 | `Microsoft.CognitiveServices/accounts` | 2025-06-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.cognitiveservices_accounts.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.CognitiveServices/2025-06-01/accounts)</li></ul> |
 | `Microsoft.CognitiveServices/accounts/commitmentPlans` | 2025-06-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.cognitiveservices_accounts_commitmentplans.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.CognitiveServices/2025-06-01/accounts/commitmentPlans)</li></ul> |
+| `Microsoft.CognitiveServices/accounts/defenderForAISettings` | 2025-06-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.cognitiveservices_accounts_defenderforaisettings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.CognitiveServices/2025-06-01/accounts/defenderForAISettings)</li></ul> |
 | `Microsoft.CognitiveServices/accounts/deployments` | 2025-06-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.cognitiveservices_accounts_deployments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.CognitiveServices/2025-06-01/accounts/deployments)</li></ul> |
 | `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.insights_diagnosticsettings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)</li></ul> |
 | `Microsoft.KeyVault/vaults/secrets` | 2025-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.keyvault_vaults_secrets.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KeyVault/2025-05-01/vaults/secrets)</li></ul> |
@@ -1048,6 +1049,7 @@ module account 'br/public:avm/res/cognitive-services/account:<version>' = {
         workspaceResourceId: '<workspaceResourceId>'
       }
     ]
+    enableDefenderForAI: true
     location: '<location>'
     lock: {
       kind: 'CanNotDelete'
@@ -1213,6 +1215,9 @@ module account 'br/public:avm/res/cognitive-services/account:<version>' = {
           "workspaceResourceId": "<workspaceResourceId>"
         }
       ]
+    },
+    "enableDefenderForAI": {
+      "value": true
     },
     "location": {
       "value": "<location>"
@@ -1388,6 +1393,7 @@ param diagnosticSettings = [
     workspaceResourceId: '<workspaceResourceId>'
   }
 ]
+param enableDefenderForAI = true
 param location = '<location>'
 param lock = {
   kind: 'CanNotDelete'
@@ -2042,6 +2048,7 @@ param tags = {
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. |
 | [`disableLocalAuth`](#parameter-disablelocalauth) | bool | Allow only Azure AD authentication. Should be enabled for security reasons. |
 | [`dynamicThrottlingEnabled`](#parameter-dynamicthrottlingenabled) | bool | The flag to enable dynamic throttling. |
+| [`enableDefenderForAI`](#parameter-enabledefenderforai) | bool | Enable (or disable) Microsoft Defender for AI for the account. When not set, the Defender for AI settings are left unmanaged by this module. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`location`](#parameter-location) | string | Location for all Resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
@@ -2588,6 +2595,13 @@ The flag to enable dynamic throttling.
 - Required: No
 - Type: bool
 - Default: `False`
+
+### Parameter: `enableDefenderForAI`
+
+Enable (or disable) Microsoft Defender for AI for the account. When not set, the Defender for AI settings are left unmanaged by this module.
+
+- Required: No
+- Type: bool
 
 ### Parameter: `enableTelemetry`
 

--- a/avm/res/cognitive-services/account/main.bicep
+++ b/avm/res/cognitive-services/account/main.bicep
@@ -142,6 +142,9 @@ param allowProjectManagement bool?
 @description('Optional. Commitment plans to deploy for the cognitive services account.')
 param commitmentPlans commitmentPlanType[]?
 
+@description('Optional. Enable (or disable) Microsoft Defender for AI for the account. When not set, the Defender for AI settings are left unmanaged by this module.')
+param enableDefenderForAI bool?
+
 var enableReferencedModulesTelemetry = false
 
 var formattedUserAssignedIdentities = reduce(
@@ -422,6 +425,14 @@ resource cognitiveService_commitmentPlans 'Microsoft.CognitiveServices/accounts/
     properties: plan
   }
 ]
+
+resource cognitiveService_defenderForAISettings 'Microsoft.CognitiveServices/accounts/defenderForAISettings@2025-06-01' = if (enableDefenderForAI != null) {
+  parent: cognitiveService
+  name: 'Default'
+  properties: {
+    state: enableDefenderForAI! ? 'Enabled' : 'Disabled'
+  }
+}
 
 #disable-next-line use-recent-api-versions
 resource cognitiveService_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = [

--- a/avm/res/cognitive-services/account/main.json
+++ b/avm/res/cognitive-services/account/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "15201989127235081097"
+      "templateHash": "13459132619001493579"
     },
     "name": "Cognitive Services",
     "description": "This module deploys a Cognitive Service."
@@ -1382,6 +1382,13 @@
       "metadata": {
         "description": "Optional. Commitment plans to deploy for the cognitive services account."
       }
+    },
+    "enableDefenderForAI": {
+      "type": "bool",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Enable (or disable) Microsoft Defender for AI for the account. When not set, the Defender for AI settings are left unmanaged by this module."
+      }
     }
   },
   "variables": {
@@ -1553,6 +1560,18 @@
       "apiVersion": "2025-06-01",
       "name": "[format('{0}/{1}', parameters('name'), format('{0}-{1}', coalesce(parameters('commitmentPlans'), createArray())[copyIndex()].hostingModel, coalesce(parameters('commitmentPlans'), createArray())[copyIndex()].planType))]",
       "properties": "[coalesce(parameters('commitmentPlans'), createArray())[copyIndex()]]",
+      "dependsOn": [
+        "cognitiveService"
+      ]
+    },
+    "cognitiveService_defenderForAISettings": {
+      "condition": "[not(equals(parameters('enableDefenderForAI'), null()))]",
+      "type": "Microsoft.CognitiveServices/accounts/defenderForAISettings",
+      "apiVersion": "2025-06-01",
+      "name": "[format('{0}/{1}', parameters('name'), 'Default')]",
+      "properties": {
+        "state": "[if(parameters('enableDefenderForAI'), 'Enabled', 'Disabled')]"
+      },
       "dependsOn": [
         "cognitiveService"
       ]

--- a/avm/res/cognitive-services/account/tests/e2e/max/main.test.bicep
+++ b/avm/res/cognitive-services/account/tests/e2e/max/main.test.bicep
@@ -67,6 +67,7 @@ module testDeployment '../../../main.bicep' = [
       customSubDomainName: '${namePrefix}x${serviceShort}'
       location: resourceLocation
       allowProjectManagement: false
+      enableDefenderForAI: true
       diagnosticSettings: [
         {
           name: 'customSetting'

--- a/avm/res/cognitive-services/account/version.json
+++ b/avm/res/cognitive-services/account/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.15"
+  "version": "0.16"
 }


### PR DESCRIPTION
## Description

Adds an optional `enableDefenderForAI` parameter to `avm/res/cognitive-services/account` that manages `Microsoft.CognitiveServices/accounts/defenderForAISettings` (state `Enabled`/`Disabled`). When the parameter is not set, the Defender for AI settings are left unmanaged by the module, keeping the change fully backward-compatible. First-party accounts are unaffected unless the toggle is provided.

Fixes #6603

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.cognitive-services.account](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml/badge.svg)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.cognitive-services.account.yml) |

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version
