### PR TITLE
feat: CI - Added vebosity to job re-run

### DIFF
--- a/utilities/tools/Invoke-WorkflowsFailedJobsReRun.ps1
+++ b/utilities/tools/Invoke-WorkflowsFailedJobsReRun.ps1
@@ -47,8 +47,12 @@ function Invoke-ReRun {
         $percentageComplete = [math]::Round(($currentCount / $totalCount) * 100)
         Write-Progress -Activity ('Re-running failed jobs for workflow [{0}]' -f $run.name) -Status "$percentageComplete% complete" -PercentComplete $percentageComplete
 
-        if ($PSCmdlet.ShouldProcess(("Re-run of failed jobs for GitHub workflow [{0}] for branch [$TargetBranch]" -f $run.name), 'Invoke')) {
-            $null = Invoke-GitHubWorkflowRunFailedJobsReRun @RestInputObject -RunId $run.id
+        try {
+            if ($PSCmdlet.ShouldProcess(("Re-run of failed jobs for GitHub workflow [{0}] for branch [$TargetBranch]" -f $run.name), 'Invoke')) {
+                $null = Invoke-GitHubWorkflowRunFailedJobsReRun @RestInputObject -RunId $run.id
+            }
+        } catch {
+            Write-Warning ('Failed to re-run failed jobs for workflow [{0}] for branch [{1}]. Error: {2}' -f $run.name, $TargetBranch, $_.Exception.Message)
         }
         $currentCount++
     }
@@ -306,6 +310,7 @@ function Invoke-WorkflowsFailedJobsReRun {
     Write-Verbose ('Re-run summary for branch [{0}]:' -f $TargetBranch) -Verbose
     Write-Verbose ('  Workflows analyzed: [{0}]' -f $workflows.Count) -Verbose
     Write-Verbose ('  Failed runs {0}: [{1}]' -f $reRunState, $runsToReTrigger.Count) -Verbose
+    $runsToReTrigger | ForEach-Object { Write-Verbose ('    - [{0}]' -f $_.name) -Verbose }
     Write-Verbose ('  Skipped by hard stop (>= [{0}] attempts): [{1}]' -f $MaxAttempts, $hardStoppedRuns.Count) -Verbose
     if ($hardStoppedRuns.Count -gt 0) {
         Write-Verbose ('  Hard-stopped workflows: {0}' -f (($hardStoppedRuns | ForEach-Object { $_.name }) -join ', ')) -Verbose


### PR DESCRIPTION
## Description

- Added vebosity to job re-run
- Currently it shows you only that it failed but not for what workflow

Example output
```
VERBOSE: Fetching current GitHub workflows
VERBOSE: Fetched [217] workflows
VERBOSE: Hard stop for workflow [avm.res.api-management.service]: run [29846539076] already at attempt [11] (>= [3]). Skipping re-run.
VERBOSE: Hard stop for workflow [avm.res.compute.virtual-machine]: run [28888858118] already at attempt [3] (>= [3]). Skipping re-run.
VERBOSE: Runs to re-run failed jobs for [1/217]
gh: Unable to retry this workflow run because it was created over a month ago (HTTP 403)
WARNING: Failed to re-run failed jobs for workflow [avm.ptn.app.container-job-toolkit.yml] for branch [main]. Error: Request failed. Response: [@{message=Unable to retry this workflow run because it was created over a month ago; documentation_url=https://docs.github.com/rest/actions/workflow-runs#re-run-failed-jobs-from-a-workflow-run; status=403}]
VERBOSE: Re-run summary for branch [main]:
VERBOSE:   Workflows analyzed: [217]
VERBOSE:   Failed runs re-triggered: [1]
VERBOSE:     - [avm.ptn.app.container-job-toolkit.yml]
VERBOSE:   Skipped by hard stop (>= [3] attempts): [2]
VERBOSE:   Hard-stopped workflows: avm.res.api-management.service, avm.res.compute.virtual-machine
VERBOSE: Re-triggering complete
```

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
[![.Platform - Rerun failed workflows](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.rerun-failed-workflows.yml/badge.svg?branch=users%2Falsehr%2FretriggerVerbosity&event=workflow_dispatch)](https://github.com/Azure/bicep-registry-modules/actions/workflows/platform.rerun-failed-workflows.yml)

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)
