### PR TITLE
feat: expose disableLocalAuth and publicNetworkAccess on communication-service module

### DIFF
--- a/avm/res/communication/communication-service/CHANGELOG.md
+++ b/avm/res/communication/communication-service/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/communication/communication-service/CHANGELOG.md).
 
+## 0.6.0
+
+### Changes
+
+- Exposed `disableLocalAuth` (bool) and `publicNetworkAccess` (string) properties already supported by `Microsoft.Communication/communicationServices@2025-09-01`. Both parameters are nullable and default to null so existing deployments are unaffected.
+- Updated `max` test to exercise both new parameters.
+- Updated `waf-aligned` test to demonstrate the hardened configuration (`disableLocalAuth: true`, `publicNetworkAccess: 'Disabled'`).
+
+### Breaking Changes
+
+- None
+
 ## 0.5.0
 
 ### Changes

--- a/avm/res/communication/communication-service/README.md
+++ b/avm/res/communication/communication-service/README.md
@@ -142,6 +142,7 @@ module communicationService 'br/public:avm/res/communication/communication-servi
         workspaceResourceId: '<workspaceResourceId>'
       }
     ]
+    disableLocalAuth: false
     linkedDomains: [
       '<emailDomainResourceId>'
     ]
@@ -156,6 +157,7 @@ module communicationService 'br/public:avm/res/communication/communication-servi
         '<managedIdentityResourceId>'
       ]
     }
+    publicNetworkAccess: 'Enabled'
     roleAssignments: [
       {
         name: '9237b909-e8fb-4bb8-8194-34aae537cee2'
@@ -220,6 +222,9 @@ module communicationService 'br/public:avm/res/communication/communication-servi
         }
       ]
     },
+    "disableLocalAuth": {
+      "value": false
+    },
     "linkedDomains": {
       "value": [
         "<emailDomainResourceId>"
@@ -241,6 +246,9 @@ module communicationService 'br/public:avm/res/communication/communication-servi
           "<managedIdentityResourceId>"
         ]
       }
+    },
+    "publicNetworkAccess": {
+      "value": "Enabled"
     },
     "roleAssignments": {
       "value": [
@@ -302,6 +310,7 @@ param diagnosticSettings = [
     workspaceResourceId: '<workspaceResourceId>'
   }
 ]
+param disableLocalAuth = false
 param linkedDomains = [
   '<emailDomainResourceId>'
 ]
@@ -316,6 +325,7 @@ param managedIdentities = {
     '<managedIdentityResourceId>'
   ]
 }
+param publicNetworkAccess = 'Enabled'
 param roleAssignments = [
   {
     name: '9237b909-e8fb-4bb8-8194-34aae537cee2'
@@ -371,7 +381,9 @@ module communicationService 'br/public:avm/res/communication/communication-servi
         workspaceResourceId: '<workspaceResourceId>'
       }
     ]
+    disableLocalAuth: true
     location: 'global'
+    publicNetworkAccess: 'Disabled'
     tags: {
       Environment: 'Non-Prod'
       'hidden-title': 'This is visible in the resource name'
@@ -411,8 +423,14 @@ module communicationService 'br/public:avm/res/communication/communication-servi
         }
       ]
     },
