### PR TITLE
ci: distribute Bicep tests across configured subscriptions

### DIFF
--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -17,6 +17,8 @@
 ##   | modulePath                 | true     | ''      | The path to the module file directory                 | 'modules/api-management/service/main.bicep'                                |
 ##   | templateFilePath           | true     | ''      | The path to the template file to use for deployment   | 'modules/api-management/service/tests/e2e/maix/main.test.bicep'            |
 ##   | deploymentMetadataLocation | true     | ''      | The location to store the deployment metadata         | 'WestEurope'                                                               |
+##   | subscriptionSelectionSeed  | true     | ''      | Shared seed for shuffling the test subscription pool  | '12345'                                                                    |
+##   | subscriptionJobIndex       | false    | '0'     | Matrix job index for round-robin subscription selection | '0'                                                                      |
 ##   | managementGroupId          | false    | ''      | The managementGroupId to deploy to                    | '1a97b80a-4dda-4f50-ab53-349e29344654'                                     |
 ##   | customTokens               | false    | ''      | Additional token pairs in json format.                | '{"tokenName":"tokenValue"}'                                               |
 ##   | removeDeployment           | false    | 'true'  | Set "true" to set module up for removal               | 'true'                                                                     |
@@ -38,6 +40,13 @@ inputs:
   deploymentMetadataLocation:
     description: "The location to store the deployment metadata"
     required: true
+  subscriptionSelectionSeed:
+    description: "Shared random seed for shuffling TEST_SUBSCRIPTION_IDS across the test matrix"
+    required: true
+  subscriptionJobIndex:
+    description: "Matrix job index used to assign a subscription from the shuffled pool"
+    default: "0"
+    required: false
   managementGroupId:
     description: "The management group ID to deploy to"
     required: false
@@ -86,12 +95,39 @@ runs:
             Write-Output "skip_deployment_ci=false" >> $env:GITHUB_ENV
           }
 
+    - name: "Select test subscription"
+      id: get-test-subscription
+      if: env.skip_deployment_ci == 'false'
+      shell: pwsh
+      env:
+        SUBSCRIPTION_SELECTION_SEED: ${{ inputs.subscriptionSelectionSeed }}
+        SUBSCRIPTION_JOB_INDEX: ${{ inputs.subscriptionJobIndex }}
+      run: |
+        . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Get-TestSubscriptionList.ps1')
+
+        $functionInput = @{
+          TestSubscriptionIds    = $env:TEST_SUBSCRIPTION_IDS
+          FallbackSubscriptionId = $env:VALIDATE_SUBSCRIPTION_ID
+          RandomSeed             = [int]::Parse($env:SUBSCRIPTION_SELECTION_SEED)
+        }
+        $subscriptions = @(Get-TestSubscriptionList @functionInput -Verbose)
+        $jobIndex = [int]::Parse($env:SUBSCRIPTION_JOB_INDEX)
+        if ($jobIndex -lt 0) {
+          throw 'The subscription job index must not be negative.'
+        }
+        $subscription = $subscriptions[$jobIndex % $subscriptions.Count]
+
+        Write-Output ("subscriptionId={0}" -f $subscription.id) >> $env:GITHUB_OUTPUT
+        Write-Verbose ("Using test subscription [{0}] from a pool of [{1}]." -f $subscription.name, $subscriptions.Count) -Verbose
+
     # [Azure login] task(s)
     # ------------------------------
     - name: "Set OIDC temporary exception"
       id: set-oidc-exception
       if: env.skip_deployment_ci == 'false'
       uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2
+      env:
+        SELECTED_SUBSCRIPTION_ID: ${{ steps.get-test-subscription.outputs.subscriptionId }}
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -116,6 +152,14 @@ runs:
             Write-Verbose ('The module [{0}] supports OIDC.' -f $modulePath) -Verbose
           }
 
+          if ($oidcException -eq 'true') {
+            $credentials = ConvertFrom-Json -InputObject $env:AZURE_CREDENTIALS -AsHashtable -ErrorAction Stop
+            $credentials['subscriptionId'] = $env:SELECTED_SUBSCRIPTION_ID
+            $credentialsJson = ConvertTo-Json -InputObject $credentials -Depth 10 -Compress
+            Write-Output "::add-mask::$credentialsJson"
+            Write-Output "azureCredentials=$credentialsJson" >> $env:GITHUB_OUTPUT
+          }
+
           Write-Output ('{0}={1}' -f 'oidcException', $oidcException) >> $env:GITHUB_OUTPUT
           Write-Output '::endgroup::'
 
@@ -127,7 +171,7 @@ runs:
       with:
         client-id: ${{ env.VALIDATE_CLIENT_ID }}
         tenant-id: ${{ env.VALIDATE_TENANT_ID }}
-        subscription-id: ${{ env.VALIDATE_SUBSCRIPTION_ID }}
+        subscription-id: ${{ steps.get-test-subscription.outputs.subscriptionId }}
         enable-AzPSSession: true
 
     # Exception: module requires login by using service principal with secret
@@ -136,7 +180,7 @@ runs:
       if: ${{ steps.set-oidc-exception.outputs.oidcException == 'true'  && env.skip_deployment_ci == 'false'}}
       uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2
       with:
-        creds: ${{ env.AZURE_CREDENTIALS }}
+        creds: ${{ steps.set-oidc-exception.outputs.azureCredentials }}
         enable-AzPSSession: true
 
     # [Set Deployment Location] task(s)
@@ -209,7 +253,7 @@ runs:
 
           # Add enforced tokens
           $ConvertTokensInputs.Tokens += @{
-            subscriptionId    = '${{ env.VALIDATE_SUBSCRIPTION_ID }}'
+            subscriptionId    = '${{ steps.get-test-subscription.outputs.subscriptionId }}'
             managementGroupId = '${{ inputs.managementGroupId }}'
             tenantId          = '${{ env.VALIDATE_TENANT_ID }}'
           }
