### PR TITLE
fix: create release tags through GitHub API

### DIFF
--- a/.github/workflows/avm.template.module.publish-only.yml
+++ b/.github/workflows/avm.template.module.publish-only.yml
@@ -60,6 +60,7 @@ jobs:
         env:
           BASE_COMMIT: "${{ inputs.baseCommit }}"
           FORCE_PUBLISH: "${{ inputs.forcePublish }}"
+          GH_TOKEN: "${{ github.token }}"
           MODULE_PATH: "${{ inputs.modulePath }}"
           TARGET_COMMIT: "${{ inputs.targetCommit }}"
         run: |

--- a/.github/workflows/avm.template.module.publish.yml
+++ b/.github/workflows/avm.template.module.publish.yml
@@ -210,6 +210,7 @@ jobs:
         env:
           BASE_COMMIT: "${{ inputs.baseCommit }}"
           FORCE_PUBLISH: "${{ inputs.forcePublish }}"
+          GH_TOKEN: "${{ github.token }}"
           MODULE_PATH: "${{ inputs.modulePath }}"
           TARGET_COMMIT: "${{ inputs.targetCommit }}"
         run: |

--- a/.github/workflows/avm.template.module.yml
+++ b/.github/workflows/avm.template.module.yml
@@ -175,6 +175,8 @@ jobs:
         uses: ./.github/actions/templates/avm-setEnvironment
       - name: "Create module release tag"
         shell: pwsh
+        env:
+          GH_TOKEN: "${{ github.token }}"
         run: |
           # Grouping task logs
           Write-Output '::group::Create module release tag'

--- a/utilities/pipelines/publish/Set-ModuleWorkflowReleaseTag.ps1
+++ b/utilities/pipelines/publish/Set-ModuleWorkflowReleaseTag.ps1
@@ -1,3 +1,5 @@
+. (Join-Path $PSScriptRoot 'helper' 'New-ModuleReleaseTagReference.ps1')
+
 function Invoke-ModuleWorkflowGitLsRemote {
 
     [CmdletBinding()]
@@ -263,25 +265,8 @@ function New-ModuleWorkflowReleaseTag {
     }
 
     if ($PSCmdlet.ShouldProcess("release tag [$tagName] at commit [$TargetCommit]", 'Create and publish')) {
-        git tag $tagName $TargetCommit
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to create local tag [$tagName]."
-        }
-
-        git push origin "refs/tags/${tagName}:refs/tags/${tagName}"
-        if ($LASTEXITCODE -eq 0) {
-            return $tagName
-        }
-
-        $concurrentTags = ConvertTo-ModuleWorkflowRemoteTag -Reference @(
-            Invoke-ModuleWorkflowGitLsRemote -Remote origin -Pattern "$tagName*"
-        ) | Where-Object { $_.name -eq $tagName }
-        if ($concurrentTags.commit -contains $TargetCommit) {
-            Write-Verbose "Tag [$tagName] was concurrently published at the target commit." -Verbose
-            return $tagName
-        }
-
-        throw "Failed to publish tag [$tagName]."
+        New-ModuleReleaseTagReference -TagName $tagName -TargetCommit $TargetCommit
+        return $tagName
     }
 
     return $null

--- a/utilities/pipelines/publish/helper/New-ModuleReleaseTag.ps1
+++ b/utilities/pipelines/publish/helper/New-ModuleReleaseTag.ps1
@@ -17,6 +17,8 @@ New-ModuleReleaseTag -ModuleFolderPath 'C:\avm\res\key-vault\vault' -TargetVersi
 Creates 'avm/res/key-vault/vault/1.0.0' release tag
 #>
 
