### PR TITLE
fix: Update product subscription limit descriptions

### DIFF
--- a/avm/res/api-management/service/README.md
+++ b/avm/res/api-management/service/README.md
@@ -6244,7 +6244,7 @@ Products.
 | [`policies`](#parameter-productspolicies) | array | Array of Policies to apply to the Service Product. |
 | [`state`](#parameter-productsstate) | string | Whether product is published or not. Published products are discoverable by users of developer portal. Non-published products are visible only to administrators. |
 | [`subscriptionRequired`](#parameter-productssubscriptionrequired) | bool | Whether a product subscription is required for accessing APIs included in this product. If true, the product is referred to as "protected" and a valid subscription key is required for a request to an API included in the product to succeed. If false, the product is referred to as "open" and requests to an API included in the product can be made without a subscription key. If property is omitted when creating a new product it's value is assumed to be true. |
-| [`subscriptionsLimit`](#parameter-productssubscriptionslimit) | int | Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false. |
+| [`subscriptionsLimit`](#parameter-productssubscriptionslimit) | int | The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false. |
 | [`terms`](#parameter-productsterms) | string | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process. |
 
 ### Parameter: `products.displayName`
@@ -6362,7 +6362,7 @@ Whether a product subscription is required for accessing APIs included in this p
 
 ### Parameter: `products.subscriptionsLimit`
 
-Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.
+The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.
 
 - Required: No
 - Type: int
@@ -8150,7 +8150,7 @@ Products to deploy in this workspace.
 | [`policies`](#parameter-workspacesproductspolicies) | array | Array of Policies to apply to the Product. |
 | [`state`](#parameter-workspacesproductsstate) | string | Whether product is published or not. Published products are discoverable by users of developer portal. Non published products are visible only to administrators. |
 | [`subscriptionRequired`](#parameter-workspacesproductssubscriptionrequired) | bool | Whether a product subscription is required for accessing APIs included in this product. If true, the product is referred to as "protected" and a valid subscription key is required for a request to an API included in the product to succeed. If false, the product is referred to as "open" and requests to an API included in the product can be made without a subscription key. If property is omitted when creating a new product it's value is assumed to be true. |
-| [`subscriptionsLimit`](#parameter-workspacesproductssubscriptionslimit) | int | Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false. |
+| [`subscriptionsLimit`](#parameter-workspacesproductssubscriptionslimit) | int | The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false. |
 | [`terms`](#parameter-workspacesproductsterms) | string | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process. |
 
 ### Parameter: `workspaces.products.displayName`
@@ -8310,7 +8310,7 @@ Whether a product subscription is required for accessing APIs included in this p
 
 ### Parameter: `workspaces.products.subscriptionsLimit`
 
-Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.
+The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.
 
 - Required: No
 - Type: int

--- a/avm/res/api-management/service/main.bicep
+++ b/avm/res/api-management/service/main.bicep
@@ -1358,7 +1358,7 @@ type productType = {
   @description('Optional. Whether a product subscription is required for accessing APIs included in this product. If true, the product is referred to as "protected" and a valid subscription key is required for a request to an API included in the product to succeed. If false, the product is referred to as "open" and requests to an API included in the product can be made without a subscription key. If property is omitted when creating a new product it\'s value is assumed to be true.')
   subscriptionRequired: bool?
 
-  @description('Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.')
+  @description('Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.')
   subscriptionsLimit: int?
 
   @description('Optional. Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process.')

--- a/avm/res/api-management/service/main.json
+++ b/avm/res/api-management/service/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.44.1.10279",
-      "templateHash": "16356176531956294673"
+      "version": "0.43.8.12551",
+      "templateHash": "12781593242656841982"
     },
     "name": "API Management Services",
     "description": "This module deploys an API Management Service. The default deployment is set to use a Premium SKU to align with Microsoft WAF-aligned best practices. In most cases, non-prod deployments should use a lower-tier SKU."
@@ -1446,7 +1446,7 @@
           "type": "int",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
+            "description": "Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
           }
         },
         "terms": {
@@ -3134,7 +3134,7 @@
           "type": "int",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
+            "description": "Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
           }
         },
         "terms": {
@@ -4417,8 +4417,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "5455841474053206965"
+              "version": "0.43.8.12551",
+              "templateHash": "10002243494708919797"
             },
             "name": "API Management Service APIs",
             "description": "This module deploys an API Management Service API."
@@ -5045,8 +5045,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "4131403788924825953"
+                      "version": "0.43.8.12551",
+                      "templateHash": "10912392573659853066"
                     },
                     "name": "API Management Service APIs Policies",
                     "description": "This module deploys an API Management Service API Policy."
@@ -5222,8 +5222,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "12042257876257337198"
+                      "version": "0.43.8.12551",
+                      "templateHash": "13347409519222298979"
                     },
                     "name": "API Management Service API Diagnostics",
                     "description": "This module deploys an API Management Service API Diagnostic."
@@ -5497,8 +5497,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "2184452332819340263"
+                      "version": "0.43.8.12551",
+                      "templateHash": "11940781952522449963"
                     },
                     "name": "API Management Service APIs Operations",
                     "description": "This module deploys an API Management Service API Operation."
@@ -5727,8 +5727,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "7118544767518157862"
+                              "version": "0.43.8.12551",
+                              "templateHash": "2402717399770982442"
                             },
                             "name": "API Management Service API Operation Policies",
                             "description": "This module deploys an API Management Service API Operation Policy."
@@ -5954,8 +5954,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "11295968982494407857"
+              "version": "0.43.8.12551",
+              "templateHash": "6325164945929205251"
             },
             "name": "API Management Service API Version Sets",
             "description": "This module deploys an API Management Service API Version Set."
@@ -6174,8 +6174,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "8676095085614458256"
+              "version": "0.43.8.12551",
+              "templateHash": "4535197848314064053"
             },
             "name": "API Management Service Authorization Servers",
             "description": "This module deploys an API Management Service Authorization Server."
@@ -6492,8 +6492,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "16754690629571272611"
+              "version": "0.43.8.12551",
+              "templateHash": "9424725867802371628"
             },
             "name": "API Management Service Backends",
             "description": "This module deploys an API Management Service Backend."
@@ -6733,8 +6733,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "163100700482505136"
+              "version": "0.43.8.12551",
+              "templateHash": "12208674977937508330"
             },
             "name": "API Management Service Caches",
             "description": "This module deploys an API Management Service Cache."
@@ -6918,8 +6918,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "11597763046709748029"
+              "version": "0.43.8.12551",
+              "templateHash": "11360590942634989583"
             },
             "name": "API Management Service Identity Providers",
             "description": "This module deploys an API Management Service Identity Provider."
