### PR TITLE
fix: Deployment name creation for child modules of `avm/res/operational-insights/workspace`

### DIFF
--- a/avm/res/operational-insights/workspace/CHANGELOG.md
+++ b/avm/res/operational-insights/workspace/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/operational-insights/workspace/CHANGELOG.md).
 
+## 0.16.1
+
+### Changes
+
+- Fixed child module deployment names creation to prevent conflicts when two workspaces are deployed in the same resource group at the same time.
+
+### Breaking Changes
+
+- None
+
 ## 0.16.0
 
 ### Changes

--- a/avm/res/operational-insights/workspace/main.bicep
+++ b/avm/res/operational-insights/workspace/main.bicep
@@ -176,7 +176,7 @@ var formattedRoleAssignments = [
 ]
 
 #disable-next-line no-deployments-resources
-resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
+resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableTelemetry) {
   name: '46d3xbcp.res.operationalinsights-workspace.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
   properties: {
     mode: 'Incremental'
@@ -260,7 +260,7 @@ resource logAnalyticsWorkspace_diagnosticSettings 'Microsoft.Insights/diagnostic
 
 module logAnalyticsWorkspace_storageInsightConfigs 'storage-insight-config/main.bicep' = [
   for (storageInsightsConfig, index) in storageInsightsConfigs ?? []: {
-    name: '${uniqueString(subscription().id, resourceGroup().id, location)}-LAW-StorageInsightsConfig-${index}'
+    name: '${uniqueString(subscription().id, resourceGroup().id, location, name)}-LAW-StorageInsightsConfig-${index}'
     params: {
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
       containers: storageInsightsConfig.?containers
@@ -273,7 +273,7 @@ module logAnalyticsWorkspace_storageInsightConfigs 'storage-insight-config/main.
 
 module logAnalyticsWorkspace_linkedServices 'linked-service/main.bicep' = [
   for (linkedService, index) in linkedServices ?? []: {
-    name: '${uniqueString(subscription().id, resourceGroup().id, location)}-LAW-LinkedService-${index}'
+    name: '${uniqueString(subscription().id, resourceGroup().id, location, name)}-LAW-LinkedService-${index}'
     params: {
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
       name: linkedService.name
@@ -286,7 +286,7 @@ module logAnalyticsWorkspace_linkedServices 'linked-service/main.bicep' = [
 
 module logAnalyticsWorkspace_linkedStorageAccounts 'linked-storage-account/main.bicep' = [
   for (linkedStorageAccount, index) in linkedStorageAccounts ?? []: {
-    name: '${uniqueString(subscription().id, resourceGroup().id, location)}-LAW-LinkedStorageAccount-${index}'
+    name: '${uniqueString(subscription().id, resourceGroup().id, location, name)}-LAW-LinkedStorageAccount-${index}'
     params: {
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
       name: linkedStorageAccount.name
@@ -298,7 +298,7 @@ module logAnalyticsWorkspace_linkedStorageAccounts 'linked-storage-account/main.
 
 module logAnalyticsWorkspace_savedSearches 'saved-search/main.bicep' = [
   for (savedSearch, index) in savedSearches ?? []: {
-    name: '${uniqueString(subscription().id, resourceGroup().id, location)}-LAW-SavedSearch-${index}'
+    name: '${uniqueString(subscription().id, resourceGroup().id, location, name)}-LAW-SavedSearch-${index}'
     params: {
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
       name: '${savedSearch.name}${uniqueString(subscription().id, resourceGroup().id)}'
@@ -320,7 +320,7 @@ module logAnalyticsWorkspace_savedSearches 'saved-search/main.bicep' = [
 
 module logAnalyticsWorkspace_dataExports 'data-export/main.bicep' = [
   for (dataExport, index) in dataExports ?? []: {
-    name: '${uniqueString(subscription().id, resourceGroup().id, location)}-LAW-DataExport-${index}'
+    name: '${uniqueString(subscription().id, resourceGroup().id, location, name)}-LAW-DataExport-${index}'
     params: {
       workspaceName: logAnalyticsWorkspace.name
       name: dataExport.name
@@ -334,7 +334,7 @@ module logAnalyticsWorkspace_dataExports 'data-export/main.bicep' = [
 
 module logAnalyticsWorkspace_dataSources 'data-source/main.bicep' = [
   for (dataSource, index) in dataSources ?? []: {
-    name: '${uniqueString(subscription().id, resourceGroup().id, location)}-LAW-DataSource-${index}'
+    name: '${uniqueString(subscription().id, resourceGroup().id, location, name)}-LAW-DataSource-${index}'
     params: {
       logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
       name: dataSource.name
@@ -358,7 +358,7 @@ module logAnalyticsWorkspace_dataSources 'data-source/main.bicep' = [
 
 module logAnalyticsWorkspace_tables 'table/main.bicep' = [
   for (table, index) in tables ?? []: {
-    name: '${uniqueString(subscription().id, resourceGroup().id, location)}-LAW-Table-${index}'
+    name: '${uniqueString(subscription().id, resourceGroup().id, location, name)}-LAW-Table-${index}'
     params: {
       workspaceName: logAnalyticsWorkspace.name
       name: table.name
@@ -376,7 +376,7 @@ module logAnalyticsWorkspace_tables 'table/main.bicep' = [
 
 module logAnalyticsWorkspace_solutions 'br/public:avm/res/operations-management/solution:0.3.1' = [
   for (gallerySolution, index) in gallerySolutions ?? []: if (!empty(gallerySolutions)) {
-    name: '${uniqueString(subscription().id, resourceGroup().id, location)}-LAW-Solution-${index}'
+    name: '${uniqueString(subscription().id, resourceGroup().id, location, name)}-LAW-Solution-${index}'
     params: {
       name: gallerySolution.name
       location: location

--- a/avm/res/operational-insights/workspace/main.json
+++ b/avm/res/operational-insights/workspace/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.44.1.10279",
-      "templateHash": "300151097824750787"
+      "version": "0.46.1.21595",
+      "templateHash": "773252277109044901"
     },
     "name": "Log Analytics Workspaces",
     "description": "This module deploys a Log Analytics Workspace."
@@ -1247,7 +1247,7 @@
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2024-03-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('46d3xbcp.res.operationalinsights-workspace.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
       "properties": {
         "mode": "Incremental",
@@ -1389,7 +1389,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
-      "name": "[format('{0}-LAW-StorageInsightsConfig-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location')), copyIndex())]",
+      "name": "[format('{0}-LAW-StorageInsightsConfig-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location'), parameters('name')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -1419,8 +1419,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "3203247719223471150"
+              "version": "0.46.1.21595",
+              "templateHash": "10369222486830126860"
             },
             "name": "Log Analytics Workspace Storage Insight Configs",
             "description": "This module deploys a Log Analytics Workspace Storage Insight Config."
@@ -1567,7 +1567,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
-      "name": "[format('{0}-LAW-LinkedService-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location')), copyIndex())]",
+      "name": "[format('{0}-LAW-LinkedService-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location'), parameters('name')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -1597,8 +1597,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "3016855963248138529"
+              "version": "0.46.1.21595",
+              "templateHash": "18347348702261716625"
             },
             "name": "Log Analytics Workspace Linked Services",
             "description": "This module deploys a Log Analytics Workspace Linked Service."
@@ -1722,7 +1722,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
-      "name": "[format('{0}-LAW-LinkedStorageAccount-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location')), copyIndex())]",
+      "name": "[format('{0}-LAW-LinkedStorageAccount-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location'), parameters('name')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -1749,8 +1749,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "12144141992286941590"
+              "version": "0.46.1.21595",
+              "templateHash": "10724696111872632042"
             },
             "name": "Log Analytics Workspace Linked Storage Accounts",
             "description": "This module deploys a Log Analytics Workspace Linked Storage Account."
@@ -1864,7 +1864,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
-      "name": "[format('{0}-LAW-SavedSearch-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location')), copyIndex())]",
+      "name": "[format('{0}-LAW-SavedSearch-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location'), parameters('name')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -1912,8 +1912,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "16955699423458003144"
+              "version": "0.46.1.21595",
+              "templateHash": "157060859772163225"
             },
             "name": "Log Analytics Workspace Saved Searches",
             "description": "This module deploys a Log Analytics Workspace Saved Search."
@@ -2075,7 +2075,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
-      "name": "[format('{0}-LAW-DataExport-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location')), copyIndex())]",
+      "name": "[format('{0}-LAW-DataExport-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location'), parameters('name')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -2108,8 +2108,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "11267398656136162186"
+              "version": "0.46.1.21595",
+              "templateHash": "17814816351436813252"
             },
             "name": "Log Analytics Workspace Data Exports",
             "description": "This module deploys a Log Analytics Workspace Data Export."
@@ -2268,7 +2268,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
-      "name": "[format('{0}-LAW-DataSource-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location')), copyIndex())]",
+      "name": "[format('{0}-LAW-DataSource-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location'), parameters('name')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -2331,8 +2331,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "8051473449088627486"
+              "version": "0.46.1.21595",
+              "templateHash": "7684305028057669338"
             },
             "name": "Log Analytics Workspace Datasources",
             "description": "This module deploys a Log Analytics Workspace Data Source."
@@ -2546,7 +2546,7 @@
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
-      "name": "[format('{0}-LAW-Table-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location')), copyIndex())]",
+      "name": "[format('{0}-LAW-Table-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location'), parameters('name')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -2591,8 +2591,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "16504931700340537294"
+              "version": "0.46.1.21595",
+              "templateHash": "17581420628338980692"
             },
             "name": "Log Analytics Workspace Tables",
             "description": "This module deploys a Log Analytics Workspace Table."
@@ -3044,7 +3044,7 @@
       "condition": "[not(empty(parameters('gallerySolutions')))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
-      "name": "[format('{0}-LAW-Solution-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location')), copyIndex())]",
+      "name": "[format('{0}-LAW-Solution-{1}', uniqueString(subscription().id, resourceGroup().id, parameters('location'), parameters('name')), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"

--- a/avm/res/operational-insights/workspace/tests/e2e/adv/dependencies.bicep
+++ b/avm/res/operational-insights/workspace/tests/e2e/adv/dependencies.bicep
@@ -16,7 +16,7 @@ param eventHubName string
 @description('Required. The name of the Managed Identity to create.')
 param managedIdentityName string
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2026-04-01' = {
   name: storageAccountName
   location: location
   sku: {
@@ -41,7 +41,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2024-10-23' 
   }
 }
 
-resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = {
+resource eventHubNamespace 'Microsoft.EventHub/namespaces@2026-01-01' = {
   name: eventHubNamespaceName
   location: location
   sku: {
@@ -59,7 +59,7 @@ resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = {
     zoneRedundant: true
   }
 
-  resource eventHub 'eventhubs@2024-01-01' = {
+  resource eventHub 'eventhubs@2026-01-01' = {
     name: eventHubName
     properties: {
       messageRetentionInDays: 1

--- a/avm/res/operational-insights/workspace/tests/e2e/max/dependencies.bicep
+++ b/avm/res/operational-insights/workspace/tests/e2e/max/dependencies.bicep
@@ -13,7 +13,7 @@ param managedIdentityName string
 @description('Required. The name of the Deployment Script to create to get the paired region name.')
 param pairedRegionScriptName string
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2026-04-01' = {
   name: storageAccountName
   location: location
   sku: {

--- a/avm/res/operational-insights/workspace/tests/e2e/max/dependencies.bicep
+++ b/avm/res/operational-insights/workspace/tests/e2e/max/dependencies.bicep
@@ -71,6 +71,9 @@ resource getPairedRegionScript 'Microsoft.Resources/deploymentScripts@2023-08-01
     arguments: '-Location \\"${location}\\"'
     scriptContent: loadTextContent('../../../../../../../utilities/e2e-template-assets/scripts/Get-PairedRegion.ps1')
   }
+  tags: {
+    SecurityControl: 'Ignore' // SFI policies would prevent key based authentication to the storage account
+  }
   dependsOn: [
     roleAssignment
   ]

--- a/avm/res/operational-insights/workspace/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/operational-insights/workspace/tests/e2e/waf-aligned/dependencies.bicep
@@ -13,7 +13,7 @@ param managedIdentityName string
 @description('Required. The name of the Deployment Script to create to get the paired region name.')
 param pairedRegionScriptName string
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2026-04-01' = {
   name: storageAccountName
   location: location
   sku: {

--- a/avm/res/operational-insights/workspace/tests/e2e/waf-aligned/dependencies.bicep
+++ b/avm/res/operational-insights/workspace/tests/e2e/waf-aligned/dependencies.bicep
@@ -71,6 +71,9 @@ resource getPairedRegionScript 'Microsoft.Resources/deploymentScripts@2023-08-01
     arguments: '-Location \\"${location}\\"'
     scriptContent: loadTextContent('../../../../../../../utilities/e2e-template-assets/scripts/Get-PairedRegion.ps1')
   }
+  tags: {
+    SecurityControl: 'Ignore' // SFI policies would prevent key based authentication to the storage account
+  }
   dependsOn: [
     roleAssignment
   ]


### PR DESCRIPTION
## Description

Fixes #7194 

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |
| [![avm.res.operational-insights.workspace](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml/badge.svg?branch=users%2Fkrbar%2FlawExportDeploymentName)](https://github.com/krbar/bicep-registry-modules/actions/workflows/avm.res.operational-insights.workspace.yml) |



## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