+. (Join-Path $PSScriptRoot 'New-ModuleReleaseTagReference.ps1')
+
 function New-ModuleReleaseTag {
 
     [CmdletBinding()]
@@ -40,25 +42,15 @@ function New-ModuleReleaseTag {
         throw "Tag [$tagName] is not well formatted."
     }
 
-    # 3 Check tag not already existing
-    $existingTag = git ls-remote --tags origin $tagName
-    if ($existingTag) {
-        Write-Verbose "Tag [$tagName] already exists" -Verbose
-        return $tagName
-    }
-
-
-    # 3 Create local tag
-    Write-Verbose "Creating release tag: [$tagName]" -Verbose
-    git tag $tagName
-
-    # 4 Publish release tag
-    Write-Verbose "Publishing release tag: [$tagName]" -Verbose
-    git push origin $tagName
-
+    # 3 Resolve target commit
+    $targetCommit = git rev-parse HEAD
     if ($LASTEXITCODE -ne 0) {
-        throw 'Git Tag creation failed. Please review error log.'
+        throw 'Failed to resolve the target commit for the release tag.'
     }
+
+    # 4 Create remote tag
+    Write-Verbose "Publishing release tag: [$tagName]" -Verbose
+    New-ModuleReleaseTagReference -TagName $tagName -TargetCommit $targetCommit
 
     # 5 Return tag
     return $tagName

--- a/utilities/pipelines/publish/helper/New-ModuleReleaseTagReference.ps1
+++ b/utilities/pipelines/publish/helper/New-ModuleReleaseTagReference.ps1
@@ -1,0 +1,127 @@
+function Get-ModuleReleaseTagRemoteCommit {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string] $TagName,
+
+        [Parameter()]
+        [string] $Remote = 'origin'
+    )
+
+    $references = @(
+        & git ls-remote --tags $Remote "refs/tags/$TagName" "refs/tags/$TagName^{}" 2>&1 |
+        ForEach-Object { $_.ToString() }
+    )
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to query release tag [$TagName] from remote [$Remote]. Git output: $($references -join [Environment]::NewLine)"
+    }
+
+    $directCommit = $null
+    $peeledCommit = $null
+    foreach ($reference in $references) {
+        if ($reference -notmatch '^([0-9a-fA-F]{40,64})\s+(.+)$') {
+            continue
+        }
+
+        if ($matches[2] -eq "refs/tags/$TagName^{}") {
+            $peeledCommit = $matches[1]
+        } elseif ($matches[2] -eq "refs/tags/$TagName") {
+            $directCommit = $matches[1]
+        }
+    }
+
+    return $peeledCommit ?? $directCommit
+}
+
+function Invoke-ModuleReleaseTagGitHubApi {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string] $Repository,
+
+        [Parameter(Mandatory)]
+        [string] $TagName,
+
+        [Parameter(Mandatory)]
+        [string] $TargetCommit,
+
+        [Parameter()]
+        [string] $GitHubToken = ($env:GH_TOKEN ?? $env:GITHUB_TOKEN)
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Repository)) {
+        throw 'The GitHub repository is required to create a release tag.'
+    }
+    if ([string]::IsNullOrWhiteSpace($GitHubToken)) {
+        throw 'A GitHub token is required to create a release tag.'
+    }
+
+    $requestInput = @{
+        Uri         = "https://api.github.com/repos/$Repository/git/refs"
+        Method      = 'Post'
+        ErrorAction = 'Stop'
+        Headers     = @{
+            Accept                 = 'application/vnd.github+json'
+            Authorization          = "Bearer $GitHubToken"
+            'X-GitHub-Api-Version' = '2022-11-28'
+        }
+        ContentType = 'application/json'
+        Body        = @{
+            ref = "refs/tags/$TagName"
+            sha = $TargetCommit
+        } | ConvertTo-Json -Compress
+    }
+
+    Invoke-RestMethod @requestInput | Out-Null
+}
+
+function New-ModuleReleaseTagReference {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string] $TagName,
+
+        [Parameter(Mandatory)]
+        [string] $TargetCommit,
+
+        [Parameter()]
+        [string] $Repository = $env:GITHUB_REPOSITORY,
+
+        [Parameter()]
+        [string] $Remote = 'origin'
+    )
+
+    $existingCommit = Get-ModuleReleaseTagRemoteCommit -TagName $TagName -Remote $Remote
+    if ($existingCommit) {
+        if ($existingCommit -eq $TargetCommit) {
+            Write-Verbose "Tag [$TagName] already exists at the target commit." -Verbose
+            return
+        }
+
+        throw "Tag [$TagName] already exists at a different commit [$existingCommit]."
+    }
+
+    try {
+        Invoke-ModuleReleaseTagGitHubApi `
+            -Repository $Repository `
+            -TagName $TagName `
+            -TargetCommit $TargetCommit
+        return
+    } catch {
+        $creationError = $_
+    }
+
+    $concurrentCommit = Get-ModuleReleaseTagRemoteCommit -TagName $TagName -Remote $Remote
+    if ($concurrentCommit -eq $TargetCommit) {
+        Write-Verbose "Tag [$TagName] was concurrently created at the target commit." -Verbose
+        return
+    }
+    if ($concurrentCommit) {
+        throw "Tag [$TagName] was concurrently created at a different commit [$concurrentCommit]."
+    }
+
+    throw "Failed to create release tag [$TagName] through the GitHub API. Error: $($creationError.Exception.Message)"
+}

--- a/utilities/tests/pipelines/Set-ModuleWorkflowReleaseTag.Tests.ps1
+++ b/utilities/tests/pipelines/Set-ModuleWorkflowReleaseTag.Tests.ps1
@@ -41,6 +41,7 @@ Describe 'Set-ModuleWorkflowReleaseTag' {
 
             return @{
                 modulePath = $modulePath
+                remotePath = $remotePath
                 repoPath   = $repoPath
             }
         }
@@ -49,12 +50,29 @@ Describe 'Set-ModuleWorkflowReleaseTag' {
     BeforeEach {
         $testRepository = Initialize-ReleaseTagTestRepository
         $script:modulePath = $testRepository.modulePath
+        $script:remotePath = $testRepository.remotePath
         $script:repoPath = $testRepository.repoPath
+        $script:originalGitHubRepository = $env:GITHUB_REPOSITORY
+        $env:GITHUB_REPOSITORY = 'Azure/bicep-registry-modules'
+        Mock Invoke-ModuleReleaseTagGitHubApi {
+            param (
+                [string] $Repository,
+                [string] $TagName,
+                [string] $TargetCommit,
+                [string] $GitHubToken
+            )
+
+            git --git-dir $script:remotePath update-ref "refs/tags/$TagName" $TargetCommit
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to create test tag [$TagName]."
+            }
+        }
         Push-Location $script:repoPath
     }
 
     AfterEach {
         Pop-Location
+        $env:GITHUB_REPOSITORY = $script:originalGitHubRepository
     }
 
     It 'Previews a forced release tag without creating it' {
@@ -81,6 +99,7 @@ Describe 'Set-ModuleWorkflowReleaseTag' {
 
         $firstResult['avm/res/test/module'].gitTagName | Should -Be 'avm/res/test/module/1.0.0'
         $secondResult['avm/res/test/module'].gitTagName | Should -Be 'avm/res/test/module/1.0.0'
+        Should -Invoke Invoke-ModuleReleaseTagGitHubApi -Times 1 -Exactly
     }
 
     It 'Reuses an annotated tag that points at the target commit' {
@@ -109,6 +128,51 @@ Describe 'Set-ModuleWorkflowReleaseTag' {
                 -TargetVersion '1.0.0' `
                 -TargetCommit $targetCommit
         } | Should -Throw '*already exists at a different commit.'