+    "disableLocalAuth": {
+      "value": true
+    },
     "location": {
       "value": "global"
+    },
+    "publicNetworkAccess": {
+      "value": "Disabled"
     },
     "tags": {
       "value": {
@@ -447,7 +465,9 @@ param diagnosticSettings = [
     workspaceResourceId: '<workspaceResourceId>'
   }
 ]
+param disableLocalAuth = true
 param location = 'global'
+param publicNetworkAccess = 'Disabled'
 param tags = {
   Environment: 'Non-Prod'
   'hidden-title': 'This is visible in the resource name'
@@ -472,11 +492,13 @@ param tags = {
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
 | [`diagnosticSettings`](#parameter-diagnosticsettings) | array | The diagnostic settings of the service. If neither metrics nor logs are specified, all metrics & logs are configured by default. If only one of them is specified, the other one will not be configured. |
+| [`disableLocalAuth`](#parameter-disablelocalauth) | bool | Disable local authentication for the Communication Service. When set to true, access key-based authentication is disabled. Defaults to null (not set), preserving existing behaviour. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
 | [`linkedDomains`](#parameter-linkeddomains) | array | List of email Domain resource Ids. |
 | [`location`](#parameter-location) | string | Location for all Resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. |
+| [`publicNetworkAccess`](#parameter-publicnetworkaccess) | string | Allow, disallow, or let network security perimeter configuration control public network access to the Communication Service. Defaults to null (not set), preserving existing behaviour. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`tags`](#parameter-tags) | object | Resource tags. |
 
@@ -640,6 +662,13 @@ Resource ID of the diagnostic log analytics workspace. For security reasons, it 
 - Required: No
 - Type: string
 
+### Parameter: `disableLocalAuth`
+
+Disable local authentication for the Communication Service. When set to true, access key-based authentication is disabled. Defaults to null (not set), preserving existing behaviour.
+
+- Required: No
+- Type: bool
+
 ### Parameter: `enableTelemetry`
 
 Enable/Disable usage telemetry for module.
@@ -734,6 +763,21 @@ The resource ID(s) to assign to the resource. Required if a user assigned identi
 
 - Required: No
 - Type: array
+
+### Parameter: `publicNetworkAccess`
+
+Allow, disallow, or let network security perimeter configuration control public network access to the Communication Service. Defaults to null (not set), preserving existing behaviour.
+
+- Required: No
+- Type: string
+- Allowed:
+  ```Bicep
+  [
+    'Disabled'
+    'Enabled'
+    'SecuredByPerimeter'
+  ]
+  ```
 
 ### Parameter: `roleAssignments`
 

--- a/avm/res/communication/communication-service/main.bicep
+++ b/avm/res/communication/communication-service/main.bicep
@@ -34,6 +34,17 @@ param dataLocation string
 @description('Optional. List of email Domain resource Ids.')
 param linkedDomains string[]?
 
+@description('Optional. Disable local authentication for the Communication Service. When set to true, access key-based authentication is disabled. Defaults to null (not set), preserving existing behaviour.')
+param disableLocalAuth bool?
+
+@allowed([
+  'Disabled'
+  'Enabled'
+  'SecuredByPerimeter'
+])
+@description('Optional. Allow, disallow, or let network security perimeter configuration control public network access to the Communication Service. Defaults to null (not set), preserving existing behaviour.')
+param publicNetworkAccess string?
+
 @description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
 
@@ -111,7 +122,9 @@ resource communicationService 'Microsoft.Communication/communicationServices@202
   tags: tags
   properties: {
     dataLocation: dataLocation
+    disableLocalAuth: disableLocalAuth
     linkedDomains: linkedDomains
+    publicNetworkAccess: publicNetworkAccess
   }
 }
 

--- a/avm/res/communication/communication-service/main.json
+++ b/avm/res/communication/communication-service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.44.1.10279",
-      "templateHash": "11362996184152667836"
+      "version": "0.46.1.21595",
+      "templateHash": "10855568302773785436"
     },
     "name": "Communication Services",
     "description": "This module deploys a Communication Service"
@@ -351,6 +351,25 @@
         "description": "Optional. List of email Domain resource Ids."
       }
     },
+    "disableLocalAuth": {
+      "type": "bool",
+      "nullable": true,
+      "metadata": {
+        "description": "Optional. Disable local authentication for the Communication Service. When set to true, access key-based authentication is disabled. Defaults to null (not set), preserving existing behaviour."
+      }
+    },
+    "publicNetworkAccess": {
+      "type": "string",
+      "nullable": true,
+      "allowedValues": [
+        "Disabled",
+        "Enabled",
+        "SecuredByPerimeter"
+      ],
+      "metadata": {
+        "description": "Optional. Allow, disallow, or let network security perimeter configuration control public network access to the Communication Service. Defaults to null (not set), preserving existing behaviour."
+      }
+    },
     "enableTelemetry": {
       "type": "bool",
       "defaultValue": true,
@@ -408,7 +427,9 @@
       "tags": "[parameters('tags')]",
       "properties": {
         "dataLocation": "[parameters('dataLocation')]",
-        "linkedDomains": "[parameters('linkedDomains')]"
+        "disableLocalAuth": "[parameters('disableLocalAuth')]",
+        "linkedDomains": "[parameters('linkedDomains')]",
+        "publicNetworkAccess": "[parameters('publicNetworkAccess')]"
       }
     },
     "communicationService_lock": {

--- a/avm/res/communication/communication-service/tests/e2e/max/main.test.bicep
+++ b/avm/res/communication/communication-service/tests/e2e/max/main.test.bicep
@@ -71,6 +71,8 @@ module testDeployment '../../../main.bicep' = [
       name: '${namePrefix}${serviceShort}001'
       location: 'global'
       dataLocation: 'Germany'
+      disableLocalAuth: false
+      publicNetworkAccess: 'Enabled'
       linkedDomains: [
         nestedDependencies.outputs.emailDomainResourceId
       ]

--- a/avm/res/communication/communication-service/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/communication/communication-service/tests/e2e/waf-aligned/main.test.bicep
@@ -59,6 +59,8 @@ module testDeployment '../../../main.bicep' = [
       name: '${namePrefix}${serviceShort}001'
       location: 'global'
       dataLocation: 'Germany'
+      disableLocalAuth: true
+      publicNetworkAccess: 'Disabled'
       diagnosticSettings: [
         {
           eventHubName: diagnosticDependencies.outputs.eventHubNamespaceEventHubName

--- a/avm/res/communication/communication-service/version.json
+++ b/avm/res/communication/communication-service/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
-  "version": "0.5"
+  "version": "0.6"
 }


### PR DESCRIPTION
## Description

The `avm/res/communication/communication-service` module pins API version `Microsoft.Communication/communicationServices@2025-09-01`, which supports `disableLocalAuth` and `publicNetworkAccess` as writable properties, but the module never exposed them.

This PR adds both as nullable parameters:

| Parameter | Type | Default | Notes |
|---|---|---|---|
| `disableLocalAuth` | `bool?` | `null` (omitted) | Disables access-key auth when `true` |
| `publicNetworkAccess` | `string?` | `null` (omitted) | `Enabled`, `Disabled`, or `SecuredByPerimeter` |

**No API version bump is required** because the pinned `2025-09-01` version already supports both properties.

**Non-breaking defaults:** Both parameters are nullable and default to `null`, so the ARM payload is unchanged for existing consumers who pass nothing. Notably, `disableLocalAuth` does **not** default to `true` (unlike some other AVM modules) because doing so would silently break consumers using the primary access-key authentication path of the Azure Communication Services SDKs. The hardened configuration (`disableLocalAuth: true`, `publicNetworkAccess: 'Disabled'`) is demonstrated in the `waf-aligned` test instead.

## Pipeline Reference

| Pipeline |
| -------- |
| [![avm.res.communication.communication-service](https://github.com/donk-msft/bicep-registry-modules/actions/workflows/avm.res.communication.communication-service.yml/badge.svg?branch=feat%2FupdateCommunicationServicesModule)](https://github.com/donk-msft/bicep-registry-modules/actions/workflows/avm.res.communication.communication-service.yml) |

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version
