### PR TITLE
docs: Remove stale model pin and dead `/AVM-Boostrap` reference from pre-flight check

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ This repository contains **Azure Verified Modules (AVM)** for Bicep - the offici
 
 ### Pre-flight check
 
-> **MANDATORY**: You MUST output the following block visibly to the user at the very start of the workflow, before any other actions.
+> **MANDATORY**: You MUST output the following block visibly to the user at the very start of the workflow, before any other actions. This makes the configuration in use visible when a transcript is shared for triage.
 
 ```json
 {
@@ -26,8 +26,6 @@ This repository contains **Azure Verified Modules (AVM)** for Bicep - the offici
   "model": "<your model name>"
 }
 ```
-
-> **MANDATORY**: If the agent-mode is set to anything else but `agent` or the model is set to anything else but `Claude Opus 4.6`, you **MUST** warn the user that they are using a configuration the AVM team did not test and validate the custom prompts/skills/agents on. Currently, AVM's custom prompts/skills/agents are only tested with agent-mode `agent` and model `Claude Opus 4.6`. Inform the user that there is a bootstrapping prompt available to set the correct configuration, and provide instructions on how to use it --> `/AVM-Boostrap`
 
 ### Compliance with ALL AVM Bicep and Shared specifications
 


### PR DESCRIPTION
## Description

The "Pre-flight check" block mandated two things: emit a JSON block self-reporting agent-mode and model, and warn the user if the model is not `Claude Opus 4.6` while pointing them at a `/AVM-Boostrap` prompt. This PR keeps the first and drops the second.

Two defects with the warning:

- **`/AVM-Boostrap` does not exist.** `.github/prompts/` contains three files, none of them a bootstrap prompt, and `git grep -i boostrap` returns exactly one hit — the sentence telling users to run it. It is also misspelled (missing the second `t`), which suggests it was never exercised.
- **The `Claude Opus 4.6` pin rots by design.** It was added in #6751 when Opus 4.6 was current and has never been updated, so every model released since then trips the warning. Nothing consumes this file programmatically (`git grep -ril copilot-instructions` outside the file itself returns nothing) — it is prose injected into model context, so the warning cannot actually change anyone's configuration. Its only effect is to tell contributors on current models that they are misconfigured and point them at a prompt that does not exist.

Bumping the pin to a newer model was considered and rejected: it resets the same clock.

**Kept:** the mandatory `agent-mode` / `model` JSON self-report, plus one sentence noting it is there so the configuration is visible when a transcript is shared for triage.

**Removed:** the version comparison, the "untested configuration" warning, and the `/AVM-Boostrap` instruction.

## Pipeline Reference

Not applicable — docs-only change to `.github/copilot-instructions.md`. No module, template, or workflow is touched.

## Type of Change

- [x] Update to documentation or CI/CD or a module's `README.md` file.

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings