### PR TITLE
feat: support GitHub secrets and variables for CI test parameters

### DIFF
--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -362,10 +362,11 @@ runs:
           }
 
           $ciParameterInput = @{
-            TemplateParameters = $moduleTemplateParameters
-            GitHubVariables    = $env:AVM_CI_VARIABLES
-            GitHubSecrets      = $env:AVM_CI_SECRETS
-            KeyVaultName       = $env:CI_KEY_VAULT_NAME
+            TemplateParameters  = $moduleTemplateParameters
+            TemplateDefinitions = $moduleTemplateContent.definitions ?? @{}
+            GitHubVariables     = $env:AVM_CI_VARIABLES
+            GitHubSecrets       = $env:AVM_CI_SECRETS
+            KeyVaultName        = $env:CI_KEY_VAULT_NAME
           }
           $ciParameters = Get-CIParameterMap @ciParameterInput
           foreach ($parameter in $ciParameters.GetEnumerator()) {
@@ -445,10 +446,11 @@ runs:
           }
 
           $ciParameterInput = @{
-            TemplateParameters = $moduleTemplateParameters
-            GitHubVariables    = $env:AVM_CI_VARIABLES
-            GitHubSecrets      = $env:AVM_CI_SECRETS
-            KeyVaultName       = $env:CI_KEY_VAULT_NAME
+            TemplateParameters  = $moduleTemplateParameters
+            TemplateDefinitions = $moduleTemplateContent.definitions ?? @{}
+            GitHubVariables     = $env:AVM_CI_VARIABLES
+            GitHubSecrets       = $env:AVM_CI_SECRETS
+            KeyVaultName        = $env:CI_KEY_VAULT_NAME
           }
           $ciParameters = Get-CIParameterMap @ciParameterInput
           foreach ($parameter in $ciParameters.GetEnumerator()) {

--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -53,6 +53,14 @@ inputs:
   customTokens:
     description: 'Additional parameter file token pairs in json format. e.g. {"tokenName":"tokenValue"}'
     required: false
+  githubVariables:
+    description: "Resolved GitHub Actions vars context as JSON. Only CI_-prefixed test parameters are used."
+    default: "{}"
+    required: false
+  githubSecrets:
+    description: "Resolved GitHub Actions secrets context as JSON. CI_-prefixed secrets override variables."
+    default: "{}"
+    required: false
   removeDeployment:
     description: 'Set "true" to set module up for removal'
     default: "true"
@@ -94,6 +102,12 @@ runs:
             Write-Output "File '.e2eignore' does not exist in the folder: $moduleTestFilePath" -Verbose
             Write-Output "skip_deployment_ci=false" >> $env:GITHUB_ENV
           }
+
+    - name: "Warn about CI Key Vault deprecation"
+      if: env.skip_deployment_ci == 'false' && env.CI_KEY_VAULT_NAME != ''
+      shell: pwsh
+      run: |
+        Write-Output '::warning title=CI Key Vault deprecation::CI_KEY_VAULT_NAME support may be removed in a future release. Use CI_-prefixed GitHub Actions secrets or variables instead. GitHub secrets override variables, and both override Key Vault values.'
 
     - name: "Select test subscription"
       id: get-test-subscription
@@ -289,6 +303,9 @@ runs:
     - name: "Validate template file"
       if: env.skip_deployment_ci == 'false'
       uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2
+      env:
+        AVM_CI_VARIABLES: ${{ inputs.githubVariables }}
+        AVM_CI_SECRETS: ${{ inputs.githubSecrets }}
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -297,6 +314,7 @@ runs:
 
           # Load used functions
           . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'e2eValidation' 'resourceDeployment' 'Test-TemplateDeployment.ps1')
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Get-CIParameterMap.ps1')
 
           # Prepare general parameters
           # --------------------------
@@ -310,10 +328,14 @@ runs:
           # Determine possible parameters depending on file type
           if ((Split-Path $moduleTestFilePath -Extension) -eq '.bicep') {
             $moduleTemplateContent = bicep build $moduleTestFilePath --stdout | ConvertFrom-Json -AsHashtable
-            $moduleTemplatePossibleParameters = $moduleTemplateContent.parameters.Keys
+            if ($LASTEXITCODE -ne 0) {
+              throw 'Failed to compile the test template.'
+            }
           } else {
-            $moduleTemplatePossibleParameters = ((Get-Content $moduleTestFilePath -Raw) | ConvertFrom-Json -AsHashtable).parameters.keys
+            $moduleTemplateContent = Get-Content $moduleTestFilePath -Raw | ConvertFrom-Json -AsHashtable
           }
+          $moduleTemplateParameters = $moduleTemplateContent.parameters ?? @{}
+          $moduleTemplatePossibleParameters = $moduleTemplateParameters.psbase.Keys
 
           # ----------------- #
           # Invoke validation #
@@ -339,26 +361,21 @@ runs:
             }
           }
 
-          # Fetch & add custom secrets, if any
-          # -----------------------------------
-          $keyVaultName = "${{ env.CI_KEY_VAULT_NAME }}"
-          if(-not [String]::IsNullOrEmpty($keyVaultName)) {
-            # Note: This action requires at least 'Key Vault Secrets User' permissions
-            $customKeyVaultSecrets = Get-AzKeyVaultSecret -VaultName $keyVaultName | Where-Object { $_.Name -match '^CI-.+' }
-
-            foreach($customSecret in $customKeyVaultSecrets) {
-              $formattedName = $customSecret.Name -replace '^CI-' # e.g. 'CI-mySecret' -> 'mySecret'
-              if($moduleTemplatePossibleParameters -contains $formattedName) {
-                Write-Verbose ('Setting value for parameter [{0}]' -f $formattedName) -Verbose
-                $functionInput.AdditionalParameters += @{
-                  $formattedName = (Get-AzKeyVaultSecret -VaultName $keyVaultName -Name $customSecret.Name).SecretValue
-                }
-              }
-            }
+          $ciParameterInput = @{
+            TemplateParameters = $moduleTemplateParameters
+            GitHubVariables    = $env:AVM_CI_VARIABLES
+            GitHubSecrets      = $env:AVM_CI_SECRETS
+            KeyVaultName       = $env:CI_KEY_VAULT_NAME
+          }
+          $ciParameters = Get-CIParameterMap @ciParameterInput
+          foreach ($parameter in $ciParameters.GetEnumerator()) {
+            $functionInput.AdditionalParameters[$parameter.Key] = $parameter.Value
           }
 
           Write-Verbose 'Invoke task with' -Verbose
-          Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+          $logInput = $functionInput.Clone()
+          $logInput.AdditionalParameters = @($functionInput.AdditionalParameters.psbase.Keys)
+          Write-Verbose ($logInput | ConvertTo-Json | Out-String) -Verbose
 
           Test-TemplateDeployment @functionInput -Verbose
 
@@ -370,6 +387,9 @@ runs:
       if: env.skip_deployment_ci == 'false'
       id: deploy_step
       uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2
+      env:
+        AVM_CI_VARIABLES: ${{ inputs.githubVariables }}
+        AVM_CI_SECRETS: ${{ inputs.githubSecrets }}
       with:
         azPSVersion: "latest"
         inlineScript: |
@@ -378,6 +398,7 @@ runs:
 
           # Load used functions
           . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'e2eValidation' 'resourceDeployment' 'New-TemplateDeployment.ps1')
+          . (Join-Path $env:GITHUB_WORKSPACE 'utilities' 'pipelines' 'sharedScripts' 'Get-CIParameterMap.ps1')
 
           # Prepare general parameters
           # --------------------------
@@ -390,10 +411,14 @@ runs:
           # Determine possible parameters depending on file type
           if ((Split-Path $moduleTestFilePath -Extension) -eq '.bicep') {
             $moduleTemplateContent = bicep build $moduleTestFilePath --stdout | ConvertFrom-Json -AsHashtable
-            $moduleTemplatePossibleParameters = $moduleTemplateContent.parameters.Keys
+            if ($LASTEXITCODE -ne 0) {
+              throw 'Failed to compile the test template.'
+            }
           } else {
-            $moduleTemplatePossibleParameters = ((Get-Content $moduleTestFilePath -Raw) | ConvertFrom-Json -AsHashtable).parameters.keys
+            $moduleTemplateContent = Get-Content $moduleTestFilePath -Raw | ConvertFrom-Json -AsHashtable
           }
+          $moduleTemplateParameters = $moduleTemplateContent.parameters ?? @{}
+          $moduleTemplatePossibleParameters = $moduleTemplateParameters.psbase.Keys
 
           # ----------------- #
           # Invoke deployment #
@@ -419,26 +444,21 @@ runs:
             }
           }
 
-          # Fetch & add custom secrets, if any
-          # -----------------------------------
-          $keyVaultName = "${{ env.CI_KEY_VAULT_NAME }}"
-          if(-not [String]::IsNullOrEmpty($keyVaultName)) {
-            # Note: This action requires at least 'Key Vault Secrets User' permissions
-            $customKeyVaultSecrets = Get-AzKeyVaultSecret -VaultName $keyVaultName | Where-Object { $_.Name -match '^CI-.+' }
-
-            foreach($customSecret in $customKeyVaultSecrets) {
-              $formattedName = $customSecret.Name -replace '^CI-' # e.g. 'CI-mySecret' -> 'mySecret'
-              if($moduleTemplatePossibleParameters -contains $formattedName) {
-                Write-Verbose ('Setting value for parameter [{0}]' -f $formattedName) -Verbose
-                $functionInput.AdditionalParameters += @{
-                  $formattedName = (Get-AzKeyVaultSecret -VaultName $keyVaultName -Name $customSecret.Name).SecretValue
-                }
-              }
-            }
+          $ciParameterInput = @{
+            TemplateParameters = $moduleTemplateParameters
+            GitHubVariables    = $env:AVM_CI_VARIABLES
+            GitHubSecrets      = $env:AVM_CI_SECRETS
+            KeyVaultName       = $env:CI_KEY_VAULT_NAME
+          }
+          $ciParameters = Get-CIParameterMap @ciParameterInput
+          foreach ($parameter in $ciParameters.GetEnumerator()) {
+            $functionInput.AdditionalParameters[$parameter.Key] = $parameter.Value
           }
 
           Write-Verbose 'Invoke task with' -Verbose
-          Write-Verbose ($functionInput | ConvertTo-Json | Out-String) -Verbose
+          $logInput = $functionInput.Clone()
+          $logInput.AdditionalParameters = @($functionInput.AdditionalParameters.psbase.Keys)
+          Write-Verbose ($logInput | ConvertTo-Json | Out-String) -Verbose
 
           # Invoke deployment
           $res = New-TemplateDeployment @functionInput -Verbose

--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -54,11 +54,11 @@ inputs:
     description: 'Additional parameter file token pairs in json format. e.g. {"tokenName":"tokenValue"}'
     required: false
   githubVariables:
-    description: "Resolved GitHub Actions vars context as JSON. Only CI_-prefixed test parameters are used."
+    description: "Resolved GitHub Actions vars context as JSON. CI_ ignores underscores; CI__ preserves literal spelling."
     default: "{}"
     required: false
   githubSecrets:
-    description: "Resolved GitHub Actions secrets context as JSON. CI_-prefixed secrets override variables."
+    description: "Resolved GitHub Actions secrets context as JSON. CI_ or CI__ secrets override variables for the same parameter."
     default: "{}"
     required: false
   removeDeployment:

--- a/.github/workflows/avm.template.module.preview.yml
+++ b/.github/workflows/avm.template.module.preview.yml
@@ -167,6 +167,8 @@ jobs:
           removeDeployment: "${{ fromJson(inputs.workflowInput).removeDeployment }}"
           customLocation: "${{ fromJson(inputs.workflowInput).customLocation }}"
           e2eIgnore: "${{ matrix.testCases.e2eIgnore }}"
+          githubVariables: ${{ toJSON(vars) }}
+          githubSecrets: ${{ toJSON(secrets) }}
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           TEST_SUBSCRIPTION_IDS: ${{ vars.TEST_SUBSCRIPTION_IDS }}

--- a/.github/workflows/avm.template.module.publish.yml
+++ b/.github/workflows/avm.template.module.publish.yml
@@ -175,6 +175,8 @@ jobs:
           removeDeployment: "${{ fromJson(inputs.workflowInput).removeDeployment }}"
           customLocation: "${{ fromJson(inputs.workflowInput).customLocation }}"
           e2eIgnore: "${{ matrix.testCases.e2eIgnore }}"
+          githubVariables: ${{ toJSON(vars) }}
+          githubSecrets: ${{ toJSON(secrets) }}
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           TEST_SUBSCRIPTION_IDS: ${{ vars.TEST_SUBSCRIPTION_IDS }}

--- a/.github/workflows/avm.template.module.yml
+++ b/.github/workflows/avm.template.module.yml
@@ -159,6 +159,8 @@ jobs:
           removeDeployment: "${{ fromJson(inputs.workflowInput).removeDeployment }}"
           customLocation: "${{ fromJson(inputs.workflowInput).customLocation }}"
           e2eIgnore: "${{ matrix.testCases.e2eIgnore }}"
+          githubVariables: ${{ toJSON(vars) }}
+          githubSecrets: ${{ toJSON(secrets) }}
         env:
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }} # Still required for OIDC exception list
           TEST_SUBSCRIPTION_IDS: ${{ vars.TEST_SUBSCRIPTION_IDS }}

--- a/utilities/pipelines/sharedScripts/ConvertFrom-CIParameterName.ps1
+++ b/utilities/pipelines/sharedScripts/ConvertFrom-CIParameterName.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+Decode a GitHub CI input name. CI_ ignores underscores; CI__ preserves them.
+Unrelated names and the reserved CI_KEY_VAULT_NAME selector return no parameter name.
+#>
+function ConvertFrom-CIParameterName {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string] $Name
+    )
+
+    if ($Name -ieq 'CI_KEY_VAULT_NAME') {
+        return $null
+    }
+    if ($Name.StartsWith('CI__', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $Name.Substring(4)
+    }
+    if ($Name.StartsWith('CI_', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $Name.Substring(3).Replace('_', '')
+    }
+    return $null
+}

--- a/utilities/pipelines/sharedScripts/ConvertTo-CIParameterName.ps1
+++ b/utilities/pipelines/sharedScripts/ConvertTo-CIParameterName.ps1
@@ -1,0 +1,27 @@
+<#
+.SYNOPSIS
+Create a readable GitHub CI_ name, or a CI__ name when literal spelling is needed.
+#>
+function ConvertTo-CIParameterName {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidatePattern('^[A-Za-z_][A-Za-z0-9_]*$')]
+        [string] $ParameterName
+    )
+
+    if ($ParameterName.Contains('_')) {
+        return 'CI__{0}' -f $ParameterName.ToUpperInvariant()
+    }
+
+    $words = [regex]::Replace($ParameterName, '([A-Z]+)([A-Z][a-z])', '$1_$2')
+    $words = [regex]::Replace($words, '([a-z0-9])([A-Z])', '$1_$2')
+    $name = 'CI_{0}' -f $words.ToUpperInvariant()
+    if ($name -eq 'CI_KEY_VAULT_NAME') {
+        return 'CI__{0}' -f $ParameterName.ToUpperInvariant()
+    }
+    if ($name.Length -gt 100) {
+        return 'CI_{0}' -f $ParameterName.ToUpperInvariant()
+    }
+    return $name
+}

--- a/utilities/pipelines/sharedScripts/Get-CIParameterMap.ps1
+++ b/utilities/pipelines/sharedScripts/Get-CIParameterMap.ps1
@@ -3,9 +3,11 @@
 Resolve additional test parameters from GitHub Actions and the legacy CI Key Vault.
 
 .DESCRIPTION
-Matches CI_ GitHub names and CI- Key Vault names to template parameters without
-regard to case. GitHub secrets override variables; Key Vault only supplies missing
-parameters. GitHub values are converted to the declared ARM parameter types.
+Matches GitHub names without regard to case: CI_ removes separator underscores,
+while CI__ preserves literal underscores. Key Vault CI- names remain literal.
+GitHub secrets override variables; Key Vault only supplies missing parameters.
+Aliases within the same GitHub source must not target the same template parameter.
+GitHub values are converted to the declared ARM parameter types.
 
 .PARAMETER TemplateParameters
 The parameters object from the compiled test template.
@@ -44,6 +46,17 @@ function Get-CIParameterMap {
         [string] $KeyVaultName
     )
 