@@ -7161,8 +7161,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "9223293477917179357"
+              "version": "0.43.8.12551",
+              "templateHash": "1531209412088875123"
             },
             "name": "API Management Service Loggers",
             "description": "This module deploys an API Management Service Logger."
@@ -7341,8 +7341,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "3283742502574814541"
+              "version": "0.43.8.12551",
+              "templateHash": "12147778806962026075"
             },
             "name": "API Management Service Named Values",
             "description": "This module deploys an API Management Service Named Value."
@@ -7513,8 +7513,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "7213214673355491699"
+              "version": "0.43.8.12551",
+              "templateHash": "7866370993818282974"
             },
             "name": "API Management Service Portal Settings",
             "description": "This module deploys an API Management Service Portal Setting."
@@ -7647,8 +7647,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "255563544010101723"
+              "version": "0.43.8.12551",
+              "templateHash": "1179941603572728762"
             },
             "name": "API Management Service Policies",
             "description": "This module deploys an API Management Service Policy."
@@ -7815,8 +7815,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "1515968291611041173"
+              "version": "0.43.8.12551",
+              "templateHash": "17446094151857588618"
             },
             "name": "API Management Service Products",
             "description": "This module deploys an API Management Service Product."
@@ -7946,9 +7946,9 @@
             },
             "subscriptionsLimit": {
               "type": "int",
-              "defaultValue": 1,
+              "nullable": true,
               "metadata": {
-                "description": "Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
+                "description": "Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
               }
             },
             "terms": {
@@ -8043,8 +8043,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "10435443823229620277"
+                      "version": "0.43.8.12551",
+                      "templateHash": "14496337784420497578"
                     },
                     "name": "API Management Service Products APIs",
                     "description": "This module deploys an API Management Service Product API."
