### PR TITLE
feat(aks): add Gateway API and agent pool update support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ generated-moduleIndex.json
 .DS_Store
 .idea
 **/AzureBackupGeoCodeMappings.json
+.copilot-tracking/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ generated-moduleIndex.json
 .DS_Store
 .idea
 **/AzureBackupGeoCodeMappings.json
-.copilot-tracking/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ generated-moduleIndex.json
 .DS_Store
 .idea
 **/AzureBackupGeoCodeMappings.json
+/.copilot-tracking/

--- a/avm/res/container-service/managed-cluster/CHANGELOG.md
+++ b/avm/res/container-service/managed-cluster/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/container-service/managed-cluster/CHANGELOG.md).
 
+## 0.15.0
+
+### Changes
+
+- Updated the managed cluster and agent pool ARM API versions to `2026-03-01` to support agent pool VM size updates.
+- Added the `gatewayAPI` parameter to configure the Kubernetes Gateway API profile.
+- Updated Cilium network plugin mode handling to support agent pools that use pod subnets.
+
+### Breaking Changes
+
+- None
+
 ## 0.14.0
 
 ### Changes

--- a/avm/res/container-service/managed-cluster/README.md
+++ b/avm/res/container-service/managed-cluster/README.md
@@ -25,8 +25,8 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | :-- | :-- | :-- |
 | `Microsoft.Authorization/locks` | 2020-05-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_locks.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks)</li></ul> |
 | `Microsoft.Authorization/roleAssignments` | 2022-04-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.authorization_roleassignments.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments)</li></ul> |
-| `Microsoft.ContainerService/managedClusters` | 2025-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2025-10-01/managedClusters)</li></ul> |
-| `Microsoft.ContainerService/managedClusters/agentPools` | 2025-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters_agentpools.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2025-10-01/managedClusters/agentPools)</li></ul> |
+| `Microsoft.ContainerService/managedClusters` | 2026-03-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2026-03-01/managedClusters)</li></ul> |
+| `Microsoft.ContainerService/managedClusters/agentPools` | 2026-03-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters_agentpools.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2026-03-01/managedClusters/agentPools)</li></ul> |
 | `Microsoft.ContainerService/managedClusters/maintenanceConfigurations` | 2025-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters_maintenanceconfigurations.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2025-10-01/managedClusters/maintenanceConfigurations)</li></ul> |
 | `Microsoft.Insights/diagnosticSettings` | 2021-05-01-preview | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.insights_diagnosticsettings.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Insights/2021-05-01-preview/diagnosticSettings)</li></ul> |
 | `Microsoft.KubernetesConfiguration/extensions` | 2024-11-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.kubernetesconfiguration_extensions.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.KubernetesConfiguration/2024-11-01/extensions)</li></ul> |
@@ -1140,6 +1140,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
         osDiskSizeGB: 128
         osDiskType: 'Managed'
         osType: 'Linux'
+        podSubnetResourceId: '<podSubnetResourceId>'
         powerState: {
           code: 'Running'
         }
@@ -1149,7 +1150,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
           maxSurge: '33%'
           nodeSoakDurationInMinutes: 0
         }
-        vmSize: 'Standard_DS2_v2'
+        vmSize: '<vmSize>'
         vnetSubnetResourceId: '<vnetSubnetResourceId>'
       }
     ]
@@ -1196,6 +1197,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
         osDiskSizeGB: 30
         osDiskType: 'Ephemeral'
         osType: 'Linux'
+        podSubnetResourceId: '<podSubnetResourceId>'
         powerState: {
           code: 'Running'
         }
@@ -1207,7 +1209,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
           maxSurge: '50%'
           nodeSoakDurationInMinutes: 0
         }
-        vmSize: 'Standard_D2s_v3'
+        vmSize: '<vmSize>'
         vnetSubnetResourceId: '<vnetSubnetResourceId>'
       }
     ]
@@ -1314,6 +1316,9 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
     enableStorageProfileDiskCSIDriver: true
     enableStorageProfileFileCSIDriver: true
     enableStorageProfileSnapshotController: true
