### PR TITLE
fix: pin composite action dependencies

### DIFF
--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -62,7 +62,7 @@ runs:
     # [Deployment validation] task(s)
     # -------------------------------
     - name: "Validate Test Execution"
-      uses: azure/powershell@v2
+      uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2
       with:
         azPSVersion: "latest"
         errorActionPreference: "SilentlyContinue"
@@ -91,7 +91,7 @@ runs:
     - name: "Set OIDC temporary exception"
       id: set-oidc-exception
       if: env.skip_deployment_ci == 'false'
-      uses: azure/powershell@v2
+      uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -123,7 +123,7 @@ runs:
     # 'creds' will be ignored if 'client-id', 'subscription-id' or 'tenant-id' is set
     - name: "Azure Login - Default"
       if: ${{ steps.set-oidc-exception.outputs.oidcException == 'false' && env.skip_deployment_ci == 'false' }}
-      uses: azure/login@v2
+      uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2
       with:
         client-id: ${{ env.VALIDATE_CLIENT_ID }}
         tenant-id: ${{ env.VALIDATE_TENANT_ID }}
@@ -134,7 +134,7 @@ runs:
     # Should only be leveraged by modules listed in $exceptionModulePaths above
     - name: "Azure Login - Exception"
       if: ${{ steps.set-oidc-exception.outputs.oidcException == 'true'  && env.skip_deployment_ci == 'false'}}
-      uses: azure/login@v2
+      uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2
       with:
         creds: ${{ env.AZURE_CREDENTIALS }}
         enable-AzPSSession: true
@@ -144,7 +144,7 @@ runs:
     - name: "Get Resource Location"
       id: get-resource-location
       if: env.skip_deployment_ci == 'false'
-      uses: azure/powershell@v2
+      uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -179,7 +179,7 @@ runs:
     # ---------------------------
     - name: "Replace tokens in template file"
       if: env.skip_deployment_ci == 'false'
-      uses: azure/powershell@v2
+      uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -244,7 +244,7 @@ runs:
 
     - name: "Validate template file"
       if: env.skip_deployment_ci == 'false'
-      uses: azure/powershell@v2
+      uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -325,7 +325,7 @@ runs:
     - name: "Deploy template file"
       if: env.skip_deployment_ci == 'false'
       id: deploy_step
-      uses: azure/powershell@v2
+      uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -421,7 +421,7 @@ runs:
     # 'creds' will be ignored if 'client-id', 'subscription-id' or 'tenant-id' is set
     - name: "Azure Login - Default"
       if: ${{ steps.set-oidc-exception.outputs.oidcException == 'false' && env.skip_deployment_ci == 'false' }}
-      uses: azure/login@v2
+      uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2
       with:
         client-id: ${{ env.VALIDATE_CLIENT_ID }}
         tenant-id: ${{ env.VALIDATE_TENANT_ID }}
@@ -432,7 +432,7 @@ runs:
     # Should only be leveraged by modules listed in $exceptionModulePaths above
     - name: "Azure Login - Exception"
       if: ${{ steps.set-oidc-exception.outputs.oidcException == 'true'  && env.skip_deployment_ci == 'false'}}
-      uses: azure/login@v2
+      uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2
       with:
         creds: ${{ env.AZURE_CREDENTIALS }}
         enable-AzPSSession: true
@@ -532,7 +532,7 @@ runs:
     # ----------------------------
     - name: "Remove deployed resources"
       if: ${{ (success() || failure()) && inputs.removeDeployment == 'true' && steps.deploy_step.outputs.deploymentNames != '' && env.skip_deployment_ci == 'false' }}
-      uses: azure/powershell@v2
+      uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2
       with:
         azPSVersion: "latest"
         inlineScript: |

--- a/.github/actions/templates/avm-validateModulePSRule/action.yml
+++ b/.github/actions/templates/avm-validateModulePSRule/action.yml
@@ -38,7 +38,7 @@ runs:
     # [Token replacement] task(s)
     # ---------------------------
     - name: "Replace tokens in template file"
-      uses: azure/powershell@v2
+      uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -104,7 +104,7 @@ runs:
     # [PSRule validation] task(s)
     #-----------------------------
     - name: Run PSRule analysis
-      uses: microsoft/ps-rule@v2.9.0
+      uses: microsoft/ps-rule@24eda55e317e99b3921c62c27e2acfc9970e0dfa # v2.9.0
       env:
         CONTINUE_ON_ERROR: ${{ inputs.softFailure }}
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}
@@ -123,7 +123,7 @@ runs:
     #-----------------------------
     - name: "Parse CSV content"
       if: always()
-      uses: azure/powershell@v2
+      uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2
       with:
         azPSVersion: "latest"
         inlineScript: |

--- a/.github/actions/templates/avm-validateModulePester/action.yml
+++ b/.github/actions/templates/avm-validateModulePester/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Upload artifacts
       if: always()
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: Upload & store test results
         path: |


### PR DESCRIPTION
## Summary

- Pin every third-party action used by the composite action templates to a full-length commit SHA.
- Preserve the existing action versions in comments for Dependabot compatibility and readability.
- Cover the `azure/powershell`, `azure/login`, `microsoft/ps-rule`, and `actions/upload-artifact` references missed by #7306.

## Validation

- Confirmed every external action reference under `.github` uses a 40-character SHA.
- `git diff --check` passes.