### PR TITLE
docs: replace unedited SUPPORT.md template with AVM support content

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,25 +1,15 @@
-# TODO: The maintainer of this repo has not yet edited this file
-
-**REPO OWNER**: Do you want Customer Service & Support (CSS) support for this product/project?
-
-- **No CSS support:** Fill out this template with information about how to file issues and get help.
-- **Yes CSS support:** Fill out an intake form at [aka.ms/spot](https://aka.ms/spot). CSS will work with/help you to determine next steps. More details also available at [aka.ms/onboardsupport](https://aka.ms/onboardsupport).
-- **Not sure?** Fill out a SPOT intake as though the answer were "Yes". CSS will help you decide.
-
-_Then remove this first heading from this SUPPORT.MD file before publishing your repo._
-
 # Support
+
+> ⚠️**Note:** For the full details on the support statements, SLAs, and more for the Azure Verified Modules (AVM) initiative please visit [aka.ms/AVM/Support](https://aka.ms/avm/support) ⚠️
 
 ## How to file issues and get help
 
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing
-issues before filing new issues to avoid duplicates. For new issues, file your bug or
-feature request as a new Issue.
+This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new issue.
 
-For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE
-FOR HOW TO ENGAGE REPO OWNERS OR COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER
-CHANNEL. WHERE WILL YOU HELP PEOPLE?**.
+Existing issues can be searched [here](https://github.com/Azure/bicep-registry-modules/issues). To report a bug in, or request a feature for, an AVM Bicep module, use the [AVM Module Issue](https://aka.ms/AVM/Bicep/ModuleIssue) template.
 
-## Microsoft Support Policy
+Please provide as much information as possible when filing an issue. Include screenshots or correlation IDs if possible (please redact any sensitive information).
 
-Support for this **PROJECT or PRODUCT** is limited to the resources listed above.
+For instructions on how to get deployments and correlation ID, please follow this link [here](https://learn.microsoft.com/azure/azure-resource-manager/templates/deployment-history?tabs=azure-portal#get-deployments-and-correlation-id).
+
+We may ask you to create an Azure support request once we have triaged the issue following the process documented [here](https://learn.microsoft.com/azure/azure-portal/supportability/how-to-create-azure-support-request).


### PR DESCRIPTION
Fixes #6736

`SUPPORT.md` was still Microsoft's unedited boilerplate template. Beyond the `TODO` heading called out in the issue, it also shipped two unanswered placeholders: `**REPO MAINTAINER: INSERT INSTRUCTIONS HERE...**` and `Support for this **PROJECT or PRODUCT**`. Removing only the TODO block would have left those visible, so this replaces the whole file with the standard AVM support content.

The text is taken from [`Azure/terraform-azurerm-avm-template/SUPPORT.md`](https://github.com/Azure/terraform-azurerm-avm-template/blob/dee81a7057852117e5fc0739ee97282d7f33fc86/SUPPORT.md) (the same content `Azure/Azure-Verified-Modules` uses) and is identical to it apart from one line, which points at this repo's issues and the AVM Bicep module issue template instead of the template's relative link:

```diff
-Issues can be created and searched through for existing [issues here](../../issues).
+Existing issues can be searched [here](https://github.com/Azure/bicep-registry-modules/issues). To report a bug in, or request a feature for, an AVM Bicep module, use the [AVM Module Issue](https://aka.ms/AVM/Bicep/ModuleIssue) template.
```

Note: the `## Microsoft Support Policy` section is dropped rather than filled in, matching the other AVM repos — the `aka.ms/AVM/Support` callout at the top covers the support statement and SLAs. Happy to restore it if maintainers prefer.
