### PR TITLE
feat: Add VNET-level IPAM Pool Prefix Allocations support to `avm/res/network/virtual-network`

### DIFF
--- a/avm/res/network/virtual-network/CHANGELOG.md
+++ b/avm/res/network/virtual-network/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/virtual-network/CHANGELOG.md).
 
+## 0.10.2
+
+### Changes
+
+- Added support for the Virtual Network-level `ipamPoolPrefixAllocations` parameter, enabling IPAM Pool prefix allocations and allowing them to be combined with explicit `addressPrefixes`.
+
+### Breaking Changes
+
+- None
+
 ## 0.10.1
 
 ### Changes

--- a/avm/res/network/virtual-network/CHANGELOG.md
+++ b/avm/res/network/virtual-network/CHANGELOG.md
@@ -6,7 +6,7 @@ The latest version of the changelog can be found [here](https://github.com/Azure
 
 ### Changes
 
-- Added support for the Virtual Network-level `ipamPoolPrefixAllocations` parameter, enabling IPAM Pool prefix allocations and allowing them to be combined with explicit `addressPrefixes`.
+- Added support for the Virtual Network-level `ipamPoolPrefixAllocations` parameter, enabling IPAM Pool prefix allocations for the Virtual Network address space as an alternative to explicit `addressPrefixes`.
 
 ### Breaking Changes
 

--- a/avm/res/network/virtual-network/README.md
+++ b/avm/res/network/virtual-network/README.md
@@ -61,10 +61,11 @@ You can find the full example and the setup of its dependencies in the deploymen
 module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   params: {
     // Required parameters
+    name: 'nvnmin001'
+    // Non-required parameters
     addressPrefixes: [
       '10.0.0.0/16'
     ]
-    name: 'nvnmin001'
   }
 }
 ```
@@ -82,13 +83,14 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "name": {
+      "value": "nvnmin001"
+    },
+    // Non-required parameters
     "addressPrefixes": {
       "value": [
         "10.0.0.0/16"
       ]
-    },
-    "name": {
-      "value": "nvnmin001"
     }
   }
 }
@@ -105,10 +107,11 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
 using 'br/public:avm/res/network/virtual-network:<version>'
 
 // Required parameters
+param name = 'nvnmin001'
+// Non-required parameters
 param addressPrefixes = [
   '10.0.0.0/16'
 ]
-param name = 'nvnmin001'
 ```
 
 </details>