@@ -8165,8 +8165,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "14396182756289495352"
+                      "version": "0.43.8.12551",
+                      "templateHash": "17818658795677985621"
                     },
                     "name": "API Management Service Products Groups",
                     "description": "This module deploys an API Management Service Product Group."
@@ -8293,8 +8293,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "16749119491803982432"
+                      "version": "0.43.8.12551",
+                      "templateHash": "16071893957946908505"
                     },
                     "name": "API Management Service Product Policies",
                     "description": "This module deploys an API Management Service Product Policy."
@@ -8522,8 +8522,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "9777157182545899553"
+              "version": "0.43.8.12551",
+              "templateHash": "6533628464707198271"
             },
             "name": "API Management Service Subscriptions",
             "description": "This module deploys an API Management Service Subscription."
@@ -8745,8 +8745,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "949841950040159357"
+              "version": "0.43.8.12551",
+              "templateHash": "8794019127252477599"
             },
             "name": "API Management Service Diagnostics",
             "description": "This module deploys an API Management Service Diagnostic."
@@ -9013,8 +9013,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "7986493739206363971"
+              "version": "0.43.8.12551",
+              "templateHash": "5137384448978703811"
             },
             "name": "API Management Service Workspace",
             "description": "This module deploys an API Management Service Workspace."
@@ -9779,7 +9779,7 @@
                   "type": "int",
                   "nullable": true,
                   "metadata": {
-                    "description": "Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
+                    "description": "Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
                   }
                 },
                 "terms": {
@@ -10824,8 +10824,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "4706748973999638707"
+                      "version": "0.43.8.12551",
+                      "templateHash": "11031755075499903131"
                     },
                     "name": "API Management Workspace APIs",
                     "description": "This module deploys an API in an API Management Workspace."
@@ -11467,8 +11467,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "11897582436329275168"
+                              "version": "0.43.8.12551",
+                              "templateHash": "5980991102197274208"
                             },
                             "name": "API Management Workspace APIs Policies",
                             "description": "This module deploys an API Policy in an API Management Workspace."
@@ -11653,8 +11653,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "15124732220042481564"
+                              "version": "0.43.8.12551",
+                              "templateHash": "15032468180306699703"
                             },
                             "name": "API Management Workspace APIs Diagnostics",
                             "description": "This module deploys an API Diagnostic in an API Management Workspace."
@@ -11943,8 +11943,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "1929283578608942041"
+                              "version": "0.43.8.12551",
+                              "templateHash": "6163208646596351509"
                             },
                             "name": "API Management Workspace API Operations",
                             "description": "This module deploys an API Operation under an API Management Workspace."
@@ -12188,8 +12188,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.44.1.10279",
-                                      "templateHash": "894064821792271770"
+                                      "version": "0.43.8.12551",
+                                      "templateHash": "16921901218007297275"
                                     },
                                     "name": "API Management Workspace API Operation Policies",
                                     "description": "This module deploys an API Operation Policy in an API Management Workspace."
@@ -12424,8 +12424,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "2059079781749164786"
+                      "version": "0.43.8.12551",
+                      "templateHash": "6558048148288981126"
                     },
                     "name": "API Management Workspace API Version Sets",
                     "description": "This module deploys an API Version Set in an API Management Workspace."
@@ -12647,8 +12647,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "2397930977363682172"
+                      "version": "0.43.8.12551",
+                      "templateHash": "8489261232884532000"
                     },
                     "name": "API Management Workspace Backends",
                     "description": "This module deploys a Backend in an API Management Workspace."
@@ -12921,8 +12921,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "15639615768032937912"
+                      "version": "0.43.8.12551",
+                      "templateHash": "13615014754933533446"
                     },
                     "name": "API Management Workspace Diagnostics",
                     "description": "This module deploys a Diagnostic at API Management Workspace scope."