@@ -257,7 +301,7 @@ runs:
           # Prepare general parameters
           # --------------------------
           # Fetching parameters
-          $subscriptionId = '${{ env.VALIDATE_SUBSCRIPTION_ID }}'
+          $subscriptionId = '${{ steps.get-test-subscription.outputs.subscriptionId }}'
           $managementGroupId = '${{ inputs.managementGroupId }}'
 
           # Resolve template file path
@@ -337,7 +381,7 @@ runs:
 
           # Prepare general parameters
           # --------------------------
-          $subscriptionId = '${{ env.VALIDATE_SUBSCRIPTION_ID }}'
+          $subscriptionId = '${{ steps.get-test-subscription.outputs.subscriptionId }}'
           $managementGroupId = '${{ inputs.managementGroupId }}'
 
           # Resolve template file path
@@ -425,7 +469,7 @@ runs:
       with:
         client-id: ${{ env.VALIDATE_CLIENT_ID }}
         tenant-id: ${{ env.VALIDATE_TENANT_ID }}
-        subscription-id: ${{ env.VALIDATE_SUBSCRIPTION_ID }}
+        subscription-id: ${{ steps.get-test-subscription.outputs.subscriptionId }}
         enable-AzPSSession: true
 
     # Exception: module requires login by using service principal with secret
@@ -434,7 +478,7 @@ runs:
       if: ${{ steps.set-oidc-exception.outputs.oidcException == 'true'  && env.skip_deployment_ci == 'false'}}
       uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2
       with:
-        creds: ${{ env.AZURE_CREDENTIALS }}
+        creds: ${{ steps.set-oidc-exception.outputs.azureCredentials }}
         enable-AzPSSession: true
 
     # [Post-Deployment test] task(s)
@@ -548,8 +592,8 @@ runs:
             ManagementGroupId = '${{ inputs.managementGroupId }}'
           }
 