@@ -129,22 +132,22 @@ You can find the full example and the setup of its dependencies in the deploymen
 module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   params: {
     // Required parameters
-    addressPrefixes: [
-      '<networkManagerIpamPoolId>'
-    ]
     name: 'nvnipam001'
     // Non-required parameters
-    ipamPoolNumberOfIpAddresses: '254'
+    addressPrefixes: [
+      '10.0.0.0/24'
+    ]
+    ipamPoolPrefixAllocations: [
+      {
+        numberOfIpAddresses: '254'
+        pool: {
+          id: '<id>'
+        }
+      }
+    ]
     subnets: [
       {
-        ipamPoolPrefixAllocations: [
-          {
-            numberOfIpAddresses: '64'
-            pool: {
-              id: '<id>'
-            }
-          }
-        ]
+        addressPrefix: '10.0.0.0/26'
         name: 'subnet-1'
       }
       {
@@ -187,29 +190,29 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
-    "addressPrefixes": {
-      "value": [
-        "<networkManagerIpamPoolId>"
-      ]
-    },
     "name": {
       "value": "nvnipam001"
     },
     // Non-required parameters
-    "ipamPoolNumberOfIpAddresses": {
-      "value": "254"
+    "addressPrefixes": {
+      "value": [
+        "10.0.0.0/24"
+      ]
+    },
+    "ipamPoolPrefixAllocations": {
+      "value": [
+        {
+          "numberOfIpAddresses": "254",
+          "pool": {
+            "id": "<id>"
+          }
+        }
+      ]
     },
     "subnets": {
       "value": [
         {
-          "ipamPoolPrefixAllocations": [
-            {
-              "numberOfIpAddresses": "64",
-              "pool": {
-                "id": "<id>"
-              }
-            }
-          ],
+          "addressPrefix": "10.0.0.0/26",
           "name": "subnet-1"
         },
         {
@@ -251,22 +254,22 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
 using 'br/public:avm/res/network/virtual-network:<version>'
 
 // Required parameters
-param addressPrefixes = [
-  '<networkManagerIpamPoolId>'
-]
 param name = 'nvnipam001'
 // Non-required parameters
-param ipamPoolNumberOfIpAddresses = '254'
+param addressPrefixes = [
+  '10.0.0.0/24'
+]
+param ipamPoolPrefixAllocations = [
+  {
+    numberOfIpAddresses: '254'
+    pool: {
+      id: '<id>'
+    }
+  }
+]
 param subnets = [
   {
-    ipamPoolPrefixAllocations: [
-      {
-        numberOfIpAddresses: '64'
-        pool: {
-          id: '<id>'
-        }
-      }
-    ]
+    addressPrefix: '10.0.0.0/26'
     name: 'subnet-1'
   }
   {
@@ -312,12 +315,12 @@ You can find the full example and the setup of its dependencies in the deploymen
 module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   params: {
     // Required parameters
+    name: 'nvnipv6001'
+    // Non-required parameters
     addressPrefixes: [
       '10.0.0.0/21'
       'fd00:592b:3014::/64'
     ]
-    name: 'nvnipv6001'
-    // Non-required parameters
     subnets: [
       {
         addressPrefixes: [
@@ -344,16 +347,16 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "name": {
+      "value": "nvnipv6001"
+    },
+    // Non-required parameters
     "addressPrefixes": {
       "value": [
         "10.0.0.0/21",
         "fd00:592b:3014::/64"
       ]
     },
-    "name": {
-      "value": "nvnipv6001"
-    },
-    // Non-required parameters
     "subnets": {
       "value": [
         {
@@ -380,12 +383,12 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
 using 'br/public:avm/res/network/virtual-network:<version>'
 
 // Required parameters
+param name = 'nvnipv6001'
+// Non-required parameters
 param addressPrefixes = [
   '10.0.0.0/21'
   'fd00:592b:3014::/64'
 ]
-param name = 'nvnipv6001'
-// Non-required parameters
 param subnets = [
   {
     addressPrefixes: [
@@ -415,11 +418,11 @@ You can find the full example and the setup of its dependencies in the deploymen
 module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   params: {
     // Required parameters
+    name: 'nvnmax001'
+    // Non-required parameters
     addressPrefixes: [
       '<addressPrefix>'
     ]
-    name: 'nvnmax001'
-    // Non-required parameters
     diagnosticSettings: [
       {
         eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -551,15 +554,15 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "name": {
+      "value": "nvnmax001"
+    },
+    // Non-required parameters
     "addressPrefixes": {
       "value": [
         "<addressPrefix>"
       ]
     },
-    "name": {
-      "value": "nvnmax001"
-    },
-    // Non-required parameters
     "diagnosticSettings": {
       "value": [
         {
@@ -705,11 +708,11 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
 using 'br/public:avm/res/network/virtual-network:<version>'
 
 // Required parameters
+param name = 'nvnmax001'
+// Non-required parameters
 param addressPrefixes = [
   '<addressPrefix>'
 ]
-param name = 'nvnmax001'
-// Non-required parameters
 param diagnosticSettings = [
   {
     eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -844,11 +847,11 @@ You can find the full example and the setup of its dependencies in the deploymen
 module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   params: {
     // Required parameters
+    name: 'nvnpeer001'
+    // Non-required parameters
     addressPrefixes: [
       '10.1.0.0/24'
     ]
-    name: 'nvnpeer001'
-    // Non-required parameters
     peerings: [
       {
         allowForwardedTraffic: true
@@ -899,15 +902,15 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "name": {
+      "value": "nvnpeer001"
+    },
+    // Non-required parameters
     "addressPrefixes": {
       "value": [
         "10.1.0.0/24"
       ]
     },
-    "name": {
-      "value": "nvnpeer001"
-    },
-    // Non-required parameters
     "peerings": {
       "value": [
         {
@@ -962,11 +965,11 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
 using 'br/public:avm/res/network/virtual-network:<version>'
 
 // Required parameters
+param name = 'nvnpeer001'
+// Non-required parameters
 param addressPrefixes = [
   '10.1.0.0/24'
 ]
-param name = 'nvnpeer001'
-// Non-required parameters
 param peerings = [
   {
     allowForwardedTraffic: true
@@ -1020,11 +1023,11 @@ You can find the full example and the setup of its dependencies in the deploymen
 module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   params: {
     // Required parameters
+    name: 'nvnwaf001'
+    // Non-required parameters
     addressPrefixes: [
       '<addressPrefix>'
     ]
-    name: 'nvnwaf001'
-    // Non-required parameters
     diagnosticSettings: [
       {
         eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -1114,15 +1117,15 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   "contentVersion": "1.0.0.0",
   "parameters": {
     // Required parameters
+    "name": {
+      "value": "nvnwaf001"
+    },
+    // Non-required parameters
     "addressPrefixes": {
       "value": [
         "<addressPrefix>"
       ]
     },
-    "name": {
-      "value": "nvnwaf001"
-    },
-    // Non-required parameters
     "diagnosticSettings": {
       "value": [
         {
@@ -1220,11 +1223,11 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
 using 'br/public:avm/res/network/virtual-network:<version>'
 
 // Required parameters
+param name = 'nvnwaf001'
+// Non-required parameters
 param addressPrefixes = [
   '<addressPrefix>'
 ]
-param name = 'nvnwaf001'
-// Non-required parameters
 param diagnosticSettings = [
   {
     eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -1308,8 +1311,14 @@ param tags = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`addressPrefixes`](#parameter-addressprefixes) | array | An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. |
 | [`name`](#parameter-name) | string | The name of the Virtual Network (vNet). |
+
+**Conditional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`addressPrefixes`](#parameter-addressprefixes) | array | An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. Can be combined with `ipamPoolPrefixAllocations`. Required if `ipamPoolPrefixAllocations` is empty. |
+| [`ipamPoolPrefixAllocations`](#parameter-ipampoolprefixallocations) | array | The IPAM pool prefix allocations to use for the Virtual Network address space. Can be combined with `addressPrefixes` to mix explicit prefixes with IPAM-allocated prefixes. Required if `addressPrefixes` is empty. |
 
 **Optional parameters**
 
@@ -1334,19 +1343,26 @@ param tags = {
 | [`vnetEncryption`](#parameter-vnetencryption) | bool | Indicates if encryption is enabled on virtual network and if VM without encryption is allowed in encrypted VNet. Requires the EnableVNetEncryption feature to be registered for the subscription and a supported region to use this property. |
 | [`vnetEncryptionEnforcement`](#parameter-vnetencryptionenforcement) | string | If the encrypted VNet allows VM that does not support encryption. Can only be used when vnetEncryption is enabled. |
 
-### Parameter: `addressPrefixes`
-
-An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`.
-
-- Required: Yes
-- Type: array
-
 ### Parameter: `name`
 
 The name of the Virtual Network (vNet).
 
 - Required: Yes
 - Type: string
+
+### Parameter: `addressPrefixes`
+
+An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. Can be combined with `ipamPoolPrefixAllocations`. Required if `ipamPoolPrefixAllocations` is empty.
+
+- Required: No
+- Type: array
+
+### Parameter: `ipamPoolPrefixAllocations`
+
+The IPAM pool prefix allocations to use for the Virtual Network address space. Can be combined with `addressPrefixes` to mix explicit prefixes with IPAM-allocated prefixes. Required if `addressPrefixes` is empty.
+
+- Required: No
+- Type: array
 
 ### Parameter: `ddosProtectionPlanResourceId`
 

--- a/avm/res/network/virtual-network/README.md
+++ b/avm/res/network/virtual-network/README.md
@@ -132,14 +132,11 @@ You can find the full example and the setup of its dependencies in the deploymen
 module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   params: {
     // Required parameters
-    name: 'nvnipam001'
+    name: '<name>'
     // Non-required parameters
-    addressPrefixes: [
-      '10.0.0.0/24'
-    ]
     ipamPoolPrefixAllocations: [
       {
-        numberOfIpAddresses: '254'
+        numberOfIpAddresses: '256'
         pool: {
           id: '<id>'
         }
@@ -147,7 +144,14 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
     ]
     subnets: [
       {
-        addressPrefix: '10.0.0.0/26'
+        ipamPoolPrefixAllocations: [
+          {
+            numberOfIpAddresses: '64'
+            pool: {
+              id: '<id>'
+            }
+          }
+        ]
         name: 'subnet-1'
       }
       {
@@ -191,18 +195,13 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
   "parameters": {
     // Required parameters
     "name": {
-      "value": "nvnipam001"
+      "value": "<name>"
     },
     // Non-required parameters
-    "addressPrefixes": {
-      "value": [
-        "10.0.0.0/24"
-      ]
-    },
     "ipamPoolPrefixAllocations": {
       "value": [
         {
-          "numberOfIpAddresses": "254",
+          "numberOfIpAddresses": "256",
           "pool": {
             "id": "<id>"
           }
@@ -212,7 +211,14 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
     "subnets": {
       "value": [
         {
-          "addressPrefix": "10.0.0.0/26",
+          "ipamPoolPrefixAllocations": [
+            {
+              "numberOfIpAddresses": "64",
+              "pool": {
+                "id": "<id>"
+              }
+            }
+          ],
           "name": "subnet-1"
         },
         {
@@ -254,14 +260,11 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:<version>' = {
 using 'br/public:avm/res/network/virtual-network:<version>'
 
 // Required parameters
-param name = 'nvnipam001'
+param name = '<name>'
 // Non-required parameters
-param addressPrefixes = [
-  '10.0.0.0/24'
-]
 param ipamPoolPrefixAllocations = [
   {
-    numberOfIpAddresses: '254'
+    numberOfIpAddresses: '256'
     pool: {
       id: '<id>'
     }
@@ -269,7 +272,14 @@ param ipamPoolPrefixAllocations = [
 ]
 param subnets = [
   {
-    addressPrefix: '10.0.0.0/26'
+    ipamPoolPrefixAllocations: [
+      {
+        numberOfIpAddresses: '64'
+        pool: {
+          id: '<id>'
+        }
+      }
+    ]
     name: 'subnet-1'
   }
   {
@@ -1317,8 +1327,8 @@ param tags = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`addressPrefixes`](#parameter-addressprefixes) | array | An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. Can be combined with `ipamPoolPrefixAllocations`. Required if `ipamPoolPrefixAllocations` is empty. |
-| [`ipamPoolPrefixAllocations`](#parameter-ipampoolprefixallocations) | array | The IPAM pool prefix allocations to use for the Virtual Network address space. Can be combined with `addressPrefixes` to mix explicit prefixes with IPAM-allocated prefixes. Required if `addressPrefixes` is empty. |
+| [`addressPrefixes`](#parameter-addressprefixes) | array | An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. Required if `ipamPoolPrefixAllocations` is empty. Cannot be combined with `ipamPoolPrefixAllocations` as Azure does not allow mixing explicit prefixes and IPAM pool references in the same address space. |
+| [`ipamPoolPrefixAllocations`](#parameter-ipampoolprefixallocations) | array | The IPAM pool prefix allocations to use for the Virtual Network address space. Required if `addressPrefixes` is empty. Cannot be combined with `addressPrefixes` as Azure does not allow mixing explicit prefixes and IPAM pool references in the same address space. |
 
 **Optional parameters**
 
@@ -1352,14 +1362,14 @@ The name of the Virtual Network (vNet).
 
 ### Parameter: `addressPrefixes`
 
-An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. Can be combined with `ipamPoolPrefixAllocations`. Required if `ipamPoolPrefixAllocations` is empty.
+An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. Required if `ipamPoolPrefixAllocations` is empty. Cannot be combined with `ipamPoolPrefixAllocations` as Azure does not allow mixing explicit prefixes and IPAM pool references in the same address space.
 
 - Required: No
 - Type: array
 
 ### Parameter: `ipamPoolPrefixAllocations`
 
-The IPAM pool prefix allocations to use for the Virtual Network address space. Can be combined with `addressPrefixes` to mix explicit prefixes with IPAM-allocated prefixes. Required if `addressPrefixes` is empty.
+The IPAM pool prefix allocations to use for the Virtual Network address space. Required if `addressPrefixes` is empty. Cannot be combined with `addressPrefixes` as Azure does not allow mixing explicit prefixes and IPAM pool references in the same address space.
 
 - Required: No
 - Type: array

--- a/avm/res/network/virtual-network/main.bicep
+++ b/avm/res/network/virtual-network/main.bicep
@@ -7,11 +7,14 @@ param name string
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
-@description('Required. An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`.')
-param addressPrefixes string[]
+@description('Conditional. An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. Can be combined with `ipamPoolPrefixAllocations`. Required if `ipamPoolPrefixAllocations` is empty.')
+param addressPrefixes string[]?
 
 @description('Optional. Number of IP addresses allocated from the pool. To be used only when the addressPrefix param is defined with a resource ID of an IPAM pool.')
 param ipamPoolNumberOfIpAddresses string?
+
+@description('Conditional. The IPAM pool prefix allocations to use for the Virtual Network address space. Can be combined with `addressPrefixes` to mix explicit prefixes with IPAM-allocated prefixes. Required if `addressPrefixes` is empty.')
+param ipamPoolPrefixAllocations resourceInput<'Microsoft.Network/virtualNetworks@2025-05-01'>.properties.addressSpace.ipamPoolPrefixAllocations?
 
 @description('Optional. The BGP community associated with the virtual network.')
 param virtualNetworkBgpCommunity string?
@@ -75,6 +78,12 @@ param ipAllocations resourceInput<'Microsoft.Network/virtualNetworks@2025-05-01'
 
 var enableReferencedModulesTelemetry = false
 
+// When the first entry of `addressPrefixes` is an IPAM pool resource ID, the legacy single-pool syntax is used.
+var addressPrefixIsIpamPoolResourceId = !empty(addressPrefixes ?? []) && contains(
+  (addressPrefixes ?? [''])[0],
+  '/Microsoft.Network/networkManagers/'
+)
+
 var builtInRoleNames = {
   Contributor: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
   'Network Contributor': subscriptionResourceId(
@@ -133,20 +142,19 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
   tags: tags
   properties: {
     ipAllocations: ipAllocations
-    addressSpace: contains(addressPrefixes[0], '/Microsoft.Network/networkManagers/')
-      ? {
-          ipamPoolPrefixAllocations: [
+    addressSpace: {
+      addressPrefixes: addressPrefixIsIpamPoolResourceId || empty(addressPrefixes ?? []) ? null : addressPrefixes
+      ipamPoolPrefixAllocations: addressPrefixIsIpamPoolResourceId
+        ? [
             {
               pool: {
-                id: addressPrefixes[0]
+                id: (addressPrefixes ?? [''])[0]
               }
               numberOfIpAddresses: ipamPoolNumberOfIpAddresses
             }
           ]
-        }
-      : {
-          addressPrefixes: addressPrefixes
-        }
+        : ipamPoolPrefixAllocations
+    }
     bgpCommunities: !empty(virtualNetworkBgpCommunity)
       ? {
           virtualNetworkCommunity: virtualNetworkBgpCommunity!

--- a/avm/res/network/virtual-network/main.bicep
+++ b/avm/res/network/virtual-network/main.bicep
@@ -7,13 +7,13 @@ param name string
 @description('Optional. Location for all resources.')
 param location string = resourceGroup().location
 
-@description('Conditional. An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. Can be combined with `ipamPoolPrefixAllocations`. Required if `ipamPoolPrefixAllocations` is empty.')
+@description('Conditional. An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. Required if `ipamPoolPrefixAllocations` is empty. Cannot be combined with `ipamPoolPrefixAllocations` as Azure does not allow mixing explicit prefixes and IPAM pool references in the same address space.')
 param addressPrefixes string[]?
 
 @description('Optional. Number of IP addresses allocated from the pool. To be used only when the addressPrefix param is defined with a resource ID of an IPAM pool.')
 param ipamPoolNumberOfIpAddresses string?
 
-@description('Conditional. The IPAM pool prefix allocations to use for the Virtual Network address space. Can be combined with `addressPrefixes` to mix explicit prefixes with IPAM-allocated prefixes. Required if `addressPrefixes` is empty.')
+@description('Conditional. The IPAM pool prefix allocations to use for the Virtual Network address space. Required if `addressPrefixes` is empty. Cannot be combined with `addressPrefixes` as Azure does not allow mixing explicit prefixes and IPAM pool references in the same address space.')
 param ipamPoolPrefixAllocations resourceInput<'Microsoft.Network/virtualNetworks@2025-05-01'>.properties.addressSpace.ipamPoolPrefixAllocations?
 
 @description('Optional. The BGP community associated with the virtual network.')

--- a/avm/res/network/virtual-network/main.json
+++ b/avm/res/network/virtual-network/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.46.1.21595",
-      "templateHash": "13917018782411515499"
+      "templateHash": "11440488347061703093"
     },
     "name": "Virtual Networks",
     "description": "This module deploys a Virtual Network (vNet)."
@@ -551,7 +551,7 @@
       },
       "nullable": true,
       "metadata": {
-        "description": "Conditional. An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. Can be combined with `ipamPoolPrefixAllocations`. Required if `ipamPoolPrefixAllocations` is empty."
+        "description": "Conditional. An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. Required if `ipamPoolPrefixAllocations` is empty. Cannot be combined with `ipamPoolPrefixAllocations` as Azure does not allow mixing explicit prefixes and IPAM pool references in the same address space."
       }
     },
     "ipamPoolNumberOfIpAddresses": {
@@ -567,7 +567,7 @@
         "__bicep_resource_derived_type!": {
           "source": "Microsoft.Network/virtualNetworks@2025-05-01#properties/properties/properties/addressSpace/properties/ipamPoolPrefixAllocations"
         },
-        "description": "Conditional. The IPAM pool prefix allocations to use for the Virtual Network address space. Can be combined with `addressPrefixes` to mix explicit prefixes with IPAM-allocated prefixes. Required if `addressPrefixes` is empty."
+        "description": "Conditional. The IPAM pool prefix allocations to use for the Virtual Network address space. Required if `addressPrefixes` is empty. Cannot be combined with `addressPrefixes` as Azure does not allow mixing explicit prefixes and IPAM pool references in the same address space."
       },
       "nullable": true
     },

--- a/avm/res/network/virtual-network/main.json
+++ b/avm/res/network/virtual-network/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.46.1.21595",
-      "templateHash": "13630607735860133857"
+      "templateHash": "13917018782411515499"
     },
     "name": "Virtual Networks",
     "description": "This module deploys a Virtual Network (vNet)."
@@ -549,8 +549,9 @@
       "items": {
         "type": "string"
       },
+      "nullable": true,
       "metadata": {
-        "description": "Required. An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`."
+        "description": "Conditional. An Array of 1 or more IP Address Prefixes OR the resource ID of the IPAM pool to be used for the Virtual Network. When specifying an IPAM pool resource ID you must also set a value for the parameter called `ipamPoolNumberOfIpAddresses`. Can be combined with `ipamPoolPrefixAllocations`. Required if `ipamPoolPrefixAllocations` is empty."
       }
     },
     "ipamPoolNumberOfIpAddresses": {
@@ -559,6 +560,16 @@
       "metadata": {
         "description": "Optional. Number of IP addresses allocated from the pool. To be used only when the addressPrefix param is defined with a resource ID of an IPAM pool."
       }
+    },
+    "ipamPoolPrefixAllocations": {
+      "type": "array",
+      "metadata": {
+        "__bicep_resource_derived_type!": {
+          "source": "Microsoft.Network/virtualNetworks@2025-05-01#properties/properties/properties/addressSpace/properties/ipamPoolPrefixAllocations"
+        },
+        "description": "Conditional. The IPAM pool prefix allocations to use for the Virtual Network address space. Can be combined with `addressPrefixes` to mix explicit prefixes with IPAM-allocated prefixes. Required if `addressPrefixes` is empty."
+      },
+      "nullable": true
     },
     "virtualNetworkBgpCommunity": {
       "type": "string",
@@ -712,6 +723,7 @@
       }
     ],
     "enableReferencedModulesTelemetry": false,
+    "addressPrefixIsIpamPoolResourceId": "[and(not(empty(coalesce(parameters('addressPrefixes'), createArray()))), contains(coalesce(parameters('addressPrefixes'), createArray(''))[0], '/Microsoft.Network/networkManagers/'))]",
     "builtInRoleNames": {
       "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
       "Network Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
@@ -750,7 +762,10 @@
       "tags": "[parameters('tags')]",
       "properties": {
         "ipAllocations": "[parameters('ipAllocations')]",
-        "addressSpace": "[if(contains(parameters('addressPrefixes')[0], '/Microsoft.Network/networkManagers/'), createObject('ipamPoolPrefixAllocations', createArray(createObject('pool', createObject('id', parameters('addressPrefixes')[0]), 'numberOfIpAddresses', parameters('ipamPoolNumberOfIpAddresses')))), createObject('addressPrefixes', parameters('addressPrefixes')))]",
+        "addressSpace": {
+          "addressPrefixes": "[if(or(variables('addressPrefixIsIpamPoolResourceId'), empty(coalesce(parameters('addressPrefixes'), createArray()))), null(), parameters('addressPrefixes'))]",
+          "ipamPoolPrefixAllocations": "[if(variables('addressPrefixIsIpamPoolResourceId'), createArray(createObject('pool', createObject('id', coalesce(parameters('addressPrefixes'), createArray(''))[0]), 'numberOfIpAddresses', parameters('ipamPoolNumberOfIpAddresses'))), parameters('ipamPoolPrefixAllocations'))]"
+        },
         "bgpCommunities": "[if(not(empty(parameters('virtualNetworkBgpCommunity'))), createObject('virtualNetworkCommunity', parameters('virtualNetworkBgpCommunity')), null())]",
         "ddosProtectionPlan": "[if(not(empty(parameters('ddosProtectionPlanResourceId'))), createObject('id', parameters('ddosProtectionPlanResourceId')), null())]",
         "dhcpOptions": "[if(not(empty(parameters('dnsServers'))), createObject('dnsServers', array(parameters('dnsServers'))), null())]",

--- a/avm/res/network/virtual-network/tests/e2e/ipam/dependencies.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/ipam/dependencies.bicep
@@ -4,14 +4,11 @@ param location string = resourceGroup().location
 @description('Required. The name of the Network Manager to create.')
 param networkManagerName string
 
-@description('Required. List of IP address prefixes to be used for the IPAM pool.')
-param addressPrefixes array
-
 @description('Required. The name of the pre-existing Virtual Network to link to the IPAM pool.')
 param virtualNetworkName string
 
-@description('Required. The classical address prefix to assign to the pre-existing Virtual Network. Must fall within the IPAM pool range.')
-param virtualNetworkAddressPrefix string
+var addressPrefixVnet = '10.0.0.0/16'
+var addressPrefixNetworkManager = '172.16.0.0/22'
 
 resource networkManager 'Microsoft.Network/networkManagers@2025-05-01' = {
   name: networkManagerName
@@ -31,7 +28,9 @@ resource networkManagerIpamPool 'Microsoft.Network/networkManagers/ipamPools@202
   location: location
   properties: {
     displayName: '${networkManagerName}-ipamPool'
-    addressPrefixes: addressPrefixes
+    addressPrefixes: [
+      addressPrefixNetworkManager
+    ]
   }
 }
 
@@ -42,7 +41,7 @@ resource existingVirtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' =
   properties: {
     addressSpace: {
       addressPrefixes: [
-        virtualNetworkAddressPrefix
+        addressPrefixVnet
       ]
     }
   }

--- a/avm/res/network/virtual-network/tests/e2e/ipam/dependencies.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/ipam/dependencies.bicep
@@ -7,6 +7,12 @@ param networkManagerName string
 @description('Required. List of IP address prefixes to be used for the IPAM pool.')
 param addressPrefixes array
 
+@description('Required. The name of the pre-existing Virtual Network to link to the IPAM pool.')
+param virtualNetworkName string
+
+@description('Required. The classical address prefix to assign to the pre-existing Virtual Network. Must fall within the IPAM pool range.')
+param virtualNetworkAddressPrefix string
+
 resource networkManager 'Microsoft.Network/networkManagers@2025-05-01' = {
   name: networkManagerName
   location: location
@@ -29,8 +35,24 @@ resource networkManagerIpamPool 'Microsoft.Network/networkManagers/ipamPools@202
   }
 }
 
+// Pre-existing Virtual Network created with a classical address prefix. The module under test later links it to the IPAM pool.
+resource existingVirtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
+  name: virtualNetworkName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        virtualNetworkAddressPrefix
+      ]
+    }
+  }
+}
+
 @description('The resource ID of the Network Manager.')
 output networkManagerId string = networkManager.id
 
 @description('The resource ID of the Network Manager IPAM Pool.')
 output networkManagerIpamPoolId string = networkManagerIpamPool.id
+
+@description('The name of the pre-existing Virtual Network.')
+output virtualNetworkName string = existingVirtualNetwork.name

--- a/avm/res/network/virtual-network/tests/e2e/ipam/dependencies.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/ipam/dependencies.bicep
@@ -7,7 +7,7 @@ param networkManagerName string
 @description('Required. The name of the pre-existing Virtual Network to link to the IPAM pool.')
 param virtualNetworkName string
 
-var addressPrefixVnet = '10.0.0.0/16'
+var addressPrefixVnet = '172.16.0.0/24'
 var addressPrefixNetworkManager = '172.16.0.0/22'
 
 resource networkManager 'Microsoft.Network/networkManagers@2025-05-01' = {

--- a/avm/res/network/virtual-network/tests/e2e/ipam/main.test.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/ipam/main.test.bicep
@@ -39,9 +39,9 @@ module nestedDependencies 'dependencies.bicep' = {
     addressPrefixes: [
       '172.16.0.0/22'
     ]
-    // The Virtual Network is pre-deployed with a classical address prefix and later linked to the IPAM pool by the test below.
+    // The Virtual Network is pre-deployed with a classical address prefix (within the IPAM pool range) and later linked to the IPAM pool by the test below.
     virtualNetworkName: '${namePrefix}${serviceShort}001'
-    virtualNetworkAddressPrefix: '10.0.0.0/24'
+    virtualNetworkAddressPrefix: '172.16.0.0/24'
   }
 }
 

--- a/avm/res/network/virtual-network/tests/e2e/ipam/main.test.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/ipam/main.test.bicep
@@ -36,12 +36,8 @@ module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
   params: {
     networkManagerName: 'dep-${namePrefix}-vnm-${serviceShort}'
-    addressPrefixes: [
-      '172.16.0.0/22'
-    ]
     // The Virtual Network is pre-deployed with a classical address prefix (within the IPAM pool range) and later linked to the IPAM pool by the test below.
     virtualNetworkName: '${namePrefix}${serviceShort}001'
-    virtualNetworkAddressPrefix: '172.16.0.0/24'
   }
 }
 

--- a/avm/res/network/virtual-network/tests/e2e/ipam/main.test.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/ipam/main.test.bicep
@@ -53,21 +53,22 @@ module testDeployment '../../../main.bicep' = [
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
       name: '${namePrefix}${serviceShort}001'
+      // Combining explicit address prefixes with IPAM Pool Prefix Allocations
       addressPrefixes: [
-        nestedDependencies.outputs.networkManagerIpamPoolId
+        '10.0.0.0/24'
       ]
-      ipamPoolNumberOfIpAddresses: '254'
+      ipamPoolPrefixAllocations: [
+        {
+          pool: {
+            id: nestedDependencies.outputs.networkManagerIpamPoolId
+          }
+          numberOfIpAddresses: '254'
+        }
+      ]
       subnets: [
         {
           name: 'subnet-1'
-          ipamPoolPrefixAllocations: [
-            {
-              pool: {
-                id: nestedDependencies.outputs.networkManagerIpamPoolId
-              }
-              numberOfIpAddresses: '64'
-            }
-          ]
+          addressPrefix: '10.0.0.0/26'
         }
         {
           name: 'subnet-2'

--- a/avm/res/network/virtual-network/tests/e2e/ipam/main.test.bicep
+++ b/avm/res/network/virtual-network/tests/e2e/ipam/main.test.bicep
@@ -39,6 +39,9 @@ module nestedDependencies 'dependencies.bicep' = {
     addressPrefixes: [
       '172.16.0.0/22'
     ]
+    // The Virtual Network is pre-deployed with a classical address prefix and later linked to the IPAM pool by the test below.
+    virtualNetworkName: '${namePrefix}${serviceShort}001'
+    virtualNetworkAddressPrefix: '10.0.0.0/24'
   }
 }
 
@@ -52,23 +55,27 @@ module testDeployment '../../../main.bicep' = [
     scope: resourceGroup
     name: '${uniqueString(deployment().name, resourceLocation)}-test-${serviceShort}-${iteration}'
     params: {
-      name: '${namePrefix}${serviceShort}001'
-      // Combining explicit address prefixes with IPAM Pool Prefix Allocations
-      addressPrefixes: [
-        '10.0.0.0/24'
-      ]
+      name: nestedDependencies.outputs.virtualNetworkName
+      // Link the pre-existing Virtual Network (classical address prefix) to the IPAM Pool
       ipamPoolPrefixAllocations: [
         {
           pool: {
             id: nestedDependencies.outputs.networkManagerIpamPoolId
           }
-          numberOfIpAddresses: '254'
+          numberOfIpAddresses: '256'
         }
       ]
       subnets: [
         {
           name: 'subnet-1'
-          addressPrefix: '10.0.0.0/26'
+          ipamPoolPrefixAllocations: [
+            {
+              pool: {
+                id: nestedDependencies.outputs.networkManagerIpamPoolId
+              }
+              numberOfIpAddresses: '64'
+            }
+          ]
         }
         {
           name: 'subnet-2'


### PR DESCRIPTION
## Description

This change adds support for Virtual Network-level IPAM Pool prefix allocations to the `avm/res/network/virtual-network` module, allowing a VNet's address space to be defined from (or an existing VNet to be linked to) an Azure IPAM Pool.

Resolves #6695 

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.network.virtual-network](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network.yml/badge.svg?branch=users%2Fkrbar%2FvnetIpam)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.virtual-network.yml) |

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->