### PR TITLE
fix: AVM-RES: Update GPT model and VM size defaults

### DIFF
--- a/avm/ptn/sa/document-knowledge-mining/README.md
+++ b/avm/ptn/sa/document-knowledge-mining/README.md
@@ -516,11 +516,11 @@ Name of the GPT model to deploy.
 
 - Required: No
 - Type: string
-- Default: `'gpt-4.1-mini'`
+- Default: `'gpt-5-mini'`
 - Allowed:
   ```Bicep
   [
-    'gpt-4.1-mini'
+    'gpt-5-mini'
   ]
   ```
 
@@ -530,7 +530,7 @@ Version of the GPT model to deploy.
 
 - Required: No
 - Type: string
-- Default: `'2025-04-14'`
+- Default: `'2025-08-07'`
 
 ### Parameter: `location`
 
@@ -584,7 +584,7 @@ Size of the Jumpbox Virtual Machine when created. Set to custom value if enableP
 
 - Required: No
 - Type: string
-- Default: `'Standard_DS2_v2'`
+- Default: `'Standard_D2s_v6'`
 
 ## Outputs
 

--- a/avm/ptn/sa/document-knowledge-mining/main.bicep
+++ b/avm/ptn/sa/document-knowledge-mining/main.bicep
@@ -46,12 +46,12 @@ param gptModelDeploymentType string = 'GlobalStandard'
 @minLength(1)
 @description('Optional. Name of the GPT model to deploy.')
 @allowed([
-  'gpt-4.1-mini'
+  'gpt-5-mini'
 ])
-param gptModelName string = 'gpt-4.1-mini'
+param gptModelName string = 'gpt-5-mini'
 
 @description('Optional. Version of the GPT model to deploy.')
-param gptModelVersion string = '2025-04-14'
+param gptModelVersion string = '2025-08-07'
 
 @description('Optional. Capacity of the GPT model deployment.')
 @minValue(10)
@@ -80,7 +80,7 @@ param vmAdminUsername string?
 param vmAdminPassword string?
 
 @description('Optional. Size of the Jumpbox Virtual Machine when created. Set to custom value if enablePrivateNetworking is true.')
-param vmSize string = 'Standard_DS2_v2'
+param vmSize string = 'Standard_D2s_v6'
 
 @description('Optional. The tags to apply to all deployed Azure resources.')
 param tags resourceInput<'Microsoft.Resources/resourceGroups@2025-04-01'>.tags = {}