-          if (-not [String]::IsNullOrEmpty('${{ env.VALIDATE_SUBSCRIPTION_ID }}')) {
-              $functionInput['SubscriptionId'] = '${{ env.VALIDATE_SUBSCRIPTION_ID }}'
+          if (-not [String]::IsNullOrEmpty('${{ steps.get-test-subscription.outputs.subscriptionId }}')) {
+              $functionInput['SubscriptionId'] = '${{ steps.get-test-subscription.outputs.subscriptionId }}'
           }
 
           Write-Verbose 'Invoke task with' -Verbose

--- a/.github/workflows/avm.template.module.preview.yml
+++ b/.github/workflows/avm.template.module.preview.yml
@@ -110,6 +110,20 @@ jobs:
           psruleBaseline: ${{ matrix.baseline.baselineName }}
           softFailure: true
 
+  job_initialize_subscription_selection:
+    name: "Initialize subscription selection"
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: inputs.moduleTestFilePaths != '[]' && (fromJson(inputs.workflowInput)).deploymentValidation == 'true'
+    outputs:
+      randomSeed: ${{ steps.random-seed.outputs.randomSeed }}
+    steps:
+      - name: "Generate shared subscription shuffle seed"
+        id: random-seed
+        shell: pwsh
+        run: |
+          Write-Output ("randomSeed={0}" -f (Get-Random -Minimum 0 -Maximum 2147483647)) >> $env:GITHUB_OUTPUT
+
   job_module_deploy_validation:
     name: "Deploy [${{ matrix.testCases.name }}]"
     environment: avm-validation
@@ -121,9 +135,11 @@ jobs:
       !cancelled() &&
       inputs.moduleTestFilePaths != '[]' &&
       (fromJson(inputs.workflowInput)).deploymentValidation == 'true' &&
+      needs.job_initialize_subscription_selection.result == 'success' &&
       needs.job_module_static_validation.result != 'failure' &&
       needs.job_psrule_must.result != 'failure'
     needs:
+      - job_initialize_subscription_selection
       - job_module_static_validation
       - job_psrule_must
     strategy:
@@ -145,12 +161,15 @@ jobs:
           modulePath: "${{ inputs.modulePath }}"
           templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
           deploymentMetadataLocation: "WestEurope"
+          subscriptionSelectionSeed: "${{ needs.job_initialize_subscription_selection.outputs.randomSeed }}"
+          subscriptionJobIndex: "${{ strategy.job-index }}"
           managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
           removeDeployment: "${{ fromJson(inputs.workflowInput).removeDeployment }}"
           customLocation: "${{ fromJson(inputs.workflowInput).customLocation }}"
           e2eIgnore: "${{ matrix.testCases.e2eIgnore }}"
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+          TEST_SUBSCRIPTION_IDS: ${{ vars.TEST_SUBSCRIPTION_IDS }}
           VALIDATE_CLIENT_ID: ${{ secrets.VALIDATE_CLIENT_ID }}
           VALIDATE_SUBSCRIPTION_ID: ${{ secrets.VALIDATE_SUBSCRIPTION_ID }}
           VALIDATE_TENANT_ID: ${{ secrets.VALIDATE_TENANT_ID }}

--- a/.github/workflows/avm.template.module.publish.yml
+++ b/.github/workflows/avm.template.module.publish.yml
@@ -118,6 +118,20 @@ jobs:
           psruleBaseline: ${{ matrix.baseline.baselineName }}
           softFailure: true
 
+  job_initialize_subscription_selection:
+    name: "Initialize subscription selection"
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: inputs.moduleTestFilePaths != '[]' && (fromJson(inputs.workflowInput)).deploymentValidation == 'true'
+    outputs:
+      randomSeed: ${{ steps.random-seed.outputs.randomSeed }}
+    steps:
+      - name: "Generate shared subscription shuffle seed"
+        id: random-seed
+        shell: pwsh
+        run: |
+          Write-Output ("randomSeed={0}" -f (Get-Random -Minimum 0 -Maximum 2147483647)) >> $env:GITHUB_OUTPUT
+
   job_module_deploy_validation:
     name: "Deploy [${{ matrix.testCases.name }}]"
     environment: avm-validation
@@ -129,9 +143,11 @@ jobs:
       !cancelled() &&
       inputs.moduleTestFilePaths != '[]' &&
       (fromJson(inputs.workflowInput)).deploymentValidation == 'true' &&
+      needs.job_initialize_subscription_selection.result == 'success' &&
       needs.job_module_static_validation.result != 'failure' &&
       needs.job_psrule_must.result != 'failure'
     needs:
+      - job_initialize_subscription_selection
       - job_module_static_validation
       - job_psrule_must
     strategy:
@@ -153,12 +169,15 @@ jobs:
           modulePath: "${{ inputs.modulePath }}"
           templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
           deploymentMetadataLocation: "WestEurope"
+          subscriptionSelectionSeed: "${{ needs.job_initialize_subscription_selection.outputs.randomSeed }}"
+          subscriptionJobIndex: "${{ strategy.job-index }}"
           managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
           removeDeployment: "${{ fromJson(inputs.workflowInput).removeDeployment }}"
           customLocation: "${{ fromJson(inputs.workflowInput).customLocation }}"
           e2eIgnore: "${{ matrix.testCases.e2eIgnore }}"
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+          TEST_SUBSCRIPTION_IDS: ${{ vars.TEST_SUBSCRIPTION_IDS }}
           VALIDATE_CLIENT_ID: ${{ secrets.VALIDATE_CLIENT_ID }}
           VALIDATE_SUBSCRIPTION_ID: ${{ secrets.VALIDATE_SUBSCRIPTION_ID }}
           VALIDATE_TENANT_ID: ${{ secrets.VALIDATE_TENANT_ID }}

--- a/.github/workflows/avm.template.module.yml
+++ b/.github/workflows/avm.template.module.yml
@@ -106,6 +106,20 @@ jobs:
   #############################
   #   Deployment validation   #
   #############################
+  job_initialize_subscription_selection:
+    name: "Initialize subscription selection"
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: (fromJson(inputs.workflowInput)).deploymentValidation == 'true'
+    outputs:
+      randomSeed: ${{ steps.random-seed.outputs.randomSeed }}
+    steps:
+      - name: "Generate shared subscription shuffle seed"
+        id: random-seed
+        shell: pwsh
+        run: |
+          Write-Output ("randomSeed={0}" -f (Get-Random -Minimum 0 -Maximum 2147483647)) >> $env:GITHUB_OUTPUT
+
   job_module_deploy_validation: # Note: Please don't change this job name. It is used by the setEnvironment action to define which PS modules to install on runners.
     name: "Deploy [${{ matrix.testCases.name}}]"
     environment: avm-validation
@@ -113,9 +127,11 @@ jobs:
     if: |
       !cancelled() &&
       (fromJson(inputs.workflowInput)).deploymentValidation == 'true' &&
+      needs.job_initialize_subscription_selection.result == 'success' &&
       needs.job_module_static_validation.result != 'failure' &&
       needs.job_psrule_must.result != 'failure'
     needs:
+      - job_initialize_subscription_selection
       - job_module_static_validation
       - job_psrule_must
     strategy:
@@ -137,12 +153,15 @@ jobs:
           modulePath: "${{ inputs.modulePath }}"
           templateFilePath: "${{ inputs.modulePath }}/${{ matrix.testCases.path }}"
           deploymentMetadataLocation: "WestEurope"
+          subscriptionSelectionSeed: "${{ needs.job_initialize_subscription_selection.outputs.randomSeed }}"
+          subscriptionJobIndex: "${{ strategy.job-index }}"
           managementGroupId: "${{ secrets.ARM_MGMTGROUP_ID }}"
           removeDeployment: "${{ fromJson(inputs.workflowInput).removeDeployment }}"
           customLocation: "${{ fromJson(inputs.workflowInput).customLocation }}"
           e2eIgnore: "${{ matrix.testCases.e2eIgnore }}"
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }} # Still required for OIDC exception list
+          TEST_SUBSCRIPTION_IDS: ${{ vars.TEST_SUBSCRIPTION_IDS }}
           VALIDATE_CLIENT_ID: ${{ secrets.VALIDATE_CLIENT_ID }}
           VALIDATE_SUBSCRIPTION_ID: ${{ secrets.VALIDATE_SUBSCRIPTION_ID }}
           VALIDATE_TENANT_ID: ${{ secrets.VALIDATE_TENANT_ID }}

--- a/.github/workflows/platform.deployment.history.cleanup.yml
+++ b/.github/workflows/platform.deployment.history.cleanup.yml
@@ -65,6 +65,19 @@ jobs:
       - name: Set environment
         uses: ./.github/actions/templates/avm-setEnvironment
 
+      - name: Get test subscriptions
+        id: get-test-subscriptions
+        shell: pwsh
+        env:
+          TEST_SUBSCRIPTION_IDS: ${{ vars.TEST_SUBSCRIPTION_IDS }}
+          VALIDATE_SUBSCRIPTION_ID: ${{ secrets.VALIDATE_SUBSCRIPTION_ID }}
+        run: |
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Get-TestSubscriptionList.ps1')
+
+          $subscriptions = @(Get-TestSubscriptionList -TestSubscriptionIds $env:TEST_SUBSCRIPTION_IDS -FallbackSubscriptionId $env:VALIDATE_SUBSCRIPTION_ID -Verbose)
+          Write-Output ("subscriptionId={0}" -f $subscriptions[0].id) >> $env:GITHUB_OUTPUT
+          Write-Output ("subscriptions={0}" -f (ConvertTo-Json -InputObject $subscriptions -Compress)) >> $env:GITHUB_OUTPUT
+
       # [Azure login] task(s)
       # ------------------------------
       # Supports both OIDC and service principal with secret