+    . (Join-Path $PSScriptRoot 'ConvertFrom-CIParameterName.ps1')
+
+    $parameterNames = @{}
+    # Parameter names can shadow dictionary properties such as Keys and Count.
+    foreach ($parameterName in $TemplateParameters.psbase.Keys) {
+        if ($parameterNames.ContainsKey($parameterName)) {
+            throw "Template parameter [$parameterName] differs from another parameter only in case and cannot be resolved from GitHub inputs."
+        }
+        $parameterNames[$parameterName] = $parameterName
+    }
+
     $sources = @{
         Variables = @{ Json = $GitHubVariables; Values = @{} }
         Secrets   = @{ Json = $GitHubSecrets; Values = @{} }
@@ -64,31 +77,34 @@ function Get-CIParameterMap {
         }
 
         foreach ($entry in $values.GetEnumerator()) {
-            if ($entry.Key -notmatch '^CI_.+') {
+            $name = ConvertFrom-CIParameterName -Name $entry.Key
+            if ([string]::IsNullOrEmpty($name) -or -not $parameterNames.ContainsKey($name)) {
                 continue
             }
-            if ($source.Values.ContainsKey($entry.Key)) {
-                throw "The GitHub $sourceName context contains duplicate CI_ names differing only in case."
+            $parameterName = $parameterNames[$name]
+            if ($source.Values.ContainsKey($parameterName)) {
+                throw "Multiple GitHub $sourceName names [$($source.Values[$parameterName].Name)] and [$($entry.Key)] map to parameter [$parameterName]."
             }
-            $source.Values[$entry.Key] = $entry.Value
+            $source.Values[$parameterName] = @{
+                Name  = $entry.Key
+                Value = $entry.Value
+            }
         }
     }
 
     $parameters = @{}
-    $parameterNames = @{}
-    # Parameter names can shadow dictionary properties such as Keys and Count.
     foreach ($parameterName in $TemplateParameters.psbase.Keys) {
-        $parameterNames[$parameterName] = $parameterName
-        $githubName = "CI_$parameterName"
-        if ($sources.Secrets.Values.ContainsKey($githubName)) {
-            $value = $sources.Secrets.Values[$githubName]
+        if ($sources.Secrets.Values.ContainsKey($parameterName)) {
+            $entry = $sources.Secrets.Values[$parameterName]
             $isSecret = $true
-        } elseif ($sources.Variables.Values.ContainsKey($githubName)) {
-            $value = $sources.Variables.Values[$githubName]
+        } elseif ($sources.Variables.Values.ContainsKey($parameterName)) {
+            $entry = $sources.Variables.Values[$parameterName]
             $isSecret = $false
         } else {
             continue
         }
+        $value = $entry.Value
+        $githubName = $entry.Name
 
         if ($value -isnot [string]) {
             throw "The GitHub value for parameter [$parameterName] must be a string."

--- a/utilities/pipelines/sharedScripts/Get-CIParameterMap.ps1
+++ b/utilities/pipelines/sharedScripts/Get-CIParameterMap.ps1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+Resolve additional test parameters from GitHub Actions and the legacy CI Key Vault.
+
+.DESCRIPTION
+Matches CI_ GitHub names and CI- Key Vault names to template parameters without
+regard to case. GitHub secrets override variables; Key Vault only supplies missing
+parameters. GitHub values are converted to the declared ARM parameter types.
+
+.PARAMETER TemplateParameters
+The parameters object from the compiled test template.
+
+.PARAMETER GitHubVariables
+The JSON-serialized, resolved GitHub Actions vars context.
+
+.PARAMETER GitHubSecrets
+The JSON-serialized, resolved GitHub Actions secrets context.
+
+.PARAMETER KeyVaultName
+Optional legacy vault supplying CI- secrets for parameters not configured in GitHub.
+#>
+function Get-CIParameterMap {
+
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'GitHub Actions supplies strings; secure ARM parameters require SecureString values.')]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [System.Collections.IDictionary] $TemplateParameters,
+
+        [Parameter()]
+        [string] $GitHubVariables = '{}',
+
+        [Parameter()]
+        [string] $GitHubSecrets = '{}',
+
+        [Parameter()]
+        [string] $KeyVaultName
+    )
+
+    $sources = @{
+        Variables = @{ Json = $GitHubVariables; Values = @{} }
+        Secrets   = @{ Json = $GitHubSecrets; Values = @{} }
+    }
+    foreach ($sourceName in @('Variables', 'Secrets')) {
+        $source = $sources[$sourceName]
+        if ([string]::IsNullOrWhiteSpace($source.Json)) {
+            continue
+        }
+
+        try {
+            $values = ConvertFrom-Json -InputObject $source.Json -AsHashtable -ErrorAction Stop
+        } catch [System.ArgumentException] {
+            throw "The GitHub $sourceName context must be a valid JSON object."
+        }
+        if ($values -isnot [System.Collections.IDictionary]) {
+            throw "The GitHub $sourceName context must be a JSON object."
+        }
+
+        foreach ($entry in $values.GetEnumerator()) {
+            if ($entry.Key -notmatch '^CI_.+') {
+                continue
+            }
+            if ($source.Values.ContainsKey($entry.Key)) {
+                throw "The GitHub $sourceName context contains duplicate CI_ names differing only in case."
+            }
+            $source.Values[$entry.Key] = $entry.Value
+        }
+    }
+
+    $parameters = @{}
+    $parameterNames = @{}
+    # Parameter names can shadow dictionary properties such as Keys and Count.
+    foreach ($parameterName in $TemplateParameters.psbase.Keys) {
+        $parameterNames[$parameterName] = $parameterName
+        $githubName = "CI_$parameterName"
+        if ($sources.Secrets.Values.ContainsKey($githubName)) {
+            $value = $sources.Secrets.Values[$githubName]
+            $isSecret = $true
+        } elseif ($sources.Variables.Values.ContainsKey($githubName)) {
+            $value = $sources.Variables.Values[$githubName]
+            $isSecret = $false
+        } else {
+            continue
+        }
+
+        if ($value -isnot [string]) {
+            throw "The GitHub value for parameter [$parameterName] must be a string."
+        }
+
+        $parameterType = $TemplateParameters[$parameterName].type
+        if ($isSecret -and $parameterType -notin @('secureString', 'secureObject')) {
+            Write-Warning "GitHub secret [$githubName] targets non-secure parameter [$parameterName]. Sensitive values require a secureString or secureObject test parameter."
+        }
+
+        switch ($parameterType) {
+            'string' {
+                $parameters[$parameterName] = $value
+            }
+            'secureString' {
+                $parameters[$parameterName] = $value.Length -eq 0 ? [securestring]::new() : (ConvertTo-SecureString -String $value -AsPlainText -Force)
+            }
+            { $_ -in @('int', 'bool', 'array', 'object', 'secureObject') } {
+                try {
+                    $convertedValue = ConvertFrom-Json -InputObject $value -AsHashtable -NoEnumerate -ErrorAction Stop
+                } catch [System.ArgumentException] {
+                    throw "The GitHub value for parameter [$parameterName] must be valid JSON of type [$parameterType]."
+                }
+
+                $validType = switch ($parameterType) {
+                    'int' { $convertedValue -is [int] -or $convertedValue -is [long] }
+                    'bool' { $convertedValue -is [bool] }
+                    'array' { $convertedValue -is [array] }
+                    default { $convertedValue -is [System.Collections.IDictionary] }
+                }
+                if (-not $validType) {
+                    throw "The GitHub value for parameter [$parameterName] must be JSON of type [$parameterType]."
+                }
+                $parameters[$parameterName] = $convertedValue
+            }
+            default {
+                throw "Parameter [$parameterName] has unsupported ARM type [$parameterType] for GitHub CI inputs."
+            }
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($KeyVaultName) -and $parameters.psbase.Count -lt $TemplateParameters.psbase.Count) {
+        $vaultSecrets = Get-AzKeyVaultSecret -VaultName $KeyVaultName -ErrorAction Stop |
+            Where-Object { $_.Name -match '^CI-.+' }
+        foreach ($vaultSecret in $vaultSecrets) {
+            $name = $vaultSecret.Name.Substring(3)
+            if (-not $parameterNames.ContainsKey($name) -or $parameters.ContainsKey($name)) {
+                continue
+            }
+
+            $secret = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $vaultSecret.Name -ErrorAction Stop
+            if ($secret.SecretValue -isnot [securestring]) {
+                throw "Key Vault did not return a secure value for CI parameter [$name]."
+            }
+            $parameters[$parameterNames[$name]] = $secret.SecretValue
+        }
+    }
+
+    return $parameters
+}

--- a/utilities/pipelines/sharedScripts/Get-CIParameterMap.ps1
+++ b/utilities/pipelines/sharedScripts/Get-CIParameterMap.ps1
@@ -10,6 +10,9 @@ parameters. GitHub values are converted to the declared ARM parameter types.
 .PARAMETER TemplateParameters
 The parameters object from the compiled test template.
 
+.PARAMETER TemplateDefinitions
+The definitions object used to resolve user-defined parameter types.
+
 .PARAMETER GitHubVariables
 The JSON-serialized, resolved GitHub Actions vars context.
 
@@ -27,6 +30,9 @@ function Get-CIParameterMap {
         [Parameter(Mandatory)]
         [AllowEmptyCollection()]
         [System.Collections.IDictionary] $TemplateParameters,
+
+        [Parameter()]
+        [System.Collections.IDictionary] $TemplateDefinitions = @{},
 
         [Parameter()]
         [string] $GitHubVariables = '{}',
@@ -88,7 +94,20 @@ function Get-CIParameterMap {
             throw "The GitHub value for parameter [$parameterName] must be a string."
         }
 
-        $parameterType = $TemplateParameters[$parameterName].type
+        $definition = $TemplateParameters[$parameterName]
+        $visitedDefinitions = [System.Collections.Generic.HashSet[string]]::new()
+        while (-not $definition.type -and $definition.Contains('$ref')) {
+            $reference = [string] $definition['$ref']
+            if (-not $reference.StartsWith('#/definitions/', [System.StringComparison]::Ordinal)) {
+                throw "Parameter [$parameterName] has an unsupported type reference."
+            }
+            $definitionName = $reference.Substring('#/definitions/'.Length).Replace('~1', '/').Replace('~0', '~')
+            if (-not $TemplateDefinitions.Contains($definitionName) -or -not $visitedDefinitions.Add($definitionName)) {
+                throw "Parameter [$parameterName] has an unresolved or circular type reference."
+            }
+            $definition = $TemplateDefinitions[$definitionName]
+        }
+        $parameterType = $definition.type
         if ($isSecret -and $parameterType -notin @('secureString', 'secureObject')) {
             Write-Warning "GitHub secret [$githubName] targets non-secure parameter [$parameterName]. Sensitive values require a secureString or secureObject test parameter."
         }

--- a/utilities/pipelines/sharedScripts/Get-CIParameterMap.ps1
+++ b/utilities/pipelines/sharedScripts/Get-CIParameterMap.ps1
@@ -6,7 +6,8 @@ Resolve additional test parameters from GitHub Actions and the legacy CI Key Vau
 Matches GitHub names without regard to case: CI_ removes separator underscores,
 while CI__ preserves literal underscores. Key Vault CI- names remain literal.
 GitHub secrets override variables; Key Vault only supplies missing parameters.
-Aliases within the same GitHub source must not target the same template parameter.
+Within each GitHub source, CI_ takes precedence over CI__. Multiple aliases in the
+winning prefix must not target the same template parameter.
 GitHub values are converted to the declared ARM parameter types.
 
 .PARAMETER TemplateParameters
@@ -47,6 +48,7 @@ function Get-CIParameterMap {
     )
 
     . (Join-Path $PSScriptRoot 'ConvertFrom-CIParameterName.ps1')
+    . (Join-Path $PSScriptRoot 'Select-CIParameterAlias.ps1')
 
     $parameterNames = @{}
     # Parameter names can shadow dictionary properties such as Keys and Count.
@@ -82,12 +84,20 @@ function Get-CIParameterMap {
                 continue
             }
             $parameterName = $parameterNames[$name]
-            if ($source.Values.ContainsKey($parameterName)) {
-                throw "Multiple GitHub $sourceName names [$($source.Values[$parameterName].Name)] and [$($entry.Key)] map to parameter [$parameterName]."
+            if (-not $source.Values.ContainsKey($parameterName)) {
+                $source.Values[$parameterName] = @()
+            }
+            $source.Values[$parameterName] += $entry.Key
+        }
+
+        foreach ($parameterName in @($source.Values.psbase.Keys)) {
+            $names = @(Select-CIParameterAlias -Name $source.Values[$parameterName])
+            if ($names.Count -gt 1) {
+                throw "Multiple GitHub $sourceName names [$($names -join ', ')] in the preferred prefix map to parameter [$parameterName]."
             }
             $source.Values[$parameterName] = @{
-                Name  = $entry.Key
-                Value = $entry.Value
+                Name  = $names[0]
+                Value = $values[$names[0]]
             }
         }
     }

--- a/utilities/pipelines/sharedScripts/Select-CIParameterAlias.ps1
+++ b/utilities/pipelines/sharedScripts/Select-CIParameterAlias.ps1
@@ -1,0 +1,21 @@
+<#
+.SYNOPSIS
+Prefer CI_ names over CI__ names already matched to the same parameter and source.
+Returns all names in the winning prefix so callers can detect remaining ambiguity.
+#>
+function Select-CIParameterAlias {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [string[]] $Name
+    )
+
+    $readableNames = @($Name | Where-Object {
+            -not $_.StartsWith('CI__', [System.StringComparison]::OrdinalIgnoreCase)
+        })
+    if ($readableNames.Count -gt 0) {
+        return $readableNames
+    }
+    return $Name
+}

--- a/utilities/tests/pipelines/CIParameterWorkflow.Tests.ps1
+++ b/utilities/tests/pipelines/CIParameterWorkflow.Tests.ps1
@@ -61,8 +61,8 @@ Describe 'CI parameter workflow integration' {
         }
         $env:GITHUB_WORKSPACE = $repoRootPath
         $env:GITHUB_OUTPUT = Join-Path $TestDrive 'output.txt'
-        $env:AVM_CI_VARIABLES = '{"CI_ADMINMEMBERSSECRET":"variable-value","CI_RESOURCE_LOCATION":"eastus","CI__RESOURCE_NAME":"literal-name"}'
-        $env:AVM_CI_SECRETS = '{"CI_ADMIN_MEMBERS_SECRET":"secret-value","CI__SECURECONFIG":"{\"password\":\"nested-secret-value\"}"}'
+        $env:AVM_CI_VARIABLES = '{"CI_ADMINMEMBERSSECRET":"variable-value","CI_RESOURCE_LOCATION":"eastus","CI__RESOURCELOCATION":"unused-region","CI__RESOURCE_NAME":"literal-name"}'
+        $env:AVM_CI_SECRETS = '{"CI__ADMINMEMBERSSECRET":"shadowed-secret-value","CI_ADMIN_MEMBERS_SECRET":"secret-value","CI__SECURECONFIG":"{\"password\":\"nested-secret-value\"}"}'
 
         $templatePath = Join-Path $TestDrive 'template.json'
         @{

--- a/utilities/tests/pipelines/CIParameterWorkflow.Tests.ps1
+++ b/utilities/tests/pipelines/CIParameterWorkflow.Tests.ps1
@@ -1,0 +1,179 @@
+param(
+    [Parameter()]
+    [string] $repoRootPath = (Get-Item -Path $PSScriptRoot).Parent.Parent.Parent.FullName
+)
+
+Describe 'CI parameter workflow integration' {
+
+    BeforeAll {
+        $workflows = @{}
+        foreach ($workflowName in @('avm.template.module', 'avm.template.module.preview', 'avm.template.module.publish')) {
+            $workflowPath = Join-Path $repoRootPath '.github' 'workflows' "$workflowName.yml"
+            $workflows[$workflowName] = ConvertFrom-Yaml -Yaml (Get-Content -Path $workflowPath -Raw)
+        }
+        $actionPath = Join-Path $repoRootPath '.github' 'actions' 'templates' 'avm-validateModuleDeployment' 'action.yml'
+        $action = ConvertFrom-Yaml -Yaml (Get-Content -Path $actionPath -Raw)
+        $environmentNames = @('GITHUB_WORKSPACE', 'GITHUB_OUTPUT', 'AVM_CI_VARIABLES', 'AVM_CI_SECRETS', 'CI_KEY_VAULT_NAME')
+
+        function Test-TemplateDeployment {
+            [CmdletBinding()]
+            param(
+                [string] $TemplateFilePath, [string] $DeploymentMetadataLocation,
+                [string] $SubscriptionId, [string] $ManagementGroupId,
+                [string] $RepoRoot, [hashtable] $AdditionalParameters
+            )
+            throw 'Unexpected deployment validation.'
+        }
+        function New-TemplateDeployment {
+            [CmdletBinding()]
+            param(
+                [string] $TemplateFilePath, [string] $DeploymentMetadataLocation,
+                [string] $SubscriptionId, [string] $ManagementGroupId,
+                [string] $RepoRoot, [hashtable] $AdditionalParameters, [bool] $DoNotThrow
+            )
+            throw 'Unexpected deployment.'
+        }
+
+        function Get-TestStepScript {
+            param([string] $StepName, [string] $TemplatePath)
+
+            $script = ($action.runs.steps | Where-Object { $_.name -eq $StepName }).with.inlineScript
+            # Keep mocks in place instead of loading the real Azure deployment functions.
+            $script = $script -replace "(?m)^.*\. \(Join-Path.*'resourceDeployment'.*\)\r?\n", ''
+            $script = $script.Replace(
+                'Join-Path $env:GITHUB_WORKSPACE ''${{ inputs.templateFilePath }}''',
+                "'{0}'" -f $TemplatePath.Replace("'", "''")
+            )
+            $script = $script.Replace('${{ inputs.deploymentMetadataLocation }}', 'westeurope')
+            $script = $script.Replace('${{ inputs.managementGroupId }}', '')
+            $script = $script.Replace('${{ steps.get-test-subscription.outputs.subscriptionId }}', '11111111-1111-1111-1111-111111111111')
+            $script = $script.Replace('${{ steps.get-resource-location.outputs.resourceLocation }}', 'westus')
+            return [scriptblock]::Create($script)
+        }
+    }
+
+    BeforeEach {
+        $savedExitCode = $global:LASTEXITCODE
+        $savedEnvironment = @{}
+        foreach ($name in $environmentNames) {
+            $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name)
+            [Environment]::SetEnvironmentVariable($name, $null)
+        }
+        $env:GITHUB_WORKSPACE = $repoRootPath
+        $env:GITHUB_OUTPUT = Join-Path $TestDrive 'output.txt'
+        $env:AVM_CI_VARIABLES = '{"CI_ADMINMEMBERSSECRET":"variable-value","CI_RESOURCELOCATION":"eastus"}'
+        $env:AVM_CI_SECRETS = '{"CI_ADMINMEMBERSSECRET":"secret-value","CI_SECURECONFIG":"{\"password\":\"nested-secret-value\"}"}'
+
+        $templatePath = Join-Path $TestDrive 'template.json'
+        @{
+            parameters = @{
+                adminMembersSecret = @{ type = 'secureString' }
+                secureConfig       = @{ type = 'secureObject' }
+                resourceLocation   = @{ type = 'string' }
+                baseTime           = @{ type = 'string' }
+            }
+        } | ConvertTo-Json -Depth 5 | Set-Content -Path $templatePath
+        $bicepPath = Join-Path $TestDrive 'template.bicep'
+        @'
+@secure()
+param adminMembersSecret string
+@secure()
+param secureConfig object
+param resourceLocation string
+param baseTime string
+
+@secure()
+output configuredParameters object = {
+  adminMembersSecret: adminMembersSecret
+  secureConfig: secureConfig
+  resourceLocation: resourceLocation
+  baseTime: baseTime
+}
+'@ | Set-Content -Path $bicepPath
+
+        Mock Test-TemplateDeployment {}
+        Mock New-TemplateDeployment { @{ deploymentNames = @('test-deployment'); deploymentOutput = @{} } }
+    }
+
+    AfterEach {
+        $global:LASTEXITCODE = $savedExitCode
+        foreach ($name in $environmentNames) {
+            [Environment]::SetEnvironmentVariable($name, $savedEnvironment[$name])
+        }
+    }
+
+    It 'Reads resolved contexts inside the environment job for <workflowName>' -ForEach @(
+        @{ workflowName = 'avm.template.module' }
+        @{ workflowName = 'avm.template.module.preview' }
+        @{ workflowName = 'avm.template.module.publish' }
+    ) {
+        $workflow = $workflows[$workflowName]
+        $deployment = $workflow.jobs.job_module_deploy_validation
+        $step = $deployment.steps | Where-Object { $_.uses -eq './.github/actions/templates/avm-validateModuleDeployment' }
+
+        $deployment.environment | Should -Be 'avm-validation'
+        $step.with.githubVariables | Should -Be '${{ toJSON(vars) }}'
+        $step.with.githubSecrets | Should -Be '${{ toJSON(secrets) }}'
+        $workflow.env.CI_KEY_VAULT_NAME | Should -Be '${{ vars.CI_KEY_VAULT_NAME }}'
+        @($workflow.env.Keys) | Should -Not -Contain 'AVM_CI_SECRETS'
+        @($deployment.env.Keys) | Should -Not -Contain 'AVM_CI_SECRETS'
+    }
+
+    It 'Only exposes context payloads as environment data to validation and deployment steps' {
+        $action.inputs.githubVariables.default | Should -Be '{}'
+        $action.inputs.githubSecrets.default | Should -Be '{}'
+        $stepsWithSecrets = @($action.runs.steps | Where-Object { $_.env -and $_.env.ContainsKey('AVM_CI_SECRETS') })
+        $stepsWithSecrets.Count | Should -Be 2
+        foreach ($step in $stepsWithSecrets) {
+            $step.name | Should -BeIn @('Validate template file', 'Deploy template file')
+            $step.env.AVM_CI_VARIABLES | Should -Be '${{ inputs.githubVariables }}'
+            $step.env.AVM_CI_SECRETS | Should -Be '${{ inputs.githubSecrets }}'
+            $step.with.inlineScript | Should -Not -Match '\$\{\{\s*inputs\.github(Secrets|Variables)'
+            $step.with.inlineScript | Should -Not -Match 'GITHUB_ENV'
+        }
+    }
+
+    It 'Warns about legacy vault support without exposing the vault name or values' {
+        $step = $action.runs.steps | Where-Object { $_.name -eq 'Warn about CI Key Vault deprecation' }
+
+        $step.if | Should -Be "env.skip_deployment_ci == 'false' && env.CI_KEY_VAULT_NAME != ''"
+        $messages = @(. ([scriptblock]::Create($step.run)))
+        $messages | Should -Match '^::warning'
+        $messages | Should -Match 'support may be removed'
+        $messages | Should -Match 'GitHub Actions secrets or variables'
+    }
+
+    It 'Passes <format> parameters to <stepName> without modifying the template or logging values' -ForEach @(
+        @{ stepName = 'Validate template file'; commandName = 'Test-TemplateDeployment'; format = 'JSON' }
+        @{ stepName = 'Deploy template file'; commandName = 'New-TemplateDeployment'; format = 'JSON' }
+        @{ stepName = 'Validate template file'; commandName = 'Test-TemplateDeployment'; format = 'Bicep' }
+        @{ stepName = 'Deploy template file'; commandName = 'New-TemplateDeployment'; format = 'Bicep' }
+    ) {
+        $path = $format -eq 'Bicep' ? $bicepPath : $templatePath
+        $before = Get-Content -Path $path -Raw
+        $script = Get-TestStepScript -StepName $stepName -TemplatePath $path
+
+        $messages = @(. $script 4>&1)
+
+        Should -Invoke $commandName -Times 1 -Exactly -ParameterFilter {
+            $AdditionalParameters.adminMembersSecret -is [securestring] -and
+            (ConvertFrom-SecureString -SecureString $AdditionalParameters.adminMembersSecret -AsPlainText) -eq 'secret-value' -and
+            $AdditionalParameters.secureConfig.password -eq 'nested-secret-value' -and
+            $AdditionalParameters.resourceLocation -eq 'eastus' -and
+            -not [string]::IsNullOrEmpty($AdditionalParameters.baseTime)
+        }
+        ($messages | Out-String) | Should -Not -Match 'secret-value|nested-secret-value|variable-value'
+        Get-Content -Path $path -Raw | Should -BeExactly $before
+    }
+
+    It 'Stops <stepName> when Bicep compilation fails' -ForEach @(
+        @{ stepName = 'Validate template file'; commandName = 'Test-TemplateDeployment' }
+        @{ stepName = 'Deploy template file'; commandName = 'New-TemplateDeployment' }
+    ) {
+        Mock bicep { $global:LASTEXITCODE = 1; return '{"parameters":{}}' }
+        $script = Get-TestStepScript -StepName $stepName -TemplatePath $bicepPath
+
+        { . $script } | Should -Throw '*Failed to compile the test template*'
+        Should -Invoke $commandName -Times 0 -Exactly
+    }
+}

--- a/utilities/tests/pipelines/CIParameterWorkflow.Tests.ps1
+++ b/utilities/tests/pipelines/CIParameterWorkflow.Tests.ps1
@@ -78,7 +78,10 @@ Describe 'CI parameter workflow integration' {
 @secure()
 param adminMembersSecret string
 @secure()
-param secureConfig object
+type testConfig = {
+  password: string
+}
+param secureConfig testConfig
 param resourceLocation string
 param baseTime string
 

--- a/utilities/tests/pipelines/CIParameterWorkflow.Tests.ps1
+++ b/utilities/tests/pipelines/CIParameterWorkflow.Tests.ps1
@@ -61,8 +61,8 @@ Describe 'CI parameter workflow integration' {
         }
         $env:GITHUB_WORKSPACE = $repoRootPath
         $env:GITHUB_OUTPUT = Join-Path $TestDrive 'output.txt'
-        $env:AVM_CI_VARIABLES = '{"CI_ADMINMEMBERSSECRET":"variable-value","CI_RESOURCELOCATION":"eastus"}'
-        $env:AVM_CI_SECRETS = '{"CI_ADMINMEMBERSSECRET":"secret-value","CI_SECURECONFIG":"{\"password\":\"nested-secret-value\"}"}'
+        $env:AVM_CI_VARIABLES = '{"CI_ADMINMEMBERSSECRET":"variable-value","CI_RESOURCE_LOCATION":"eastus","CI__RESOURCE_NAME":"literal-name"}'
+        $env:AVM_CI_SECRETS = '{"CI_ADMIN_MEMBERS_SECRET":"secret-value","CI__SECURECONFIG":"{\"password\":\"nested-secret-value\"}"}'
 
         $templatePath = Join-Path $TestDrive 'template.json'
         @{
@@ -70,6 +70,7 @@ Describe 'CI parameter workflow integration' {
                 adminMembersSecret = @{ type = 'secureString' }
                 secureConfig       = @{ type = 'secureObject' }
                 resourceLocation   = @{ type = 'string' }
+                resource_name      = @{ type = 'string' }
                 baseTime           = @{ type = 'string' }
             }
         } | ConvertTo-Json -Depth 5 | Set-Content -Path $templatePath
@@ -83,6 +84,7 @@ type testConfig = {
 }
 param secureConfig testConfig
 param resourceLocation string
+param resource_name string
 param baseTime string
 
 @secure()
@@ -90,6 +92,7 @@ output configuredParameters object = {
   adminMembersSecret: adminMembersSecret
   secureConfig: secureConfig
   resourceLocation: resourceLocation
+  resource_name: resource_name
   baseTime: baseTime
 }
 '@ | Set-Content -Path $bicepPath
@@ -163,6 +166,7 @@ output configuredParameters object = {
             (ConvertFrom-SecureString -SecureString $AdditionalParameters.adminMembersSecret -AsPlainText) -eq 'secret-value' -and
             $AdditionalParameters.secureConfig.password -eq 'nested-secret-value' -and
             $AdditionalParameters.resourceLocation -eq 'eastus' -and
+            $AdditionalParameters.resource_name -eq 'literal-name' -and
             -not [string]::IsNullOrEmpty($AdditionalParameters.baseTime)
         }
         ($messages | Out-String) | Should -Not -Match 'secret-value|nested-secret-value|variable-value'

--- a/utilities/tests/pipelines/Copy-CIKeyVaultSecretsToGitHub.Tests.ps1
+++ b/utilities/tests/pipelines/Copy-CIKeyVaultSecretsToGitHub.Tests.ps1
@@ -100,7 +100,7 @@ Describe 'Copy-CIKeyVaultSecretsToGitHub' {
 
         $result.Count | Should -Be 1
         $result[0].SourceName | Should -Be 'CI-clientSecret'
-        $result[0].DestinationName | Should -BeExactly 'CI_CLIENTSECRET'
+        $result[0].DestinationName | Should -BeExactly 'CI_CLIENT_SECRET'
         $result[0].Kind | Should -Be 'Secret'
         $result[0].Status | Should -Be 'Planned'
         $result[0].Scope | Should -Be 'Repository'
@@ -120,9 +120,9 @@ Describe 'Copy-CIKeyVaultSecretsToGitHub' {
         Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
     }
 
-    It 'Filters only the anchored CI- prefix and preserves the parameter suffix case-insensitively' {
+    It 'Filters only the anchored CI- prefix and emits readable names' {
         $script:sources = @(
-            New-TestSecretMetadata -Name 'ci-ClIeNtId'
+            New-TestSecretMetadata -Name 'ci-clientId'
             New-TestSecretMetadata -Name 'CI-location'
             New-TestSecretMetadata -Name 'other-CI-clientId'
             New-TestSecretMetadata -Name 'CI_clientId'
@@ -131,7 +131,7 @@ Describe 'Copy-CIKeyVaultSecretsToGitHub' {
 
         $result = @(Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo')
 
-        $result.DestinationName | Should -Be @('CI_CLIENTID', 'CI_LOCATION')
+        $result.DestinationName | Should -Be @('CI_CLIENT_ID', 'CI_LOCATION')
         $result.Kind | Should -Be @('Secret', 'Secret')
     }
 
@@ -145,7 +145,7 @@ Describe 'Copy-CIKeyVaultSecretsToGitHub' {
 
         $result.Count | Should -Be 1
         $result[0].SourceName | Should -BeExactly 'CI-clientSecret'
-        $result[0].DestinationName | Should -BeExactly 'CI_CLIENTSECRET'
+        $result[0].DestinationName | Should -BeExactly 'CI_CLIENT_SECRET'
         $result[0].Kind | Should -Be 'Secret'
         $result[0].Status | Should -Be 'Copied'
         $script:writes.Count | Should -Be 1
@@ -245,7 +245,7 @@ Describe 'Copy-CIKeyVaultSecretsToGitHub' {
 
         $result.Kind | Should -Be @('Secret', 'Variable')
         $result.Status | Should -Be @('Copied', 'Copied')
-        ($script:writes[0].Arguments -join '|') | Should -Be 'secret|set|CI_CLIENTSECRET|--repo|owner/repo'
+        ($script:writes[0].Arguments -join '|') | Should -Be 'secret|set|CI_CLIENT_SECRET|--repo|owner/repo'
         ($script:writes[1].Arguments -join '|') | Should -Be 'variable|set|CI_LOCATION|--repo|owner/repo'
         ($result | ConvertTo-Json) | Should -Not -Match ([regex]::Escape($script:payload))
         $result[0].PSObject.Properties.Name | Should -Be @(
@@ -262,7 +262,7 @@ Describe 'Copy-CIKeyVaultSecretsToGitHub' {
         $result.Scope | Should -Be $scope
         $result.Environment | Should -Be $environment
         $expectedSuffix = $environment ? "|--env|$environment" : ''
-        ($script:writes[0].Arguments -join '|') | Should -Be "secret|set|CI_CLIENTSECRET|--repo|owner/repo$expectedSuffix"
+        ($script:writes[0].Arguments -join '|') | Should -Be "secret|set|CI_CLIENT_SECRET|--repo|owner/repo$expectedSuffix"
         Should -Invoke Invoke-CIGitHubCommand -Times 4 -Exactly -ParameterFilter {
             $ArgumentList[1] -eq 'list' -and ($ArgumentList -join '|').EndsWith("--json|name$expectedSuffix")
         }
@@ -293,6 +293,111 @@ Describe 'Copy-CIKeyVaultSecretsToGitHub' {
         $result.Status | Should -Be 'PlannedOverwrite'
         Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
         Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Reuses an existing <alias> instead of creating a conflicting name' -ForEach @(
+        @{ alias = 'CI_CLIENTSECRET'; applyCopy = $false; expectedStatus = 'PlannedOverwrite' }
+        @{ alias = 'CI__CLIENTSECRET'; applyCopy = $true; expectedStatus = 'Copied' }
+        @{ alias = 'CI_CLIENT_SECRET'; applyCopy = $true; expectedStatus = 'Copied' }
+    ) {
+        $script:secretNames = @($alias)
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Overwrite -Apply:$applyCopy -Confirm:$false
+
+        $result.DestinationName | Should -BeExactly $alias
+        $result.Status | Should -Be $expectedStatus
+        if ($applyCopy) {
+            $script:writes[0].Arguments[2] | Should -BeExactly $alias
+        } else {
+            Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        }
+    }
+
+    It 'Blocks multiple same-kind aliases even with explicit overwrite' {
+        $script:secretNames = @('CI_CLIENTSECRET', 'CI__CLIENTSECRET')
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite -Confirm:$false
+
+        $result.Status | Should -Be 'BlockedByAmbiguousAliases'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Blocks new ambiguity found after the preview' {
+        $script:secretNames = @('CI_CLIENTSECRET')
+        $script:lateSecretNames = @('CI__CLIENTSECRET')
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite -Confirm:$false
+
+        $result.Status | Should -Be 'BlockedByAmbiguousAliases'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+    }
+
+    It 'Does not retarget an approved copy when a different alias appears' {
+        $script:lateSecretNames = @('CI__CLIENTSECRET')
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite -Confirm:$false
+
+        $result.Status | Should -Be 'BlockedChangedDestination'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+    }
+
+    It 'Does not recreate an alias removed after approval' {
+        Mock Invoke-CIGitHubCommand {
+            $script:listCounts.secret++
+            if ($script:listCounts.secret -eq 1) {
+                return '[{"name":"CI__CLIENTSECRET"}]'
+            }
+            return '[]'
+        } -ParameterFilter { $ArgumentList[0] -eq 'secret' -and $ArgumentList[1] -eq 'list' }
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite -Confirm:$false
+
+        $result.Status | Should -Be 'BlockedChangedDestination'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+    }
+
+    It 'Matches opposite-kind aliases by parameter identity rather than spelling' {
+        $script:variableNames = @('CI__CLIENTSECRET')
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite -Confirm:$false
+
+        $result.Status | Should -Be 'BlockedByOppositeKind'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+    }
+
+    It 'Separates camelCase and literal underscore inputs during migration' {
+        $script:sources = @(
+            New-TestSecretMetadata -Name 'CI-resourceName'
+            New-TestSecretMetadata -Name 'CI-resource_name'
+        )
+        $script:secretNames = @('CI__RESOURCE_NAME')
+
+        $result = @(Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo')
+
+        $result.DestinationName | Should -Be @('CI_RESOURCE_NAME', 'CI__RESOURCE_NAME')
+        $result.Status | Should -Be @('Planned', 'SkippedExisting')
+    }
+
+    It 'Preserves acronym boundaries and avoids the reserved vault selector' {
+        $script:sources = @(
+            New-TestSecretMetadata -Name 'CI-managedHSMResourceId'
+            New-TestSecretMetadata -Name 'CI-keyVaultName'
+        )
+        $script:variableNames = @('CI_KEY_VAULT_NAME')
+
+        $result = @(Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -VariableName 'CI__KEYVAULTNAME')
+
+        $result.DestinationName | Should -Be @('CI_MANAGED_HSM_RESOURCE_ID', 'CI__KEYVAULTNAME')
+        $result.Kind | Should -Be @('Secret', 'Variable')
+        $result.Status | Should -Be @('Planned', 'Planned')
+    }
+
+    It 'Accepts an exact VariableName alias for a selected camelCase source' {
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -VariableName 'CI__CLIENTSECRET'
+
+        $result.Kind | Should -Be 'Variable'
+        $result.DestinationName | Should -Be 'CI_CLIENT_SECRET'
     }
 
     It 'Deliberately overwrites same-kind <kind> entries only when requested' -ForEach @(

--- a/utilities/tests/pipelines/Copy-CIKeyVaultSecretsToGitHub.Tests.ps1
+++ b/utilities/tests/pipelines/Copy-CIKeyVaultSecretsToGitHub.Tests.ps1
@@ -1,0 +1,745 @@
+param(
+    [Parameter()]
+    [string] $repoRootPath = (Get-Item -Path $PSScriptRoot).Parent.Parent.Parent.FullName
+)
+
+Describe 'Copy-CIKeyVaultSecretsToGitHub' {
+
+    BeforeAll {
+        . (Join-Path $repoRootPath 'utilities' 'tools' 'Copy-CIKeyVaultSecretsToGitHub.ps1')
+
+        # A local stub keeps these tests independent of Az installation and authentication.
+        function Get-AzKeyVaultSecret {
+            [CmdletBinding()]
+            param(
+                [string] $VaultName,
+                [string] $Name,
+                [string] $Version,
+                [switch] $IncludeVersions
+            )
+            throw 'Get-AzKeyVaultSecret must be mocked.'
+        }
+
+        function New-TestSecretMetadata {
+            param(
+                [string] $Name = 'CI-clientSecret',
+                [string] $Version = 'version-one',
+                [DateTimeOffset] $Created = '2026-01-01T00:00:00Z',
+                [bool] $Enabled = $true
+            )
+            [pscustomobject]@{
+                Name      = $Name
+                Version   = $Version
+                Created   = $Created
+                Enabled   = $Enabled
+                Expires   = $null
+                NotBefore = $null
+            }
+        }
+    }
+
+    BeforeEach {
+        $script:sources = @(New-TestSecretMetadata)
+        $script:versions = @(New-TestSecretMetadata)
+        $script:secretNames = @()
+        $script:variableNames = @()
+        $script:lateSecretNames = @()
+        $script:lateVariableNames = @()
+        $script:listCounts = @{ secret = 0; variable = 0 }
+        $script:payload = 'synthetic-test-value'
+        $script:writes = [System.Collections.Generic.List[object]]::new()
+
+        Mock Get-Command {
+            [pscustomobject]@{ Path = 'mock-gh' }
+        } -ParameterFilter { $Name -eq 'gh' -and $CommandType -eq 'Application' }
+
+        Mock Get-AzKeyVaultSecret {
+            if (-not $Name) {
+                return $script:sources
+            }
+            if ($IncludeVersions) {
+                return $script:versions
+            }
+            [pscustomobject]@{
+                Name        = $Name
+                Version     = $Version
+                Enabled     = $true
+                SecretValue = ConvertTo-SecureString -String $script:payload -AsPlainText -Force
+            }
+        }
+
+        Mock Invoke-CIGitHubCommand {
+            if ($ArgumentList[1] -eq 'list') {
+                $kind = $ArgumentList[0]
+                $script:listCounts[$kind]++
+                $names = $kind -eq 'secret' ? $script:secretNames : $script:variableNames
+                if ($script:listCounts[$kind] -gt 1) {
+                    $names += $kind -eq 'secret' ? $script:lateSecretNames : $script:lateVariableNames
+                }
+                return ConvertTo-Json -InputObject @($names | ForEach-Object { @{ name = $_ } }) -Compress
+            }
+            if ($ArgumentList[1] -eq 'set') {
+                $script:writes.Add([pscustomobject]@{
+                        Arguments = @($ArgumentList)
+                        Value     = [System.Net.NetworkCredential]::new('', $InputValue).Password
+                    })
+                return
+            }
+            throw 'Unexpected GitHub command.'
+        }
+    }
+
+    AfterEach {
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter {
+            $ArgumentList -contains '--body' -or $ArgumentList -contains '--env-file' -or $ArgumentList -contains 'delete'
+        }
+    }
+
+    It 'Defaults to a metadata-only dry run with secret classification' {
+        $result = @(Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo')
+
+        $result.Count | Should -Be 1
+        $result[0].SourceName | Should -Be 'CI-clientSecret'
+        $result[0].DestinationName | Should -BeExactly 'CI_CLIENTSECRET'
+        $result[0].Kind | Should -Be 'Secret'
+        $result[0].Status | Should -Be 'Planned'
+        $result[0].Scope | Should -Be 'Repository'
+        $result[0].Environment | Should -Be ''
+        Should -Invoke Get-AzKeyVaultSecret -Times 1 -Exactly -ParameterFilter { -not $Name }
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Does not retrieve values or write with Apply and WhatIf, including overwrite previews' {
+        $script:secretNames = @('CI_CLIENTSECRET')
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite -WhatIf
+
+        $result.Status | Should -Be 'SkippedShouldProcess'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Filters only the anchored CI- prefix and preserves the parameter suffix case-insensitively' {
+        $script:sources = @(
+            New-TestSecretMetadata -Name 'ci-ClIeNtId'
+            New-TestSecretMetadata -Name 'CI-location'
+            New-TestSecretMetadata -Name 'other-CI-clientId'
+            New-TestSecretMetadata -Name 'CI_clientId'
+            New-TestSecretMetadata -Name 'unrelated-with-hyphens'
+        )
+
+        $result = @(Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo')
+
+        $result.DestinationName | Should -Be @('CI_CLIENTID', 'CI_LOCATION')
+        $result.Kind | Should -Be @('Secret', 'Secret')
+    }
+
+    It 'Copies only reviewed source names, ignoring unselected invalid legacy names' {
+        $script:sources += @(
+            New-TestSecretMetadata -Name 'CI-location'
+            New-TestSecretMetadata -Name 'CI-legacy-invalid-name'
+        )
+
+        $result = @(Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -SecretName 'ci-CLIENTSECRET', 'CI-clientSecret' -Apply -Confirm:$false)
+
+        $result.Count | Should -Be 1
+        $result[0].SourceName | Should -BeExactly 'CI-clientSecret'
+        $result[0].DestinationName | Should -BeExactly 'CI_CLIENTSECRET'
+        $result[0].Kind | Should -Be 'Secret'
+        $result[0].Status | Should -Be 'Copied'
+        $script:writes.Count | Should -Be 1
+        Should -Invoke Get-AzKeyVaultSecret -Times 1 -Exactly -ParameterFilter { $Name -eq 'CI-clientSecret' -and -not $IncludeVersions }
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name -and $Name -ne 'CI-clientSecret' }
+    }
+
+    It 'Keeps an explicit source allowlist metadata-only during <mode>' -ForEach @(
+        @{ mode = 'dry run'; useApply = $false; useWhatIf = $false; expectedStatus = 'Planned' }
+        @{ mode = 'WhatIf'; useApply = $true; useWhatIf = $true; expectedStatus = 'SkippedShouldProcess' }
+    ) {
+        $script:sources += New-TestSecretMetadata -Name 'CI-legacy-invalid-name'
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -SecretName 'CI-clientSecret' -Apply:$useApply -WhatIf:$useWhatIf
+
+        $result.Status | Should -Be $expectedStatus
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Rejects an explicitly <description> source allowlist instead of copying everything' -ForEach @(
+        @{ description = 'empty'; selection = @() }
+        @{ description = 'null'; selection = $null }
+    ) {
+        { Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -SecretName $selection -Apply -Confirm:$false } | Should -Throw '*SecretName was explicitly empty*'
+
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly
+    }
+
+    It 'Rejects unrecognized or non-source selection <selection> before any copy' -ForEach @(
+        @{ selection = 'CI-misspelled'; expectedMessage = '*does not match a source secret*' }
+        @{ selection = 'CI-client*'; expectedMessage = '*does not match a source secret*' }
+        @{ selection = 'CI-client_secret'; expectedMessage = '*does not match a source secret*' }
+        @{ selection = 'CI_CLIENTSECRET'; expectedMessage = '*must be an exact CI- Key Vault source name*' }
+        @{ selection = 'other-clientSecret'; expectedMessage = '*must be an exact CI- Key Vault source name*' }
+        @{ selection = ''; expectedMessage = '*must be an exact CI- Key Vault source name*' }
+    ) {
+        {
+            Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -SecretName @('CI-clientSecret', $selection) -Apply -Confirm:$false
+        } | Should -Throw $expectedMessage
+
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Still validates an explicitly selected legacy name rather than rewriting its suffix' {
+        $script:sources += New-TestSecretMetadata -Name 'CI-client-secret'
+
+        {
+            Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -SecretName 'CI-client-secret' -Apply -Confirm:$false
+        } | Should -Throw '*Cannot map*'
+
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Allows non-sensitive variable selection only within the selected source plan' {
+        $script:sources += New-TestSecretMetadata -Name 'CI-location'
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -SecretName 'ci-LOCATION' -VariableName 'ci_location' -Apply -Confirm:$false
+
+        $result.SourceName | Should -BeExactly 'CI-location'
+        $result.DestinationName | Should -BeExactly 'CI_LOCATION'
+        $result.Kind | Should -Be 'Variable'
+        $script:writes.Count | Should -Be 1
+        ($script:writes[0].Arguments -join '|') | Should -Be 'variable|set|CI_LOCATION|--repo|owner/repo'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name -eq 'CI-clientSecret' }
+    }
+
+    It 'Rejects variable selection for an excluded source instead of extending the allowlist' {
+        $script:sources += New-TestSecretMetadata -Name 'CI-location'
+
+        {
+            Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -SecretName 'CI-clientSecret' -VariableName 'CI_LOCATION' -Apply -Confirm:$false
+        } | Should -Throw '*does not match a planned CI_ destination name*'
+
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Inventories both destination kinds using only --json name and no stdin payload' {
+        $null = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo'
+
+        Should -Invoke Invoke-CIGitHubCommand -Times 1 -Exactly -ParameterFilter {
+            ($ArgumentList -join '|') -eq 'secret|list|--repo|owner/repo|--json|name' -and $null -eq $InputValue
+        }
+        Should -Invoke Invoke-CIGitHubCommand -Times 1 -Exactly -ParameterFilter {
+            ($ArgumentList -join '|') -eq 'variable|list|--repo|owner/repo|--json|name' -and $null -eq $InputValue
+        }
+    }
+
+    It 'Copies secrets by default and opts only explicit case-insensitive names into variables' {
+        $script:sources += New-TestSecretMetadata -Name 'CI-location'
+
+        $result = @(Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -VariableName 'ci_location' -Apply -Confirm:$false)
+
+        $result.Kind | Should -Be @('Secret', 'Variable')
+        $result.Status | Should -Be @('Copied', 'Copied')
+        ($script:writes[0].Arguments -join '|') | Should -Be 'secret|set|CI_CLIENTSECRET|--repo|owner/repo'
+        ($script:writes[1].Arguments -join '|') | Should -Be 'variable|set|CI_LOCATION|--repo|owner/repo'
+        ($result | ConvertTo-Json) | Should -Not -Match ([regex]::Escape($script:payload))
+        $result[0].PSObject.Properties.Name | Should -Be @(
+            'VaultName', 'SourceName', 'DestinationName', 'Repository', 'Environment', 'Scope', 'Kind', 'Status'
+        )
+    }
+
+    It 'Uses <scope> scope consistently for inventory, rechecks, and writes' -ForEach @(
+        @{ scope = 'Repository'; environment = '' }
+        @{ scope = 'Environment'; environment = 'CI validation' }
+    ) {
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Environment $environment -Apply -Confirm:$false
+
+        $result.Scope | Should -Be $scope
+        $result.Environment | Should -Be $environment
+        $expectedSuffix = $environment ? "|--env|$environment" : ''
+        ($script:writes[0].Arguments -join '|') | Should -Be "secret|set|CI_CLIENTSECRET|--repo|owner/repo$expectedSuffix"
+        Should -Invoke Invoke-CIGitHubCommand -Times 4 -Exactly -ParameterFilter {
+            $ArgumentList[1] -eq 'list' -and ($ArgumentList -join '|').EndsWith("--json|name$expectedSuffix")
+        }
+    }
+
+    It 'Skips existing same-kind <kind> entries without overwriting or reading a value' -ForEach @(
+        @{ kind = 'Secret'; variables = @() }
+        @{ kind = 'Variable'; variables = @('CI_CLIENTSECRET') }
+    ) {
+        if ($kind -eq 'Secret') {
+            $script:secretNames = @('ci_clientsecret')
+        } else {
+            $script:variableNames = @('ci_clientsecret')
+        }
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -VariableName $variables -Apply -Confirm:$false
+
+        $result.Status | Should -Be 'SkippedExisting'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Requires Apply even when Overwrite was selected' {
+        $script:secretNames = @('CI_CLIENTSECRET')
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Overwrite
+
+        $result.Status | Should -Be 'PlannedOverwrite'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Deliberately overwrites same-kind <kind> entries only when requested' -ForEach @(
+        @{ kind = 'Secret'; variables = @() }
+        @{ kind = 'Variable'; variables = @('CI_CLIENTSECRET') }
+    ) {
+        if ($kind -eq 'Secret') {
+            $script:secretNames = @('CI_CLIENTSECRET')
+        } else {
+            $script:variableNames = @('CI_CLIENTSECRET')
+        }
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -VariableName $variables -Apply -Overwrite -Confirm:$false
+
+        $result.Status | Should -Be 'Copied'
+        $script:writes.Count | Should -Be 1
+        $script:writes[0].Arguments[0] | Should -Be $kind.ToLowerInvariant()
+        Should -Invoke Get-AzKeyVaultSecret -Times 1 -Exactly -ParameterFilter { $Name -and -not $IncludeVersions }
+    }
+
+    It 'Blocks opposite-kind collisions for <kind> even with Overwrite' -ForEach @(
+        @{ kind = 'Secret'; variables = @() }
+        @{ kind = 'Variable'; variables = @('CI_CLIENTSECRET') }
+    ) {
+        if ($kind -eq 'Secret') {
+            $script:variableNames = @('CI_CLIENTSECRET')
+        } else {
+            $script:secretNames = @('CI_CLIENTSECRET')
+        }
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -VariableName $variables -Apply -Overwrite -Confirm:$false
+
+        $result.Status | Should -Be 'BlockedByOppositeKind'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Blocks a name already present in both kinds' {
+        $script:secretNames = @('CI_CLIENTSECRET')
+        $script:variableNames = @('CI_CLIENTSECRET')
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite -Confirm:$false
+
+        $result.Status | Should -Be 'BlockedByOppositeKind'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+    }
+
+    It 'Detects newly created <kind> collisions in the last metadata recheck' -ForEach @(
+        @{ kind = 'Secret'; overwrite = $false; status = 'SkippedExisting' }
+        @{ kind = 'Variable'; overwrite = $true; status = 'BlockedByOppositeKind' }
+    ) {
+        if ($kind -eq 'Secret') {
+            $script:lateSecretNames = @('CI_CLIENTSECRET')
+        } else {
+            $script:lateVariableNames = @('CI_CLIENTSECRET')
+        }
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite:$overwrite -Confirm:$false
+
+        $result.Status | Should -Be $status
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Rejects unrepresentable source name <sourceName> before any write' -ForEach @(
+        @{ sourceName = 'CI-client-secret' }
+        @{ sourceName = 'CI-' }
+        @{ sourceName = 'CI-123name' }
+        @{ sourceName = ('CI-na{0}ve' -f [char]0x00ef) }
+        @{ sourceName = 'CI-name.with.dot' }
+        @{ sourceName = ('CI-' + ('x' * 98)) }
+    ) {
+        $script:sources += New-TestSecretMetadata -Name $sourceName
+
+        { Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false } | Should -Throw '*Cannot map*'
+
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Rejects case-insensitive source mappings that would collapse into one destination' {
+        $script:sources += New-TestSecretMetadata -Name 'ci-CLIENTSECRET'
+
+        { Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false } | Should -Throw '*Multiple source names*'
+
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+    }
+
+    It 'Rejects an unmatched VariableName <selection> before any copy' -ForEach @(
+        @{ selection = 'CI_MISSPELLED' }
+        @{ selection = 'CI-clientSecret' }
+        @{ selection = '' }
+        @{ selection = '  ' }
+    ) {
+        { Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -VariableName $selection -Apply -Confirm:$false } | Should -Throw '*does not match a planned*'
+
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Rejects a whitespace-only environment rather than selecting another scope' {
+        { Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Environment '  ' } | Should -Throw '*Environment must*'
+    }
+
+    It 'Reports disabled, expired, and not-yet-valid sources without reading values' {
+        $disabled = New-TestSecretMetadata -Name 'CI-disabled' -Enabled $false
+        $expired = New-TestSecretMetadata -Name 'CI-expired'
+        $expired.Expires = [DateTimeOffset]::UtcNow.AddDays(-1)
+        $future = New-TestSecretMetadata -Name 'CI-future'
+        $future.NotBefore = [DateTimeOffset]::UtcNow.AddDays(1)
+        $script:sources = @($disabled, $expired, $future)
+
+        $result = @(Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false)
+
+        $result.Status | Should -Be @('SkippedDisabled', 'SkippedExpired', 'SkippedNotYetValid')
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Pins the version supplied by source inventory' {
+        $null = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false
+
+        Should -Invoke Get-AzKeyVaultSecret -Times 1 -Exactly -ParameterFilter {
+            $Name -eq 'CI-clientSecret' -and $Version -eq 'version-one' -and -not $IncludeVersions
+        }
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $IncludeVersions }
+    }
+
+    It 'Pins the uniquely newest metadata-only version when the vault list has no version' {
+        $script:sources[0].Version = ''
+        $script:versions = @(
+            New-TestSecretMetadata -Version 'newest' -Created '2026-02-01T00:00:00Z'
+            New-TestSecretMetadata -Version 'oldest' -Created '2026-01-01T00:00:00Z'
+        )
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false
+
+        $result.Status | Should -Be 'Copied'
+        Should -Invoke Get-AzKeyVaultSecret -Times 1 -Exactly -ParameterFilter { $IncludeVersions }
+        Should -Invoke Get-AzKeyVaultSecret -Times 1 -Exactly -ParameterFilter { $Version -eq 'newest' }
+    }
+
+    It 'Does not fall back to an older enabled version when the newest version is disabled' {
+        $script:sources[0].Version = ''
+        $script:versions = @(
+            New-TestSecretMetadata -Version 'older' -Created '2026-01-01T00:00:00Z'
+            New-TestSecretMetadata -Version 'newest' -Created '2026-02-01T00:00:00Z' -Enabled $false
+        )
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false
+
+        $result.Status | Should -Be 'SkippedDisabled'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name -and -not $IncludeVersions }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Fails rather than guessing when version metadata is <description>' -ForEach @(
+        @{ description = 'missing'; versionCase = 'missing' }
+        @{ description = 'ambiguous'; versionCase = 'ambiguous' }
+        @{ description = 'incomplete'; versionCase = 'incomplete' }
+    ) {
+        $script:sources[0].Version = ''
+        switch ($versionCase) {
+            'missing' { $script:versions = @() }
+            'ambiguous' { $script:versions += New-TestSecretMetadata -Version 'same-time' }
+            'incomplete' { $script:versions[0].Created = $null }
+        }
+
+        { Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false } | Should -Throw '*Cannot pin*'
+
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name -and -not $IncludeVersions }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Preserves quotes, Unicode, whitespace, multiline content, and trailing newlines for <kind>' -ForEach @(
+        @{ kind = 'Secret'; variables = @() }
+        @{ kind = 'Variable'; variables = @('CI_CLIENTSECRET') }
+    ) {
+        $script:payload = "  `"quoted`" 'single' $([char]0x00e9) $([char]::ConvertFromUtf32(0x1f510))`r`nsecond line`n`n"
+
+        $null = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -VariableName $variables -Apply -Confirm:$false
+
+        $script:writes[0].Value | Should -BeExactly $script:payload
+        ($script:writes[0].Arguments -join '|') | Should -Not -Match ([regex]::Escape($script:payload))
+    }
+
+    It 'Stops when the GitHub CLI prerequisite is missing without touching Key Vault' {
+        Mock Get-Command { throw [System.Management.Automation.CommandNotFoundException]::new('Command not found.') } -ParameterFilter { $Name -eq 'gh' -and $CommandType -eq 'Application' }
+
+        { Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' } | Should -Throw '*must be installed on PATH*'
+
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly
+    }
+
+    It 'Stops visibly when source metadata cannot be read' {
+        Mock Get-AzKeyVaultSecret { Write-Error 'Synthetic metadata failure.' -ErrorAction Stop } -ParameterFilter { -not $Name }
+
+        { Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false } | Should -Throw '*Cannot inventory Key Vault*'
+
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly
+    }
+
+    It 'Surfaces Key Vault failures without disclosing the underlying exception value' {
+        Mock Get-AzKeyVaultSecret { Write-Error "Upstream failure: $script:payload" -ErrorAction Stop } -ParameterFilter { $Name -and -not $IncludeVersions }
+
+        $failure = $null
+        try {
+            Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false
+        } catch {
+            $failure = $_
+        }
+
+        $failure | Should -Not -BeNullOrEmpty
+        $failure.Exception.Message | Should -Match 'Cannot read the pinned version'
+        $failure.Exception.ToString() | Should -Not -Match ([regex]::Escape($script:payload))
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Fails when the approved source has no accessible value' {
+        Mock Get-AzKeyVaultSecret { return $null } -ParameterFilter { $Name -and -not $IncludeVersions }
+
+        { Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false } | Should -Throw '*no accessible, non-empty value*'
+
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Rejects a value that became <state> after source inventory' -ForEach @(
+        @{ state = 'disabled'; expectedMessage = '*now disabled*' }
+        @{ state = 'expired'; expectedMessage = '*outside its validity period*' }
+        @{ state = 'not yet valid'; expectedMessage = '*outside its validity period*' }
+        @{ state = 'empty'; expectedMessage = '*no accessible, non-empty value*' }
+    ) {
+        Mock Get-AzKeyVaultSecret {
+            [pscustomobject]@{
+                Version     = $Version
+                Enabled     = $state -ne 'disabled'
+                Expires     = $state -eq 'expired' ? [DateTimeOffset]::UtcNow.AddDays(-1) : $null
+                NotBefore   = $state -eq 'not yet valid' ? [DateTimeOffset]::UtcNow.AddDays(1) : $null
+                SecretValue = $state -eq 'empty' ? [System.Security.SecureString]::new() : (ConvertTo-SecureString -String $script:payload -AsPlainText -Force)
+            }
+        } -ParameterFilter { $Name -and -not $IncludeVersions }
+
+        { Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false } | Should -Throw $expectedMessage
+
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Fails if the returned value does not match the pinned version' {
+        Mock Get-AzKeyVaultSecret {
+            [pscustomobject]@{
+                Version     = 'unexpected-version'
+                Enabled     = $true
+                SecretValue = ConvertTo-SecureString -String $script:payload -AsPlainText -Force
+            }
+        } -ParameterFilter { $Name -and -not $IncludeVersions }
+
+        { Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false } | Should -Throw '*did not return the pinned version*'
+
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Propagates native write failure and never reports a copied entry' {
+        Mock Invoke-CIGitHubCommand { throw 'GitHub CLI exited with code [17]. Native output is suppressed to protect values.' } -ParameterFilter { $ArgumentList[1] -eq 'set' }
+        $result = [System.Collections.Generic.List[object]]::new()
+
+        {
+            Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false | ForEach-Object { $result.Add($_) }
+        } | Should -Throw '*code *17*'
+
+        $result.Count | Should -Be 0
+    }
+
+    It 'Rejects malformed <kind> inventories without echoing response data or copying' -ForEach @(
+        @{ kind = 'secret'; response = 'not-json' }
+        @{ kind = 'variable'; response = '{"name":"CI_CLIENTSECRET"}' }
+        @{ kind = 'variable'; response = '[{"value":"synthetic-test-value"}]' }
+    ) {
+        Mock Invoke-CIGitHubCommand { $response } -ParameterFilter { $ArgumentList[1] -eq 'list' -and $ArgumentList[0] -eq $kind }
+
+        $failure = $null
+        try {
+            Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false
+        } catch {
+            $failure = $_
+        }
+
+        $failure | Should -Not -BeNullOrEmpty
+        $failure.Exception.Message | Should -Match 'Invalid'
+        $failure.Exception.ToString() | Should -Not -Match ([regex]::Escape($script:payload))
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+}
+
+Describe 'Invoke-CIGitHubCommand stdin transport' {
+
+    BeforeAll {
+        . (Join-Path $repoRootPath 'utilities' 'tools' 'Copy-CIKeyVaultSecretsToGitHub.ps1')
+    }
+
+    BeforeEach {
+        $script:payload = "  `"quoted`" 'single' $([char]0x00e9) $([char]::ConvertFromUtf32(0x1f510))`r`nsecond line`n`n"
+        $script:process = [pscustomobject]@{
+            StartInfo      = $null
+            StandardInput  = [System.IO.StringWriter]::new()
+            StandardOutput = [System.IO.StringReader]::new('synthetic stdout')
+            StandardError  = [System.IO.StringReader]::new('synthetic stderr')
+            ExitCode       = 0
+            HasExited      = $true
+            Started        = $false
+            Waited         = $false
+            Disposed       = $false
+            Killed         = $false
+        }
+        $script:process | Add-Member -MemberType ScriptMethod -Name Start -Value { $this.Started = $true; return $true }
+        $script:process | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { $this.Waited = $true }
+        $script:process | Add-Member -MemberType ScriptMethod -Name Kill -Value { $this.Killed = $true; $this.HasExited = $true }
+        $script:process | Add-Member -MemberType ScriptMethod -Name Dispose -Value {
+            $this.Disposed = $true
+            $this.StandardInput.Dispose()
+            $this.StandardOutput.Dispose()
+            $this.StandardError.Dispose()
+        }
+        Mock New-Object { $script:process } -ParameterFilter { $TypeName -eq 'System.Diagnostics.Process' }
+        $script:securePayload = ConvertTo-SecureString -String $script:payload -AsPlainText -Force
+    }
+
+    AfterEach {
+        $script:securePayload.Dispose()
+    }
+
+    It 'Preserves trailing line endings for <kind> using quoted dotenv data on stdin' -ForEach @(
+        @{ kind = 'secret' }
+        @{ kind = 'variable' }
+    ) {
+        $arguments = @($kind, 'set', 'CI_CLIENTSECRET', '--repo', 'owner/repo', '--env', 'CI validation')
+
+        $result = @(Invoke-CIGitHubCommand -ExecutablePath 'mock-gh' -ArgumentList $arguments -InputValue $script:securePayload)
+
+        $result.Count | Should -Be 0
+        $expectedBody = 'CI_CLIENTSECRET="  \"quoted\" ''single'' {0} {1}\r\nsecond line\n\n"' -f [char]0x00e9, [char]::ConvertFromUtf32(0x1f510)
+        $script:process.StandardInput.ToString() | Should -BeExactly $expectedBody
+        $script:process.StartInfo.ArgumentList | Should -Be ($arguments + @('--env-file', '-'))
+        $script:process.StartInfo.StandardInputEncoding.WebName | Should -Be 'utf-8'
+        $script:process.StartInfo.StandardInputEncoding.GetPreamble().Length | Should -Be 0
+        $script:process.StartInfo.UseShellExecute | Should -BeFalse
+        $script:process.StartInfo.RedirectStandardInput | Should -BeTrue
+        $script:process.StartInfo.RedirectStandardOutput | Should -BeTrue
+        $script:process.StartInfo.RedirectStandardError | Should -BeTrue
+        $script:process.StartInfo.Environment['GH_HOST'] | Should -Be 'github.com'
+        $script:process.StartInfo.Environment['GH_PROMPT_DISABLED'] | Should -Be '1'
+        $script:process.StartInfo.Environment.ContainsKey('GH_DEBUG') | Should -BeFalse
+        $script:process.Started | Should -BeTrue
+        $script:process.Waited | Should -BeTrue
+        $script:process.Disposed | Should -BeTrue
+    }
+
+    It 'Uses unmodified raw stdin when no trailing line ending would be trimmed' {
+        $value = '  quotes" '' literal $VALUE ${VALUE} backslash\'
+        $secureValue = ConvertTo-SecureString -String $value -AsPlainText -Force
+        $arguments = @('secret', 'set', 'CI_CLIENTSECRET', '--repo', 'owner/repo')
+        try {
+            $null = Invoke-CIGitHubCommand -ExecutablePath 'mock-gh' -ArgumentList $arguments -InputValue $secureValue
+        } finally {
+            $secureValue.Dispose()
+        }
+
+        $script:process.StandardInput.ToString() | Should -BeExactly $value
+        $script:process.StartInfo.ArgumentList | Should -Be $arguments
+    }
+
+    It 'Escapes dotenv metacharacters to prevent interpolation or additional entries' {
+        $value = 'literal $TOKEN ${TOKEN} $(TOKEN) \n \" # comment' + "`n" + 'CI_UNEXPECTED=not-an-entry' + "`r`n"
+        $secureValue = ConvertTo-SecureString -String $value -AsPlainText -Force
+        try {
+            $null = Invoke-CIGitHubCommand -ExecutablePath 'mock-gh' -ArgumentList @('variable', 'set', 'CI_CLIENTSECRET', '--repo', 'owner/repo') -InputValue $secureValue
+        } finally {
+            $secureValue.Dispose()
+        }
+
+        $script:process.StandardInput.ToString() | Should -BeExactly 'CI_CLIENTSECRET="literal \$TOKEN \${TOKEN} \$(TOKEN) \\n \\\" # comment\nCI_UNEXPECTED=not-an-entry\r\n"'
+        $script:process.StandardInput.ToString() | Should -Not -Match '[\r\n]'
+    }
+
+    It 'Returns only name-list stdout for a metadata inventory command' {
+        $script:process.StandardOutput = [System.IO.StringReader]::new('[{"name":"CI_CLIENTSECRET"}]')
+
+        $result = Invoke-CIGitHubCommand -ExecutablePath 'mock-gh' -ArgumentList @('secret', 'list', '--repo', 'owner/repo', '--json', 'name')
+
+        $result | Should -BeExactly '[{"name":"CI_CLIENTSECRET"}]'
+        $script:process.StandardInput.ToString() | Should -Be ''
+        $script:process.Disposed | Should -BeTrue
+    }
+
+    It 'Surfaces the exit code but never stdout or stderr containing the value' {
+        $script:process.StandardOutput = [System.IO.StringReader]::new($script:payload)
+        $script:process.StandardError = [System.IO.StringReader]::new($script:payload)
+        $script:process.ExitCode = 19
+
+        $failure = $null
+        try {
+            Invoke-CIGitHubCommand -ExecutablePath 'mock-gh' -ArgumentList @('variable', 'set', 'CI_CLIENTSECRET', '--repo', 'owner/repo') -InputValue $script:securePayload
+        } catch {
+            $failure = $_
+        }
+
+        $failure | Should -Not -BeNullOrEmpty
+        $failure.Exception.Message | Should -Match 'code \[19\]'
+        $failure.Exception.ToString() | Should -Not -Match ([regex]::Escape($script:payload))
+        $script:process.Disposed | Should -BeTrue
+    }
+
+    It 'Sanitizes process exceptions and disposes the process' {
+        $script:process | Add-Member -MemberType ScriptMethod -Name Start -Force -Value { throw $script:payload }
+
+        $failure = $null
+        try {
+            Invoke-CIGitHubCommand -ExecutablePath 'mock-gh' -ArgumentList @('secret', 'set', 'CI_CLIENTSECRET') -InputValue $script:securePayload
+        } catch {
+            $failure = $_
+        }
+
+        $failure | Should -Not -BeNullOrEmpty
+        $failure.Exception.Message | Should -Match 'GitHub CLI process failed'
+        $failure.Exception.ToString() | Should -Not -Match ([regex]::Escape($script:payload))
+        $script:process.Disposed | Should -BeTrue
+    }
+
+    It 'Stops and disposes its own process after a stdin failure without exposing the exception payload' {
+        $inputStream = [pscustomobject]@{}
+        $inputStream | Add-Member -MemberType ScriptMethod -Name Write -Value { throw $script:payload }
+        $inputStream | Add-Member -MemberType ScriptMethod -Name Dispose -Value {}
+        $script:process.StandardInput = $inputStream
+        $script:process.HasExited = $false
+
+        $failure = $null
+        try {
+            Invoke-CIGitHubCommand -ExecutablePath 'mock-gh' -ArgumentList @('secret', 'set', 'CI_CLIENTSECRET') -InputValue $script:securePayload
+        } catch {
+            $failure = $_
+        }
+
+        $failure | Should -Not -BeNullOrEmpty
+        $failure.Exception.Message | Should -Match 'GitHub CLI process failed'
+        $failure.Exception.ToString() | Should -Not -Match ([regex]::Escape($script:payload))
+        $script:process.Killed | Should -BeTrue
+        $script:process.Disposed | Should -BeTrue
+    }
+}

--- a/utilities/tests/pipelines/Copy-CIKeyVaultSecretsToGitHub.Tests.ps1
+++ b/utilities/tests/pipelines/Copy-CIKeyVaultSecretsToGitHub.Tests.ps1
@@ -135,6 +135,16 @@ Describe 'Copy-CIKeyVaultSecretsToGitHub' {
         $result.Kind | Should -Be @('Secret', 'Secret')
     }
 
+    It 'Imports CI-fooBar as the readable CI_FOO_BAR name by default' {
+        $script:sources = @(New-TestSecretMetadata -Name 'CI-fooBar')
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Confirm:$false
+
+        $result.DestinationName | Should -BeExactly 'CI_FOO_BAR'
+        $result.Status | Should -Be 'Copied'
+        ($script:writes[0].Arguments -join '|') | Should -Be 'secret|set|CI_FOO_BAR|--repo|owner/repo'
+    }
+
     It 'Copies only reviewed source names, ignoring unselected invalid legacy names' {
         $script:sources += @(
             New-TestSecretMetadata -Name 'CI-location'
@@ -313,8 +323,50 @@ Describe 'Copy-CIKeyVaultSecretsToGitHub' {
         }
     }
 
-    It 'Blocks multiple same-kind aliases even with explicit overwrite' {
-        $script:secretNames = @('CI_CLIENTSECRET', 'CI__CLIENTSECRET')
+    It 'Selects CI_ over CI__ for existing <kind> aliases [reverse: <reverse>]' -ForEach @(
+        @{ kind = 'Secret'; reverse = $false; variables = @() }
+        @{ kind = 'Secret'; reverse = $true; variables = @() }
+        @{ kind = 'Variable'; reverse = $false; variables = @('CI_CLIENT_SECRET') }
+        @{ kind = 'Variable'; reverse = $true; variables = @('CI_CLIENT_SECRET') }
+    ) {
+        $aliases = $reverse ? @('CI__CLIENTSECRET', 'CI_CLIENT_SECRET') : @('CI_CLIENT_SECRET', 'CI__CLIENTSECRET')
+        if ($kind -eq 'Secret') {
+            $script:secretNames = $aliases
+        } else {
+            $script:variableNames = $aliases
+        }
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -VariableName $variables -Apply -Confirm:$false
+
+        $result.DestinationName | Should -BeExactly 'CI_CLIENT_SECRET'
+        $result.Status | Should -Be 'SkippedExisting'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
+    }
+
+    It 'Overwrites only the preferred CI_ <kind> alias when explicitly approved' -ForEach @(
+        @{ kind = 'Secret'; variables = @() }
+        @{ kind = 'Variable'; variables = @('CI_CLIENT_SECRET') }
+    ) {
+        if ($kind -eq 'Secret') {
+            $script:secretNames = @('CI__CLIENTSECRET', 'CI_CLIENT_SECRET')
+        } else {
+            $script:variableNames = @('CI_CLIENT_SECRET', 'CI__CLIENTSECRET')
+        }
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -VariableName $variables -Apply -Overwrite -Confirm:$false
+
+        $result.DestinationName | Should -BeExactly 'CI_CLIENT_SECRET'
+        $result.Status | Should -Be 'Copied'
+        $script:writes.Count | Should -Be 1
+        $script:writes[0].Arguments[2] | Should -BeExactly 'CI_CLIENT_SECRET'
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter {
+            $ArgumentList[1] -eq 'set' -and $ArgumentList[2] -eq 'CI__CLIENTSECRET'
+        }
+    }
+
+    It 'Blocks multiple aliases within the winning prefix even with explicit overwrite' {
+        $script:secretNames = @('CI_CLIENTSECRET', 'CI_CLIENT_SECRET', 'CI__CLIENTSECRET')
 
         $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite -Confirm:$false
 
@@ -325,12 +377,33 @@ Describe 'Copy-CIKeyVaultSecretsToGitHub' {
 
     It 'Blocks new ambiguity found after the preview' {
         $script:secretNames = @('CI_CLIENTSECRET')
-        $script:lateSecretNames = @('CI__CLIENTSECRET')
+        $script:lateSecretNames = @('CI_CLIENT_SECRET')
 
         $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite -Confirm:$false
 
         $result.Status | Should -Be 'BlockedByAmbiguousAliases'
         Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+    }
+
+    It 'Keeps the approved CI_ destination when a lower-priority exact alias appears' {
+        $script:secretNames = @('CI_CLIENT_SECRET')
+        $script:lateSecretNames = @('CI__CLIENTSECRET')
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite -Confirm:$false
+
+        $result.Status | Should -Be 'Copied'
+        $script:writes[0].Arguments[2] | Should -BeExactly 'CI_CLIENT_SECRET'
+    }
+
+    It 'Blocks a new higher-priority alias instead of retargeting an approved exact alias' {
+        $script:secretNames = @('CI__CLIENTSECRET')
+        $script:lateSecretNames = @('CI_CLIENT_SECRET')
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite -Confirm:$false
+
+        $result.Status | Should -Be 'BlockedChangedDestination'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
     }
 
     It 'Does not retarget an approved copy when a different alias appears' {

--- a/utilities/tests/pipelines/Get-CIParameterMap.Tests.ps1
+++ b/utilities/tests/pipelines/Get-CIParameterMap.Tests.ps1
@@ -53,11 +53,84 @@ Describe 'Get-CIParameterMap' {
         Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly
     }
 
-    It 'Preserves underscores instead of guessing snake_case to camelCase mappings' {
-        $result = Get-CIParameterMap -TemplateParameters $templateParameters -GitHubVariables '{"CI_RESOURCE_NAME":"example","CI_ADMIN_MEMBERS_SECRET":"not-matched"}'
+    It 'Uses readable names for camelCase parameters and double underscores for literal names' {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters `
+            -GitHubVariables '{"CI__RESOURCE_NAME":"example","CI_ADMIN_MEMBERS_SECRET":"readable"}'
 
-        @($result.Keys) | Should -Be @('resource_name')
+        @($result.Keys | Sort-Object) | Should -Be @('adminMembersSecret', 'resource_name')
         $result.resource_name | Should -Be 'example'
+        ConvertFrom-SecureString -SecureString $result.adminMembersSecret -AsPlainText | Should -Be 'readable'
+    }
+
+    It 'Does not remove literal underscores from double-prefix inputs or declared parameter names' {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters `
+            -GitHubVariables '{"CI_RESOURCE_NAME":"not-literal","CI__ADMIN_MEMBERS_SECRET":"not-camelCase"}'
+
+        $result.Count | Should -Be 0
+    }
+
+    It 'Distinguishes camelCase and underscored parameters in the same template' {
+        $result = Get-CIParameterMap -TemplateParameters @{
+            adminMembersSecret   = @{ type = 'secureString' }
+            admin_members_secret = @{ type = 'secureString' }
+        } -GitHubSecrets '{"CI_ADMIN_MEMBERS_SECRET":"camel","CI__ADMIN_MEMBERS_SECRET":"literal"}'
+
+        ConvertFrom-SecureString -SecureString $result.adminMembersSecret -AsPlainText | Should -Be 'camel'
+        ConvertFrom-SecureString -SecureString $result.admin_members_secret -AsPlainText | Should -Be 'literal'
+    }
+
+    It 'Keeps secret precedence across different aliases' -ForEach @(
+        @{ variableName = 'CI_ADMIN_MEMBERS_SECRET'; secretName = 'CI__ADMINMEMBERSSECRET' }
+        @{ variableName = 'CI__ADMINMEMBERSSECRET'; secretName = 'CI_ADMIN_MEMBERS_SECRET' }
+    ) {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters `
+            -GitHubVariables (@{ $variableName = 'variable' } | ConvertTo-Json -Compress) `
+            -GitHubSecrets (@{ $secretName = 'secret' } | ConvertTo-Json -Compress)
+
+        ConvertFrom-SecureString -SecureString $result.adminMembersSecret -AsPlainText | Should -Be 'secret'
+    }
+
+    It 'Rejects multiple <source> aliases for the same parameter before accessing Key Vault' -ForEach @(
+        @{ source = 'Variables'; names = @('CI_ADMIN_MEMBERS_SECRET', 'CI_ADMINMEMBERSSECRET') }
+        @{ source = 'Secrets'; names = @('CI__ADMINMEMBERSSECRET', 'CI_ADMIN_MEMBERS_SECRET') }
+    ) {
+        $arguments = @{
+            TemplateParameters = $templateParameters
+            KeyVaultName       = 'test-vault'
+            "GitHub$source"    = @{ $names[0] = 'one'; $names[1] = 'two' } | ConvertTo-Json -Compress
+        }
+
+        { Get-CIParameterMap @arguments } | Should -Throw "*Multiple GitHub $source names*map to parameter*"
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly
+    }
+
+    It 'Ignores conflicting aliases that do not target the current template' {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters `
+            -GitHubVariables '{"CI_OTHER_INPUT":"one","CI__OTHERINPUT":"two"}'
+
+        $result.Count | Should -Be 0
+    }
+
+    It 'Does not inject the reserved Key Vault selector into a template parameter' {
+        $result = Get-CIParameterMap -TemplateParameters @{ keyVaultName = @{ type = 'string' } } `
+            -GitHubVariables '{"CI_KEY_VAULT_NAME":"legacy-vault"}'
+
+        $result.Count | Should -Be 0
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly
+    }
+
+    It 'Uses an exact alias to supply keyVaultName independently of the legacy selector' {
+        $result = Get-CIParameterMap -TemplateParameters @{ keyVaultName = @{ type = 'string' } } `
+            -GitHubVariables '{"CI_KEY_VAULT_NAME":"legacy-vault","CI__KEYVAULTNAME":"test-vault"}'
+
+        $result.keyVaultName | Should -Be 'test-vault'
+    }
+
+    It 'Rejects template parameter names that GitHub cannot distinguish by case' {
+        $definitions = ConvertFrom-Json '{"name":{"type":"string"},"NAME":{"type":"string"}}' -AsHashtable
+
+        { Get-CIParameterMap -TemplateParameters $definitions -GitHubVariables '{"CI_NAME":"ambiguous"}' } |
+            Should -Throw '*differs from another parameter only in case*'
     }
 
     It 'Supports parameters whose names shadow dictionary properties' {
@@ -243,7 +316,63 @@ Describe 'Get-CIParameterMap' {
     It 'Rejects duplicate case-insensitive names' {
         {
             Get-CIParameterMap -TemplateParameters $templateParameters -GitHubVariables '{"CI_LOCATION":"one","ci_location":"two"}'
-        } | Should -Throw '*duplicate CI_ names*'
+        } | Should -Throw '*Multiple GitHub Variables names*'
+    }
+
+    Describe 'CI parameter name formats' {
+
+        BeforeAll {
+            . (Join-Path $repoRootPath 'utilities' 'pipelines' 'sharedScripts' 'ConvertFrom-CIParameterName.ps1')
+            . (Join-Path $repoRootPath 'utilities' 'pipelines' 'sharedScripts' 'ConvertTo-CIParameterName.ps1')
+        }
+
+        It 'Decodes <name> using its explicit prefix' -ForEach @(
+            @{ name = 'CI_ADMIN_MEMBERS_SECRET'; expected = 'ADMINMEMBERSSECRET' }
+            @{ name = 'CI_ADMINMEMBERSSECRET'; expected = 'ADMINMEMBERSSECRET' }
+            @{ name = 'ci_admin_members_secret'; expected = 'adminmemberssecret' }
+            @{ name = 'CI_ADMIN__MEMBERS_SECRET'; expected = 'ADMINMEMBERSSECRET' }
+            @{ name = 'CI__ADMIN_MEMBERS_SECRET'; expected = 'ADMIN_MEMBERS_SECRET' }
+            @{ name = 'CI__ADMINMEMBERSSECRET'; expected = 'ADMINMEMBERSSECRET' }
+            @{ name = 'CI___NAME'; expected = '_NAME' }
+        ) {
+            ConvertFrom-CIParameterName -Name $name | Should -BeExactly $expected
+        }
+
+        It 'Does not treat <name> as a parameter' -ForEach @(
+            @{ name = 'CI_KEY_VAULT_NAME' }
+            @{ name = 'ci_key_vault_name' }
+            @{ name = 'OTHER_VALUE' }
+            @{ name = 'CI-value' }
+            @{ name = 'CI_' }
+            @{ name = 'CI__' }
+            @{ name = '' }
+        ) {
+            ConvertFrom-CIParameterName -Name $name | Should -BeNullOrEmpty
+        }
+
+        It 'Formats <parameterName> without losing its identity' -ForEach @(
+            @{ parameterName = 'adminMembersSecret'; expected = 'CI_ADMIN_MEMBERS_SECRET' }
+            @{ parameterName = 'managedHSMResourceId'; expected = 'CI_MANAGED_HSM_RESOURCE_ID' }
+            @{ parameterName = 'clientID'; expected = 'CI_CLIENT_ID' }
+            @{ parameterName = 'tls1Version'; expected = 'CI_TLS1_VERSION' }
+            @{ parameterName = 'resource_name'; expected = 'CI__RESOURCE_NAME' }
+            @{ parameterName = '_name'; expected = 'CI___NAME' }
+            @{ parameterName = 'keyVaultName'; expected = 'CI__KEYVAULTNAME' }
+        ) {
+            $name = ConvertTo-CIParameterName -ParameterName $parameterName
+
+            $name | Should -BeExactly $expected
+            ConvertFrom-CIParameterName -Name $name | Should -Be $parameterName
+        }
+
+        It 'Keeps long camelCase names compact instead of exceeding the GitHub name limit' {
+            $parameterName = 'aB' * 48
+            $name = ConvertTo-CIParameterName -ParameterName $parameterName
+
+            $name | Should -BeExactly ('CI_' + $parameterName.ToUpperInvariant())
+            $name.Length | Should -BeLessOrEqual 100
+            ConvertFrom-CIParameterName -Name $name | Should -Be $parameterName
+        }
     }
 
     It 'Rejects a non-string matching context value' {

--- a/utilities/tests/pipelines/Get-CIParameterMap.Tests.ps1
+++ b/utilities/tests/pipelines/Get-CIParameterMap.Tests.ps1
@@ -1,0 +1,259 @@
+param(
+    [Parameter()]
+    [string] $repoRootPath = (Get-Item -Path $PSScriptRoot).Parent.Parent.Parent.FullName
+)
+
+Describe 'Get-CIParameterMap' {
+
+    BeforeAll {
+        . (Join-Path $repoRootPath 'utilities' 'pipelines' 'sharedScripts' 'Get-CIParameterMap.ps1')
+
+        function Get-AzKeyVaultSecret {
+            [CmdletBinding()]
+            param([string] $VaultName, [string] $Name)
+            throw 'Unexpected Key Vault access.'
+        }
+
+        $templateParameters = @{
+            adminMembersSecret = @{ type = 'secureString' }
+            legacyOnly         = @{ type = 'secureString' }
+            location           = @{ type = 'string' }
+            resource_name      = @{ type = 'string' }
+            count              = @{ type = 'int' }
+            enabled            = @{ type = 'bool' }
+            allowedIps         = @{ type = 'array' }
+            options            = @{ type = 'object' }
+            secureConfig       = @{ type = 'secureObject' }
+        }
+    }
+
+    BeforeEach {
+        Mock Get-AzKeyVaultSecret {
+            if (-not $Name) {
+                return @(
+                    @{ Name = 'CI-adminMembersSecret' }
+                    @{ Name = 'CI-LEGACYONLY' }
+                    @{ Name = 'CI-unrelated' }
+                    @{ Name = 'unrelated' }
+                )
+            }
+            return @{
+                SecretValue = ConvertTo-SecureString -String "vault-$Name" -AsPlainText -Force
+            }
+        }
+    }
+
+    It 'Matches uppercase GitHub names and returns the declared parameter spelling' {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters -GitHubVariables '{"CI_ADMINMEMBERSSECRET":"admin@example.invalid","CI_LOCATION":"westus"}'
+
+        @($result.Keys | Sort-Object) | Should -Be @('adminMembersSecret', 'location')
+        $result.adminMembersSecret | Should -BeOfType [securestring]
+        ConvertFrom-SecureString -SecureString $result.adminMembersSecret -AsPlainText | Should -Be 'admin@example.invalid'
+        $result.location | Should -Be 'westus'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly
+    }
+
+    It 'Preserves underscores instead of guessing snake_case to camelCase mappings' {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters -GitHubVariables '{"CI_RESOURCE_NAME":"example","CI_ADMIN_MEMBERS_SECRET":"not-matched"}'
+
+        @($result.Keys) | Should -Be @('resource_name')
+        $result.resource_name | Should -Be 'example'
+    }
+
+    It 'Supports parameters whose names shadow dictionary properties' {
+        $definitions = @{
+            keys   = @{ type = 'secureString' }
+            count  = @{ type = 'int' }
+            values = @{ type = 'string' }
+        }
+        $result = Get-CIParameterMap -TemplateParameters $definitions -KeyVaultName 'test-vault' `
+            -GitHubVariables '{"CI_KEYS":"example","CI_COUNT":"0","CI_VALUES":"example"}'
+
+        @($result.psbase.Keys | Sort-Object) | Should -Be @('count', 'keys', 'values')
+        $result['keys'] | Should -BeOfType [securestring]
+        $result['count'] | Should -Be 0
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly
+    }
+
+    It 'Gives a GitHub secret precedence over a variable and a Key Vault secret' {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters -KeyVaultName 'test-vault' `
+            -GitHubVariables '{"CI_ADMINMEMBERSSECRET":"variable","CI_LOCATION":"westus"}' `
+            -GitHubSecrets '{"ci_adminMembersSecret":"secret"}'
+
+        ConvertFrom-SecureString -SecureString $result.adminMembersSecret -AsPlainText | Should -Be 'secret'
+        $result.location | Should -Be 'westus'
+        ConvertFrom-SecureString -SecureString $result.legacyOnly -AsPlainText | Should -Be 'vault-CI-LEGACYONLY'
+        Should -Invoke Get-AzKeyVaultSecret -Times 1 -Exactly -ParameterFilter { -not $Name }
+        Should -Invoke Get-AzKeyVaultSecret -Times 1 -Exactly -ParameterFilter { $Name -eq 'CI-LEGACYONLY' }
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name -eq 'CI-adminMembersSecret' -or $Name -eq 'CI-unrelated' -or $Name -eq 'unrelated' }
+    }
+
+    It 'Gives a GitHub variable precedence over Key Vault' {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters -KeyVaultName 'test-vault' `
+            -GitHubVariables '{"CI_ADMINMEMBERSSECRET":"variable"}'
+
+        ConvertFrom-SecureString -SecureString $result.adminMembersSecret -AsPlainText | Should -Be 'variable'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name -eq 'CI-adminMembersSecret' }
+    }
+
+    It 'Does not fall back when a GitHub secret is an empty string' {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters -KeyVaultName 'test-vault' `
+            -GitHubVariables '{"CI_ADMINMEMBERSSECRET":"variable"}' -GitHubSecrets '{"CI_ADMINMEMBERSSECRET":""}'
+
+        $result.adminMembersSecret | Should -BeOfType [securestring]
+        $result.adminMembersSecret.Length | Should -Be 0
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly -ParameterFilter { $Name -eq 'CI-adminMembersSecret' }
+    }
+
+    It 'Preserves an explicitly empty variable' {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters -GitHubVariables '{"CI_LOCATION":""}'
+
+        $result.ContainsKey('location') | Should -BeTrue
+        $result.location | Should -BeExactly ''
+    }
+
+    It 'Keeps legacy secure values without converting them to plaintext' {
+        $vaultValue = ConvertTo-SecureString -String 'legacy-value' -AsPlainText -Force
+        Mock Get-AzKeyVaultSecret { @{ SecretValue = $vaultValue } } -ParameterFilter { $Name -eq 'CI-LEGACYONLY' }
+
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters -KeyVaultName 'test-vault'
+
+        [object]::ReferenceEquals($result.legacyOnly, $vaultValue) | Should -BeTrue
+    }
+
+    It 'Avoids Key Vault access when every parameter is supplied by GitHub' {
+        $result = Get-CIParameterMap -TemplateParameters @{ location = @{ type = 'string' } } -KeyVaultName 'test-vault' `
+            -GitHubVariables '{"CI_LOCATION":"westus"}'
+
+        $result.location | Should -Be 'westus'
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly
+    }
+
+    It 'Ignores unrelated credentials and unmatched names' {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters `
+            -GitHubVariables '{"OTHER_LOCATION":"westus","CI-LOCATION":"not-github","CI_MISSING":"unknown","CI_":"empty-suffix"}' `
+            -GitHubSecrets '{"GITHUB_TOKEN":"not-a-real-token","AZURE_CREDENTIALS":"not-a-real-secret"}'
+
+        $result.Count | Should -Be 0
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly
+    }
+
+    It 'Supports absent contexts and templates without parameters' {
+        $result = Get-CIParameterMap -TemplateParameters @{} -GitHubVariables '' -GitHubSecrets '' -KeyVaultName 'test-vault'
+
+        $result.Count | Should -Be 0
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly
+    }
+
+    It 'Preserves quotes, newlines, Unicode and whitespace in strings' {
+        $value = "  O'Brien `"quoted`" % `${notCode}`r`n$([char]0x00e9)`n"
+        $json = @{ CI_ADMINMEMBERSSECRET = $value; CI_LOCATION = $value } | ConvertTo-Json -Compress
+
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters -GitHubVariables $json -GitHubSecrets $json -WarningAction SilentlyContinue
+
+        ConvertFrom-SecureString -SecureString $result.adminMembersSecret -AsPlainText | Should -BeExactly $value
+        $result.location | Should -BeExactly $value
+    }
+
+    It 'Converts JSON to the declared primitive and structured types' {
+        $json = @{
+            CI_COUNT        = '0'
+            CI_ENABLED      = 'false'
+            CI_ALLOWEDIPS   = '["one"]'
+            CI_OPTIONS      = '{"nested":{"enabled":true}}'
+            CI_SECURECONFIG = '{"password":"not-a-real-password"}'
+        } | ConvertTo-Json -Compress
+
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters -GitHubVariables $json
+
+        $result.count | Should -Be 0
+        $result.count | Should -BeOfType [long]
+        $result.enabled | Should -BeOfType [bool]
+        $result.enabled | Should -BeFalse
+        $result.allowedIps -is [array] | Should -BeTrue
+        $result.allowedIps.Count | Should -Be 1
+        $result.allowedIps[0] | Should -Be 'one'
+        $result.options.nested.enabled | Should -BeTrue
+        $result.secureConfig.password | Should -Be 'not-a-real-password'
+    }
+
+    It 'Preserves empty arrays and objects' {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters -GitHubVariables '{"CI_ALLOWEDIPS":"[]","CI_OPTIONS":"{}"}'
+
+        $result.ContainsKey('allowedIps') | Should -BeTrue
+        $result.allowedIps -is [array] | Should -BeTrue
+        $result.allowedIps.Count | Should -Be 0
+        $result.options.Count | Should -Be 0
+    }
+
+    It 'Warns without logging the value when a secret targets a non-secure parameter' {
+        $result = Get-CIParameterMap -TemplateParameters $templateParameters -GitHubSecrets '{"CI_LOCATION":"sensitive-example"}' `
+            -WarningVariable warnings -WarningAction SilentlyContinue
+
+        $result.location | Should -Be 'sensitive-example'
+        $warnings | Should -Match 'non-secure parameter \[location\]'
+        $warnings | Should -Not -Match 'sensitive-example'
+    }
+
+    It 'Does not log parameter values, including secure objects, with Verbose enabled' {
+        $messages = @(
+            Get-CIParameterMap -TemplateParameters $templateParameters `
+                -GitHubSecrets '{"CI_ADMINMEMBERSSECRET":"sensitive-example","CI_SECURECONFIG":"{\"password\":\"sensitive-example\"}"}' `
+                -Verbose 3>&1 4>&1 6>&1
+        )
+
+        @($messages | Where-Object { $_ -isnot [hashtable] }).Count | Should -Be 0
+    }
+
+    It 'Rejects invalid <source> contexts without including their content' -ForEach @(
+        @{ source = 'Variables'; json = '{"CI_LOCATION":"sensitive-example"' }
+        @{ source = 'Secrets'; json = '{"CI_LOCATION":"sensitive-example"' }
+        @{ source = 'Variables'; json = '[]' }
+        @{ source = 'Secrets'; json = 'null' }
+        @{ source = 'Secrets'; json = '"sensitive-example"' }
+    ) {
+        $arguments = @{ TemplateParameters = $templateParameters; "GitHub$source" = $json }
+
+        { Get-CIParameterMap @arguments } | Should -Throw "*GitHub $source context must be*JSON object*"
+    }
+
+    It 'Rejects duplicate case-insensitive names' {
+        {
+            Get-CIParameterMap -TemplateParameters $templateParameters -GitHubVariables '{"CI_LOCATION":"one","ci_location":"two"}'
+        } | Should -Throw '*duplicate CI_ names*'
+    }
+
+    It 'Rejects a non-string matching context value' {
+        { Get-CIParameterMap -TemplateParameters $templateParameters -GitHubSecrets '{"CI_ADMINMEMBERSSECRET":null}' } |
+            Should -Throw '*must be a string*'
+    }
+
+    It 'Rejects invalid JSON types for <parameterName>' -ForEach @(
+        @{ parameterName = 'count'; value = '1.5' }
+        @{ parameterName = 'count'; value = 'true' }
+        @{ parameterName = 'enabled'; value = '"false"' }
+        @{ parameterName = 'allowedIps'; value = '"one"' }
+        @{ parameterName = 'allowedIps'; value = 'null' }
+        @{ parameterName = 'options'; value = '[]' }
+        @{ parameterName = 'secureConfig'; value = '{"password":"sensitive-example"' }
+    ) {
+        $json = @{ "CI_$parameterName" = $value } | ConvertTo-Json -Compress
+
+        { Get-CIParameterMap -TemplateParameters $templateParameters -GitHubVariables $json } |
+            Should -Throw "*parameter *$parameterName*JSON*"
+    }
+
+    It 'Surfaces vault failures instead of pretending no fallback values exist' {
+        Mock Get-AzKeyVaultSecret { throw 'Vault access denied.' }
+
+        { Get-CIParameterMap -TemplateParameters $templateParameters -KeyVaultName 'test-vault' } |
+            Should -Throw '*Vault access denied*'
+    }
+
+    It 'Rejects a missing vault secret value' {
+        Mock Get-AzKeyVaultSecret { @{ SecretValue = $null } } -ParameterFilter { $Name -eq 'CI-LEGACYONLY' }
+
+        { Get-CIParameterMap -TemplateParameters $templateParameters -KeyVaultName 'test-vault' } |
+            Should -Throw '*did not return a secure value*'
+    }
+}

--- a/utilities/tests/pipelines/Get-CIParameterMap.Tests.ps1
+++ b/utilities/tests/pipelines/Get-CIParameterMap.Tests.ps1
@@ -90,9 +90,72 @@ Describe 'Get-CIParameterMap' {
         ConvertFrom-SecureString -SecureString $result.adminMembersSecret -AsPlainText | Should -Be 'secret'
     }
 
+    It 'Prefers readable <source> aliases regardless of order [reverse: <reverse>]' -ForEach @(
+        @{ source = 'Variables'; reverse = $false }
+        @{ source = 'Variables'; reverse = $true }
+        @{ source = 'Secrets'; reverse = $false }
+        @{ source = 'Secrets'; reverse = $true }
+    ) {
+        $entries = $reverse ? [ordered]@{
+            CI__ADMINMEMBERSSECRET = 'exact'
+            CI_ADMIN_MEMBERS_SECRET = 'readable'
+            CI__FOO = 'exact-foo'
+            CI_FOO = 'readable-foo'
+        } : [ordered]@{
+            CI_ADMIN_MEMBERS_SECRET = 'readable'
+            CI__ADMINMEMBERSSECRET = 'exact'
+            CI_FOO = 'readable-foo'
+            CI__FOO = 'exact-foo'
+        }
+        $arguments = @{
+            TemplateParameters = @{
+                adminMembersSecret = @{ type = 'secureString' }
+                foo = @{ type = 'secureString' }
+            }
+            "GitHub$source" = $entries | ConvertTo-Json -Compress
+        }
+
+        $result = Get-CIParameterMap @arguments
+
+        ConvertFrom-SecureString -SecureString $result.adminMembersSecret -AsPlainText | Should -Be 'readable'
+        ConvertFrom-SecureString -SecureString $result.foo -AsPlainText | Should -Be 'readable-foo'
+    }
+
+    It 'Keeps an empty winning CI_ <source> value instead of falling back to CI__ or Key Vault' -ForEach @(
+        @{ source = 'Variables' }
+        @{ source = 'Secrets' }
+    ) {
+        $arguments = @{
+            TemplateParameters = @{ foo = @{ type = 'secureString' } }
+            KeyVaultName = 'test-vault'
+            "GitHub$source" = '{"CI__FOO":"exact","CI_FOO":""}'
+        }
+
+        $result = Get-CIParameterMap @arguments
+
+        $result.foo | Should -BeOfType [securestring]
+        $result.foo.Length | Should -Be 0
+        Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly
+    }
+
+    It 'Applies source precedence before prefix precedence' {
+        $result = Get-CIParameterMap -TemplateParameters @{ foo = @{ type = 'secureString' } } `
+            -GitHubVariables '{"CI_FOO":"readable-variable","CI__FOO":"exact-variable"}' `
+            -GitHubSecrets '{"CI__FOO":"exact-secret","CI_FOO":"readable-secret"}'
+
+        ConvertFrom-SecureString -SecureString $result.foo -AsPlainText | Should -Be 'readable-secret'
+    }
+
+    It 'Does not inspect the value of a shadowed exact alias' {
+        $result = Get-CIParameterMap -TemplateParameters @{ foo = @{ type = 'secureString' } } `
+            -GitHubSecrets '{"CI__FOO":null,"CI_FOO":"readable"}'
+
+        ConvertFrom-SecureString -SecureString $result.foo -AsPlainText | Should -Be 'readable'
+    }
+
     It 'Rejects multiple <source> aliases for the same parameter before accessing Key Vault' -ForEach @(
         @{ source = 'Variables'; names = @('CI_ADMIN_MEMBERS_SECRET', 'CI_ADMINMEMBERSSECRET') }
-        @{ source = 'Secrets'; names = @('CI__ADMINMEMBERSSECRET', 'CI_ADMIN_MEMBERS_SECRET') }
+        @{ source = 'Secrets'; names = @('CI_ADMIN_MEMBERS_SECRET', 'CI_ADMINMEMBERSSECRET') }
     ) {
         $arguments = @{
             TemplateParameters = $templateParameters
@@ -102,6 +165,13 @@ Describe 'Get-CIParameterMap' {
 
         { Get-CIParameterMap @arguments } | Should -Throw "*Multiple GitHub $source names*map to parameter*"
         Should -Invoke Get-AzKeyVaultSecret -Times 0 -Exactly
+    }
+
+    It 'Does not use an exact alias to resolve two competing readable aliases' {
+        {
+            Get-CIParameterMap -TemplateParameters $templateParameters `
+                -GitHubSecrets '{"CI__ADMINMEMBERSSECRET":"exact","CI_ADMIN_MEMBERS_SECRET":"one","CI_ADMINMEMBERSSECRET":"two"}'
+        } | Should -Throw '*Multiple GitHub Secrets names*preferred prefix*'
     }
 
     It 'Ignores conflicting aliases that do not target the current template' {
@@ -352,6 +422,7 @@ Describe 'Get-CIParameterMap' {
 
         It 'Formats <parameterName> without losing its identity' -ForEach @(
             @{ parameterName = 'adminMembersSecret'; expected = 'CI_ADMIN_MEMBERS_SECRET' }
+            @{ parameterName = 'fooBar'; expected = 'CI_FOO_BAR' }
             @{ parameterName = 'managedHSMResourceId'; expected = 'CI_MANAGED_HSM_RESOURCE_ID' }
             @{ parameterName = 'clientID'; expected = 'CI_CLIENT_ID' }
             @{ parameterName = 'tls1Version'; expected = 'CI_TLS1_VERSION' }

--- a/utilities/tests/pipelines/Get-CIParameterMap.Tests.ps1
+++ b/utilities/tests/pipelines/Get-CIParameterMap.Tests.ps1
@@ -186,6 +186,29 @@ Describe 'Get-CIParameterMap' {
         $result.options.Count | Should -Be 0
     }
 
+    It 'Resolves user-defined parameter types, including secure aliases' {
+        $definitions = @{
+            'private/config' = @{ type = 'secureObject' }
+            alias            = @{ '$ref' = '#/definitions/private~1config' }
+        }
+        $result = Get-CIParameterMap -TemplateParameters @{ secureConfig = @{ '$ref' = '#/definitions/alias' } } `
+            -TemplateDefinitions $definitions -GitHubSecrets '{"CI_SECURECONFIG":"{\"password\":\"example\"}"}' `
+            -WarningVariable warnings
+
+        $result.secureConfig.password | Should -Be 'example'
+        $warnings.Count | Should -Be 0
+    }
+
+    It 'Rejects missing or circular user-defined types' -ForEach @(
+        @{ definitions = @{} }
+        @{ definitions = @{ alias = @{ '$ref' = '#/definitions/alias' } } }
+    ) {
+        {
+            Get-CIParameterMap -TemplateParameters @{ secureConfig = @{ '$ref' = '#/definitions/alias' } } `
+                -TemplateDefinitions $definitions -GitHubSecrets '{"CI_SECURECONFIG":"{}"}'
+        } | Should -Throw '*unresolved or circular type reference*'
+    }
+
     It 'Warns without logging the value when a secret targets a non-secure parameter' {
         $result = Get-CIParameterMap -TemplateParameters $templateParameters -GitHubSecrets '{"CI_LOCATION":"sensitive-example"}' `
             -WarningVariable warnings -WarningAction SilentlyContinue

--- a/utilities/tools/Copy-CIKeyVaultSecretsToGitHub.ps1
+++ b/utilities/tools/Copy-CIKeyVaultSecretsToGitHub.ps1
@@ -140,6 +140,9 @@ function Get-CIGitHubConfigurationMap {
             $names[$parameterName] += $entry.name
         }
     }
+    foreach ($parameterName in @($names.psbase.Keys)) {
+        $names[$parameterName] = @(Select-CIParameterAlias -Name $names[$parameterName])
+    }
     return $names
 }
 #endregion
@@ -156,8 +159,9 @@ literal underscores and avoids the reserved CI_KEY_VAULT_NAME selector.
 Values remain secrets unless explicitly selected using VariableName. Variables are NON-SENSITIVE.
 Dry run is the default. Apply and per-entry ShouldProcess approval are required before reading values.
 Existing aliases are skipped unless Overwrite is supplied, in which case their names are reused.
-Ambiguous aliases and opposite-kind collisions are always blocked; resolve the classification or
-destination configuration explicitly before retrying.
+Within the selected kind, CI_ takes precedence over CI__ for the same parameter.
+Multiple aliases in the winning prefix and opposite-kind collisions are always blocked;
+resolve the classification or destination configuration explicitly before retrying.
 Never deletes source or destination entries, writes value files, or prints values.
 
 Only the selected repository or environment scope is inventoried; GitHub resolves inherited scopes
@@ -261,6 +265,7 @@ function Copy-CIKeyVaultSecretsToGitHub {
 
     . (Join-Path $PSScriptRoot '..' 'pipelines' 'sharedScripts' 'ConvertFrom-CIParameterName.ps1')
     . (Join-Path $PSScriptRoot '..' 'pipelines' 'sharedScripts' 'ConvertTo-CIParameterName.ps1')
+    . (Join-Path $PSScriptRoot '..' 'pipelines' 'sharedScripts' 'Select-CIParameterAlias.ps1')
 
     try {
         $ghPath = (Get-Command -Name gh -CommandType Application -ErrorAction Stop).Path

--- a/utilities/tools/Copy-CIKeyVaultSecretsToGitHub.ps1
+++ b/utilities/tools/Copy-CIKeyVaultSecretsToGitHub.ps1
@@ -93,7 +93,7 @@ function Invoke-CIGitHubCommand {
     }
 }
 
-function Get-CIGitHubConfigurationNameSet {
+function Get-CIGitHubConfigurationMap {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
@@ -124,14 +124,23 @@ function Get-CIGitHubConfigurationNameSet {
         throw "Invalid GitHub $Kind name inventory: expected an array."
     }
 
-    $names = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $names = @{}
     foreach ($entry in $entries) {
         if ($entry -isnot [System.Collections.IDictionary] -or $entry.name -isnot [string] -or $entry.name -cnotmatch '^[A-Za-z_][A-Za-z0-9_]*$') {
             throw "Invalid entry in GitHub $Kind name inventory. Response details are suppressed."
         }
-        $null = $names.Add($entry.name)
+        $parameterName = ConvertFrom-CIParameterName -Name $entry.name
+        if ([string]::IsNullOrEmpty($parameterName)) {
+            continue
+        }
+        if (-not $names.ContainsKey($parameterName)) {
+            $names[$parameterName] = @()
+        }
+        if ($names[$parameterName] -notcontains $entry.name) {
+            $names[$parameterName] += $entry.name
+        }
     }
-    return ,$names
+    return $names
 }
 #endregion
 
@@ -142,11 +151,13 @@ Preview or copy CI Key Vault secrets to GitHub Actions secrets or explicitly sel
 .DESCRIPTION
 Inventories CI-<parameterName> Key Vault secret metadata and GitHub destination names.
 SecretName optionally limits the plan to reviewed, existing source names; omitted means all CI- entries.
-Maps names to uppercase CI_<parameterName> without changing the parameter suffix.
+Creates readable uppercase CI_ names from camelCase source parameters. CI__ preserves
+literal underscores and avoids the reserved CI_KEY_VAULT_NAME selector.
 Values remain secrets unless explicitly selected using VariableName. Variables are NON-SENSITIVE.
 Dry run is the default. Apply and per-entry ShouldProcess approval are required before reading values.
-Existing entries are skipped unless Overwrite is supplied. Opposite-kind collisions are always blocked;
-resolve the classification or destination configuration explicitly before retrying.
+Existing aliases are skipped unless Overwrite is supplied, in which case their names are reused.
+Ambiguous aliases and opposite-kind collisions are always blocked; resolve the classification or
+destination configuration explicitly before retrying.
 Never deletes source or destination entries, writes value files, or prints values.
 
 Only the selected repository or environment scope is inventoried; GitHub resolves inherited scopes
@@ -170,8 +181,8 @@ Omitted includes all CI- entries. An explicitly empty selection, unknown name, o
 Unselected legacy entries are not validated or copied. This does not change destination classification.
 
 .PARAMETER VariableName
-Optional. Explicit CI_<parameterName> destination names to copy as NON-SENSITIVE GitHub variables.
-Names are matched case-insensitively and must match the selected source plan. All other entries are secrets.
+Optional. CI_ or CI__ destination names resolving to selected source parameters to copy as
+NON-SENSITIVE GitHub variables. All other entries are secrets.
 
 .PARAMETER Apply
 Optional. Perform approved copies. Without this switch, only metadata is read.
@@ -248,6 +259,9 @@ function Copy-CIKeyVaultSecretsToGitHub {
         throw 'SecretName was explicitly empty. Supply reviewed CI- source names or omit the parameter to include all CI- entries.'
     }
 
+    . (Join-Path $PSScriptRoot '..' 'pipelines' 'sharedScripts' 'ConvertFrom-CIParameterName.ps1')
+    . (Join-Path $PSScriptRoot '..' 'pipelines' 'sharedScripts' 'ConvertTo-CIParameterName.ps1')
+
     try {
         $ghPath = (Get-Command -Name gh -CommandType Application -ErrorAction Stop).Path
     } catch [System.Management.Automation.CommandNotFoundException] {
@@ -286,7 +300,7 @@ function Copy-CIKeyVaultSecretsToGitHub {
         }
     }
 
-    $plannedNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $plannedParameters = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
     $plan = @(
         foreach ($source in $sources) {
             if ($null -ne $selectedNames -and -not $selectedNames.Contains($source.Name)) {
@@ -295,26 +309,32 @@ function Copy-CIKeyVaultSecretsToGitHub {
             if ($source.Name -notmatch '^CI-') {
                 continue
             }
-            if ($source.Name -cnotmatch '^(?i:CI)-[A-Za-z_][A-Za-z0-9_]*$' -or $source.Name.Length -gt 100) {
+            if ($source.Name -cnotmatch '^(?i:CI)-[A-Za-z_][A-Za-z0-9_]*$') {
                 throw "Cannot map Key Vault name [$($source.Name)] to CI_<parameterName>. The suffix must be a Bicep identifier and the target at most 100 characters; hyphens are not replaced."
             }
-            $targetName = 'CI_{0}' -f $source.Name.Substring(3).ToUpperInvariant()
-            if (-not $plannedNames.Add($targetName)) {
-                throw "Multiple source names map to GitHub name [$targetName]. Resolve the ambiguity before copying."
+            $parameterName = $source.Name.Substring(3)
+            $targetName = ConvertTo-CIParameterName -ParameterName $parameterName
+            if ($targetName.Length -gt 100) {
+                throw "Cannot map Key Vault name [$($source.Name)]: the generated GitHub name exceeds 100 characters."
+            }
+            if (-not $plannedParameters.Add($parameterName)) {
+                throw "Multiple source names map to parameter [$parameterName]. Resolve the ambiguity before copying."
             }
             @{
-                Source = $source
-                Name   = $targetName
+                Source        = $source
+                Name          = $targetName
+                ParameterName = $parameterName
             }
         }
     )
 
-    $variableNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $variableParameters = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
     foreach ($name in $VariableName) {
-        if ([string]::IsNullOrWhiteSpace($name) -or -not $plannedNames.Contains($name)) {
-            throw "VariableName [$name] does not match a planned CI_ destination name. Use exact mapped names, not Key Vault CI- names."
+        $parameterName = [string]::IsNullOrWhiteSpace($name) ? $null : (ConvertFrom-CIParameterName -Name $name)
+        if ([string]::IsNullOrEmpty($parameterName) -or -not $plannedParameters.Contains($parameterName)) {
+            throw "VariableName [$name] does not match a planned CI_ destination name. Use a CI_ or CI__ alias for a selected source parameter, not a Key Vault CI- name."
         }
-        $null = $variableNames.Add($name)
+        $null = $variableParameters.Add($parameterName)
     }
 
     $githubOptions = @{
@@ -324,11 +344,11 @@ function Copy-CIKeyVaultSecretsToGitHub {
     }
     $destinationNames = @{}
     foreach ($kind in @('Secret', 'Variable')) {
-        $destinationNames[$kind] = Get-CIGitHubConfigurationNameSet @githubOptions -Kind $kind
+        $destinationNames[$kind] = Get-CIGitHubConfigurationMap @githubOptions -Kind $kind
     }
 
     foreach ($item in $plan) {
-        $kind = $variableNames.Contains($item.Name) ? 'Variable' : 'Secret'
+        $kind = $variableParameters.Contains($item.ParameterName) ? 'Variable' : 'Secret'
         $oppositeKind = $kind -eq 'Secret' ? 'Variable' : 'Secret'
         $result = [pscustomobject]@{
             VaultName       = $VaultName
@@ -341,9 +361,15 @@ function Copy-CIKeyVaultSecretsToGitHub {
             Status          = 'Planned'
         }
 
-        if ($destinationNames[$oppositeKind].Contains($item.Name)) {
+        $matchingNames = $destinationNames[$kind][$item.ParameterName] ?? @()
+        if ($matchingNames.Count -eq 1) {
+            $result.DestinationName = $matchingNames[0]
+        }
+        if ($destinationNames[$oppositeKind].ContainsKey($item.ParameterName)) {
             $result.Status = 'BlockedByOppositeKind'
-        } elseif ($destinationNames[$kind].Contains($item.Name) -and -not $Overwrite) {
+        } elseif ($matchingNames.Count -gt 1) {
+            $result.Status = 'BlockedByAmbiguousAliases'
+        } elseif ($matchingNames.Count -eq 1 -and -not $Overwrite) {
             $result.Status = 'SkippedExisting'
         } elseif ($item.Source.Enabled -eq $false) {
             $result.Status = 'SkippedDisabled'
@@ -351,7 +377,7 @@ function Copy-CIKeyVaultSecretsToGitHub {
             $result.Status = 'SkippedExpired'
         } elseif ($item.Source.NotBefore -and [DateTimeOffset] $item.Source.NotBefore -gt [DateTimeOffset]::UtcNow) {
             $result.Status = 'SkippedNotYetValid'
-        } elseif ($destinationNames[$kind].Contains($item.Name)) {
+        } elseif ($matchingNames.Count -eq 1) {
             $result.Status = 'PlannedOverwrite'
         }
 
@@ -361,7 +387,7 @@ function Copy-CIKeyVaultSecretsToGitHub {
         }
 
         $action = $Overwrite ? 'Copy or overwrite from Key Vault' : 'Copy from Key Vault'
-        $target = "$Repository [$($result.Scope):$Environment] $kind [$($item.Name)] from [$($item.Source.Name)]"
+        $target = "$Repository [$($result.Scope):$Environment] $kind [$($result.DestinationName)] from [$($item.Source.Name)]"
         if (-not $PSCmdlet.ShouldProcess($target, $action)) {
             $result.Status = 'SkippedShouldProcess'
             $result
@@ -371,15 +397,28 @@ function Copy-CIKeyVaultSecretsToGitHub {
         # Recheck both kinds after approval, before retrieving a value.
         $currentNames = @{}
         foreach ($currentKind in @('Secret', 'Variable')) {
-            $currentNames[$currentKind] = Get-CIGitHubConfigurationNameSet @githubOptions -Kind $currentKind
+            $currentNames[$currentKind] = Get-CIGitHubConfigurationMap @githubOptions -Kind $currentKind
         }
-        if ($currentNames[$oppositeKind].Contains($item.Name)) {
+        $currentMatches = $currentNames[$kind][$item.ParameterName] ?? @()
+        if ($currentNames[$oppositeKind].ContainsKey($item.ParameterName)) {
             $result.Status = 'BlockedByOppositeKind'
             $result
             continue
         }
-        if ($currentNames[$kind].Contains($item.Name) -and -not $Overwrite) {
+        if ($currentMatches.Count -gt 1) {
+            $result.Status = 'BlockedByAmbiguousAliases'
+            $result
+            continue
+        }
+        if ($currentMatches.Count -eq 1 -and -not $Overwrite) {
+            $result.DestinationName = $currentMatches[0]
             $result.Status = 'SkippedExisting'
+            $result
+            continue
+        }
+        if (($currentMatches.Count -eq 1 -and $currentMatches[0] -ine $result.DestinationName) -or
+            ($result.Status -eq 'PlannedOverwrite' -and $currentMatches.Count -eq 0)) {
+            $result.Status = 'BlockedChangedDestination'
             $result
             continue
         }
@@ -436,7 +475,7 @@ function Copy-CIKeyVaultSecretsToGitHub {
                 throw "Key Vault secret [$($item.Source.Name)] did not return the pinned version. Nothing was copied for this entry."
             }
 
-            $arguments = @($kind.ToLowerInvariant(), 'set', $item.Name, '--repo', $Repository)
+            $arguments = @($kind.ToLowerInvariant(), 'set', $result.DestinationName, '--repo', $Repository)
             if ($Environment) {
                 $arguments += @('--env', $Environment)
             }

--- a/utilities/tools/Copy-CIKeyVaultSecretsToGitHub.ps1
+++ b/utilities/tools/Copy-CIKeyVaultSecretsToGitHub.ps1
@@ -1,0 +1,454 @@
+#requires -Version 7.2
+
+#region helper functions
+function Invoke-CIGitHubCommand {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string] $ExecutablePath,
+
+        [Parameter(Mandatory)]
+        [string[]] $ArgumentList,
+
+        [Parameter()]
+        [System.Security.SecureString] $InputValue
+    )
+
+    $hasInput = $PSBoundParameters.ContainsKey('InputValue')
+    $process = $null
+    $started = $false
+    $plainText = $null
+
+    try {
+        $arguments = @($ArgumentList)
+        if ($hasInput) {
+            $plainText = [System.Net.NetworkCredential]::new('', $InputValue).Password
+            # gh trims CR/LF from raw stdin; a quoted dotenv value preserves trailing line endings.
+            if ($plainText.EndsWith("`r") -or $plainText.EndsWith("`n")) {
+                $escapedValue = $plainText.Replace('\', '\\').Replace('"', '\"').Replace('$', '\$').Replace("`r", '\r').Replace("`n", '\n')
+                $plainText = '{0}="{1}"' -f $arguments[2], $escapedValue
+                $escapedValue = $null
+                $arguments += @('--env-file', '-')
+            }
+        }
+
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = $ExecutablePath
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.RedirectStandardInput = $true
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+        $startInfo.StandardInputEncoding = [System.Text.UTF8Encoding]::new($false)
+        $startInfo.StandardOutputEncoding = [System.Text.UTF8Encoding]::new($false)
+        $startInfo.StandardErrorEncoding = [System.Text.UTF8Encoding]::new($false)
+        $startInfo.Environment['GH_HOST'] = 'github.com'
+        $startInfo.Environment['GH_PROMPT_DISABLED'] = '1'
+        $null = $startInfo.Environment.Remove('GH_DEBUG')
+        foreach ($argument in $arguments) {
+            $startInfo.ArgumentList.Add($argument)
+        }
+
+        $process = New-Object -TypeName System.Diagnostics.Process
+        $process.StartInfo = $startInfo
+        $started = $process.Start()
+        if (-not $started) {
+            throw [System.InvalidOperationException]::new('The process did not start.')
+        }
+
+        # Drain both streams concurrently, but never disclose native diagnostics or write output.
+        $outputTask = $process.StandardOutput.ReadToEndAsync()
+        $errorTask = $process.StandardError.ReadToEndAsync()
+        if ($hasInput) {
+            $process.StandardInput.Write($plainText)
+        }
+        $process.StandardInput.Close()
+        $plainText = $null
+        $process.WaitForExit()
+        $output = $outputTask.GetAwaiter().GetResult()
+        $null = $errorTask.GetAwaiter().GetResult()
+        $exitCode = $process.ExitCode
+    } catch [System.ComponentModel.Win32Exception], [System.InvalidOperationException], [System.IO.IOException], [System.Management.Automation.MethodInvocationException] {
+        throw 'GitHub CLI process failed. Native output and exception details are suppressed to protect values.'
+    } finally {
+        $plainText = $null
+        $escapedValue = $null
+        if ($null -ne $process) {
+            try {
+                if ($started -and -not $process.HasExited) {
+                    $process.Kill($true)
+                    $process.WaitForExit()
+                }
+            } finally {
+                $process.Dispose()
+            }
+        }
+    }
+
+    if ($exitCode -ne 0) {
+        throw "GitHub CLI exited with code [$exitCode]. Native output is suppressed to protect values."
+    }
+    if (-not $hasInput) {
+        return $output
+    }
+}
+
+function Get-CIGitHubConfigurationNameSet {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string] $ExecutablePath,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Secret', 'Variable')]
+        [string] $Kind,
+
+        [Parameter(Mandatory)]
+        [string] $Repository,
+
+        [Parameter()]
+        [string] $Environment = ''
+    )
+
+    $arguments = @($Kind.ToLowerInvariant(), 'list', '--repo', $Repository, '--json', 'name')
+    if ($Environment) {
+        $arguments += @('--env', $Environment)
+    }
+    $json = Invoke-CIGitHubCommand -ExecutablePath $ExecutablePath -ArgumentList $arguments
+    try {
+        $entries = ConvertFrom-Json -InputObject $json -AsHashtable -NoEnumerate -ErrorAction Stop
+    } catch [System.ArgumentException] {
+        throw "Invalid GitHub $Kind name inventory. Response details are suppressed."
+    }
+    if ($entries -isnot [array]) {
+        throw "Invalid GitHub $Kind name inventory: expected an array."
+    }
+
+    $names = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($entry in $entries) {
+        if ($entry -isnot [System.Collections.IDictionary] -or $entry.name -isnot [string] -or $entry.name -cnotmatch '^[A-Za-z_][A-Za-z0-9_]*$') {
+            throw "Invalid entry in GitHub $Kind name inventory. Response details are suppressed."
+        }
+        $null = $names.Add($entry.name)
+    }
+    return ,$names
+}
+#endregion
+
+<#
+.SYNOPSIS
+Preview or copy CI Key Vault secrets to GitHub Actions secrets or explicitly selected variables.
+
+.DESCRIPTION
+Inventories CI-<parameterName> Key Vault secret metadata and GitHub destination names.
+SecretName optionally limits the plan to reviewed, existing source names; omitted means all CI- entries.
+Maps names to uppercase CI_<parameterName> without changing the parameter suffix.
+Values remain secrets unless explicitly selected using VariableName. Variables are NON-SENSITIVE.
+Dry run is the default. Apply and per-entry ShouldProcess approval are required before reading values.
+Existing entries are skipped unless Overwrite is supplied. Opposite-kind collisions are always blocked;
+resolve the classification or destination configuration explicitly before retrying.
+Never deletes source or destination entries, writes value files, or prints values.
+
+Only the selected repository or environment scope is inventoried; GitHub resolves inherited scopes
+at runtime. Destination names are rechecked before each approved copy, but GitHub CLI set operations
+are upserts, not atomic create-only operations. Avoid concurrent destination configuration changes.
+The inventory's source version is used when available; otherwise metadata-only version enumeration
+pins the uniquely newest version before reading it. Failures stop the run without rollback.
+
+.PARAMETER VaultName
+Mandatory. Existing Azure Key Vault containing CI-<parameterName> secrets.
+
+.PARAMETER Repository
+Mandatory. Public github.com destination in owner/repo form.
+
+.PARAMETER Environment
+Optional. Existing GitHub environment name. Empty or omitted selects repository scope.
+
+.PARAMETER SecretName
+Optional. Exact CI-<parameterName> Key Vault source names to include, matched case-insensitively.
+Omitted includes all CI- entries. An explicitly empty selection, unknown name, or wildcard fails.
+Unselected legacy entries are not validated or copied. This does not change destination classification.
+
+.PARAMETER VariableName
+Optional. Explicit CI_<parameterName> destination names to copy as NON-SENSITIVE GitHub variables.
+Names are matched case-insensitively and must match the selected source plan. All other entries are secrets.
+
+.PARAMETER Apply
+Optional. Perform approved copies. Without this switch, only metadata is read.
+
+.PARAMETER Overwrite
+Optional. Allow replacement of existing entries of the same kind only. Never deletes or changes kinds.
+
+.OUTPUTS
+System.Management.Automation.PSCustomObject
+Source/destination names, repository/environment scope, kind, and status. No values.
+
+.NOTES
+Requires PowerShell 7.2+, Az.KeyVault, an authenticated Azure PowerShell context with secret list/get
+permissions, and GitHub CLI (gh) on PATH authenticated to github.com with destination write permissions.
+Does not install dependencies, log in, switch subscriptions, create environments, or manage tokens.
+The current Azure context and the existing GitHub CLI authenticated session are used.
+Dry run/WhatIf still require metadata read permissions. No secret values are read for skipped entries.
+
+.EXAMPLE
+. .\utilities\tools\Copy-CIKeyVaultSecretsToGitHub.ps1
+Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo'
+
+Preview repository-scoped copies using names and metadata only.
+
+.EXAMPLE
+Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -SecretName 'CI-clientId', 'CI-location' -VariableName 'CI_LOCATION'
+
+Preview only reviewed source names, opting CI_LOCATION into a non-sensitive variable.
+
+.EXAMPLE
+Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Environment 'validation' -VariableName 'CI_LOCATION' -Apply -WhatIf
+
+Preview environment-scoped copies, opting only CI_LOCATION into a non-sensitive variable.
+
+.EXAMPLE
+Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo' -Apply -Overwrite
+
+Copy entries and deliberately replace same-kind entries. Opposite-kind collisions remain blocked.
+#>
+function Copy-CIKeyVaultSecretsToGitHub {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param (
+        [Parameter(Mandatory)]
+        [ValidatePattern('^(?!.*--)[A-Za-z][A-Za-z0-9-]{1,22}[A-Za-z0-9]$')]
+        [string] $VaultName,
+
+        [Parameter(Mandatory)]
+        [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9_.-]+$')]
+        [string] $Repository,
+
+        [Parameter()]
+        [AllowEmptyString()]
+        [ValidateLength(0, 255)]
+        [ValidatePattern('^[^\x00-\x1F\x7F]*$')]
+        [string] $Environment = '',
+
+        [Parameter()]
+        [string[]] $SecretName = @(),
+
+        [Parameter()]
+        [string[]] $VariableName = @(),
+
+        [Parameter()]
+        [switch] $Apply,
+
+        [Parameter()]
+        [switch] $Overwrite
+    )
+
+    if ($Environment -and [string]::IsNullOrWhiteSpace($Environment)) {
+        throw 'Environment must be an existing environment name or empty for repository scope.'
+    }
+    if ($PSBoundParameters.ContainsKey('SecretName') -and ($null -eq $SecretName -or $SecretName.Count -eq 0)) {
+        throw 'SecretName was explicitly empty. Supply reviewed CI- source names or omit the parameter to include all CI- entries.'
+    }
+
+    try {
+        $ghPath = (Get-Command -Name gh -CommandType Application -ErrorAction Stop).Path
+    } catch [System.Management.Automation.CommandNotFoundException] {
+        throw 'GitHub CLI (gh) must be installed on PATH and authenticated to github.com.'
+    }
+
+    $azOptions = @{
+        VaultName         = $VaultName
+        ErrorAction       = 'Stop'
+        Verbose           = $false
+        Debug             = $false
+        WarningAction     = 'SilentlyContinue'
+        InformationAction = 'SilentlyContinue'
+    }
+    try {
+        $sources = @(Get-AzKeyVaultSecret @azOptions)
+    } catch [System.Management.Automation.ActionPreferenceStopException], [System.Management.Automation.CmdletInvocationException], [System.Net.Http.HttpRequestException], [System.TimeoutException] {
+        throw "Cannot inventory Key Vault [$VaultName]. Check Az.KeyVault, the current Azure context, and list permissions. Details are suppressed."
+    }
+
+    $selectedNames = $null
+    if ($PSBoundParameters.ContainsKey('SecretName')) {
+        $selectedNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        $availableNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($source in $sources) {
+            $null = $availableNames.Add($source.Name)
+        }
+        foreach ($name in $SecretName) {
+            if ([string]::IsNullOrWhiteSpace($name) -or $name -notmatch '^CI-') {
+                throw "SecretName [$name] must be an exact CI- Key Vault source name, not a CI_ destination name."
+            }
+            if (-not $availableNames.Contains($name)) {
+                throw "SecretName [$name] does not match a source secret in the Key Vault inventory. Names are literal; wildcards and name conversions are not supported."
+            }
+            $null = $selectedNames.Add($name)
+        }
+    }
+
+    $plannedNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $plan = @(
+        foreach ($source in $sources) {
+            if ($null -ne $selectedNames -and -not $selectedNames.Contains($source.Name)) {
+                continue
+            }
+            if ($source.Name -notmatch '^CI-') {
+                continue
+            }
+            if ($source.Name -cnotmatch '^(?i:CI)-[A-Za-z_][A-Za-z0-9_]*$' -or $source.Name.Length -gt 100) {
+                throw "Cannot map Key Vault name [$($source.Name)] to CI_<parameterName>. The suffix must be a Bicep identifier and the target at most 100 characters; hyphens are not replaced."
+            }
+            $targetName = 'CI_{0}' -f $source.Name.Substring(3).ToUpperInvariant()
+            if (-not $plannedNames.Add($targetName)) {
+                throw "Multiple source names map to GitHub name [$targetName]. Resolve the ambiguity before copying."
+            }
+            @{
+                Source = $source
+                Name   = $targetName
+            }
+        }
+    )
+
+    $variableNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($name in $VariableName) {
+        if ([string]::IsNullOrWhiteSpace($name) -or -not $plannedNames.Contains($name)) {
+            throw "VariableName [$name] does not match a planned CI_ destination name. Use exact mapped names, not Key Vault CI- names."
+        }
+        $null = $variableNames.Add($name)
+    }
+
+    $githubOptions = @{
+        ExecutablePath = $ghPath
+        Repository     = $Repository
+        Environment    = $Environment
+    }
+    $destinationNames = @{}
+    foreach ($kind in @('Secret', 'Variable')) {
+        $destinationNames[$kind] = Get-CIGitHubConfigurationNameSet @githubOptions -Kind $kind
+    }
+
+    foreach ($item in $plan) {
+        $kind = $variableNames.Contains($item.Name) ? 'Variable' : 'Secret'
+        $oppositeKind = $kind -eq 'Secret' ? 'Variable' : 'Secret'
+        $result = [pscustomobject]@{
+            VaultName       = $VaultName
+            SourceName      = $item.Source.Name
+            DestinationName = $item.Name
+            Repository      = $Repository
+            Environment     = $Environment
+            Scope           = $Environment ? 'Environment' : 'Repository'
+            Kind            = $kind
+            Status          = 'Planned'
+        }
+
+        if ($destinationNames[$oppositeKind].Contains($item.Name)) {
+            $result.Status = 'BlockedByOppositeKind'
+        } elseif ($destinationNames[$kind].Contains($item.Name) -and -not $Overwrite) {
+            $result.Status = 'SkippedExisting'
+        } elseif ($item.Source.Enabled -eq $false) {
+            $result.Status = 'SkippedDisabled'
+        } elseif ($item.Source.Expires -and [DateTimeOffset] $item.Source.Expires -le [DateTimeOffset]::UtcNow) {
+            $result.Status = 'SkippedExpired'
+        } elseif ($item.Source.NotBefore -and [DateTimeOffset] $item.Source.NotBefore -gt [DateTimeOffset]::UtcNow) {
+            $result.Status = 'SkippedNotYetValid'
+        } elseif ($destinationNames[$kind].Contains($item.Name)) {
+            $result.Status = 'PlannedOverwrite'
+        }
+
+        if (-not $Apply -or $result.Status -notin @('Planned', 'PlannedOverwrite')) {
+            $result
+            continue
+        }
+
+        $action = $Overwrite ? 'Copy or overwrite from Key Vault' : 'Copy from Key Vault'
+        $target = "$Repository [$($result.Scope):$Environment] $kind [$($item.Name)] from [$($item.Source.Name)]"
+        if (-not $PSCmdlet.ShouldProcess($target, $action)) {
+            $result.Status = 'SkippedShouldProcess'
+            $result
+            continue
+        }
+
+        # Recheck both kinds after approval, before retrieving a value.
+        $currentNames = @{}
+        foreach ($currentKind in @('Secret', 'Variable')) {
+            $currentNames[$currentKind] = Get-CIGitHubConfigurationNameSet @githubOptions -Kind $currentKind
+        }
+        if ($currentNames[$oppositeKind].Contains($item.Name)) {
+            $result.Status = 'BlockedByOppositeKind'
+            $result
+            continue
+        }
+        if ($currentNames[$kind].Contains($item.Name) -and -not $Overwrite) {
+            $result.Status = 'SkippedExisting'
+            $result
+            continue
+        }
+
+        $metadata = $item.Source
+        if ([string]::IsNullOrWhiteSpace($metadata.Version)) {
+            try {
+                $versions = @(Get-AzKeyVaultSecret @azOptions -Name $metadata.Name -IncludeVersions)
+            } catch [System.Management.Automation.ActionPreferenceStopException], [System.Management.Automation.CmdletInvocationException], [System.Net.Http.HttpRequestException], [System.TimeoutException] {
+                throw "Cannot inventory versions of Key Vault secret [$($metadata.Name)]. Details are suppressed."
+            }
+            if ($versions.Count -eq 0 -or @($versions | Where-Object { -not $_.Version -or -not $_.Created }).Count -gt 0) {
+                throw "Cannot pin a version of Key Vault secret [$($metadata.Name)]: version metadata is missing."
+            }
+            $versions = @($versions | Sort-Object -Property { [DateTimeOffset] $_.Created } -Descending)
+            if ($versions.Count -gt 1 -and [DateTimeOffset] $versions[0].Created -eq [DateTimeOffset] $versions[1].Created) {
+                throw "Cannot pin a unique latest version of Key Vault secret [$($metadata.Name)]."
+            }
+            $metadata = $versions[0]
+        }
+        if ($metadata.Enabled -eq $false) {
+            $result.Status = 'SkippedDisabled'
+            $result
+            continue
+        }
+        if ($metadata.Expires -and [DateTimeOffset] $metadata.Expires -le [DateTimeOffset]::UtcNow) {
+            $result.Status = 'SkippedExpired'
+            $result
+            continue
+        }
+        if ($metadata.NotBefore -and [DateTimeOffset] $metadata.NotBefore -gt [DateTimeOffset]::UtcNow) {
+            $result.Status = 'SkippedNotYetValid'
+            $result
+            continue
+        }
+
+        $secret = $null
+        try {
+            try {
+                $secret = Get-AzKeyVaultSecret @azOptions -Name $item.Source.Name -Version $metadata.Version
+            } catch [System.Management.Automation.ActionPreferenceStopException], [System.Management.Automation.CmdletInvocationException], [System.Net.Http.HttpRequestException], [System.TimeoutException] {
+                throw "Cannot read the pinned version of Key Vault secret [$($item.Source.Name)]. Check source availability and get permissions. Details are suppressed."
+            }
+            if ($null -eq $secret -or $secret.SecretValue -isnot [System.Security.SecureString] -or $secret.SecretValue.Length -eq 0) {
+                throw "Key Vault secret [$($item.Source.Name)] has no accessible, non-empty value. Nothing was copied for this entry."
+            }
+            if ($secret.Enabled -eq $false) {
+                throw "Key Vault secret [$($item.Source.Name)] is now disabled. Nothing was copied for this entry."
+            }
+            if (($secret.Expires -and [DateTimeOffset] $secret.Expires -le [DateTimeOffset]::UtcNow) -or ($secret.NotBefore -and [DateTimeOffset] $secret.NotBefore -gt [DateTimeOffset]::UtcNow)) {
+                throw "Key Vault secret [$($item.Source.Name)] is outside its validity period. Nothing was copied for this entry."
+            }
+            if ($secret.Version -cne $metadata.Version) {
+                throw "Key Vault secret [$($item.Source.Name)] did not return the pinned version. Nothing was copied for this entry."
+            }
+
+            $arguments = @($kind.ToLowerInvariant(), 'set', $item.Name, '--repo', $Repository)
+            if ($Environment) {
+                $arguments += @('--env', $Environment)
+            }
+            $null = Invoke-CIGitHubCommand -ExecutablePath $ghPath -ArgumentList $arguments -InputValue $secret.SecretValue
+        } finally {
+            if ($null -ne $secret -and $secret.SecretValue -is [System.Security.SecureString]) {
+                $secret.SecretValue.Dispose()
+            }
+            $secret = $null
+        }
+
+        $result.Status = 'Copied'
+        $result
+    }
+}


### PR DESCRIPTION
## Description

Add GitHub Actions secrets and variables as the preferred source for extra Bicep end-to-end test parameters, while retaining the current CI Key Vault fallback.

### GitHub naming and precedence

Both formats match declared Bicep parameter names case-insensitively and pass the template's canonical spelling:

| GitHub name | Matching Bicep parameter |
| --- | --- |
| `CI_ADMIN_MEMBERS_SECRET` | `adminMembersSecret` |
| `CI_ADMINMEMBERSSECRET` | `adminMembersSecret` |
| `CI__ADMIN_MEMBERS_SECRET` | `admin_members_secret` only |
| `CI__ADMINMEMBERSSECRET` | `adminMembersSecret` |

`CI_` removes all suffix underscores for readable matching. `CI__` preserves literal suffix underscores. Prefer readable names for camelCase parameters; use the double prefix for literal spelling.

For the same parameter, precedence is **CI_ secret > CI__ secret > CI_ variable > CI__ variable > legacy Key Vault secret**.

- Within secrets or within variables, choose the `CI_` alias over a matching `CI__` alias regardless of enumeration order. For example, `CI_FOO` wins over `CI__FOO` in the same source.
- Secrets always override variables, even when only the secret uses the exact prefix. Explicitly empty winning values do not fall through.
- Multiple aliases within the same winning prefix remain ambiguous, such as `CI_ADMIN_MEMBERS_SECRET` and `CI_ADMINMEMBERSSECRET`; reject these rather than inventing another tie-breaker.
- Reserve `CI_KEY_VAULT_NAME` exclusively for legacy vault configuration. Use `CI__KEYVAULTNAME` to supply a test parameter named `keyVaultName`.
- Evaluate resolved `vars` and `secrets` contexts in each `avm-validation` job, supporting repository/environment scope without separate lookup logic.
- Convert values to declared ARM types, including user-defined aliases. Secure strings become PowerShell SecureString values; secure objects retain their ARM secureObject declaration. Log parameter names, not values.
- Wire standard, preview, and publish workflows through one parameter resolver. Azure authentication is unchanged.
- Retain literal, case-insensitive Key Vault `CI-` matching and emit a visible warning that `CI_KEY_VAULT_NAME` support may be removed in a future release.

## Migration preparation

`utilities/tools/Copy-CIKeyVaultSecretsToGitHub.ps1` provides a metadata-only preview by default. Dot-source the file, then call `Copy-CIKeyVaultSecretsToGitHub` with the source vault and destination repository.

- Readable names are the default: `CI-fooBar` imports as `CI_FOO_BAR`, and `CI-managedHSMResourceId` as `CI_MANAGED_HSM_RESOURCE_ID`. Literal underscores and reserved-name conflicts use `CI__`; long names may remain compact to fit GitHub's name limit.
- Optional `SecretName` selects reviewed source `CI-` names. Optional `VariableName` selects explicitly non-sensitive parameters using a matching `CI_` or `CI__` alias. All other selected values remain secrets.
- Recognize existing settings by decoded parameter identity and apply the same `CI_`-before-`CI__` priority within the selected kind. Skip the winning existing alias by default; explicit `Overwrite` updates only that alias and leaves lower-priority aliases unchanged.
- Block ambiguity within the winning prefix and retain opposite-kind collision protection. Migration never deletes entries or automatically changes their classification.
- Repository or existing environment scope is explicit. Recheck destination aliases after approval and block a changed winning destination rather than silently retargeting a copy.
- Read values only for approved actual copies with `Apply`, pinned to source versions, and send them through standard input. Newline-terminated values use escaped, single-entry dotenv on stdin to avoid CLI trimming of trailing CR/LF.
- No value files, value command-line arguments, source deletion, or automatic login/configuration changes. `WhatIf` never retrieves secret values.
- GitHub set operations are upserts; avoid concurrent destination changes during an approved migration.

### Merge and migration sequencing

This change can merge before migration. Existing Key Vault-based configurations can leave `CI_KEY_VAULT_NAME` and their vault secrets unchanged; the added deprecation warning is non-blocking. Merging does not run the migration helper or copy/delete secrets.

GitHub inputs take precedence immediately when configured, so any existing matching `CI_` or `CI__` settings should contain the intended values. Migration can proceed incrementally after merge, with separate operator approval. Remove `CI_KEY_VAULT_NAME` only after all required inputs have been migrated; retain the vault as needed for other consumers and rollback.

No live secret migration, cloud setting changes, or deployments have been performed. Completing migration is not a prerequisite for merging this change.

## Documentation

Public contributor guidance, including both naming modes, preferred GitHub inputs, legacy warning, and migration preview: [Azure/Azure-Verified-Modules#2909](https://github.com/Azure/Azure-Verified-Modules/pull/2909).

Operator runbook added to the existing internal documentation change: [azure-cloud-native/Azure-Verified-Modules-Docs#46](https://msft.ghe.com/azure-cloud-native/Azure-Verified-Modules-Docs/pull/46).

## Pipeline Reference

| Pipeline | Result |
| --- | --- |
| Local targeted Pester | 203 passing: naming formats, source/prefix precedence, migration safety and transport, parameter resolution, JSON/Bicep workflow transport, subscription selection, and reusable workflow integration |
| PowerShell analysis | All five parameter/migration helpers pass error/warning analysis |
| Azure deployment | Not run; production execution requires separate approval |

## Type of Change

- [x] Update to CI Environment or utilities (Non-module affecting changes)
- [x] Documentation updated in linked documentation changes

## Checklist

- [x] No other open change found for the same update
- [x] Local targeted coverage passes
- [x] Migration preparation finalized
- [x] Public and internal guidance prepared

`Set-AVMModule`, module version bumps, and module changelog updates are not applicable: no AVM module source files changed.