### PR TITLE
fix: update skuCapacity parameter description

### DIFF
--- a/avm/res/api-management/service/README.md
+++ b/avm/res/api-management/service/README.md
@@ -3674,7 +3674,7 @@ param virtualNetworkType = 'None'
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`skuCapacity`](#parameter-skucapacity) | int | The scale units for this API Management service. Required if using Basic, Standard, or Premium skus. For range of capacities for each sku, reference https://azure.microsoft.com/en-us/pricing/details/api-management/. |
+| [`skuCapacity`](#parameter-skucapacity) | int | The scale units for this API Management service. Required if using Basic, Standard, or Premium skus. Note: the `Basic` SKU supports a maximum capacity of `2`, so the default of `3` is automatically clamped to `2` for `Basic`. For the range of capacities for each sku, reference https://azure.microsoft.com/en-us/pricing/details/api-management/. |
 | [`virtualNetworkType`](#parameter-virtualnetworktype) | string | The type of VPN in which API Management service needs to be configured in. None (Default Value) means the API Management service is not part of any Virtual Network, External means the API Management deployment is set up inside a Virtual Network having an internet Facing Endpoint, and Internal means that API Management deployment is setup inside a Virtual Network having an Intranet Facing Endpoint only. VNet injection (External/Internal) is supported with Developer, Premium, and PremiumV2 SKUs only. Required if `subnetResourceId` is used and must be set to `External` or `Internal`. |
 
 **Optional parameters**
@@ -3743,7 +3743,7 @@ The name of the owner of the service.
 
 ### Parameter: `skuCapacity`
 
-The scale units for this API Management service. Required if using Basic, Standard, or Premium skus. For range of capacities for each sku, reference https://azure.microsoft.com/en-us/pricing/details/api-management/.
+The scale units for this API Management service. Required if using Basic, Standard, or Premium skus. Note: the `Basic` SKU supports a maximum capacity of `2`, so the default of `3` is automatically clamped to `2` for `Basic`. For the range of capacities for each sku, reference https://azure.microsoft.com/en-us/pricing/details/api-management/.
 
 - Required: No
 - Type: int

--- a/avm/res/api-management/service/main.bicep
+++ b/avm/res/api-management/service/main.bicep
@@ -78,7 +78,7 @@ param roleAssignments roleAssignmentType[]?
 ])
 param sku string = 'Premium'
 
-@description('Conditional. The scale units for this API Management service. Required if using Basic, Standard, or Premium skus. For range of capacities for each sku, reference https://azure.microsoft.com/en-us/pricing/details/api-management/.')
+@description('Conditional. The scale units for this API Management service. Required if using Basic, Standard, or Premium skus. Note: the `Basic` SKU supports a maximum capacity of `2`, so the default of `3` is automatically clamped to `2` for `Basic`. For the range of capacities for each sku, reference https://azure.microsoft.com/en-us/pricing/details/api-management/.')
 param skuCapacity int = 3
 
 @description('Optional. The full resource ID of a subnet in a virtual network to deploy the API Management service in. VNet injection is supported with Developer, Premium, and PremiumV2 SKUs only.')
@@ -252,7 +252,9 @@ resource service 'Microsoft.ApiManagement/service@2024-05-01' = {
   tags: tags
   sku: {
     name: sku
-    capacity: contains(sku, 'Consumption') ? 0 : contains(sku, 'Developer') ? 1 : skuCapacity
+    capacity: contains(sku, 'Consumption')
+      ? 0
+      : contains(sku, 'Developer') ? 1 : sku == 'Basic' ? min(skuCapacity, 2) : skuCapacity
   }
   zones: contains(sku, 'Premium') ? map(availabilityZones, zone => string(zone)) : []
   identity: identity

--- a/avm/res/api-management/service/main.json
+++ b/avm/res/api-management/service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.44.1.10279",
-      "templateHash": "16356176531956294673"
+      "version": "0.43.8.12551",
+      "templateHash": "9029675716602181232"
     },
     "name": "API Management Services",
     "description": "This module deploys an API Management Service. The default deployment is set to use a Premium SKU to align with Microsoft WAF-aligned best practices. In most cases, non-prod deployments should use a lower-tier SKU."
@@ -3922,7 +3922,7 @@
       "type": "int",
       "defaultValue": 3,
       "metadata": {
-        "description": "Conditional. The scale units for this API Management service. Required if using Basic, Standard, or Premium skus. For range of capacities for each sku, reference https://azure.microsoft.com/en-us/pricing/details/api-management/."
+        "description": "Conditional. The scale units for this API Management service. Required if using Basic, Standard, or Premium skus. Note: the `Basic` SKU supports a maximum capacity of `2`, so the default of `3` is automatically clamped to `2` for `Basic`. For the range of capacities for each sku, reference https://azure.microsoft.com/en-us/pricing/details/api-management/."
       }
     },
     "subnetResourceId": {
@@ -4217,7 +4217,7 @@
       "tags": "[parameters('tags')]",
       "sku": {
         "name": "[parameters('sku')]",
-        "capacity": "[if(contains(parameters('sku'), 'Consumption'), 0, if(contains(parameters('sku'), 'Developer'), 1, parameters('skuCapacity')))]"
+        "capacity": "[if(contains(parameters('sku'), 'Consumption'), 0, if(contains(parameters('sku'), 'Developer'), 1, if(equals(parameters('sku'), 'Basic'), min(parameters('skuCapacity'), 2), parameters('skuCapacity'))))]"
       },
       "zones": "[if(contains(parameters('sku'), 'Premium'), map(parameters('availabilityZones'), lambda('zone', string(lambdaVariables('zone')))), createArray())]",
       "identity": "[variables('identity')]",
@@ -4417,8 +4417,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "5455841474053206965"
+              "version": "0.43.8.12551",
+              "templateHash": "10002243494708919797"
             },
             "name": "API Management Service APIs",
             "description": "This module deploys an API Management Service API."
