### PR TITLE
fix: select first GitHub CLI executable for CI migration

### DIFF
--- a/utilities/tests/pipelines/Copy-CIKeyVaultSecretsToGitHub.Tests.ps1
+++ b/utilities/tests/pipelines/Copy-CIKeyVaultSecretsToGitHub.Tests.ps1
@@ -110,6 +110,19 @@ Describe 'Copy-CIKeyVaultSecretsToGitHub' {
         Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ArgumentList[1] -eq 'set' }
     }
 
+    It 'Uses only the first GitHub CLI executable when multiple applications are found on PATH' {
+        Mock Get-Command {
+            [pscustomobject]@{ Path = 'mock-gh-first' }
+            [pscustomobject]@{ Path = 'mock-gh-second' }
+        } -ParameterFilter { $Name -eq 'gh' -and $CommandType -eq 'Application' }
+
+        $result = Copy-CIKeyVaultSecretsToGitHub -VaultName 'ci-vault' -Repository 'owner/repo'
+
+        $result.Status | Should -Be 'Planned'
+        Should -Invoke Invoke-CIGitHubCommand -Times 2 -Exactly -ParameterFilter { $ExecutablePath -eq 'mock-gh-first' }
+        Should -Invoke Invoke-CIGitHubCommand -Times 0 -Exactly -ParameterFilter { $ExecutablePath -ne 'mock-gh-first' }
+    }
+
     It 'Does not retrieve values or write with Apply and WhatIf, including overwrite previews' {
         $script:secretNames = @('CI_CLIENTSECRET')
 

--- a/utilities/tools/Copy-CIKeyVaultSecretsToGitHub.ps1
+++ b/utilities/tools/Copy-CIKeyVaultSecretsToGitHub.ps1
@@ -268,7 +268,7 @@ function Copy-CIKeyVaultSecretsToGitHub {
     . (Join-Path $PSScriptRoot '..' 'pipelines' 'sharedScripts' 'Select-CIParameterAlias.ps1')
 
     try {
-        $ghPath = (Get-Command -Name gh -CommandType Application -ErrorAction Stop).Path
+        $ghPath = (Get-Command -Name gh -CommandType Application -ErrorAction Stop | Select-Object -First 1).Path
     } catch [System.Management.Automation.CommandNotFoundException] {
         throw 'GitHub CLI (gh) must be installed on PATH and authenticated to github.com.'
     }


### PR DESCRIPTION
## Description

Follow-up to [#7339](https://github.com/Azure/bicep-registry-modules/pull/7339). When multiple GitHub CLI installations are on PATH, `Get-Command` returns multiple applications and the migration helper passes an array to the string-valued `ExecutablePath` parameter, blocking even a metadata-only preview.

Select the first application in normal PATH resolution order before reading `.Path`. Add one regression test that returns two mocked command paths and asserts that only the first reaches `Invoke-CIGitHubCommand`.

No other helper logic, existing tests, or documentation changed. No live Azure, GitHub secret, or GitHub variable operations were performed.

## Pipeline Reference

| Pipeline | Result |
| -------- | ------ |
| Local Pester: `utilities\tests\pipelines\Copy-CIKeyVaultSecretsToGitHub.Tests.ps1` | 94 passed, 0 failed |

No deployments or manual CI reruns were performed.

## Type of Change

Azure Verified Module updates:
- [ ] Bugfix containing backwards-compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `version.json`.
- [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `version.json`.
- [ ] Breaking changes and I have bumped the MAJOR version in `version.json`.
- [ ] Update to documentation
- [x] Update to CI Environment or utilities (Non-module affecting changes)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] I have run `Set-AVMModule` locally to generate the supporting module files.
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have updated the module's CHANGELOG.md file with an entry for the next version

Module generation and changelog updates are not applicable to this utility-only fix. Only the targeted local Pester file was run.