+    gatewayAPI: {
+      installation: 'Standard'
+    }
     httpApplicationRoutingEnabled: false
     identityProfile: {
       kubeletidentity: {
@@ -1378,10 +1383,10 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
     }
     managedOutboundIPCount: 2
     monitoringWorkspaceResourceId: '<monitoringWorkspaceResourceId>'
-    networkDataplane: 'azure'
+    networkDataplane: 'cilium'
     networkPlugin: 'azure'
     networkPluginMode: 'overlay'
-    networkPolicy: 'azure'
+    networkPolicy: 'cilium'
     nodeProvisioningProfile: {
       mode: 'Manual'
     }
@@ -1396,7 +1401,6 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
       '<publicIPAKSResourceId>'
     ]
     outboundType: 'loadBalancer'
-    podCidr: '10.244.0.0/16'
     podIdentityProfile: {
       enabled: false
     }
@@ -1493,6 +1497,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
           "osDiskSizeGB": 128,
           "osDiskType": "Managed",
           "osType": "Linux",
+          "podSubnetResourceId": "<podSubnetResourceId>",
           "powerState": {
             "code": "Running"
           },
@@ -1502,7 +1507,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
             "maxSurge": "33%",
             "nodeSoakDurationInMinutes": 0
           },
-          "vmSize": "Standard_DS2_v2",
+          "vmSize": "<vmSize>",
           "vnetSubnetResourceId": "<vnetSubnetResourceId>"
         }
       ]
@@ -1555,6 +1560,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
           "osDiskSizeGB": 30,
           "osDiskType": "Ephemeral",
           "osType": "Linux",
+          "podSubnetResourceId": "<podSubnetResourceId>",
           "powerState": {
             "code": "Running"
           },
@@ -1566,7 +1572,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
             "maxSurge": "50%",
             "nodeSoakDurationInMinutes": 0
           },
-          "vmSize": "Standard_D2s_v3",
+          "vmSize": "<vmSize>",
           "vnetSubnetResourceId": "<vnetSubnetResourceId>"
         }
       ]
@@ -1722,6 +1728,11 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
     "enableStorageProfileSnapshotController": {
       "value": true
     },
+    "gatewayAPI": {
+      "value": {
+        "installation": "Standard"
+      }
+    },
     "httpApplicationRoutingEnabled": {
       "value": false
     },