@@ -5045,8 +5045,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "4131403788924825953"
+                      "version": "0.43.8.12551",
+                      "templateHash": "10912392573659853066"
                     },
                     "name": "API Management Service APIs Policies",
                     "description": "This module deploys an API Management Service API Policy."
@@ -5222,8 +5222,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "12042257876257337198"
+                      "version": "0.43.8.12551",
+                      "templateHash": "13347409519222298979"
                     },
                     "name": "API Management Service API Diagnostics",
                     "description": "This module deploys an API Management Service API Diagnostic."
@@ -5497,8 +5497,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "2184452332819340263"
+                      "version": "0.43.8.12551",
+                      "templateHash": "11940781952522449963"
                     },
                     "name": "API Management Service APIs Operations",
                     "description": "This module deploys an API Management Service API Operation."
@@ -5727,8 +5727,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "7118544767518157862"
+                              "version": "0.43.8.12551",
+                              "templateHash": "2402717399770982442"
                             },
                             "name": "API Management Service API Operation Policies",
                             "description": "This module deploys an API Management Service API Operation Policy."
@@ -5954,8 +5954,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "11295968982494407857"
+              "version": "0.43.8.12551",
+              "templateHash": "6325164945929205251"
             },
             "name": "API Management Service API Version Sets",
             "description": "This module deploys an API Management Service API Version Set."
@@ -6174,8 +6174,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "8676095085614458256"
+              "version": "0.43.8.12551",
+              "templateHash": "4535197848314064053"
             },
             "name": "API Management Service Authorization Servers",
             "description": "This module deploys an API Management Service Authorization Server."
@@ -6492,8 +6492,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "16754690629571272611"
+              "version": "0.43.8.12551",
+              "templateHash": "9424725867802371628"
             },
             "name": "API Management Service Backends",
             "description": "This module deploys an API Management Service Backend."
@@ -6733,8 +6733,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "163100700482505136"
+              "version": "0.43.8.12551",
+              "templateHash": "12208674977937508330"
             },
             "name": "API Management Service Caches",
             "description": "This module deploys an API Management Service Cache."