@@ -74,25 +87,29 @@ jobs:
         with:
           client-id: ${{ secrets.VALIDATE_CLIENT_ID }}
           tenant-id: ${{ secrets.VALIDATE_TENANT_ID }}
-          subscription-id: ${{ secrets.VALIDATE_SUBSCRIPTION_ID }}
+          subscription-id: ${{ steps.get-test-subscriptions.outputs.subscriptionId }}
           enable-AzPSSession: true
 
       - name: Remove deployments
         uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2.0.0
+        env:
+          TEST_SUBSCRIPTIONS: ${{ steps.get-test-subscriptions.outputs.subscriptions }}
         with:
           inlineScript: |
             # Load used functions
             . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'platform' 'deploymentRemoval' 'Clear-SubscriptionDeploymentHistory.ps1')
 
-            $functionInput = @{
-              SubscriptionId               = '${{ secrets.VALIDATE_SUBSCRIPTION_ID }}'
-              maxDeploymentRetentionInDays = '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).maxDeploymentRetentionInDays }}'
+            foreach ($subscription in ($env:TEST_SUBSCRIPTIONS | ConvertFrom-Json)) {
+              $functionInput = @{
+                SubscriptionId               = $subscription.id
+                maxDeploymentRetentionInDays = '${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).maxDeploymentRetentionInDays }}'
+              }
+
+              Write-Verbose "Invoke task with" -Verbose
+              Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+
+              Clear-SubscriptionDeploymentHistory @functionInput
             }
-
-            Write-Verbose "Invoke task with" -Verbose
-            Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
-
-            Clear-SubscriptionDeploymentHistory @functionInput
           azPSVersion: "latest"
 
   job_cleanup_managementGroup_deployments:
@@ -113,6 +130,18 @@ jobs:
       - name: Set environment
         uses: ./.github/actions/templates/avm-setEnvironment
 
+      - name: Get test subscriptions
+        id: get-test-subscriptions
+        shell: pwsh
+        env:
+          TEST_SUBSCRIPTION_IDS: ${{ vars.TEST_SUBSCRIPTION_IDS }}
+          VALIDATE_SUBSCRIPTION_ID: ${{ secrets.VALIDATE_SUBSCRIPTION_ID }}
+        run: |
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Get-TestSubscriptionList.ps1')
+
+          $subscriptions = @(Get-TestSubscriptionList -TestSubscriptionIds $env:TEST_SUBSCRIPTION_IDS -FallbackSubscriptionId $env:VALIDATE_SUBSCRIPTION_ID -Verbose)
+          Write-Output ("subscriptionId={0}" -f $subscriptions[0].id) >> $env:GITHUB_OUTPUT
+
       # [Azure login] task(s)
       # ------------------------------
       # Supports both OIDC and service principal with secret
@@ -122,7 +151,7 @@ jobs:
         with:
           client-id: ${{ secrets.VALIDATE_CLIENT_ID }}
           tenant-id: ${{ secrets.VALIDATE_TENANT_ID }}
-          subscription-id: ${{ secrets.VALIDATE_SUBSCRIPTION_ID }}
+          subscription-id: ${{ steps.get-test-subscriptions.outputs.subscriptionId }}
           enable-AzPSSession: true
 
       - name: Remove deployments

--- a/utilities/pipelines/sharedScripts/Get-TestSubscriptionList.ps1
+++ b/utilities/pipelines/sharedScripts/Get-TestSubscriptionList.ps1
@@ -1,0 +1,68 @@
+<#
+.SYNOPSIS
+Resolve the test subscription pool and optionally shuffle it.
+
+.DESCRIPTION
+TEST_SUBSCRIPTION_IDS uses a JSON array of { id, name } objects. An unset variable
+retains the legacy validation subscription as a singleton pool. A shared random
+seed reproduces the same shuffled order across deployment matrix jobs.
+#>
+function Get-TestSubscriptionList {
+
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string] $TestSubscriptionIds,
+
+        [Parameter()]
+        [string] $FallbackSubscriptionId,
+
+        [Parameter()]
+        [ValidateRange(0, 2147483647)]
+        [int] $RandomSeed
+    )
+
+    if ([string]::IsNullOrWhiteSpace($TestSubscriptionIds)) {
+        if ([string]::IsNullOrWhiteSpace($FallbackSubscriptionId)) {
+            throw 'No test subscriptions configured. Set the TEST_SUBSCRIPTION_IDS variable to a JSON array of { id, name } objects or set the VALIDATE_SUBSCRIPTION_ID secret.'
+        }
+
+        Write-Verbose 'TEST_SUBSCRIPTION_IDS is unset; using VALIDATE_SUBSCRIPTION_ID as a single-subscription pool.'
+        $subscriptions = @([pscustomobject]@{
+                id   = $FallbackSubscriptionId
+                name = $FallbackSubscriptionId
+            })
+    } else {
+        $subscriptions = ConvertFrom-Json -InputObject $TestSubscriptionIds -NoEnumerate -ErrorAction Stop
+        if ($subscriptions -isnot [array] -or $subscriptions.Count -eq 0) {
+            throw 'TEST_SUBSCRIPTION_IDS must be a non-empty JSON array of { id, name } objects.'
+        }
+    }
+
+    $normalizedSubscriptions = @(
+        foreach ($subscription in $subscriptions) {
+            $subscriptionId = [guid]::Empty
+            if ($subscription -isnot [pscustomobject] -or
+                $subscription.id -isnot [string] -or
+                -not [guid]::TryParseExact($subscription.id, 'D', [ref] $subscriptionId)) {
+                throw 'Each test subscription must be an object with an id containing a subscription GUID.'
+            }
+            if ($subscription.name -isnot [string] -or
+                [string]::IsNullOrWhiteSpace($subscription.name) -or
+                $subscription.name -match '[\r\n]') {
+                throw 'Each test subscription must have a non-empty, single-line name.'
+            }
+
+            [pscustomobject]@{
+                id   = $subscription.id
+                name = $subscription.name
+            }
+        }
+    )
+
+    if ($PSBoundParameters.ContainsKey('RandomSeed')) {
+        return $normalizedSubscriptions | Get-Random -Shuffle -SetSeed $RandomSeed
+    }
+
+    return $normalizedSubscriptions
+}

