### PR TITLE
fix: correct PSRule action SHA

### DIFF
--- a/.github/actions/templates/avm-validateModulePSRule/action.yml
+++ b/.github/actions/templates/avm-validateModulePSRule/action.yml
@@ -104,7 +104,7 @@ runs:
     # [PSRule validation] task(s)
     #-----------------------------
     - name: Run PSRule analysis
-      uses: microsoft/ps-rule@24eda55e317e99b3921c62c27e2acfc9970e0dfa # v2.9.0
+      uses: microsoft/ps-rule@46451b8f5258c41beb5ae69ed7190ccbba84112c # v2.9.0
       env:
         CONTINUE_ON_ERROR: ${{ inputs.softFailure }}
       continue-on-error: ${{ fromJSON(env.CONTINUE_ON_ERROR) }}


### PR DESCRIPTION
## Description

Correct the immutable `microsoft/ps-rule` v2.9.0 pin used by the AVM PSRule validation composite action.

The merged regression in https://github.com/Azure/bicep-registry-modules/pull/7320 pinned the action to commit `24eda55e317e99b3921c62c27e2acfc9970e0dfa` from the different uppercase `microsoft/PSRule` source repository (repo ID 125832556), which does not contain an action manifest. The root cause was resolving the release against that case-sensitive duplicate repository instead of the lowercase `microsoft/ps-rule` action repository (repo ID 205811333).

This change restores the v2.9.0 action commit already used by `.github/workflows/platform.check.psrule.yml`: `46451b8f5258c41beb5ae69ed7190ccbba84112c`.

## Validation

- Confirmed `microsoft/ps-rule` resolves to repository ID 205811333.
- Confirmed `action.yml` exists at commit `46451b8f5258c41beb5ae69ed7190ccbba84112c`.
- Confirmed all external action references under `.github` use full 40-character SHAs.
- Ran `git diff --check`.