@@ -6918,8 +6918,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "11597763046709748029"
+              "version": "0.43.8.12551",
+              "templateHash": "11360590942634989583"
             },
             "name": "API Management Service Identity Providers",
             "description": "This module deploys an API Management Service Identity Provider."
@@ -7161,8 +7161,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "9223293477917179357"
+              "version": "0.43.8.12551",
+              "templateHash": "1531209412088875123"
             },
             "name": "API Management Service Loggers",
             "description": "This module deploys an API Management Service Logger."
@@ -7341,8 +7341,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "3283742502574814541"
+              "version": "0.43.8.12551",
+              "templateHash": "12147778806962026075"
             },
             "name": "API Management Service Named Values",
             "description": "This module deploys an API Management Service Named Value."
@@ -7513,8 +7513,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "7213214673355491699"
+              "version": "0.43.8.12551",
+              "templateHash": "7866370993818282974"
             },
             "name": "API Management Service Portal Settings",
             "description": "This module deploys an API Management Service Portal Setting."
@@ -7647,8 +7647,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "255563544010101723"
+              "version": "0.43.8.12551",
+              "templateHash": "1179941603572728762"
             },
             "name": "API Management Service Policies",
             "description": "This module deploys an API Management Service Policy."
@@ -7815,8 +7815,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "1515968291611041173"
+              "version": "0.43.8.12551",
+              "templateHash": "6404600791534456902"
             },
             "name": "API Management Service Products",
             "description": "This module deploys an API Management Service Product."
@@ -8043,8 +8043,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "10435443823229620277"
+                      "version": "0.43.8.12551",
+                      "templateHash": "14496337784420497578"
                     },
                     "name": "API Management Service Products APIs",
                     "description": "This module deploys an API Management Service Product API."
@@ -8165,8 +8165,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "14396182756289495352"
+                      "version": "0.43.8.12551",
+                      "templateHash": "17818658795677985621"
                     },
                     "name": "API Management Service Products Groups",
                     "description": "This module deploys an API Management Service Product Group."
@@ -8293,8 +8293,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "16749119491803982432"
+                      "version": "0.43.8.12551",
+                      "templateHash": "16071893957946908505"
                     },
                     "name": "API Management Service Product Policies",
                     "description": "This module deploys an API Management Service Product Policy."
@@ -8522,8 +8522,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "9777157182545899553"
+              "version": "0.43.8.12551",
+              "templateHash": "6533628464707198271"
             },
             "name": "API Management Service Subscriptions",
             "description": "This module deploys an API Management Service Subscription."
@@ -8745,8 +8745,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "949841950040159357"
+              "version": "0.43.8.12551",
+              "templateHash": "8794019127252477599"
             },
             "name": "API Management Service Diagnostics",
             "description": "This module deploys an API Management Service Diagnostic."
@@ -9013,8 +9013,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "7986493739206363971"
+              "version": "0.43.8.12551",
+              "templateHash": "7325360733109072268"
             },
             "name": "API Management Service Workspace",
             "description": "This module deploys an API Management Service Workspace."
@@ -10824,8 +10824,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "4706748973999638707"
+                      "version": "0.43.8.12551",
+                      "templateHash": "11031755075499903131"
                     },
                     "name": "API Management Workspace APIs",
                     "description": "This module deploys an API in an API Management Workspace."
@@ -11467,8 +11467,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "11897582436329275168"
+                              "version": "0.43.8.12551",
+                              "templateHash": "5980991102197274208"
                             },
                             "name": "API Management Workspace APIs Policies",
                             "description": "This module deploys an API Policy in an API Management Workspace."
@@ -11653,8 +11653,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "15124732220042481564"
+                              "version": "0.43.8.12551",
+                              "templateHash": "15032468180306699703"
                             },
                             "name": "API Management Workspace APIs Diagnostics",
                             "description": "This module deploys an API Diagnostic in an API Management Workspace."
