### PR TITLE
fix: Recovery Services Vault - Omit soft delete properties from `backupConfig` when `softDeleteSettings` is used

### DIFF
--- a/avm/res/recovery-services/vault/CHANGELOG.md
+++ b/avm/res/recovery-services/vault/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/recovery-services/vault/CHANGELOG.md).
 
+## 0.13.1
+
+### Changes
+
+- Fixed the deployment of the `backup-config` child module failing when vault-level `softDeleteSettings` is provided together with `backupConfig`. The soft delete related properties of `backupConfig` are now omitted from the `backupconfig` request payload entirely, as the API rejects any write to these properties once they were set through the vault itself. [#7289](https://github.com/Azure/bicep-registry-modules/issues/7289)
+
+### Breaking Changes
+
+- None
+
 ## 0.13.0
 
 ### Changes

--- a/avm/res/recovery-services/vault/README.md
+++ b/avm/res/recovery-services/vault/README.md
@@ -561,7 +561,9 @@ module vault 'br/public:avm/res/recovery-services/vault:<version>' = {
     // Non-required parameters
     backupConfig: {
       enhancedSecurityState: 'AlwaysON'
+      isSoftDeleteFeatureStateEditable: true
       softDeleteFeatureState: 'AlwaysON'
+      softDeleteRetentionPeriodInDays: 7
     }
     backupPolicies: [
       {
@@ -968,7 +970,9 @@ module vault 'br/public:avm/res/recovery-services/vault:<version>' = {
     "backupConfig": {
       "value": {
         "enhancedSecurityState": "AlwaysON",
-        "softDeleteFeatureState": "AlwaysON"
+        "isSoftDeleteFeatureStateEditable": true,
+        "softDeleteFeatureState": "AlwaysON",
+        "softDeleteRetentionPeriodInDays": 7
       }
     },
     "backupPolicies": {
@@ -1401,7 +1405,9 @@ param name = 'rsvmax001'
 // Non-required parameters
 param backupConfig = {
   enhancedSecurityState: 'AlwaysON'
+  isSoftDeleteFeatureStateEditable: true
   softDeleteFeatureState: 'AlwaysON'
+  softDeleteRetentionPeriodInDays: 7
 }
 param backupPolicies = [
   {

--- a/avm/res/recovery-services/vault/backup-config/CHANGELOG.md
+++ b/avm/res/recovery-services/vault/backup-config/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/recovery-services/vault/backup-config/CHANGELOG.md).
 
+## 0.1.2
+
+### Changes
+
+- Added `'Invalid'` to the allowed values for `enhancedSecurityState` to align with the `Microsoft.RecoveryServices/vaults/backupconfig` API. [#7289](https://github.com/Azure/bicep-registry-modules/issues/7289)
+- The soft delete related properties (`enhancedSecurityState`, `softDeleteFeatureState`, `isSoftDeleteFeatureStateEditable` and `softDeleteRetentionPeriodInDays`) are now only sent to the API if a value is provided, instead of being sent as `null`. [#7289](https://github.com/Azure/bicep-registry-modules/issues/7289)
+- Changed the `isSoftDeleteFeatureStateEditable` parameter from `bool` (default `true`) to nullable `bool?`. If the parameter is not provided, the property is no longer sent to the API and the service-side value is left untouched. [#7289](https://github.com/Azure/bicep-registry-modules/issues/7289)
+
+### Breaking Changes
+
+- None
+
 ## 0.1.1
 
 ### Changes

--- a/avm/res/recovery-services/vault/backup-config/README.md
+++ b/avm/res/recovery-services/vault/backup-config/README.md
@@ -73,6 +73,7 @@ Enable this setting to protect hybrid backups against accidental deletes and add
     'AlwaysON'
     'Disabled'
     'Enabled'
+    'Invalid'
   ]
   ```
 
@@ -82,7 +83,6 @@ Is soft delete feature state editable.
 
 - Required: No
 - Type: bool
-- Default: `True`
 
 ### Parameter: `name`
 

--- a/avm/res/recovery-services/vault/backup-config/main.bicep
+++ b/avm/res/recovery-services/vault/backup-config/main.bicep
@@ -12,6 +12,7 @@ param name string = 'vaultconfig'
   'AlwaysON'
   'Disabled'
   'Enabled'
+  'Invalid'
 ])
 param enhancedSecurityState string?
 
@@ -53,7 +54,7 @@ param storageType string = 'GeoRedundant'
 param storageTypeState string = 'Locked'
 
 @description('Optional. Is soft delete feature state editable.')
-param isSoftDeleteFeatureStateEditable bool = true
+param isSoftDeleteFeatureStateEditable bool?
 
 @description('Optional. Soft delete retention period in days.')
 param softDeleteRetentionPeriodInDays int?
@@ -88,14 +89,21 @@ resource backupConfig 'Microsoft.RecoveryServices/vaults/backupconfig@2026-01-01
   name: name
   parent: rsv
   properties: {
-    enhancedSecurityState: enhancedSecurityState
     resourceGuardOperationRequests: resourceGuardOperationRequests
-    softDeleteFeatureState: softDeleteFeatureState
     storageModelType: storageModelType
     storageType: storageType
     storageTypeState: storageTypeState
-    isSoftDeleteFeatureStateEditable: isSoftDeleteFeatureStateEditable
-    softDeleteRetentionPeriodInDays: softDeleteRetentionPeriodInDays
+    // The soft delete related properties are only sent to the API if they are provided. Once the vault-level
+    // `softDeleteSettings` were used, the backupconfig API rejects any write to these properties, hence they
+    // must be omitted from the request payload entirely instead of being sent as `null`.
+    ...(enhancedSecurityState != null ? { enhancedSecurityState: enhancedSecurityState } : {})
+    ...(softDeleteFeatureState != null ? { softDeleteFeatureState: softDeleteFeatureState } : {})
+    ...(isSoftDeleteFeatureStateEditable != null
+      ? { isSoftDeleteFeatureStateEditable: isSoftDeleteFeatureStateEditable }
+      : {})
+    ...(softDeleteRetentionPeriodInDays != null
+      ? { softDeleteRetentionPeriodInDays: softDeleteRetentionPeriodInDays }
+      : {})
   }
 }
 

--- a/avm/res/recovery-services/vault/backup-config/main.json
+++ b/avm/res/recovery-services/vault/backup-config/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.45.6.27763",
-      "templateHash": "2431393405068255158"
+      "version": "0.42.1.51946",
+      "templateHash": "17536143300264072774"
     },
     "name": "Recovery Services Vault Backup Config",
     "description": "This module deploys a Recovery Services Vault Backup Config."
@@ -31,7 +31,8 @@
       "allowedValues": [
         "AlwaysON",
         "Disabled",
-        "Enabled"
+        "Enabled",
+        "Invalid"
       ],
       "metadata": {
         "description": "Optional. Enable this setting to protect hybrid backups against accidental deletes and add additional layer of authentication for critical operations."
@@ -96,7 +97,7 @@
     },
     "isSoftDeleteFeatureStateEditable": {
       "type": "bool",
-      "defaultValue": true,
+      "nullable": true,
       "metadata": {
         "description": "Optional. Is soft delete feature state editable."
       }
@@ -147,16 +148,7 @@
       "type": "Microsoft.RecoveryServices/vaults/backupconfig",
       "apiVersion": "2026-01-01",
       "name": "[format('{0}/{1}', parameters('recoveryVaultName'), parameters('name'))]",
-      "properties": {
-        "enhancedSecurityState": "[parameters('enhancedSecurityState')]",
-        "resourceGuardOperationRequests": "[parameters('resourceGuardOperationRequests')]",
-        "softDeleteFeatureState": "[parameters('softDeleteFeatureState')]",
-        "storageModelType": "[parameters('storageModelType')]",
-        "storageType": "[parameters('storageType')]",
-        "storageTypeState": "[parameters('storageTypeState')]",
-        "isSoftDeleteFeatureStateEditable": "[parameters('isSoftDeleteFeatureStateEditable')]",
-        "softDeleteRetentionPeriodInDays": "[parameters('softDeleteRetentionPeriodInDays')]"
-      }
+      "properties": "[shallowMerge(createArray(createObject('resourceGuardOperationRequests', parameters('resourceGuardOperationRequests'), 'storageModelType', parameters('storageModelType'), 'storageType', parameters('storageType'), 'storageTypeState', parameters('storageTypeState')), if(not(equals(parameters('enhancedSecurityState'), null())), createObject('enhancedSecurityState', parameters('enhancedSecurityState')), createObject()), if(not(equals(parameters('softDeleteFeatureState'), null())), createObject('softDeleteFeatureState', parameters('softDeleteFeatureState')), createObject()), if(not(equals(parameters('isSoftDeleteFeatureStateEditable'), null())), createObject('isSoftDeleteFeatureStateEditable', parameters('isSoftDeleteFeatureStateEditable')), createObject()), if(not(equals(parameters('softDeleteRetentionPeriodInDays'), null())), createObject('softDeleteRetentionPeriodInDays', parameters('softDeleteRetentionPeriodInDays')), createObject())))]"
     }
   },
   "outputs": {

--- a/avm/res/recovery-services/vault/main.bicep
+++ b/avm/res/recovery-services/vault/main.bicep
@@ -334,15 +334,17 @@ module rsv_backupConfig 'backup-config/main.bicep' = if (!empty(backupConfig)) {
   params: {
     recoveryVaultName: rsv.name
     name: backupConfig.?name
+    // Once `softDeleteSettings` is set on the vault itself, the backupconfig API no longer accepts writes to the
+    // soft delete related properties. They are therefore not forwarded to the child module in that case.
     enhancedSecurityState: !empty(softDeleteSettings) ? null : backupConfig.?enhancedSecurityState
     resourceGuardOperationRequests: backupConfig.?resourceGuardOperationRequests
     softDeleteFeatureState: !empty(softDeleteSettings) ? null : backupConfig.?softDeleteFeatureState
     storageModelType: backupConfig.?storageModelType
     storageType: backupConfig.?storageType
     storageTypeState: backupConfig.?storageTypeState
-    isSoftDeleteFeatureStateEditable: backupConfig.?isSoftDeleteFeatureStateEditable
+    isSoftDeleteFeatureStateEditable: !empty(softDeleteSettings) ? null : backupConfig.?isSoftDeleteFeatureStateEditable
     enableTelemetry: enableReferencedModulesTelemetry
-    softDeleteRetentionPeriodInDays: backupConfig.?softDeleteRetentionPeriodInDays
+    softDeleteRetentionPeriodInDays: !empty(softDeleteSettings) ? null : backupConfig.?softDeleteRetentionPeriodInDays
   }
 }
 

--- a/avm/res/recovery-services/vault/main.json
+++ b/avm/res/recovery-services/vault/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.45.6.27763",
-      "templateHash": "220046558025066618"
+      "version": "0.42.1.51946",
+      "templateHash": "10721181273595885843"
     },
     "name": "Recovery Services Vaults",
     "description": "This module deploys a Recovery Services Vault."
@@ -1705,8 +1705,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.6.27763",
-              "templateHash": "16156952054359373168"
+              "version": "0.42.1.51946",
+              "templateHash": "4300134200808733054"
             },
             "name": "Recovery Services Vault Replication Fabrics",
             "description": "This module deploys a Replication Fabric for Azure to Azure disaster recovery scenario of Azure Site Recovery.\n\n> Note: this module currently support only the `instanceType: 'Azure'` scenario."
@@ -1908,8 +1908,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.45.6.27763",
-                      "templateHash": "8736444571877131181"
+                      "version": "0.42.1.51946",
+                      "templateHash": "108524614303970407"
                     },
                     "name": "Recovery Services Vault Replication Fabric Replication Protection Containers",
                     "description": "This module deploys a Recovery Services Vault Replication Protection Container.\n\n> **Note**: this version of the module only supports the `instanceType: 'A2A'` scenario."
@@ -2104,8 +2104,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.45.6.27763",
-                              "templateHash": "6594901912927952880"
+                              "version": "0.42.1.51946",
+                              "templateHash": "6182913882922066329"
                             },
                             "name": "Recovery Services Vault Replication Fabric Replication Protection Container Replication Protection Container Mappings",
                             "description": "This module deploys a Recovery Services Vault (RSV) Replication Protection Container Mapping.\n\n> **Note**: this version of the module only supports the `instanceType: 'A2A'` scenario."
@@ -2368,8 +2368,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.6.27763",
-              "templateHash": "6356275547804494974"
+              "version": "0.42.1.51946",
+              "templateHash": "17818226242428631919"
             },
             "name": "Recovery Services Vault Replication Policies",
             "description": "This module deploys a Recovery Services Vault Replication Policy for Disaster Recovery scenario.\n\n> **Note**: this version of the module only supports the `instanceType: 'A2A'` scenario."
@@ -2537,8 +2537,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.6.27763",
-              "templateHash": "3711233916359961813"
+              "version": "0.42.1.51946",
+              "templateHash": "7094832860756691411"
             },
             "name": "Recovery Service Vaults Protection Container Protected Item",
             "description": "This module deploys a Recovery Services Vault Protection Container Protected Item."
@@ -2703,8 +2703,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.6.27763",
-              "templateHash": "27240770409910105"
+              "version": "0.42.1.51946",
+              "templateHash": "18064254233216935123"
             },
             "name": "Recovery Services Vault Backup Policies",
             "description": "This module deploys a Recovery Services Vault Backup Policy."
@@ -2824,15 +2824,11 @@
           "storageTypeState": {
             "value": "[tryGet(parameters('backupConfig'), 'storageTypeState')]"
           },
-          "isSoftDeleteFeatureStateEditable": {
-            "value": "[tryGet(parameters('backupConfig'), 'isSoftDeleteFeatureStateEditable')]"
-          },
+          "isSoftDeleteFeatureStateEditable": "[if(not(empty(parameters('softDeleteSettings'))), createObject('value', null()), createObject('value', tryGet(parameters('backupConfig'), 'isSoftDeleteFeatureStateEditable')))]",
           "enableTelemetry": {
             "value": "[variables('enableReferencedModulesTelemetry')]"
           },
-          "softDeleteRetentionPeriodInDays": {
-            "value": "[tryGet(parameters('backupConfig'), 'softDeleteRetentionPeriodInDays')]"
-          }
+          "softDeleteRetentionPeriodInDays": "[if(not(empty(parameters('softDeleteSettings'))), createObject('value', null()), createObject('value', tryGet(parameters('backupConfig'), 'softDeleteRetentionPeriodInDays')))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -2841,8 +2837,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.6.27763",
-              "templateHash": "2431393405068255158"
+              "version": "0.42.1.51946",
+              "templateHash": "17536143300264072774"
             },
             "name": "Recovery Services Vault Backup Config",
             "description": "This module deploys a Recovery Services Vault Backup Config."
@@ -2867,7 +2863,8 @@
               "allowedValues": [
                 "AlwaysON",
                 "Disabled",
-                "Enabled"
+                "Enabled",
+                "Invalid"
               ],
               "metadata": {
                 "description": "Optional. Enable this setting to protect hybrid backups against accidental deletes and add additional layer of authentication for critical operations."
@@ -2932,7 +2929,7 @@
             },
             "isSoftDeleteFeatureStateEditable": {
               "type": "bool",
-              "defaultValue": true,
+              "nullable": true,
               "metadata": {
                 "description": "Optional. Is soft delete feature state editable."
               }
@@ -2983,16 +2980,7 @@
               "type": "Microsoft.RecoveryServices/vaults/backupconfig",
               "apiVersion": "2026-01-01",
               "name": "[format('{0}/{1}', parameters('recoveryVaultName'), parameters('name'))]",
-              "properties": {
-                "enhancedSecurityState": "[parameters('enhancedSecurityState')]",
-                "resourceGuardOperationRequests": "[parameters('resourceGuardOperationRequests')]",
-                "softDeleteFeatureState": "[parameters('softDeleteFeatureState')]",
-                "storageModelType": "[parameters('storageModelType')]",
-                "storageType": "[parameters('storageType')]",
-                "storageTypeState": "[parameters('storageTypeState')]",
-                "isSoftDeleteFeatureStateEditable": "[parameters('isSoftDeleteFeatureStateEditable')]",
-                "softDeleteRetentionPeriodInDays": "[parameters('softDeleteRetentionPeriodInDays')]"
-              }
+              "properties": "[shallowMerge(createArray(createObject('resourceGuardOperationRequests', parameters('resourceGuardOperationRequests'), 'storageModelType', parameters('storageModelType'), 'storageType', parameters('storageType'), 'storageTypeState', parameters('storageTypeState')), if(not(equals(parameters('enhancedSecurityState'), null())), createObject('enhancedSecurityState', parameters('enhancedSecurityState')), createObject()), if(not(equals(parameters('softDeleteFeatureState'), null())), createObject('softDeleteFeatureState', parameters('softDeleteFeatureState')), createObject()), if(not(equals(parameters('isSoftDeleteFeatureStateEditable'), null())), createObject('isSoftDeleteFeatureStateEditable', parameters('isSoftDeleteFeatureStateEditable')), createObject()), if(not(equals(parameters('softDeleteRetentionPeriodInDays'), null())), createObject('softDeleteRetentionPeriodInDays', parameters('softDeleteRetentionPeriodInDays')), createObject())))]"
             }
           },
           "outputs": {
@@ -3061,8 +3049,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.45.6.27763",
-              "templateHash": "3580637060467830058"
+              "version": "0.42.1.51946",
+              "templateHash": "14592636309960011598"
             },
             "name": "Recovery Services Vault Replication Alert Settings",
             "description": "This module deploys a Recovery Services Vault Replication Alert Settings."

--- a/avm/res/recovery-services/vault/tests/e2e/max/main.test.bicep
+++ b/avm/res/recovery-services/vault/tests/e2e/max/main.test.bicep
@@ -72,6 +72,8 @@ module testDeployment '../../../main.bicep' = [
       backupConfig: {
         enhancedSecurityState: 'AlwaysON'
         softDeleteFeatureState: 'AlwaysON'
+        softDeleteRetentionPeriodInDays: 7
+        isSoftDeleteFeatureStateEditable: true
       }
       redundancySettings: {
         standardTierStorageRedundancy: 'LocallyRedundant'


### PR DESCRIPTION
## Description

Fixes #7289

Deploying `avm/res/recovery-services/vault` with both the vault-level `softDeleteSettings` and the `backupConfig` child configuration fails, because the two write the same underlying service state through two different APIs.

Once soft delete has been configured via the **Vault API** (`Microsoft.RecoveryServices/vaults`), the **backupconfig API** (`Microsoft.RecoveryServices/vaults/backupconfig`) permanently rejects any further write to the soft delete related properties with:

> Soft delete state for this vault cannot be modified using this API. Since the Vault API was previously used to update the soft delete property for this vault, you must again use the Vault API to make any further changes to this property. (Code: `BMSUserErrorSoftDeleteUseVaultApi`)

This happens even when the values being written are identical to the ones already set on the vault, so the two configurations cannot be reconciled by forwarding matching values. The only viable resolution is for the `backupconfig` request to not carry those properties at all.

### Changes

- **`main.bicep`** — when `softDeleteSettings` is provided, the parent no longer forwards `enhancedSecurityState`, `softDeleteFeatureState`, `isSoftDeleteFeatureStateEditable` and `softDeleteRetentionPeriodInDays` to the `backup-config` child module.
- **`backup-config/main.bicep`** — these four properties are now emitted conditionally, so an unset property is **absent** from the request payload rather than present with a `null` value. Sending them as `null` is itself rejected by the API with `UserErrorInvalidRequestParameter` ("Parameter NO_PARAM in request is invalid").
- **`backup-config/main.bicep`** — `isSoftDeleteFeatureStateEditable` changed from `bool` (default `true`) to a nullable `bool?`. When it is not specified, the service-side value is now left untouched instead of being implicitly set to `true`.
- **`backup-config/main.bicep`** — added `'Invalid'` to the allowed values of `enhancedSecurityState` to align with the API schema (`softDeleteFeatureState` already allowed it).
- **`tests/e2e/max/main.test.bicep`** — added `softDeleteRetentionPeriodInDays` and `isSoftDeleteFeatureStateEditable` to `backupConfig` so all four affected properties are exercised alongside `softDeleteSettings`.
- Updated both `CHANGELOG.md` files and regenerated the supporting module files via `Set-AVMModule`.

### Validation

Both failure modes were reproduced in CI before the fix, which brackets the solution:

| Payload for the soft delete properties | Result |
| -------------------------------------- | ------ |
| Present, value `null`                  | ❌ `UserErrorInvalidRequestParameter` |
| Present, values matching the vault     | ❌ `BMSUserErrorSoftDeleteUseVaultApi` |
| Absent                                 | ✅ Succeeds |

Both `max` and `waf-aligned` configure `softDeleteSettings` together with `backupConfig` soft delete properties, so both cover the reported scenario, and both now deploy successfully.

### Notes for reviewers

Two points that are deliberate but worth a second opinion:

1. If a consumer sets both `softDeleteSettings` and the soft delete properties of `backupConfig`, the latter are now **silently ignored** rather than causing a failure. The API offers no way to honour them, but an explicit `fail()` on the conflicting combination would be an alternative if preferred.
2. Removing the `true` default from `isSoftDeleteFeatureStateEditable` is a behaviour change for consumers deploying the `backup-config` module standalone. It has been classified under *Changes* rather than *Breaking Changes* since no deployment breaks and the property remains service-managed, but happy to reclassify.

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.recovery-services.vault](https://github.com/alexanderojala/bicep-registry-modules/actions/workflows/avm.res.recovery-services.vault.yml/badge.svg?branch=7289_softdelete)](https://github.com/alexanderojala/bicep-registry-modules/actions/workflows/avm.res.recovery-services.vault.yml) |

## Type of Change

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version
