### PR TITLE
fix: NAT Gateway - Correct `name` parameter description

### DIFF
--- a/avm/res/network/nat-gateway/CHANGELOG.md
+++ b/avm/res/network/nat-gateway/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/network/nat-gateway/CHANGELOG.md).
 
+## 2.1.1
+
+### Changes
+
+- Corrected the `name` parameter description, which incorrectly referred to the Azure Bastion resource
+
+### Breaking Changes
+
+- None
+
 ## 2.1.0
 
 ### Changes

--- a/avm/res/network/nat-gateway/README.md
+++ b/avm/res/network/nat-gateway/README.md
@@ -858,7 +858,7 @@ param tags = {
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`availabilityZone`](#parameter-availabilityzone) | int | If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones). |
-| [`name`](#parameter-name) | string | Name of the Azure Bastion resource. |
+| [`name`](#parameter-name) | string | Name of the Azure NAT gateway resource. |
 
 **Optional parameters**
 
@@ -898,7 +898,7 @@ If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to
 
 ### Parameter: `name`
 
-Name of the Azure Bastion resource.
+Name of the Azure NAT gateway resource.
 
 - Required: Yes
 - Type: string

--- a/avm/res/network/nat-gateway/main.bicep
+++ b/avm/res/network/nat-gateway/main.bicep
@@ -1,7 +1,7 @@
 metadata name = 'NAT Gateways'
 metadata description = 'This module deploys a NAT Gateway.'
 
-@description('Required. Name of the Azure Bastion resource.')
+@description('Required. Name of the Azure NAT gateway resource.')
 param name string
 
 @description('Required. If set to 1, 2 or 3, the availability zone is hardcoded to that value. If set to -1, no zone is defined. Note that the availability zone number here are the logical availability zone in your Azure subscription. Different subscriptions might have a different mapping of the physical zone and logical zone. To understand more, please refer to [Physical and logical availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview?tabs=azure-cli#physical-and-logical-availability-zones).')

--- a/avm/res/network/nat-gateway/main.json
+++ b/avm/res/network/nat-gateway/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "3507510501751778108"
+      "version": "0.43.8.12551",
+      "templateHash": "11547406171431472478"
     },
     "name": "NAT Gateways",
     "description": "This module deploys a NAT Gateway."
@@ -651,7 +651,7 @@
     "name": {
       "type": "string",
       "metadata": {
-        "description": "Required. Name of the Azure Bastion resource."
+        "description": "Required. Name of the Azure NAT gateway resource."
       }
     },
     "availabilityZone": {
@@ -1603,8 +1603,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "7479808418199292631"
+              "version": "0.43.8.12551",
+              "templateHash": "17363601923642173540"
             }
           },
           "parameters": {
@@ -2121,8 +2121,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "7479808418199292631"
+              "version": "0.43.8.12551",
+              "templateHash": "17363601923642173540"
             }
           },
           "parameters": {
@@ -2851,8 +2851,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "7479808418199292631"
+              "version": "0.43.8.12551",
+              "templateHash": "17363601923642173540"
             }
           },
           "parameters": {
@@ -3369,8 +3369,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "7479808418199292631"
+              "version": "0.43.8.12551",
+              "templateHash": "17363601923642173540"
             }
           },
           "parameters": {


### PR DESCRIPTION
## Description

The `name` parameter's `@description` in `avm/res/network/nat-gateway/main.bicep` referred to the Azure Bastion resource, a copy-paste leftover from `avm/res/network/bastion-host`. Since the decorator is a build input, the incorrect text also propagated to `main.json` and the module `README.md`.

`main.json` and `README.md` were regenerated with `Set-AVMModule`. No `version.json` change, as this is patch-level.

Fixes #6927

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.network.nat-gateway](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml/badge.svg?branch=myaschmitz-fix-nat-gateway-name-description)](https://github.com/Azure/bicep-registry-modules/actions/workflows/avm.res.network.nat-gateway.yml?query=branch%3Amyaschmitz-fix-nat-gateway-name-description) |

## Type of Change

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version