--- a/utilities/tests/pipelines/Get-TestSubscriptionList.Tests.ps1
+++ b/utilities/tests/pipelines/Get-TestSubscriptionList.Tests.ps1
@@ -1,0 +1,101 @@
+param(
+    [Parameter()]
+    [string] $repoRootPath = (Get-Item -Path $PSScriptRoot).Parent.Parent.Parent.FullName
+)
+
+Describe 'Get-TestSubscriptionList' {
+
+    BeforeAll {
+        . (Join-Path $repoRootPath 'utilities' 'pipelines' 'sharedScripts' 'Get-TestSubscriptionList.ps1')
+
+        $subscriptions = @(
+            @{ id = '11111111-1111-1111-1111-111111111111'; name = 'test-one' }
+            @{ id = '22222222-2222-2222-2222-222222222222'; name = 'test-two' }
+            @{ id = '33333333-3333-3333-3333-333333333333'; name = 'test-three' }
+        )
+        $subscriptionJson = ConvertTo-Json -InputObject $subscriptions -Compress
+    }
+
+    It 'Preserves the configured order when no shuffle seed is supplied' {
+        $result = @(Get-TestSubscriptionList -TestSubscriptionIds $subscriptionJson)
+
+        $result.id | Should -Be $subscriptions.id
+        $result.name | Should -Be $subscriptions.name
+    }
+
+    It 'Keeps a single configured subscription unchanged' {
+        $singletonJson = ConvertTo-Json -InputObject @($subscriptions[0]) -Compress
+
+        $result = @(Get-TestSubscriptionList -TestSubscriptionIds $singletonJson -RandomSeed 12345)
+
+        $result.Count | Should -Be 1
+        $result[0].id | Should -Be $subscriptions[0].id
+        $result[0].name | Should -Be $subscriptions[0].name
+    }
+
+    It 'Reproduces one shuffled permutation for every caller using the same seed' {
+        $first = @(Get-TestSubscriptionList -TestSubscriptionIds $subscriptionJson -RandomSeed 12345)
+        $second = @(Get-TestSubscriptionList -TestSubscriptionIds $subscriptionJson -RandomSeed 12345)
+
+        $first.id | Should -Be $second.id
+        ($first.id | Sort-Object) | Should -Be ($subscriptions.id | Sort-Object)
+    }
+
+    It 'Can vary the shuffled order between runs' {
+        $orders = @(
+            0..9 | ForEach-Object {
+                (Get-TestSubscriptionList -TestSubscriptionIds $subscriptionJson -RandomSeed $_).id -join ','
+            } | Sort-Object -Unique
+        )
+
+        $orders.Count | Should -BeGreaterThan 1
+    }
+
+    It 'Uses the legacy subscription as a singleton only when the variable is unset' {
+        foreach ($unsetValue in @($null, '', '  ')) {
+            $result = @(Get-TestSubscriptionList -TestSubscriptionIds $unsetValue -FallbackSubscriptionId $subscriptions[0].id -RandomSeed 12345)
+
+            $result.Count | Should -Be 1
+            $result[0].id | Should -Be $subscriptions[0].id
+            $result[0].name | Should -Be $subscriptions[0].id
+        }
+    }
+
+    It 'Prefers the configured pool over the legacy subscription' {
+        $result = @(Get-TestSubscriptionList -TestSubscriptionIds $subscriptionJson -FallbackSubscriptionId 'not-used')
+
+        $result.id | Should -Be $subscriptions.id
+    }
+
+    It 'Rejects missing configuration' {
+        { Get-TestSubscriptionList } | Should -Throw '*No test subscriptions configured*'
+    }
+
+    It 'Rejects an invalid legacy subscription' {
+        { Get-TestSubscriptionList -FallbackSubscriptionId 'not-a-guid' } | Should -Throw '*subscription GUID*'
+    }
+
+    It 'Rejects a negative shuffle seed' {
+        { Get-TestSubscriptionList -TestSubscriptionIds $subscriptionJson -RandomSeed -1 } | Should -Throw
+    }
+
+    It 'Rejects <name> instead of silently using the fallback' -ForEach @(
+        @{ name = 'malformed JSON'; json = '[invalid' }
+        @{ name = 'an empty array'; json = '[]' }
+        @{ name = 'null'; json = 'null' }
+        @{ name = 'a scalar'; json = '"11111111-1111-1111-1111-111111111111"' }
+        @{ name = 'a single object outside an array'; json = '{"id":"11111111-1111-1111-1111-111111111111","name":"test-one"}' }
+        @{ name = 'a string array'; json = '["11111111-1111-1111-1111-111111111111"]' }
+        @{ name = 'a null entry'; json = '[null]' }
+        @{ name = 'a missing ID'; json = '[{"name":"test-one"}]' }
+        @{ name = 'an invalid ID'; json = '[{"id":"not-a-guid","name":"test-one"}]' }
+        @{ name = 'a missing name'; json = '[{"id":"11111111-1111-1111-1111-111111111111"}]' }
+        @{ name = 'a blank name'; json = '[{"id":"11111111-1111-1111-1111-111111111111","name":" "}]' }
+        @{ name = 'a multiline name'; json = '[{"id":"11111111-1111-1111-1111-111111111111","name":"test\none"}]' }
+        @{ name = 'an invalid later entry'; json = '[{"id":"11111111-1111-1111-1111-111111111111","name":"test-one"},{"id":"bad","name":"test-two"}]' }
+    ) {
+        {
+            Get-TestSubscriptionList -TestSubscriptionIds $json -FallbackSubscriptionId $subscriptions[0].id -RandomSeed 12345
+        } | Should -Throw
+    }
+}