@@ -13176,8 +13176,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "15808926878736769388"
+                      "version": "0.43.8.12551",
+                      "templateHash": "17015527199002126562"
                     },
                     "name": "API Management Workspace Loggers",
                     "description": "This module deploys a Logger in an API Management Workspace."
@@ -13371,8 +13371,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "9970331846357099628"
+                      "version": "0.43.8.12551",
+                      "templateHash": "15850162644833869373"
                     },
                     "name": "API Management Workspace Named Values",
                     "description": "This module deploys a Named Value in an API Management Workspace."
@@ -13561,8 +13561,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "12175539686983332449"
+                      "version": "0.43.8.12551",
+                      "templateHash": "1109330876683291095"
                     },
                     "name": "API Management Workspace Policies",
                     "description": "This module deploys a Policy at API Management Workspace scope."
@@ -13738,8 +13738,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "18217698892820478047"
+                      "version": "0.43.8.12551",
+                      "templateHash": "5798349273925493482"
                     },
                     "name": "API Management Workspace Products",
                     "description": "This module deploys a Product in an API Management Workspace."
@@ -13917,9 +13917,9 @@
                     },
                     "subscriptionsLimit": {
                       "type": "int",
-                      "defaultValue": 1,
+                      "nullable": true,
                       "metadata": {
-                        "description": "Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
+                        "description": "Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
                       }
                     },
                     "terms": {
@@ -14026,8 +14026,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "6068763790353473725"
+                              "version": "0.43.8.12551",
+                              "templateHash": "3216344338570878007"
                             },
                             "name": "API Management Workspace Product API Links",
                             "description": "This module deploys an Product API Link in an API Management Workspace."
@@ -14169,8 +14169,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "3561678439683354115"
+                              "version": "0.43.8.12551",
+                              "templateHash": "2286955869723323139"
                             },
                             "name": "API Management Workspace Product Group Links",
                             "description": "This module deploys a Product Group Link in an API Management Workspace."
@@ -14315,8 +14315,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "756122095416536586"
+                              "version": "0.43.8.12551",
+                              "templateHash": "9043711511873546814"
                             },
                             "name": "API Management Workspace Product Policies",
                             "description": "This module deploys a Policy for a Product in an API Management Workspace."
@@ -14520,8 +14520,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "10083970573887538963"
+                      "version": "0.43.8.12551",
+                      "templateHash": "6350020031061925092"
                     },
                     "name": "API Management Workspace Subscriptions",
                     "description": "This module deploys a Subscription in an API Management Workspace."