+    }
+
+    It 'Reuses a tag created concurrently after an API failure' {
+        Mock Invoke-ModuleReleaseTagGitHubApi {
+            param (
+                [string] $Repository,
+                [string] $TagName,
+                [string] $TargetCommit,
+                [string] $GitHubToken
+            )
+
+            git --git-dir $script:remotePath update-ref "refs/tags/$TagName" $TargetCommit
+            throw 'Simulated create conflict.'
+        }
+
+        $result = Set-ModuleWorkflowReleaseTag `
+            -TemplateFilePath (Join-Path $script:modulePath 'main.bicep') `
+            -RepoRoot $script:repoPath `
+            -Force
+
+        $result['avm/res/test/module'].gitTagName | Should -Be 'avm/res/test/module/1.0.0'
+    }
+
+    It 'Rejects a tag created concurrently at a different commit' {
+        $script:conflictingCommit = git rev-parse HEAD
+        git commit --allow-empty -m 'Target commit' | Out-Null
+        $targetCommit = git rev-parse HEAD
+        Mock Invoke-ModuleReleaseTagGitHubApi {
+            param (
+                [string] $Repository,
+                [string] $TagName,
+                [string] $TargetCommit,
+                [string] $GitHubToken
+            )
+
+            git --git-dir $script:remotePath update-ref "refs/tags/$TagName" $script:conflictingCommit
+            throw 'Simulated create conflict.'
+        }
+
+        {
+            New-ModuleWorkflowReleaseTag `
+                -ModuleFolderPath $script:modulePath `
+                -TargetVersion '1.0.0' `
+                -TargetCommit $targetCommit
+        } | Should -Throw '*concurrently created at a different commit*'
     }
 
     It 'Surfaces a conflicting reset version during preview' {
@@ -169,5 +233,99 @@ Describe 'Set-ModuleWorkflowReleaseTag' {
                 -RetryCount 2 `
                 -RetryDelaySeconds 0
         } | Should -Throw '*after*Git output*'
+    }
+}
+
+Describe 'Invoke-ModuleReleaseTagGitHubApi' {
+
+    BeforeAll {
+        . (Join-Path $repoRootPath 'utilities' 'pipelines' 'publish' 'helper' 'New-ModuleReleaseTagReference.ps1')
+    }
+
+    BeforeEach {
+        $script:originalGhToken = $env:GH_TOKEN
+        $env:GH_TOKEN = 'test-token'
+        Mock Invoke-RestMethod { }
+    }
+
+    AfterEach {
+        $env:GH_TOKEN = $script:originalGhToken
+    }
+
+    It 'Creates the exact lightweight tag through the Git Refs API' {
+        $expectedBody = @{
+            ref = 'refs/tags/avm/res/test/module/1.0.0'
+            sha = '0123456789012345678901234567890123456789'
+        } | ConvertTo-Json -Compress
+
+        Invoke-ModuleReleaseTagGitHubApi `
+            -Repository 'Azure/bicep-registry-modules' `
+            -TagName 'avm/res/test/module/1.0.0' `
+            -TargetCommit '0123456789012345678901234567890123456789'
+
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Uri -eq 'https://api.github.com/repos/Azure/bicep-registry-modules/git/refs' -and
+            $Method -eq 'Post' -and
+            $ContentType -eq 'application/json' -and
+            $Body -eq $expectedBody -and
+            $Headers.Authorization -eq 'Bearer test-token'
+        }
+    }
+}
+
+Describe 'New-ModuleReleaseTag' {
+
+    BeforeAll {
+        . (Join-Path $repoRootPath 'utilities' 'pipelines' 'publish' 'helper' 'New-ModuleReleaseTag.ps1')
+    }
+
+    BeforeEach {
+        $testRootPath = Join-Path $TestDrive ([guid]::NewGuid().ToString())
+        $script:legacyRemotePath = Join-Path $testRootPath 'remote.git'
+        $script:legacyRepoPath = Join-Path $testRootPath 'repo'
+        $script:legacyModulePath = Join-Path $script:legacyRepoPath 'avm' 'res' 'test' 'module'
+        $null = New-Item -Path $script:legacyModulePath -ItemType Directory -Force
+        Set-Content -Path (Join-Path $script:legacyModulePath 'main.bicep') -Value "metadata name = 'test'"
+        git init --bare $script:legacyRemotePath | Out-Null
+        git init $script:legacyRepoPath | Out-Null
+        git -C $script:legacyRepoPath config user.email 'avm-tests@example.com'
+        git -C $script:legacyRepoPath config user.name 'AVM Tests'
+        git -C $script:legacyRepoPath remote add origin $script:legacyRemotePath
+        git -C $script:legacyRepoPath add .
+        git -C $script:legacyRepoPath commit -m 'Initial commit' | Out-Null
+        git -C $script:legacyRepoPath push -u origin HEAD:main | Out-Null
+        $script:originalGitHubRepository = $env:GITHUB_REPOSITORY
+        $env:GITHUB_REPOSITORY = 'Azure/bicep-registry-modules'
+        Mock Invoke-ModuleReleaseTagGitHubApi {
+            param (
+                [string] $Repository,
+                [string] $TagName,
+                [string] $TargetCommit,
+                [string] $GitHubToken
+            )
+
+            git --git-dir $script:legacyRemotePath update-ref "refs/tags/$TagName" $TargetCommit
+        }
+        Push-Location $script:legacyRepoPath
+    }
+
+    AfterEach {
+        Pop-Location
+        $env:GITHUB_REPOSITORY = $script:originalGitHubRepository
+    }
+
+    It 'Creates the legacy release tag through the Git Refs API helper' {
+        $targetCommit = git rev-parse HEAD
+
+        $result = New-ModuleReleaseTag `
+            -ModuleFolderPath $script:legacyModulePath `
+            -TargetVersion '1.0.0'
+
+        $result | Should -Be 'avm/res/test/module/1.0.0'
+        Should -Invoke Invoke-ModuleReleaseTagGitHubApi -Times 1 -Exactly -ParameterFilter {
+            $Repository -eq 'Azure/bicep-registry-modules' -and
+            $TagName -eq 'avm/res/test/module/1.0.0' -and
+            $TargetCommit -eq $targetCommit
+        }
     }
 }


### PR DESCRIPTION
## Description

Creates module release tags through the Git Refs API instead of Git Smart HTTP `receive-pack`. This avoids the workflow-permission race documented in [actions/checkout#1421](https://github.com/actions/checkout/issues/1421) when `main` advances while a release workflow is still validating or awaiting approval.

The change applies to both legacy and generic module publishing paths, preserves exact target-commit validation, reuses matching existing tags, and rejects conflicting concurrent tags. The approach follows [vybestack/llxprt-code PR #3119](https://github.com/vybestack/llxprt-code/pull/3119).

## Pipeline Reference

| Pipeline |
| -------- |
| [Branch workflow runs](https://github.com/Azure/bicep-registry-modules/actions?query=branch%3Ajaredfholgate-fix-release-tag-api) |

## Type of Change

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] Set-AVMModule is not applicable because no module files changed
- [x] The targeted PowerShell and workflow tests pass locally
- [x] A module CHANGELOG update is not applicable because no module changed