--- a/utilities/tests/pipelines/TestSubscriptionWorkflow.Tests.ps1
+++ b/utilities/tests/pipelines/TestSubscriptionWorkflow.Tests.ps1
@@ -1,0 +1,248 @@
+param(
+    [Parameter()]
+    [string] $repoRootPath = (Get-Item -Path $PSScriptRoot).Parent.Parent.Parent.FullName
+)
+
+Describe 'Test subscription workflow integration' {
+
+    BeforeAll {
+        . (Join-Path $repoRootPath 'utilities' 'pipelines' 'sharedScripts' 'Get-TestSubscriptionList.ps1')
+
+        $workflows = @{}
+        foreach ($workflowName in @('avm.template.module', 'avm.template.module.preview', 'avm.template.module.publish')) {
+            $workflowPath = Join-Path $repoRootPath '.github' 'workflows' "$workflowName.yml"
+            $workflows[$workflowName] = ConvertFrom-Yaml -Yaml (Get-Content -Path $workflowPath -Raw)
+        }
+        $actionPath = Join-Path $repoRootPath '.github' 'actions' 'templates' 'avm-validateModuleDeployment' 'action.yml'
+        $action = ConvertFrom-Yaml -Yaml (Get-Content -Path $actionPath -Raw)
+        $selectionStep = $action.runs.steps | Where-Object { $_.id -eq 'get-test-subscription' }
+        $exceptionStep = $action.runs.steps | Where-Object { $_.id -eq 'set-oidc-exception' }
+        $cleanupPath = Join-Path $repoRootPath '.github' 'workflows' 'platform.deployment.history.cleanup.yml'
+        $cleanupWorkflow = ConvertFrom-Yaml -Yaml (Get-Content -Path $cleanupPath -Raw)
+        $subscriptions = @(
+            @{ id = '11111111-1111-1111-1111-111111111111'; name = 'test-one' }
+            @{ id = '22222222-2222-2222-2222-222222222222'; name = 'test-two' }
+            @{ id = '33333333-3333-3333-3333-333333333333'; name = 'test-three' }
+        )
+        $subscriptionJson = ConvertTo-Json -InputObject $subscriptions -Compress
+        $environmentNames = @(
+            'GITHUB_WORKSPACE', 'GITHUB_OUTPUT', 'TEST_SUBSCRIPTION_IDS', 'VALIDATE_SUBSCRIPTION_ID',
+            'SUBSCRIPTION_SELECTION_SEED', 'SUBSCRIPTION_JOB_INDEX', 'SELECTED_SUBSCRIPTION_ID',
+            'AZURE_CREDENTIALS', 'TEST_SUBSCRIPTIONS'
+        )
+
+        function Get-StepOutput {
+            $outputs = @{}
+            foreach ($line in (Get-Content -Path $env:GITHUB_OUTPUT)) {
+                if (-not [string]::IsNullOrWhiteSpace($line)) {
+                    $name, $value = $line.Split('=', 2)
+                    $outputs[$name] = $value
+                }
+            }
+            return $outputs
+        }
+    }
+
+    BeforeEach {
+        $savedEnvironment = @{}
+        foreach ($name in $environmentNames) {
+            $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name)
+            [Environment]::SetEnvironmentVariable($name, $null)
+        }
+        $env:GITHUB_WORKSPACE = $repoRootPath
+        $env:GITHUB_OUTPUT = Join-Path $TestDrive ("output-{0}.txt" -f [guid]::NewGuid())
+        $null = New-Item -Path $env:GITHUB_OUTPUT -ItemType File
+        $env:TEST_SUBSCRIPTION_IDS = $subscriptionJson
+        $env:VALIDATE_SUBSCRIPTION_ID = '44444444-4444-4444-4444-444444444444'
+        $env:SUBSCRIPTION_SELECTION_SEED = '12345'
+        $env:SUBSCRIPTION_JOB_INDEX = '0'
+    }
+
+    AfterEach {
+        foreach ($name in $environmentNames) {
+            [Environment]::SetEnvironmentVariable($name, $savedEnvironment[$name])
+        }
+    }
+
+    It 'Wires the Actions variable and shared seed into <workflowName>' -ForEach @(
+        @{ workflowName = 'avm.template.module' }
+        @{ workflowName = 'avm.template.module.preview' }
+        @{ workflowName = 'avm.template.module.publish' }
+    ) {
+        $workflow = $workflows[$workflowName]
+        $initializer = $workflow.jobs.job_initialize_subscription_selection
+        $deployment = $workflow.jobs.job_module_deploy_validation
+        $deploymentStep = $deployment.steps | Where-Object { $_.uses -eq './.github/actions/templates/avm-validateModuleDeployment' }
+
+        $initializer.permissions.Count | Should -Be 0
+        $initializer.ContainsKey('environment') | Should -BeFalse
+        @($initializer.outputs.Keys) | Should -Be @('randomSeed')
+        $initializer.outputs.randomSeed | Should -Be '${{ steps.random-seed.outputs.randomSeed }}'
+        $initializer.if | Should -Match "deploymentValidation == 'true'"
+        $deployment.needs | Should -Contain 'job_initialize_subscription_selection'
+        $deployment.if | Should -Match "needs.job_initialize_subscription_selection.result == 'success'"
+        $deploymentStep.env.TEST_SUBSCRIPTION_IDS | Should -Be '${{ vars.TEST_SUBSCRIPTION_IDS }}'
+        $deploymentStep.env.VALIDATE_SUBSCRIPTION_ID | Should -Be '${{ secrets.VALIDATE_SUBSCRIPTION_ID }}'
+        $deploymentStep.with.subscriptionSelectionSeed | Should -Be '${{ needs.job_initialize_subscription_selection.outputs.randomSeed }}'
+        $deploymentStep.with.subscriptionJobIndex | Should -Be '${{ strategy.job-index }}'
+    }
+
+    It 'Generates a numeric seed without subscription data or Azure access' {
+        $seedStep = $workflows['avm.template.module'].jobs.job_initialize_subscription_selection.steps[0]
+
+        . ([scriptblock]::Create($seedStep.run))
+        $seed = (Get-StepOutput).randomSeed
+
+        $seed | Should -Match '^\d+$'
+        [int] $seed | Should -BeGreaterOrEqual 0
+        $seedStep.run | Should -Not -Match 'secrets\.|vars\.|Azure|AzContext'
+    }
+
+    It 'Assigns consecutive matrix jobs round-robin over the same shuffled pool' {
+        $shuffled = @(Get-TestSubscriptionList -TestSubscriptionIds $subscriptionJson -RandomSeed 12345)
+        $selectedIds = @(
+            foreach ($index in 0..7) {
+                Clear-Content -Path $env:GITHUB_OUTPUT
+                $env:SUBSCRIPTION_JOB_INDEX = [string] $index
+                . ([scriptblock]::Create($selectionStep.run))
+                (Get-StepOutput).subscriptionId
+            }
+        )
+        $expectedIds = @(0..7 | ForEach-Object { $shuffled[$_ % $shuffled.Count].id })
+
+        $selectedIds | Should -Be $expectedIds
+        @($selectedIds[0..2] | Sort-Object -Unique).Count | Should -Be 3
+        $counts = $selectedIds | Group-Object | Select-Object -ExpandProperty Count | Measure-Object -Minimum -Maximum
+        ($counts.Maximum - $counts.Minimum) | Should -BeLessOrEqual 1
+    }
+
+    It 'Keeps singleton selection unchanged for every matrix index' {
+        $env:TEST_SUBSCRIPTION_IDS = ConvertTo-Json -InputObject @($subscriptions[0]) -Compress
+        foreach ($index in @(0, 1, 99)) {
+            Clear-Content -Path $env:GITHUB_OUTPUT
+            $env:SUBSCRIPTION_JOB_INDEX = [string] $index
+
+            . ([scriptblock]::Create($selectionStep.run))
+
+            (Get-StepOutput).subscriptionId | Should -Be $subscriptions[0].id
+        }
+    }
+
+    It 'Uses the legacy singleton when the variable is not configured' {
+        $env:TEST_SUBSCRIPTION_IDS = ''
+        $env:SUBSCRIPTION_JOB_INDEX = '5'
+
+        . ([scriptblock]::Create($selectionStep.run))
+
+        (Get-StepOutput).subscriptionId | Should -Be $env:VALIDATE_SUBSCRIPTION_ID
+    }
+
+    It 'Fails before login when the configured pool is invalid' {
+        $env:TEST_SUBSCRIPTION_IDS = '[]'
+
+        { . ([scriptblock]::Create($selectionStep.run)) } | Should -Throw
+        (Get-StepOutput).Count | Should -Be 0
+        $selectionStep.if | Should -Be "env.skip_deployment_ci == 'false'"
+    }
+
+    It 'Rejects an invalid matrix index' {
+        $env:SUBSCRIPTION_JOB_INDEX = '-1'
+
+        { . ([scriptblock]::Create($selectionStep.run)) } | Should -Throw '*must not be negative*'
+        (Get-StepOutput).Count | Should -Be 0
+    }
+
+    It 'Reuses the selected subscription for both logins, token replacement, deployment and removal' {
+        $defaultLogins = @($action.runs.steps | Where-Object { $_.name -eq 'Azure Login - Default' })
+        $defaultLogins.Count | Should -Be 2
+        foreach ($login in $defaultLogins) {
+            $login.with.'subscription-id' | Should -Be '${{ steps.get-test-subscription.outputs.subscriptionId }}'
+        }
+        foreach ($stepName in @('Replace tokens in template file', 'Validate template file', 'Deploy template file', 'Remove deployed resources')) {
+            $step = $action.runs.steps | Where-Object { $_.name -eq $stepName }
+            $step.with.inlineScript | Should -Match ([regex]::Escape('${{ steps.get-test-subscription.outputs.subscriptionId }}'))
+            $step.with.inlineScript | Should -Not -Match 'env\.VALIDATE_SUBSCRIPTION_ID'
+        }
+        $exceptionLogins = @($action.runs.steps | Where-Object { $_.name -eq 'Azure Login - Exception' })
+        $exceptionLogins.Count | Should -Be 2
+        foreach ($login in $exceptionLogins) {
+            $login.with.creds | Should -Be '${{ steps.set-oidc-exception.outputs.azureCredentials }}'
+        }
+        $exceptionStep.env.SELECTED_SUBSCRIPTION_ID | Should -Be '${{ steps.get-test-subscription.outputs.subscriptionId }}'
+    }
+
+    It 'Updates and masks exception credentials without changing the original secret' {
+        $credentials = @{
+            clientId                   = 'test-client'
+            clientSecret               = 'not-a-real-secret'
+            tenantId                   = 'test-tenant'
+            subscriptionId             = $env:VALIDATE_SUBSCRIPTION_ID
+            activeDirectoryEndpointUrl = 'https://login.example.invalid'
+        }
+        $env:AZURE_CREDENTIALS = ConvertTo-Json -InputObject $credentials -Compress
+        $originalCredentials = $env:AZURE_CREDENTIALS
+        $env:SELECTED_SUBSCRIPTION_ID = $subscriptions[2].id
+        $script = $exceptionStep.with.inlineScript.Replace('${{ inputs.modulePath }}', 'avm/res/azure-stack-hci/cluster')
+
+        $messages = @(. ([scriptblock]::Create($script)))
+        $outputs = Get-StepOutput
+        $updatedCredentials = $outputs.azureCredentials | ConvertFrom-Json
+
+        $outputs.oidcException | Should -Be 'true'
+        $updatedCredentials.subscriptionId | Should -Be $subscriptions[2].id
+        $updatedCredentials.clientId | Should -Be $credentials.clientId
+        $updatedCredentials.clientSecret | Should -Be $credentials.clientSecret
+        $updatedCredentials.tenantId | Should -Be $credentials.tenantId
+        $updatedCredentials.activeDirectoryEndpointUrl | Should -Be $credentials.activeDirectoryEndpointUrl
+        $messages | Should -Contain "::add-mask::$($outputs.azureCredentials)"
+        $env:AZURE_CREDENTIALS | Should -Be $originalCredentials
+    }
+
+    It 'Does not require secret credentials for OIDC-capable modules' {
+        $script = $exceptionStep.with.inlineScript.Replace('${{ inputs.modulePath }}', 'avm/res/storage/storage-account')
+
+        $null = . ([scriptblock]::Create($script))
+        $outputs = Get-StepOutput
+
+        $outputs.oidcException | Should -Be 'false'
+        $outputs.ContainsKey('azureCredentials') | Should -BeFalse
+    }
+
+    It 'Uses the configured pool for both history cleanup logins' {
+        foreach ($jobName in @('job_cleanup_subscription_deployments', 'job_cleanup_managementGroup_deployments')) {
+            Clear-Content -Path $env:GITHUB_OUTPUT
+            $job = $cleanupWorkflow.jobs[$jobName]
+            $poolStep = $job.steps | Where-Object { $_.id -eq 'get-test-subscriptions' }
+            $login = $job.steps | Where-Object { $_.name -eq 'Azure Login' }
+
+            . ([scriptblock]::Create($poolStep.run))
+
+            $poolStep.env.TEST_SUBSCRIPTION_IDS | Should -Be '${{ vars.TEST_SUBSCRIPTION_IDS }}'
+            $login.with.'subscription-id' | Should -Be '${{ steps.get-test-subscriptions.outputs.subscriptionId }}'
+            (Get-StepOutput).subscriptionId | Should -Be $subscriptions[0].id
+        }
+    }
+
+    It 'Visits every configured subscription during history cleanup' {
+        $job = $cleanupWorkflow.jobs.job_cleanup_subscription_deployments
+        $poolStep = $job.steps | Where-Object { $_.id -eq 'get-test-subscriptions' }
+        $removalStep = $job.steps | Where-Object { $_.name -eq 'Remove deployments' }
+        . ([scriptblock]::Create($poolStep.run))
+        $env:TEST_SUBSCRIPTIONS = (Get-StepOutput).subscriptions
+
+        $removalStep.env.TEST_SUBSCRIPTIONS | Should -Be '${{ steps.get-test-subscriptions.outputs.subscriptions }}'
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($removalStep.with.inlineScript, [ref] $null, [ref] $null)
+        $loop = $ast.Find({ param($node) $node -is [System.Management.Automation.Language.ForEachStatementAst] }, $true)
+        $script = $loop.Extent.Text.Replace('${{ (fromJson(needs.job_initialize_pipeline.outputs.workflowInput)).maxDeploymentRetentionInDays }}', '14')
+
+        function Clear-SubscriptionDeploymentHistory {
+            param([string] $SubscriptionId, [int] $maxDeploymentRetentionInDays)
+            [pscustomobject]@{ id = $SubscriptionId; retention = $maxDeploymentRetentionInDays }
+        }
+
+        $visited = @(. ([scriptblock]::Create($script)))
+
+        $visited.id | Should -Be $subscriptions.id
+        $visited.retention | Should -Be @(14, 14, 14)
+    }
+}