@@ -11943,8 +11943,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "1929283578608942041"
+                              "version": "0.43.8.12551",
+                              "templateHash": "6163208646596351509"
                             },
                             "name": "API Management Workspace API Operations",
                             "description": "This module deploys an API Operation under an API Management Workspace."
@@ -12188,8 +12188,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.44.1.10279",
-                                      "templateHash": "894064821792271770"
+                                      "version": "0.43.8.12551",
+                                      "templateHash": "16921901218007297275"
                                     },
                                     "name": "API Management Workspace API Operation Policies",
                                     "description": "This module deploys an API Operation Policy in an API Management Workspace."
@@ -12424,8 +12424,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "2059079781749164786"
+                      "version": "0.43.8.12551",
+                      "templateHash": "6558048148288981126"
                     },
                     "name": "API Management Workspace API Version Sets",
                     "description": "This module deploys an API Version Set in an API Management Workspace."
@@ -12647,8 +12647,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "2397930977363682172"
+                      "version": "0.43.8.12551",
+                      "templateHash": "8489261232884532000"
                     },
                     "name": "API Management Workspace Backends",
                     "description": "This module deploys a Backend in an API Management Workspace."
@@ -12921,8 +12921,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "15639615768032937912"
+                      "version": "0.43.8.12551",
+                      "templateHash": "13615014754933533446"
                     },
                     "name": "API Management Workspace Diagnostics",
                     "description": "This module deploys a Diagnostic at API Management Workspace scope."
@@ -13176,8 +13176,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "15808926878736769388"
+                      "version": "0.43.8.12551",
+                      "templateHash": "17015527199002126562"
                     },
                     "name": "API Management Workspace Loggers",
                     "description": "This module deploys a Logger in an API Management Workspace."
@@ -13371,8 +13371,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "9970331846357099628"
+                      "version": "0.43.8.12551",
+                      "templateHash": "15850162644833869373"
                     },
                     "name": "API Management Workspace Named Values",
                     "description": "This module deploys a Named Value in an API Management Workspace."
@@ -13561,8 +13561,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "12175539686983332449"
+                      "version": "0.43.8.12551",
+                      "templateHash": "1109330876683291095"
                     },
                     "name": "API Management Workspace Policies",
                     "description": "This module deploys a Policy at API Management Workspace scope."
@@ -13738,8 +13738,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "18217698892820478047"
+                      "version": "0.43.8.12551",
+                      "templateHash": "3517063021717500432"
                     },
                     "name": "API Management Workspace Products",
                     "description": "This module deploys a Product in an API Management Workspace."
@@ -14026,8 +14026,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "6068763790353473725"
+                              "version": "0.43.8.12551",
+                              "templateHash": "3216344338570878007"
                             },
                             "name": "API Management Workspace Product API Links",
                             "description": "This module deploys an Product API Link in an API Management Workspace."
@@ -14169,8 +14169,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "3561678439683354115"
+                              "version": "0.43.8.12551",
+                              "templateHash": "2286955869723323139"
                             },
                             "name": "API Management Workspace Product Group Links",
                             "description": "This module deploys a Product Group Link in an API Management Workspace."
@@ -14315,8 +14315,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "756122095416536586"
+                              "version": "0.43.8.12551",
+                              "templateHash": "9043711511873546814"
                             },
                             "name": "API Management Workspace Product Policies",
                             "description": "This module deploys a Policy for a Product in an API Management Workspace."
@@ -14520,8 +14520,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "10083970573887538963"
+                      "version": "0.43.8.12551",
+                      "templateHash": "6350020031061925092"
                     },
                     "name": "API Management Workspace Subscriptions",
                     "description": "This module deploys a Subscription in an API Management Workspace."
@@ -14730,8 +14730,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "17631320577454329554"
+                      "version": "0.43.8.12551",
+                      "templateHash": "847244549925399675"
                     }
                   },
                   "parameters": {


### PR DESCRIPTION
- Clarified that the `Basic` SKU supports a maximum capacity of `2`, clamping the default of `3` to `2`.
- Updated related descriptions in README and main.bicep files for consistency.

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #123
-->
Fixes #7278 
## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