@@ -362,17 +362,17 @@ module jumpboxVM 'br/public:avm/res/compute/virtual-machine:0.22.1' = if (enable
   name: take('avm.res.compute.virtual-machine.${jumpboxVmName}', 64)
   params: {
     name: take(jumpboxVmName, 15) // Shorten VM name to 15 characters to avoid Azure limits
-    vmSize: vmSize ?? 'Standard_DS2_v2'
+    vmSize: vmSize ?? 'Standard_D2s_v6'
     location: solutionLocation
     adminUsername: vmAdminUsername ?? 'JumpboxAdminUser'
     adminPassword: vmAdminPassword ?? 'JumpboxAdminP@ssw0rd1234!'
     tags: tags
-    availabilityZone: 1
+    availabilityZone: -1
     maintenanceConfigurationResourceId: maintenanceConfiguration!.outputs.resourceId
     imageReference: {
       offer: 'WindowsServer'
       publisher: 'MicrosoftWindowsServer'
-      sku: '2019-datacenter'
+      sku: '2019-datacenter-gensecond'
       version: 'latest'
     }
     osType: 'Windows'
@@ -1004,6 +1004,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:0.13.
         name: 'agentpool'
         vmSize: 'Standard_D4ds_v5'
         count: 3
+        availabilityZones: []
         osType: 'Linux'
         mode: 'System'
         type: 'VirtualMachineScaleSets'

--- a/avm/ptn/sa/document-knowledge-mining/main.json
+++ b/avm/ptn/sa/document-knowledge-mining/main.json
@@ -57,9 +57,9 @@
     },
     "gptModelName": {
       "type": "string",
-      "defaultValue": "gpt-4.1-mini",
+      "defaultValue": "gpt-5-mini",
       "allowedValues": [
-        "gpt-4.1-mini"
+        "gpt-5-mini"
       ],
       "minLength": 1,
       "metadata": {
@@ -68,7 +68,7 @@
     },
     "gptModelVersion": {
       "type": "string",
-      "defaultValue": "2025-04-14",
+      "defaultValue": "2025-08-07",
       "metadata": {
         "description": "Optional. Version of the GPT model to deploy."
       }
@@ -123,7 +123,7 @@
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_DS2_v2",
+      "defaultValue": "Standard_D2s_v6",
       "metadata": {
         "description": "Optional. Size of the Jumpbox Virtual Machine when created. Set to custom value if enablePrivateNetworking is true."
       }
@@ -11888,7 +11888,7 @@
             "value": "[take(variables('jumpboxVmName'), 15)]"
           },
           "vmSize": {
-            "value": "[coalesce(parameters('vmSize'), 'Standard_DS2_v2')]"
+            "value": "[coalesce(parameters('vmSize'), 'Standard_D2s_v6')]"
           },
           "location": {
             "value": "[variables('solutionLocation')]"
@@ -11903,7 +11903,7 @@
             "value": "[parameters('tags')]"
           },
           "availabilityZone": {
-            "value": 1
+            "value": -1
           },
           "maintenanceConfigurationResourceId": {
             "value": "[reference('maintenanceConfiguration').outputs.resourceId.value]"
@@ -11912,7 +11912,7 @@
             "value": {
               "offer": "WindowsServer",
               "publisher": "MicrosoftWindowsServer",
-              "sku": "2019-datacenter",
+              "sku": "2019-datacenter-gensecond",
               "version": "latest"
             }
           },
@@ -49577,7 +49577,8 @@
                 }
               },
               "dependsOn": [
-                "cognitiveService"
+                "cognitiveService",
+                "cognitiveService_deployments"
               ]
             },
             "secretsExport": {
@@ -52089,7 +52090,8 @@
                 }
               },
               "dependsOn": [
-                "cognitiveService"
+                "cognitiveService",
+                "cognitiveService_deployments"
               ]
             },
             "secretsExport": {
@@ -52408,6 +52410,7 @@
                 "name": "agentpool",
                 "vmSize": "Standard_D4ds_v5",
                 "count": 3,
+                "availabilityZones": [],
                 "osType": "Linux",
                 "mode": "System",
                 "type": "VirtualMachineScaleSets",

--- a/avm/ptn/sa/document-knowledge-mining/main.json
+++ b/avm/ptn/sa/document-knowledge-mining/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "10257728759991762492"
+      "version": "0.44.1.10279",
+      "templateHash": "15472167044043655747"
     },
     "name": "Document Knowledge Mining Solution",
     "description": "This module contains the resources required to deploy the [Document Knowledge Mining Solution](https://github.com/microsoft/Document-Knowledge-Mining-Solution-Accelerator) for both Sandbox environments and enterprise-grade environments.\n\n|**Post-Deployment Step** |\n|-------------|\n| After completing the deployment, follow the steps in the [Post-Deployment Guide](https://github.com/microsoft/Document-Knowledge-Mining-Solution-Accelerator/blob/main/docs/AVMPostDeploymentGuide.md) to configure and verify your environment. |\n\n"
@@ -7162,8 +7162,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "5581323545890539491"
+              "version": "0.44.1.10279",
+              "templateHash": "9977062242126100831"
             }
           },
           "definitions": {
@@ -22329,8 +22329,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "5182253300933540303"
+              "version": "0.44.1.10279",
+              "templateHash": "14127094433929988855"
             },
             "name": "Container Registry Module"
           },
@@ -45196,8 +45196,8 @@
         }
       },
       "dependsOn": [
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "userAssignedIdentity",
         "virtualNetwork"
       ]
@@ -49577,8 +49577,7 @@
                 }
               },
               "dependsOn": [
-                "cognitiveService",
-                "cognitiveService_deployments"
+                "cognitiveService"
               ]
             },
             "secretsExport": {
@@ -52090,8 +52089,7 @@
                 }
               },
               "dependsOn": [
-                "cognitiveService",
-                "cognitiveService_deployments"
+                "cognitiveService"
               ]
             },
             "secretsExport": {


### PR DESCRIPTION
## Description

- Changed default GPT model from gpt-4.1-mini to gpt-5-mini.
- Updated GPT model version from 2025-04-14 to 2025-08-07.
- Modified default VM size from Standard_DS2_v2 to Standard_D2s_v6.
- Adjusted availability zone value from 1 to -1 for compatibility.
- Updated SKU for Windows Server from 2019-datacenter to 2019-datacenter-gensecond.
- Added cognitiveService_deployments as a dependency in multiple resources.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