@@ -14730,8 +14730,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "17631320577454329554"
+                      "version": "0.43.8.12551",
+                      "templateHash": "847244549925399675"
                     }
                   },
                   "parameters": {

--- a/avm/res/api-management/service/product/README.md
+++ b/avm/res/api-management/service/product/README.md
@@ -53,7 +53,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | [`policies`](#parameter-policies) | array | Array of Policies to apply to the Service Product. |
 | [`state`](#parameter-state) | string | Whether product is published or not. Published products are discoverable by users of developer portal. Non-published products are visible only to administrators. |
 | [`subscriptionRequired`](#parameter-subscriptionrequired) | bool | Whether a product subscription is required for accessing APIs included in this product. If true, the product is referred to as "protected" and a valid subscription key is required for a request to an API included in the product to succeed. If false, the product is referred to as "open" and requests to an API included in the product can be made without a subscription key. If property is omitted when creating a new product it's value is assumed to be true. |
-| [`subscriptionsLimit`](#parameter-subscriptionslimit) | int | Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false. |
+| [`subscriptionsLimit`](#parameter-subscriptionslimit) | int | The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false. |
 | [`terms`](#parameter-terms) | string | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process. |
 
 ### Parameter: `displayName`
@@ -189,11 +189,10 @@ Whether a product subscription is required for accessing APIs included in this p
 
 ### Parameter: `subscriptionsLimit`
 
-Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.
+The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.
 
 - Required: No
 - Type: int
-- Default: `1`
 
 ### Parameter: `terms`
 

--- a/avm/res/api-management/service/product/main.bicep
+++ b/avm/res/api-management/service/product/main.bicep
@@ -40,8 +40,8 @@ param state string = 'published'
 @sys.description('Optional. Whether a product subscription is required for accessing APIs included in this product. If true, the product is referred to as "protected" and a valid subscription key is required for a request to an API included in the product to succeed. If false, the product is referred to as "open" and requests to an API included in the product can be made without a subscription key. If property is omitted when creating a new product it\'s value is assumed to be true.')
 param subscriptionRequired bool = true
 
-@sys.description('Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.')
-param subscriptionsLimit int = 1
+@sys.description('Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.')
+param subscriptionsLimit int?
 
 @sys.description('Optional. Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process.')
 param terms string = ''

--- a/avm/res/api-management/service/product/main.json
+++ b/avm/res/api-management/service/product/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "6404600791534456902"
+      "templateHash": "17446094151857588618"
     },
     "name": "API Management Service Products",
     "description": "This module deploys an API Management Service Product."
@@ -136,9 +136,9 @@
     },
     "subscriptionsLimit": {
       "type": "int",
-      "defaultValue": 1,
+      "nullable": true,
       "metadata": {
-        "description": "Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
+        "description": "Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
       }
     },
     "terms": {

--- a/avm/res/api-management/service/workspace/README.md
+++ b/avm/res/api-management/service/workspace/README.md
@@ -1414,7 +1414,7 @@ Products to deploy in this workspace.
 | [`policies`](#parameter-productspolicies) | array | Array of Policies to apply to the Product. |
 | [`state`](#parameter-productsstate) | string | Whether product is published or not. Published products are discoverable by users of developer portal. Non published products are visible only to administrators. |
 | [`subscriptionRequired`](#parameter-productssubscriptionrequired) | bool | Whether a product subscription is required for accessing APIs included in this product. If true, the product is referred to as "protected" and a valid subscription key is required for a request to an API included in the product to succeed. If false, the product is referred to as "open" and requests to an API included in the product can be made without a subscription key. If property is omitted when creating a new product it's value is assumed to be true. |
-| [`subscriptionsLimit`](#parameter-productssubscriptionslimit) | int | Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false. |
+| [`subscriptionsLimit`](#parameter-productssubscriptionslimit) | int | The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false. |
 | [`terms`](#parameter-productsterms) | string | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process. |
 
 ### Parameter: `products.displayName`
@@ -1574,7 +1574,7 @@ Whether a product subscription is required for accessing APIs included in this p
 
 ### Parameter: `products.subscriptionsLimit`
 
-Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.
+The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.
 
 - Required: No
 - Type: int

--- a/avm/res/api-management/service/workspace/main.bicep
+++ b/avm/res/api-management/service/workspace/main.bicep
@@ -739,7 +739,7 @@ type productType = {
   @sys.description('Optional. Whether a product subscription is required for accessing APIs included in this product. If true, the product is referred to as "protected" and a valid subscription key is required for a request to an API included in the product to succeed. If false, the product is referred to as "open" and requests to an API included in the product can be made without a subscription key. If property is omitted when creating a new product it\'s value is assumed to be true.')
   subscriptionRequired: bool?
 
-  @sys.description('Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.')
+  @sys.description('Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.')
   subscriptionsLimit: int?
 
   @sys.description('Optional. Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process.')

--- a/avm/res/api-management/service/workspace/main.json
+++ b/avm/res/api-management/service/workspace/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "7325360733109072268"
+      "templateHash": "5137384448978703811"
     },
     "name": "API Management Service Workspace",
     "description": "This module deploys an API Management Service Workspace."
@@ -771,7 +771,7 @@
           "type": "int",
           "nullable": true,
           "metadata": {
-            "description": "Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
+            "description": "Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
           }
         },
         "terms": {
@@ -4731,7 +4731,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.43.8.12551",
-              "templateHash": "3517063021717500432"
+              "templateHash": "5798349273925493482"
             },
             "name": "API Management Workspace Products",
             "description": "This module deploys a Product in an API Management Workspace."
@@ -4909,9 +4909,9 @@
             },
             "subscriptionsLimit": {
               "type": "int",
-              "defaultValue": 1,
+              "nullable": true,
               "metadata": {
-                "description": "Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
+                "description": "Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
               }
             },
             "terms": {

--- a/avm/res/api-management/service/workspace/product/README.md
+++ b/avm/res/api-management/service/workspace/product/README.md
@@ -54,7 +54,7 @@ For examples, please refer to the [Usage Examples](#usage-examples) section.
 | [`policies`](#parameter-policies) | array | Array of Policies to apply to the Product. |
 | [`state`](#parameter-state) | string | Whether product is published or not. Published products are discoverable by users of developer portal. Non published products are visible only to administrators. |
 | [`subscriptionRequired`](#parameter-subscriptionrequired) | bool | Whether a product subscription is required for accessing APIs included in this product. If true, the product is referred to as "protected" and a valid subscription key is required for a request to an API included in the product to succeed. If false, the product is referred to as "open" and requests to an API included in the product can be made without a subscription key. If property is omitted when creating a new product it's value is assumed to be true. |
-| [`subscriptionsLimit`](#parameter-subscriptionslimit) | int | Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false. |
+| [`subscriptionsLimit`](#parameter-subscriptionslimit) | int | The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false. |
 | [`terms`](#parameter-terms) | string | Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process. |
 
 ### Parameter: `displayName`
@@ -240,11 +240,10 @@ Whether a product subscription is required for accessing APIs included in this p
 
 ### Parameter: `subscriptionsLimit`
 
-Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.
+The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.
 
 - Required: No
 - Type: int
-- Default: `1`
 
 ### Parameter: `terms`
 

--- a/avm/res/api-management/service/workspace/product/main.bicep
+++ b/avm/res/api-management/service/workspace/product/main.bicep
@@ -43,8 +43,8 @@ param state string = 'published'
 @sys.description('Optional. Whether a product subscription is required for accessing APIs included in this product. If true, the product is referred to as "protected" and a valid subscription key is required for a request to an API included in the product to succeed. If false, the product is referred to as "open" and requests to an API included in the product can be made without a subscription key. If property is omitted when creating a new product it\'s value is assumed to be true.')
 param subscriptionRequired bool = false
 
-@sys.description('Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.')
-param subscriptionsLimit int = 1
+@sys.description('Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false.')
+param subscriptionsLimit int?
 
 @sys.description('Optional. Product terms of use. Developers trying to subscribe to the product will be presented and required to accept these terms before they can complete the subscription process.')
 param terms string?

--- a/avm/res/api-management/service/workspace/product/main.json
+++ b/avm/res/api-management/service/workspace/product/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "3517063021717500432"
+      "templateHash": "5798349273925493482"
     },
     "name": "API Management Workspace Products",
     "description": "This module deploys a Product in an API Management Workspace."
@@ -184,9 +184,9 @@
     },
     "subscriptionsLimit": {
       "type": "int",
-      "defaultValue": 1,
+      "nullable": true,
       "metadata": {
-        "description": "Optional. Whether the number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
+        "description": "Optional. The number of subscriptions a user can have to this product at the same time. Set to null or omit to allow unlimited per user subscriptions. Can be present only if subscriptionRequired property is present and has a value of false."
       }
     },
     "terms": {


### PR DESCRIPTION
- Revised descriptions for `subscriptionsLimit` across multiple files to clarify that it represents the number of subscriptions a user can have to a product.
- Changed the default value of `subscriptionsLimit` to nullable in Bicep and JSON files to allow unlimited subscriptions when omitted.
- Updated README documentation to reflect these changes for better clarity and consistency.
- Affected files include README.md, main.bicep, and main.json in both service and workspace directories.

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #123
-->
Fixes #7226
## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline |
| -------- |


## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [x] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [ ] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I have run `Set-AVMModule` locally to generate the supporting module files.
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I have updated the module's CHANGELOG.md file with an entry for the next version

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->