### PR DESCRIPTION
## Description

Prepare Bicep deployment tests to scale across the test subscriptions using Terraform's `TEST_SUBSCRIPTION_IDS` name, JSON structure and shuffled round-robin allocation. As requested, Bicep reads this setting from **Actions variables**, rather than the Actions secret used by Terraform.

```json
[{"id":"<subscription-guid>","name":"<subscription-name>"}]
```

The repository variable has already been populated with a single entry, `sub-avm-core-001`, so the deployment target remains unchanged.

- Apply selection to the legacy, generic preview and generic publish workflows.
- Generate one shared random seed per test matrix. Each matrix leg reproduces the same shuffled pool and selects `job-index % subscription-count`. Only the seed crosses job boundaries, avoiding GitHub's suppression of outputs containing existing subscription secrets.
- Reuse the selected subscription for OIDC login, secret-based exception login, token replacement, deployment, post-deployment authentication and resource removal.
- Sweep scheduled subscription deployment history across the entire pool. Management-group history cleanup still runs once, using the first configured subscription for authentication.
- Retain `VALIDATE_SUBSCRIPTION_ID` as an explicit singleton fallback only when the variable is unset. Reject malformed or empty pools and invalid entries before login.

Terraform reference: [shared subscription shuffle](https://github.com/Azure/azure-verified-modules-tools/blob/b7113a365c84f424cf129b1008d904c8d477fb1c/.github/workflows/terraform-module.yml#L63-L120) and [per-example round-robin selection](https://github.com/Azure/azure-verified-modules-tools/blob/b7113a365c84f424cf129b1008d904c8d477fb1c/.github/workflows/terraform-module.yml#L541-L577).

Operational documentation should describe the variable contract, access required for additional subscriptions, and whole-pool history cleanup.

## Pipeline Reference

<!-- Insert your Pipeline Status Badge below -->

| Pipeline | Result |
| -------- | ------ |
| Targeted local Pester coverage | 44 passed across subscription parsing, allocation, authentication, cleanup routing and existing generic workflow behavior. |
| Azure deployment and cleanup workflows | Not triggered. |

## Type of Change

<!-- Use the checkboxes [x] on the options that are relevant. -->

- Azure Verified Module updates:
  - [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`:
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
  - [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files. (Not applicable: no module files changed.)
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings. (Azure workflows were not triggered.)
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version. (Not applicable: CI-only change.)

<!-- Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/bicep -->