@@ -1813,7 +1824,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
       "value": "<monitoringWorkspaceResourceId>"
     },
     "networkDataplane": {
-      "value": "azure"
+      "value": "cilium"
     },
     "networkPlugin": {
       "value": "azure"
@@ -1822,7 +1833,7 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
       "value": "overlay"
     },
     "networkPolicy": {
-      "value": "azure"
+      "value": "cilium"
     },
     "nodeProvisioningProfile": {
       "value": {
@@ -1853,9 +1864,6 @@ module managedCluster 'br/public:avm/res/container-service/managed-cluster:<vers
     },
     "outboundType": {
       "value": "loadBalancer"
-    },
-    "podCidr": {
-      "value": "10.244.0.0/16"
     },
     "podIdentityProfile": {
       "value": {
@@ -1974,6 +1982,7 @@ param primaryAgentPoolProfiles = [
     osDiskSizeGB: 128
     osDiskType: 'Managed'
     osType: 'Linux'
+    podSubnetResourceId: '<podSubnetResourceId>'
     powerState: {
       code: 'Running'
     }
@@ -1983,7 +1992,7 @@ param primaryAgentPoolProfiles = [
       maxSurge: '33%'
       nodeSoakDurationInMinutes: 0
     }
-    vmSize: 'Standard_DS2_v2'
+    vmSize: '<vmSize>'
     vnetSubnetResourceId: '<vnetSubnetResourceId>'
   }
 ]
@@ -2030,6 +2039,7 @@ param agentPools = [
     osDiskSizeGB: 30
     osDiskType: 'Ephemeral'
     osType: 'Linux'
+    podSubnetResourceId: '<podSubnetResourceId>'
     powerState: {
       code: 'Running'
     }
@@ -2041,7 +2051,7 @@ param agentPools = [
       maxSurge: '50%'
       nodeSoakDurationInMinutes: 0
     }
-    vmSize: 'Standard_D2s_v3'
+    vmSize: '<vmSize>'
     vnetSubnetResourceId: '<vnetSubnetResourceId>'
   }
 ]
@@ -2148,6 +2158,9 @@ param enableStorageProfileBlobCSIDriver = true
 param enableStorageProfileDiskCSIDriver = true
 param enableStorageProfileFileCSIDriver = true
 param enableStorageProfileSnapshotController = true
+param gatewayAPI = {
+  installation: 'Standard'
+}
 param httpApplicationRoutingEnabled = false
 param identityProfile = {
   kubeletidentity: {
@@ -2212,10 +2225,10 @@ param managedIdentities = {
 }
 param managedOutboundIPCount = 2
 param monitoringWorkspaceResourceId = '<monitoringWorkspaceResourceId>'
-param networkDataplane = 'azure'
+param networkDataplane = 'cilium'
 param networkPlugin = 'azure'
 param networkPluginMode = 'overlay'
-param networkPolicy = 'azure'
+param networkPolicy = 'cilium'
 param nodeProvisioningProfile = {
   mode: 'Manual'
 }
@@ -2230,7 +2243,6 @@ param outboundPublicIPResourceIds = [
   '<publicIPAKSResourceId>'
 ]
 param outboundType = 'loadBalancer'
-param podCidr = '10.244.0.0/16'
 param podIdentityProfile = {
   enabled: false
 }
@@ -3201,6 +3213,7 @@ param tags = {
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`fluxExtension`](#parameter-fluxextension) | object | Settings and configurations for the flux extension. |
 | [`fqdnSubdomain`](#parameter-fqdnsubdomain) | string | The FQDN subdomain of the private cluster with custom private dns zone. This cannot be updated once the Managed Cluster has been created. |
+| [`gatewayAPI`](#parameter-gatewayapi) | object | Gateway API profile for the managed cluster. |
 | [`httpApplicationRoutingEnabled`](#parameter-httpapplicationroutingenabled) | bool | Specifies whether the httpApplicationRouting add-on is enabled or not. |
 | [`httpProxyConfig`](#parameter-httpproxyconfig) | object | Configurations for provisioning the cluster with HTTP proxy servers. |
 | [`identityProfile`](#parameter-identityprofile) | object | Identities associated with the cluster. |
@@ -4628,6 +4641,13 @@ The FQDN subdomain of the private cluster with custom private dns zone. This can
 
 - Required: No
 - Type: string
+
+### Parameter: `gatewayAPI`
+
+Gateway API profile for the managed cluster.
+
+- Required: No
+- Type: object
 
 ### Parameter: `httpApplicationRoutingEnabled`
 

--- a/avm/res/container-service/managed-cluster/agent-pool/README.md
+++ b/avm/res/container-service/managed-cluster/agent-pool/README.md
@@ -21,7 +21,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 
 | Resource Type | API Version | References |
 | :-- | :-- | :-- |
-| `Microsoft.ContainerService/managedClusters/agentPools` | 2025-10-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters_agentpools.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2025-10-01/managedClusters/agentPools)</li></ul> |
+| `Microsoft.ContainerService/managedClusters/agentPools` | 2026-03-01 | <ul style="padding-left: 0px;"><li>[AzAdvertizer](https://www.azadvertizer.net/azresourcetypes/microsoft.containerservice_managedclusters_agentpools.html)</li><li>[Template reference](https://learn.microsoft.com/en-us/azure/templates/Microsoft.ContainerService/2026-03-01/managedClusters/agentPools)</li></ul> |
 
 ## Parameters
 

--- a/avm/res/container-service/managed-cluster/agent-pool/main.bicep
+++ b/avm/res/container-service/managed-cluster/agent-pool/main.bicep
@@ -186,11 +186,11 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableT
   }
 }
 
-resource managedCluster 'Microsoft.ContainerService/managedClusters@2025-10-01' existing = {
+resource managedCluster 'Microsoft.ContainerService/managedClusters@2026-03-01' existing = {
   name: managedClusterName
 }
 
-resource agentPool 'Microsoft.ContainerService/managedClusters/agentPools@2025-10-01' = {
+resource agentPool 'Microsoft.ContainerService/managedClusters/agentPools@2026-03-01' = {
   name: name
   parent: managedCluster
   properties: {

--- a/avm/res/container-service/managed-cluster/agent-pool/main.json
+++ b/avm/res/container-service/managed-cluster/agent-pool/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "8419782549162061894"
+      "version": "0.46.1.21595",
+      "templateHash": "10823651473689322161"
     },
     "name": "Azure Kubernetes Service (AKS) Managed Cluster Agent Pools",
     "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Agent Pool."
@@ -484,12 +484,12 @@
     "managedCluster": {
       "existing": true,
       "type": "Microsoft.ContainerService/managedClusters",
-      "apiVersion": "2025-10-01",
+      "apiVersion": "2026-03-01",
       "name": "[parameters('managedClusterName')]"
     },
     "agentPool": {
       "type": "Microsoft.ContainerService/managedClusters/agentPools",
-      "apiVersion": "2025-10-01",
+      "apiVersion": "2026-03-01",
       "name": "[format('{0}/{1}', parameters('managedClusterName'), parameters('name'))]",
       "properties": {
         "availabilityZones": "[if(equals(parameters('type'), 'VirtualMachines'), null(), map(coalesce(parameters('availabilityZones'), createArray()), lambda('zone', format('{0}', lambdaVariables('zone')))))]",

--- a/avm/res/container-service/managed-cluster/main.bicep
+++ b/avm/res/container-service/managed-cluster/main.bicep
@@ -150,6 +150,9 @@ param dnsZoneResourceId string?
 @description('Optional. Ingress type for the default NginxIngressController custom resource. It will be ignored if `webApplicationRoutingEnabled` is set to `false`.')
 param defaultIngressControllerType resourceInput<'Microsoft.ContainerService/managedClusters@2025-10-01'>.properties.ingressProfile.webAppRouting.nginx.defaultIngressControllerType?
 
+@description('Optional. Gateway API profile for the managed cluster.')
+param gatewayAPI resourceInput<'Microsoft.ContainerService/managedClusters@2026-03-01'>.properties.ingressProfile.gatewayAPI?
+
 @description('Optional. Specifies whether assing the DNS zone contributor role to the cluster service principal. It will be ignored if `webApplicationRoutingEnabled` is set to `false` or `dnsZoneResourceId` not provided.')
 param enableDnsZoneContributorRoleAssignment bool = true
 
@@ -379,6 +382,11 @@ var formattedRoleAssignments = [
   })
 ]
 
+var usesPodSubnet = contains(
+  map(concat(primaryAgentPoolProfiles, agentPools ?? []), profile => !empty(profile.?podSubnetResourceId)),
+  true
+)
+
 // ============ //
 // Dependencies //
 // ============ //
@@ -406,7 +414,7 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2025-04-01' = if (enableT
 // Main Resources //
 // ============== //
 
-resource managedCluster 'Microsoft.ContainerService/managedClusters@2025-10-01' = {
+resource managedCluster 'Microsoft.ContainerService/managedClusters@2026-03-01' = {
   name: name
   location: location
   tags: tags
@@ -492,6 +500,7 @@ resource managedCluster 'Microsoft.ContainerService/managedClusters@2025-10-01' 
       }
     }
     ingressProfile: {
+      gatewayAPI: gatewayAPI
       webAppRouting: {
         enabled: webApplicationRoutingEnabled
         dnsZoneResourceIds: !empty(dnsZoneResourceId)
@@ -581,7 +590,7 @@ resource managedCluster 'Microsoft.ContainerService/managedClusters@2025-10-01' 
       staticEgressGatewayProfile: staticEgressGatewayProfile
       networkDataplane: networkDataplane
       networkPlugin: networkPlugin
-      networkPluginMode: networkDataplane == 'cilium' ? 'overlay' : networkPluginMode
+      networkPluginMode: usesPodSubnet ? null : (networkDataplane == 'cilium' ? 'overlay' : networkPluginMode)
       networkPolicy: networkDataplane == 'cilium' ? 'cilium' : networkPolicy
       podCidr: podCidr
       serviceCidr: serviceCidr

--- a/avm/res/container-service/managed-cluster/main.json
+++ b/avm/res/container-service/managed-cluster/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.44.1.10279",
-      "templateHash": "1864836677966239899"
+      "version": "0.46.1.21595",
+      "templateHash": "15549213402504605076"
     },
     "name": "Azure Kubernetes Service (AKS) Managed Clusters",
     "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster."
@@ -1277,6 +1277,16 @@
       },
       "nullable": true
     },
+    "gatewayAPI": {
+      "type": "object",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.ContainerService/managedClusters@2026-03-01#properties/properties/properties/ingressProfile/properties/gatewayAPI"
+        },
+        "description": "Optional. Gateway API profile for the managed cluster."
+      },
+      "nullable": true
+    },
     "enableDnsZoneContributorRoleAssignment": {
       "type": "bool",
       "defaultValue": true,
@@ -1642,7 +1652,8 @@
       "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
       "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
       "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
-    }
+    },
+    "usesPodSubnet": "[contains(map(concat(parameters('primaryAgentPoolProfiles'), coalesce(parameters('agentPools'), createArray())), lambda('profile', not(empty(tryGet(lambdaVariables('profile'), 'podSubnetResourceId'))))), true())]"
   },
   "resources": {
     "avmTelemetry": {
@@ -1667,7 +1678,7 @@
     },
     "managedCluster": {
       "type": "Microsoft.ContainerService/managedClusters",
-      "apiVersion": "2025-10-01",
+      "apiVersion": "2026-03-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -1694,6 +1705,7 @@
           }
         },
         "ingressProfile": {
+          "gatewayAPI": "[parameters('gatewayAPI')]",
           "webAppRouting": {
             "enabled": "[parameters('webApplicationRoutingEnabled')]",
             "dnsZoneResourceIds": "[if(not(empty(parameters('dnsZoneResourceId'))), createArray(parameters('dnsZoneResourceId')), null())]",
@@ -1748,7 +1760,7 @@
           "staticEgressGatewayProfile": "[parameters('staticEgressGatewayProfile')]",
           "networkDataplane": "[parameters('networkDataplane')]",
           "networkPlugin": "[parameters('networkPlugin')]",
-          "networkPluginMode": "[if(equals(parameters('networkDataplane'), 'cilium'), 'overlay', parameters('networkPluginMode'))]",
+          "networkPluginMode": "[if(variables('usesPodSubnet'), null(), if(equals(parameters('networkDataplane'), 'cilium'), 'overlay', parameters('networkPluginMode')))]",
           "networkPolicy": "[if(equals(parameters('networkDataplane'), 'cilium'), 'cilium', parameters('networkPolicy'))]",
           "podCidr": "[parameters('podCidr')]",
           "serviceCidr": "[parameters('serviceCidr')]",
@@ -1946,8 +1958,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "8944764257590886332"
+              "version": "0.46.1.21595",
+              "templateHash": "9235080649776332574"
             },
             "name": "Azure Kubernetes Service (AKS) Managed Cluster Maintenance Configurations",
             "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Maintenance Configurations."
@@ -2245,8 +2257,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "16346140098583042094"
+              "version": "0.46.1.21595",
+              "templateHash": "10823651473689322161"
             },
             "name": "Azure Kubernetes Service (AKS) Managed Cluster Agent Pools",
             "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Agent Pool."
@@ -2724,12 +2736,12 @@
             "managedCluster": {
               "existing": true,
               "type": "Microsoft.ContainerService/managedClusters",
-              "apiVersion": "2025-10-01",
+              "apiVersion": "2026-03-01",
               "name": "[parameters('managedClusterName')]"
             },
             "agentPool": {
               "type": "Microsoft.ContainerService/managedClusters/agentPools",
-              "apiVersion": "2025-10-01",
+              "apiVersion": "2026-03-01",
               "name": "[format('{0}/{1}', parameters('managedClusterName'), parameters('name'))]",
               "properties": {
                 "availabilityZones": "[if(equals(parameters('type'), 'VirtualMachines'), null(), map(coalesce(parameters('availabilityZones'), createArray()), lambda('zone', format('{0}', lambdaVariables('zone')))))]",
@@ -3411,7 +3423,7 @@
       "metadata": {
         "description": "The principal ID of the system assigned identity."
       },
-      "value": "[tryGet(tryGet(reference('managedCluster', '2025-10-01', 'full'), 'identity'), 'principalId')]"
+      "value": "[tryGet(tryGet(reference('managedCluster', '2026-03-01', 'full'), 'identity'), 'principalId')]"
     },
     "kubeletIdentityClientId": {
       "type": "string",
@@ -3474,7 +3486,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('managedCluster', '2025-10-01', 'full').location]"
+      "value": "[reference('managedCluster', '2026-03-01', 'full').location]"
     },
     "oidcIssuerUrl": {
       "type": "string",

--- a/avm/res/container-service/managed-cluster/maintenance-configuration/main.json
+++ b/avm/res/container-service/managed-cluster/maintenance-configuration/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "6749791830023646623"
+      "version": "0.46.1.21595",
+      "templateHash": "9235080649776332574"
     },
     "name": "Azure Kubernetes Service (AKS) Managed Cluster Maintenance Configurations",
     "description": "This module deploys an Azure Kubernetes Service (AKS) Managed Cluster Maintenance Configurations."

--- a/avm/res/container-service/managed-cluster/tests/e2e/max/dependencies.bicep
+++ b/avm/res/container-service/managed-cluster/tests/e2e/max/dependencies.bicep
@@ -99,6 +99,12 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-10-01' = {
         }
       }
       {
+        name: 'podSubnet'
+        properties: {
+          addressPrefix: '10.0.32.0/19'
+        }
+      }
+      {
         name: 'appGatewaySubnet'
         properties: {
           addressPrefix: '10.0.16.0/24'
@@ -359,6 +365,9 @@ output publicIPAKSResourceId string = publicIPAKS.id
 
 @description('The resource ID of the API Server VNet Integration subnet.')
 output apiServerSubnetResourceId string = '${virtualNetwork.id}/subnets/apiServerSubnet'
+
+@description('The resource ID of the pod subnet.')
+output podSubnetResourceId string = '${virtualNetwork.id}/subnets/podSubnet'
 
 @description('The Public Key of the created SSH Key.')
 output SSHKeyPublicKey string = sshKey.properties.publicKey

--- a/avm/res/container-service/managed-cluster/tests/e2e/max/main.test.bicep
+++ b/avm/res/container-service/managed-cluster/tests/e2e/max/main.test.bicep
@@ -72,7 +72,7 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
 
 @batchSize(1)
 module testDeployment '../../../main.bicep' = [
-  for iteration in ['init', 'update', 'idem']: {
+  for iteration in ['init', 'idem']: {
     scope: resourceGroup
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {

--- a/avm/res/container-service/managed-cluster/tests/e2e/max/main.test.bicep
+++ b/avm/res/container-service/managed-cluster/tests/e2e/max/main.test.bicep
@@ -72,7 +72,7 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
 
 @batchSize(1)
 module testDeployment '../../../main.bicep' = [
-  for iteration in ['init', 'idem']: {
+  for iteration in ['init', 'update', 'idem']: {
     scope: resourceGroup
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
@@ -97,12 +97,13 @@ module testDeployment '../../../main.bicep' = [
           osDiskSizeGB: 128
           osType: 'Linux'
           type: 'VirtualMachineScaleSets'
-          vmSize: 'Standard_DS2_v2'
+          vmSize: iteration == 'init' ? 'Standard_D2s_v3' : 'Standard_D4s_v3'
           enableAutoScaling: true
           minCount: 1
           maxCount: 3
           maxPods: 50
           nodeTaints: ['CriticalAddonsOnly=true:NoSchedule']
+          podSubnetResourceId: nestedDependencies.outputs.podSubnetResourceId
           vnetSubnetResourceId: '${nestedDependencies.outputs.vNetResourceId}/subnets/defaultSubnet'
           upgradeSettings: {
             maxSurge: '33%'
@@ -130,7 +131,7 @@ module testDeployment '../../../main.bicep' = [
           osType: 'Linux'
           scaleSetPriority: 'Regular'
           type: 'VirtualMachineScaleSets'
-          vmSize: 'Standard_D2s_v3'
+          vmSize: iteration == 'init' ? 'Standard_D2s_v3' : 'Standard_D4s_v3'
           vnetSubnetResourceId: '${nestedDependencies.outputs.vNetResourceId}/subnets/defaultSubnet'
           enableAutoScaling: true
           maxCount: 2
@@ -139,6 +140,7 @@ module testDeployment '../../../main.bicep' = [
           minPods: 0
           mode: 'User'
           nodeTaints: []
+          podSubnetResourceId: nestedDependencies.outputs.podSubnetResourceId
           scaleSetEvictionPolicy: 'Delete'
           upgradeSettings: {
             maxSurge: '50%'
@@ -200,13 +202,12 @@ module testDeployment '../../../main.bicep' = [
         }
       ]
       networkPlugin: 'azure'
-      networkPolicy: 'azure'
+      networkPolicy: 'cilium'
+      networkPluginMode: 'overlay'
       skuTier: 'Standard'
       dnsServiceIP: '10.10.200.10'
       serviceCidr: '10.10.200.0/24'
-      networkPluginMode: 'overlay'
-      networkDataplane: 'azure'
-      podCidr: '10.244.0.0/16'
+      networkDataplane: 'cilium'
       loadBalancerSku: 'standard'
       backendPoolType: 'NodeIPConfiguration'
       outboundType: 'loadBalancer'
@@ -249,6 +250,9 @@ module testDeployment '../../../main.bicep' = [
       costAnalysisEnabled: true
       httpApplicationRoutingEnabled: false
       webApplicationRoutingEnabled: true
+      gatewayAPI: {
+        installation: 'Standard'
+      }
       defaultIngressControllerType: 'Internal'
       enableDnsZoneContributorRoleAssignment: true
       ingressApplicationGatewayEnabled: true

--- a/avm/res/container-service/managed-cluster/tests/e2e/priv/dependencies.bicep
+++ b/avm/res/container-service/managed-cluster/tests/e2e/priv/dependencies.bicep
@@ -22,7 +22,7 @@ resource privateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
   location: 'global'
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-07-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-07-01' = {
   name: virtualNetworkName
   location: location
   properties: {

--- a/avm/res/container-service/managed-cluster/version.json
+++ b/avm/res/container-service/managed-cluster/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.14"
+  "version": "0.15"
 }

--- a/utilities/e2e-template-assets/templates/diagnostic.dependencies.bicep
+++ b/utilities/e2e-template-assets/templates/diagnostic.dependencies.bicep
@@ -39,15 +39,15 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-02
   location: location
 }
 
-resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = {
+resource eventHubNamespace 'Microsoft.EventHub/namespaces@2026-01-01' = {
   name: eventHubNamespaceName
   location: location
 
-  resource eventHub 'eventhubs@2024-01-01' = {
+  resource eventHub 'eventhubs@2026-01-01' = {
     name: eventHubNamespaceEventHubName
   }
 
-  resource authorizationRule 'authorizationRules@2024-01-01' = {
+  resource authorizationRule 'authorizationRules@2026-01-01' = {
     name: 'RootManageSharedAccessKey'
     properties: {
       rights: [


### PR DESCRIPTION
## Description

Updated the AKS managed cluster module to use the stable `2026-03-01` API for managed clusters and agent pools. The module now exposes the Gateway API ingress profile and supports in-place VM size updates for primary and secondary agent pools.

The Cilium network configuration now omits `networkPluginMode` whenever any agent pool uses a pod subnet. The max deployment test covers explicit overlay input with pod subnets, Gateway API installation, sequential VM size updates, and a final idempotency deployment.

Fixes #3860
Fixes #7101
Fixes #7130

Related to #6612. Agent pool drain timeout is already available through `upgradeSettings` and covered by the max test.

Related to #4466. The complete managed Prometheus topology requires additional primary resources and belongs in a pattern module rather than this resource module.

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.container-service.managed-cluster](https://github.com/JPEasier/bicep-registry-modules/actions/workflows/avm.res.container-service.managed-cluster.yml/badge.svg?branch=feature%2Faks-open-issues)](https://github.com/JPEasier/bicep-registry-modules/actions/workflows/avm.res.container-service.managed-cluster.yml) |

Local validation completed with 232 AVM compliance tests passed, 0 failed, and 34 skipped. Bicep builds and `git diff --check` also passed. Azure deployment validation was not run because no subscription was selected in the Azure extensions context.

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [x] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->